### PR TITLE
Layout with flexible cols

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 stories: cd demo; bin/rails view_component_storybook:write_stories_json
-rails: cd demo; bin/rails s -p 4000
-storybook: cd demo; bin/yarn storybook -p 5000
+rails: cd demo; STORYBOOK=true bin/rails s -p 4000
+storybook: cd demo; STORYBOOK=true bin/yarn storybook -p 5000

--- a/app/components/primer/layout_component.html.erb
+++ b/app/components/primer/layout_component.html.erb
@@ -1,16 +1,16 @@
 <%= render(Primer::FlexComponent.new(**@kwargs)) do %>
   <% if @side == :left %>
-    <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, 3] : 3), mb: (@responsive ? [4, nil, 0] : nil)) do %>
+    <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, @sidebar_col] : @sidebar_col), mb: (@responsive ? [4, nil, 0] : nil)) do %>
       <%= sidebar %>
     <% end %>
   <% end %>
 
-  <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, 9] : 9), mb: (@responsive ? [4, nil, 0] : nil)) do %>
+  <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, @main_col] : @main_col), mb: (@responsive ? [4, nil, 0] : nil)) do %>
     <%= main %>
   <% end %>
 
   <% if @side == :right %>
-    <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, 3] : 3)) do %>
+    <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, @sidebar_col] : @sidebar_col)) do %>
       <%= sidebar %>
     <% end %>
   <% end %>

--- a/app/components/primer/layout_component.rb
+++ b/app/components/primer/layout_component.rb
@@ -5,9 +5,13 @@ module Primer
     with_content_areas :main, :sidebar
 
     DEFAULT_SIDE = :right
-    ALLOWED_SIDES = [DEFAULT_SIDE, :left]
+    ALLOWED_SIDES = [DEFAULT_SIDE, :left].freeze
 
-    def initialize(responsive: false, side: DEFAULT_SIDE, **kwargs)
+    MAX_COL = 12
+    DEFAULT_SIDEBAR_COL = 3
+    ALLOWED_SIDEBAR_COLS = (1..(MAX_COL - 1)).to_a.freeze
+
+    def initialize(responsive: false, side: DEFAULT_SIDE, sidebar_col: DEFAULT_SIDEBAR_COL, **kwargs)
       @kwargs = kwargs
       @side = fetch_or_fallback(ALLOWED_SIDES, side, DEFAULT_SIDE)
       @responsive = responsive
@@ -16,6 +20,9 @@ module Primer
         @kwargs[:classes]
       )
       @kwargs[:direction] = responsive ? [:column, nil, :row] : nil
+
+      @sidebar_col = fetch_or_fallback(ALLOWED_SIDEBAR_COLS, sidebar_col, DEFAULT_SIDEBAR_COL)
+      @main_col = MAX_COL - @sidebar_col
     end
   end
 end

--- a/app/components/primer/layout_component.rb
+++ b/app/components/primer/layout_component.rb
@@ -13,7 +13,7 @@ module Primer
 
     def initialize(responsive: false, side: DEFAULT_SIDE, sidebar_col: DEFAULT_SIDEBAR_COL, **kwargs)
       @kwargs = kwargs
-      @side = fetch_or_fallback(ALLOWED_SIDES, side, DEFAULT_SIDE)
+      @side = fetch_or_fallback(ALLOWED_SIDES, side.to_sym, DEFAULT_SIDE)
       @responsive = responsive
       @kwargs[:classes] = class_names(
         "gutter-condensed gutter-lg",

--- a/lib/primer/fetch_or_fallback_helper.rb
+++ b/lib/primer/fetch_or_fallback_helper.rb
@@ -23,7 +23,7 @@ module Primer
       if allowed_values.include?(given_value)
         given_value
       else
-        if fallback_raises && ENV["RAILS_ENV"] != "production"
+        if fallback_raises && ENV["RAILS_ENV"] != "production" && ENV["STORYBOOK"] != "true"
           raise InvalidValueError, <<~MSG
             fetch_or_fallback was called with an invalid value.
 

--- a/script/storybook
+++ b/script/storybook
@@ -7,6 +7,6 @@ else
   cd demo
 
   bin/rails view_component_storybook:write_stories_json
-  bin/rails s -p 4000 &
-  bin/yarn storybook -p 5000
+  STORYBOOK=true bin/rails s -p 4000 &
+  STORYBOOK=true bin/yarn storybook -p 5000
 fi

--- a/test/components/layout_component_test.rb
+++ b/test/components/layout_component_test.rb
@@ -23,4 +23,36 @@ class PrimerLayoutComponentTest < Minitest::Test
 
     assert_selector(".d-flex > .col-3:first-child")
   end
+
+  def test_defaults_to_col_3_on_sidebar
+    render_inline(Primer::LayoutComponent.new) do |component|
+      component.with(:sidebar) { "Sidebar" }
+      component.with(:main) { "Main content" }
+    end
+
+    assert_selector(".d-flex > .col-9:first-child") # main
+    assert_selector(".d-flex > .col-3:last-child") # sidebar
+  end
+
+  def test_defaults_to_col_3_on_sidebar_if_value_is_invalid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::LayoutComponent.new(sidebar_col: Primer::LayoutComponent::MAX_COL)) do |component|
+        component.with(:sidebar) { "Sidebar" }
+        component.with(:main) { "Main content" }
+      end
+    end
+
+    assert_selector(".d-flex > .col-9:first-child") # main
+    assert_selector(".d-flex > .col-3:last-child") # sidebar
+  end
+
+  def test_changes_sidebar_col_and_main_col_accordingly
+    render_inline(Primer::LayoutComponent.new(sidebar_col: 5)) do |component|
+      component.with(:sidebar) { "Sidebar" }
+      component.with(:main) { "Main content" }
+    end
+
+    assert_selector(".d-flex > .col-7:first-child") # main
+    assert_selector(".d-flex > .col-5:last-child") # sidebar
+  end
 end

--- a/test/components/stories/primer/layout_component_stories.rb
+++ b/test/components/stories/primer/layout_component_stories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Primer::LayoutComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:layout) do
+    controls do
+      responsive false
+      select(:side, Primer::LayoutComponent::ALLOWED_SIDES.each_with_object({}) { |k, h| h[k] = k }, :right)
+      sidebar_col 3
+    end
+
+    content do |component|
+      component.with(:main) { "Main" }
+      component.with(:sidebar) { "Sidebar" }
+    end
+  end
+end

--- a/test/components/stories/primer/timeline_item_component_stories.rb
+++ b/test/components/stories/primer/timeline_item_component_stories.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Primer::TimelineItemComponentStories < ViewComponent::Storybook::Stories
-  layout "storybook_preview"
+  layout "storybook_centered_preview"
 
   story(:timeline_item) do
     controls do

--- a/test/demo/app/views/layouts/storybook_centered_preview.html.erb
+++ b/test/demo/app/views/layouts/storybook_centered_preview.html.erb
@@ -7,6 +7,8 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="d-flex flex-justify-center">
+      <%= yield %>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Component change

Allows sidebar `col` to be customizable, calculating `main` col accordingly

col 6
![image](https://user-images.githubusercontent.com/11280312/89672687-b6bb7580-d8aa-11ea-82d4-5be968c5d454.png)

col 3
![image](https://user-images.githubusercontent.com/11280312/89672718-c1760a80-d8aa-11ea-92d4-27e0de139ef2.png)

## Other

1. creates`STORYBOOK` environment variable and `fetch_or_fallback` will not fail if that env var is `true`
2. separates centered and normal layouts so we can use them depending on how we want to render sotrybook for each component