### PR TITLE
Classify to return object with classes/style/height/width

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -16,14 +16,16 @@ module Primer
 
     def initialize(tag:, classes: nil, **args)
       @tag = tag
-      @classes = Primer::Classify.call(**args.merge(classes: classes))
+      @result = Primer::Classify.call(**args.merge(classes: classes))
 
       # Filter out Primer keys so they don't get assigned as HTML attributes
       @content_tag_args = add_test_selector(args).except(*Primer::Classify::VALID_KEYS)
     end
 
     def call
-      tag.public_send(@tag, content, **{ class: @classes }.merge(@content_tag_args))
+      tag.public_send(
+        @tag, content, **@content_tag_args.merge(@result)
+      )
     end
 
     private

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -103,8 +103,13 @@ module Primer
     ).freeze
 
     class << self
-      def call(classes: "", **args)
-        [validated_class_names(classes), classes_from_hash(args)].compact.join(" ").presence
+      def call(classes: "", style: nil, **args)
+        extracted_results = extract_hash(args)
+
+        {
+          class: [validated_class_names(classes), extracted_results[:classes]].compact.join(" ").presence,
+          style: [extracted_results[:styles], style].compact.join("").presence,
+        }.merge(extracted_results.except(:classes, :styles))
       end
 
       private
@@ -142,9 +147,9 @@ module Primer
       # Returns a string of Primer CSS class names to be added to an HTML class attribute
       #
       # Example usage:
-      # classes_from_hash({ mt: 4, py: 2 }) => "mt-4 py-2"
-      def classes_from_hash(styles_hash)
-        styles_hash.each_with_object([]) do |(key, value), memo|
+      # extract_hash({ mt: 4, py: 2 }) => "mt-4 py-2"
+      def extract_hash(styles_hash)
+        out = styles_hash.each_with_object({ classes: [], styles: [] }) do |(key, value), memo|
           next unless VALID_KEYS.include?(key)
 
           if value.is_a?(Array) && !RESPONSIVE_KEYS.include?(key)
@@ -167,54 +172,65 @@ module Primer
 
             if BOOLEAN_MAPPINGS.has_key?(key)
               BOOLEAN_MAPPINGS[key][:mappings].map { |m| m[:css_class] if m[:value] == val }.compact.each do |css_class|
-                memo << css_class
+                memo[:classes] << css_class
               end
             elsif key == BG_KEY
-              memo << "bg-#{dasherized_val}"
+              if val.to_s.starts_with?("#")
+                memo[:styles] << "background-color: #{val};"
+              else
+                memo[:classes] << "bg-#{dasherized_val}"
+              end
             elsif key == COLOR_KEY
               if val.to_s.chars.last !~ /\D/
-                memo << "color-#{dasherized_val}"
+                memo[:classes] << "color-#{dasherized_val}"
               else
-                memo << "text-#{dasherized_val}"
+                memo[:classes] << "text-#{dasherized_val}"
               end
             elsif key == DISPLAY_KEY
-              memo << "d#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "d#{breakpoint}-#{dasherized_val}"
             elsif key == VERTICAL_ALIGN_KEY
-              memo << "v-align-#{dasherized_val}"
+              memo[:classes] << "v-align-#{dasherized_val}"
             elsif key == WORD_BREAK_KEY
-              memo << "wb-#{dasherized_val}"
+              memo[:classes] << "wb-#{dasherized_val}"
             elsif BORDER_KEYS.include?(key)
-              memo << "border-#{dasherized_val}"
+              memo[:classes] << "border-#{dasherized_val}"
             elsif key == DIRECTION_KEY
-              memo << "flex#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "flex#{breakpoint}-#{dasherized_val}"
             elsif key == JUSTIFY_CONTENT_KEY
               formatted_value = val.to_s.gsub(/(flex\_|space\_)/, "")
-              memo << "flex#{breakpoint}-justify-#{formatted_value}"
+              memo[:classes] << "flex#{breakpoint}-justify-#{formatted_value}"
             elsif key == ALIGN_ITEMS_KEY
-              memo << "flex#{breakpoint}-items-#{val.to_s.gsub("flex_", "")}"
+              memo[:classes] << "flex#{breakpoint}-items-#{val.to_s.gsub("flex_", "")}"
             elsif key == FLEX_KEY
-              memo << "flex-#{val}"
+              memo[:classes] << "flex-#{val}"
             elsif key == FLEX_GROW_KEY
-              memo << "flex-grow-#{val}"
+              memo[:classes] << "flex-grow-#{val}"
             elsif key == FLEX_SHRINK_KEY
-              memo << "flex-shrink-#{val}"
+              memo[:classes] << "flex-shrink-#{val}"
             elsif key == ALIGN_SELF_KEY
-              memo << "flex-self-#{val}"
+              memo[:classes] << "flex-self-#{val}"
             elsif key == WIDTH_KEY || key == HEIGHT_KEY
               if val == :fit || val == :fill
-                memo << "#{key}-#{val}"
+                memo[:classes] << "#{key}-#{val}"
+              else
+                memo[key] = val
               end
             elsif TEXT_KEYS.include?(key)
-              memo << "text-#{dasherized_val}"
+              memo[:classes] << "text-#{dasherized_val}"
             elsif TYPOGRAPHY_KEYS.include?(key)
-              memo << "f#{dasherized_val}"
+              memo[:classes] << "f#{dasherized_val}"
             elsif MARGIN_DIRECTION_KEYS.include?(key) && val < 0
-              memo << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
+              memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
             else
-              memo << "#{key.to_s.dasherize}#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{dasherized_val}"
             end
           end
-        end.join(" ")
+        end
+
+        {
+          classes: out[:classes].join(" "),
+          styles: out[:styles].join(" ")
+        }.merge(out.except(:classes, :styles))
       end
     end
   end

--- a/test/components/base_component_test.rb
+++ b/test/components/base_component_test.rb
@@ -88,4 +88,30 @@ class PrimerBaseComponentTest < Minitest::Test
     refute_selector("[test_selector='bar']")
     assert_selector("[data-test-selector='bar']")
   end
+
+  def test_renders_height_attribute
+    render_inline(Primer::BaseComponent.new(tag: :div, height: 30))
+
+    assert_selector("div[height=30]")
+  end
+
+  def test_renders_width_attribute
+    render_inline(Primer::BaseComponent.new(tag: :div, width: 30))
+
+    assert_selector("div[width=30]")
+  end
+
+  def test_does_not_render_height_as_attribute_if_value_is_class
+    render_inline(Primer::BaseComponent.new(tag: :div, height: :fill))
+
+    refute_selector("div[height='fill']")
+    assert_selector("div.height-fill")
+  end
+
+  def test_does_not_render_width_as_attribute_if_value_is_class
+    render_inline(Primer::BaseComponent.new(tag: :div, width: :fill))
+
+    refute_selector("div[width='fill']")
+    assert_selector("div.width-fill")
+  end
 end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -203,6 +203,22 @@ class PrimerClassifyTest < Minitest::Test
     end
   end
 
+  def test_style
+    assert_equal("background-color: #fff;", Primer::Classify.call(bg: "#fff")[:style])
+  end
+
+  def test_height
+    assert_equal(10, Primer::Classify.call(height: 10)[:height])
+    assert_nil(Primer::Classify.call(height: :fit)[:height])
+    assert_nil(Primer::Classify.call(height: :fill)[:height])
+  end
+
+  def test_width
+    assert_equal(10, Primer::Classify.call(width: 10)[:width])
+    assert_nil(Primer::Classify.call(width: :fit)[:width])
+    assert_nil(Primer::Classify.call(width: :fill)[:width])
+  end
+
   def test_flex
     assert_generated_class("flex-1",    { flex: 1 })
     assert_generated_class("flex-auto", { flex: :auto })
@@ -248,10 +264,10 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def assert_generated_class(generated_class_name, input)
-    assert_equal(generated_class_name, Primer::Classify.call(**input))
+    assert_equal(generated_class_name, Primer::Classify.call(**input)[:class])
   end
 
   def refute_generated_class(input)
-    assert_nil(Primer::Classify.call(**input))
+    assert_nil(Primer::Classify.call(**input)[:class])
   end
 end


### PR DESCRIPTION
First syncs to dotcom code returning
```rb
{
  class: "...",
  style: "...",
}
```

then adds `width` and `height` keys when necessary