### PR TITLE
Blankslate component

### DIFF
--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,10 +1,6 @@
 <%= render Primer::BaseComponent.new(**@kwargs) do %>
   <% if @icon.present? %>
-    <%= render(GitHub::OcticonComponent.new(
-      icon: @icon,
-      size: :medium,
-      class: "blankslate-icon"
-    )) %>
+    <%= octicon @icon, height: 32, class: "blankslate-icon" %>
   <% end %>
 
   <% if @image_src.present? && @image_alt.present? %>

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -7,7 +7,7 @@
     <%= image_tag "#{@image_src}", class: "mb-3", size: "56x56", alt: "#{@image_alt}" %>
   <% end %>
 
-  <h3 class="mb-1"><%= @title %></h3>
+  <<%= @title_tag %> class="mb-1"><%= @title %></<%= @title_tag %>>
 
   <% if @description.present? %>
     <p><%= @description %></p>
@@ -16,7 +16,7 @@
   <%= content %>
 
   <% if @button_text.present? && @button_url.present? %>
-    <p><a class="btn btn-sm btn-primary" href="<%= @button_url %>"><%= @button_text %></a></p>
+    <p><a class="btn <%= @button_classes %>" href="<%= @button_url %>"><%= @button_text %></a></p>
   <% end %>
 
   <% if @link_text.present? && @link_url.present? %>

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,6 +1,6 @@
 <%= render Primer::BaseComponent.new(**@kwargs) do %>
   <% if @icon.present? %>
-    <%= octicon @icon, height: 32, class: "blankslate-icon" %>
+    <%= octicon @icon, height: @icon_height, class: "blankslate-icon" %>
   <% end %>
 
   <% if @image_src.present? && @image_alt.present? %>

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,0 +1,31 @@
+<%= render Primer::BaseComponent.new(**@kwargs) do %>
+  <% if @icon.present? %>
+    <%= render(GitHub::OcticonComponent.new(
+      icon: @icon,
+      size: :medium,
+      class: "blankslate-icon"
+    )) %>
+  <% end %>
+
+  <% if @image_src.present? && @image_alt.present? %>
+    <%= image_tag "#{@image_src}", class: "mb-3", size: "56x56", alt: "#{@image_alt}" %>
+  <% end %>
+
+  <h3 class="mb-1"><%= @title %></h3>
+
+  <% if @description.present? %>
+    <p><%= @description %></p>
+  <% end %>
+
+  <%= content %>
+
+  <% if @button_text.present? && @button_url.present? %>
+    <p><a class="btn btn-sm btn-primary" href="<%= @button_url %>"><%= @button_text %></a></p>
+  <% end %>
+
+  <% if @link_text.present? && @link_url.present? %>
+    <p class="mt-3">
+      <%= link_to "#{@link_url}" do %><%= @link_text %><% end %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -114,12 +114,14 @@ module Primer
       title:,
 
       # optional
+      title_tag: :h3,
       icon: "",
       image_src: "",
       image_alt: " ",
       description: "",
       button_text: "",
       button_url: "",
+      button_classes: "btn-sm btn-primary",
       link_text: "",
       link_url: "",
 
@@ -136,6 +138,7 @@ module Primer
         "blankslate-narrow": narrow,
       )
 
+      @title_tag = title_tag
       @icon = icon
       @image_src = image_src
       @image_alt = image_alt
@@ -143,6 +146,7 @@ module Primer
       @description = description
       @button_text = button_text
       @button_url = button_url
+      @button_classes = button_classes
       @link_text = link_text
       @link_url = link_url
     end

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -116,6 +116,7 @@ module Primer
       # optional
       title_tag: :h3,
       icon: "",
+      icon_height: 32,
       image_src: "",
       image_alt: " ",
       description: "",
@@ -140,6 +141,7 @@ module Primer
 
       @title_tag = title_tag
       @icon = icon
+      @icon_height = icon_height
       @image_src = image_src
       @image_alt = image_alt
       @title = title

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+module Primer
+  # Blankslates are for when there is a lack of content within a page or section. Use them as placeholders to tell users why something isn't there.
+  #
+  # ## Basic example
+  #
+  # The `Primer::BlankslateComponent` supports the following arguments to add a basic blankslate:
+  #
+  # 1. `title` (`String` required). Text that appears in a larger bold font.
+  # 2. `description` (`String` optional). Text that appears below the title. Typically a whole sentence.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   title: "Title",
+  #   description: "Description",
+  # ) %>
+  # ```
+  #
+  # ## Icon or graphic (optional)
+  #
+  # Add an `icon` to give additional context. Please refer to the [Octicons](https://primer.style/octicons/) documentation to choose an icon.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   icon: "octoface",
+  #   title: "Title",
+  #   description: "Description",
+  # ) %>
+  # ```
+  #
+  # Alternatively you can also add a graphic by providing a path (`image_src`) to an image instead. Note: The image needs to be in [github/github/public/static/images/](https://github.com/github/github/tree/master/public/static/images/) and the path is relative. For example: `image_src: "[mona-happy.gif](https://github.com/github/github/blob/master/public/static/images/mona-happy.gif)",`. Also, make sure to add an alternative description (`image_alt`). It will be used for the `alt` tag.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   image_src: "file.svg",
+  #   image_alt: "Description of the image",
+  #   title: "Title",
+  #   description: "Description",
+  # ) %>
+  # ```
+  #
+  # Both icon and graphic will appear above the title.
+  #
+  #
+  # ## Custom content (optional)
+  #
+  # You can add any custom content that typically is used instead of the description:
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   icon: "octoface",
+  #   title: "Title",
+  # ) do %>
+  #   <p>Your custom content here</p>
+  # <% end %>
+  # ```
+  #
+  # ## Action button (optional)
+  #
+  # You can provide an action button to help users replace the blankslate. The button will appear below the description and custom content. It takes the following arguments:
+  #
+  # - `button_text` (`String` optional). The text of the button.
+  # - `button_url` (`String` optional). The URL where the user will be taken after clicking the button.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   icon: "book",
+  #   title: "Welcome to the mona wiki!",
+  #   description: "Wikis provide a place in your repository to lay out the roadmap of your project, show the current status, and document software better, together.",
+  #
+  #   button_text: "Create the first page",
+  #   button_url: "https://github.com/monalisa/mona/wiki/_new",
+  # ) %>
+  # ```
+  #
+  # ## Link (optional)
+  #
+  # Add an additional link to help users learn more about a feature. The link will be shown at the very bottom:
+  #
+  # - `link_text` (`String` optional). The text of the link.
+  # - `link_url` (`String` optional). The URL where the user will be taken after clicking the link.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   icon: "book",
+  #   title: "Welcome to the mona wiki!",
+  #   description: "Wikis provide a place in your repository to lay out the roadmap of your project, show the current status, and document software better, together.",
+  #   button_text: "Create the first page",
+  #   button_url: "https://github.com/monalisa/mona/wiki/_new",
+  #   link_text: "Learn more about wikis",
+  #   link_url: "https://docs.github.com/en/github/building-a-strong-community/about-wikis",
+  # ) %>
+  # ```
+  #
+  # ## Variations (optional)
+  #
+  # There are a few variations of how the Blankslate appears:
+  #
+  # - `narrow` (`Boolean` optional). Adds a maximum width.
+  #
+  # ```ruby
+  # <%= render Primer::BlankslateComponent.new(
+  #   icon: "book",
+  #   title: "Welcome to the mona wiki!",
+  #   description: "Wikis provide a place in your repository to lay out the roadmap of your project, show the current status, and document software better, together.",
+  #
+  #   narrow: true,
+  # ) %>
+  # ```
+  class BlankslateComponent < Primer::Component
+    def initialize(
+      # required
+      title:,
+
+      # optional
+      icon: "",
+      image_src: "",
+      image_alt: " ",
+      description: "",
+      button_text: "",
+      button_url: "",
+      link_text: "",
+      link_url: "",
+
+      #variations
+      narrow: false,
+
+      **kwargs
+    )
+      @kwargs = kwargs
+      @kwargs[:tag] = :div
+      @kwargs[:classes] = class_names(
+        @kwargs[:classes],
+        "blankslate",
+        "blankslate-narrow": narrow,
+      )
+
+      @icon = icon
+      @image_src = image_src
+      @image_alt = image_alt
+      @title = title
+      @description = description
+      @button_text = button_text
+      @button_url = button_url
+      @link_text = link_text
+      @link_url = link_url
+    end
+  end
+end

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -29,7 +29,7 @@ module Primer
   # ) %>
   # ```
   #
-  # Alternatively you can also add a graphic by providing a path (`image_src`) to an image instead. Note: The image needs to be in [github/github/public/static/images/](https://github.com/github/github/tree/master/public/static/images/) and the path is relative. For example: `image_src: "[mona-happy.gif](https://github.com/github/github/blob/master/public/static/images/mona-happy.gif)",`. Also, make sure to add an alternative description (`image_alt`). It will be used for the `alt` tag.
+  # Alternatively you can also add a graphic by providing a path (`image_src`) to an image instead.Also, make sure to add an alternative description (`image_alt`). It will be used for the `alt` tag.
   #
   # ```ruby
   # <%= render Primer::BlankslateComponent.new(

--- a/app/components/primer/view_components.rb
+++ b/app/components/primer/view_components.rb
@@ -24,6 +24,7 @@ require_relative "slot"
 
 # Components
 
+require_relative "blankslate_component"
 require_relative "border_box_component"
 require_relative "box_component"
 require_relative "breadcrumb_component"

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class BlankslateComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  test "renders a basic blankslate component with a title" do
+  def test_renders_a_basic_blankslate_component_with_a_title
     render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       description: "Description",
@@ -16,8 +16,17 @@ class BlankslateComponentTest < Minitest::Test
     refute_selector(".blankslate-narrow")
   end
 
-  test "renders a narrow blankslate component" do
+  def test_renders_a_blankslate_component_with_a_title_and_custom_tag
     render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      title_tag: :h5
+    ))
+
+    assert_selector("h5", text: "Title")
+  end
+
+  def test_renders_a_narrow_blankslate_component
+    result = render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       narrow: true,
     ))
@@ -25,7 +34,7 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector(".blankslate.blankslate-narrow")
   end
 
-  test "renders a blankslate component with an icon" do
+  def test_renders_a_blankslate_component_with_an_icon
     render_inline(Primer::BlankslateComponent.new(
       icon: "octoface",
       title: "Title",
@@ -34,7 +43,7 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector(".blankslate-icon")
   end
 
-  test "renders a blankslate component with an image" do
+  def test_renders_a_blankslate_component_with_an_image
     render_inline(Primer::BlankslateComponent.new(
       image_src: "file.svg",
       image_alt: "Alt text",
@@ -45,7 +54,7 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector(".blankslate > img[alt='Alt text']")
   end
 
-  test "renders a blankslate component with a description" do
+  def test_renders_a_blankslate_component_with_a_description
     render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       description: "Description",
@@ -54,7 +63,7 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector("p", text: "Description")
   end
 
-  test "renders a blankslate component with custom content" do
+  def test_renders_a_blankslate_component_with_custom_content
     render_inline(Primer::BlankslateComponent.new(
       icon: "octoface",
       title: "Title",
@@ -63,7 +72,7 @@ class BlankslateComponentTest < Minitest::Test
     assert_text("Custom content")
   end
 
-  test "renders a blankslate component with a button" do
+  def test_renders_a_blankslate_component_with_a_button
     render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       button_text: "Button",
@@ -73,7 +82,18 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector("a.btn[href='https://github.com']", text: "Button")
   end
 
-  test "renders a blankslate component with a link" do
+  def test_renders_a_blankslate_component_with_a_button_with_custom_classes
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      button_text: "Button",
+      button_url: "https://github.com",
+      button_classes: "btn-outline"
+    ))
+
+    assert_selector("a.btn.btn-outline[href='https://github.com']", text: "Button")
+  end
+
+  def test_renders_a_blankslate_component_with_a_link
     render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       link_text: "Link",

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -37,10 +37,20 @@ class BlankslateComponentTest < Minitest::Test
   def test_renders_a_blankslate_component_with_an_icon
     render_inline(Primer::BlankslateComponent.new(
       icon: "octoface",
-      title: "Title",
+      title: "Title"
     ))
 
-    assert_selector(".blankslate-icon")
+    assert_selector(".blankslate-icon[height=32]")
+  end
+
+  def test_renders_a_blankslate_component_with_an_icon_with_a_custom_height
+    render_inline(Primer::BlankslateComponent.new(
+      icon: "octoface",
+      icon_height: 64,
+      title: "Title"
+    ))
+
+    assert_selector(".blankslate-icon[height=64]")
   end
 
   def test_renders_a_blankslate_component_with_an_image

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -5,112 +5,81 @@ require "test_helper"
 class BlankslateComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  def test_renders_title
-    render_inline(Primer::BaseComponent.new(tag: :div, title: "title"))
+  test "renders a basic blankslate component with a title" do
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      description: "Description",
+    ))
 
-    assert_selector("[title='title']")
+    assert_selector("div.blankslate")
+    assert_selector("h3", text: "Title")
+    refute_selector(".blankslate-narrow")
   end
 
-  def test_renders_content
-    render_inline(Primer::BaseComponent.new(tag: :div)) do
-      "content"
-    end
+  test "renders a narrow blankslate component" do
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      narrow: true,
+    ))
 
-    assert_text("content")
+    assert_selector(".blankslate.blankslate-narrow")
   end
 
-  def test_skips_rendering_primer_class_if_value_is_nil
-    result = render_inline(Primer::BaseComponent.new(tag: :div, my: nil)) # rubocop:todo ViewComponent/RenderInlineAssignment
+  test "renders a blankslate component with an icon" do
+    render_inline(Primer::BlankslateComponent.new(
+      icon: "octoface",
+      title: "Title",
+    ))
 
-    assert result.css("div").first.attribute("class").nil?
+    assert_selector(".blankslate-icon")
   end
 
-  def test_renders_arbitrary_attributes
-    render_inline(Primer::BaseComponent.new(tag: :div, itemtype: "http://schema.org/Code"))
+  test "renders a blankslate component with an image" do
+    render_inline(Primer::BlankslateComponent.new(
+      image_src: "file.svg",
+      image_alt: "Alt text",
+      title: "Title",
+    ))
 
-    assert_selector("[itemtype='http://schema.org/Code']")
+    assert_selector(".blankslate > img[src$='file.svg']")
+    assert_selector(".blankslate > img[alt='Alt text']")
   end
 
-  def test_renders_arbitrary_class_names
-    render_inline(Primer::BaseComponent.new(tag: :div, classes: "foobar"))
+  test "renders a blankslate component with a description" do
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      description: "Description",
+    ))
 
-    assert_selector(".foobar")
+    assert_selector("p", text: "Description")
   end
 
-  def test_renders_arbitrary_blank_attributes
-    render_inline(Primer::BaseComponent.new(tag: :div, itemscope: true))
+  test "renders a blankslate component with custom content" do
+    render_inline(Primer::BlankslateComponent.new(
+      icon: "octoface",
+      title: "Title",
+    )) { "Custom content" }
 
-    assert_selector("[itemscope]")
+    assert_text("Custom content")
   end
 
-  def test_conditionally_renders_arbitrary_blank_attributes
-    render_inline(Primer::BaseComponent.new(tag: :div, itemscope: false))
+  test "renders a blankslate component with a button" do
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      button_text: "Button",
+      button_url: "https://github.com",
+    ))
 
-    refute_selector("[itemscope]")
+    assert_selector("a.btn[href='https://github.com']", text: "Button")
   end
 
-  def test_does_not_render_class_attribute_if_none_is_set
-    render_inline(Primer::BaseComponent.new(tag: :div, title: "title"))
+  test "renders a blankslate component with a link" do
+    render_inline(Primer::BlankslateComponent.new(
+      title: "Title",
+      link_text: "Link",
+      link_url: "https://docs.github.com",
+    ))
 
-    refute_selector("div[class='']")
-  end
-
-  def test_does_not_render_primer_layout_classes_as_attributes
-    render_inline(Primer::BaseComponent.new(tag: :div, my: 4))
-
-    refute_selector("[my='4']")
-  end
-
-  def test_renders_as_a_link
-    render_inline(Primer::BaseComponent.new(tag: :a, href: "http://google.com"))
-
-    assert_selector("a[href='http://google.com']")
-  end
-
-  # We were calling tag.send(as), passing in :p ended up calling `p`, aka `puts`
-  # Due to how Rails uses method_missing in TagHelper.
-  def test_renders_as_a_paragraph
-    render_inline(Primer::BaseComponent.new(tag: :p))
-
-    refute_text("[")
-  end
-
-  def test_renders_data_attributes
-    render_inline(Primer::BaseComponent.new(tag: :div, data: { foo: "bar" }))
-
-    assert_selector("[data-foo='bar']")
-  end
-
-  def test_renders_test_selector
-    render_inline(Primer::BaseComponent.new(tag: :div, test_selector: "bar"))
-
-    refute_selector("[test_selector='bar']")
-    assert_selector("[data-test-selector='bar']")
-  end
-
-  def test_renders_height_attribute
-    render_inline(Primer::BaseComponent.new(tag: :div, height: 30))
-
-    assert_selector("div[height=30]")
-  end
-
-  def test_renders_width_attribute
-    render_inline(Primer::BaseComponent.new(tag: :div, width: 30))
-
-    assert_selector("div[width=30]")
-  end
-
-  def test_does_not_render_height_as_attribute_if_value_is_class
-    render_inline(Primer::BaseComponent.new(tag: :div, height: :fill))
-
-    refute_selector("div[height='fill']")
-    assert_selector("div.height-fill")
-  end
-
-  def test_does_not_render_width_as_attribute_if_value_is_class
-    render_inline(Primer::BaseComponent.new(tag: :div, width: :fill))
-
-    refute_selector("div[width='fill']")
-    assert_selector("div.width-fill")
+    assert_selector("a[href='https://docs.github.com']", text: "Link")
   end
 end

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -68,8 +68,7 @@ class BlankslateComponentTest < Minitest::Test
   end
 
   # We were calling tag.send(as), passing in :p ended up calling `p`, aka `puts`
-  # Due to how Rails uses method_missing in TagHelper. See Slack convo:
-  # https://github.slack.com/archives/C0HV3F37A/p1556216733019500
+  # Due to how Rails uses method_missing in TagHelper.
   def test_renders_as_a_paragraph
     render_inline(Primer::BaseComponent.new(tag: :p))
 

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Primer::BlankslateComponentTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_renders_title
+    render_inline(Primer::BaseComponent.new(tag: :div, title: "title"))
+
+    assert_selector("[title='title']")
+  end
+
+  def test_renders_content
+    render_inline(Primer::BaseComponent.new(tag: :div)) do
+      "content"
+    end
+
+    assert_text("content")
+  end
+
+  def test_skips_rendering_primer_class_if_value_is_nil
+    result = render_inline(Primer::BaseComponent.new(tag: :div, my: nil)) # rubocop:todo ViewComponent/RenderInlineAssignment
+
+    assert result.css("div").first.attribute("class").nil?
+  end
+
+  def test_renders_arbitrary_attributes
+    render_inline(Primer::BaseComponent.new(tag: :div, itemtype: "http://schema.org/Code"))
+
+    assert_selector("[itemtype='http://schema.org/Code']")
+  end
+
+  def test_renders_arbitrary_class_names
+    render_inline(Primer::BaseComponent.new(tag: :div, classes: "foobar"))
+
+    assert_selector(".foobar")
+  end
+
+  def test_renders_arbitrary_blank_attributes
+    render_inline(Primer::BaseComponent.new(tag: :div, itemscope: true))
+
+    assert_selector("[itemscope]")
+  end
+
+  def test_conditionally_renders_arbitrary_blank_attributes
+    render_inline(Primer::BaseComponent.new(tag: :div, itemscope: false))
+
+    refute_selector("[itemscope]")
+  end
+
+  def test_does_not_render_class_attribute_if_none_is_set
+    render_inline(Primer::BaseComponent.new(tag: :div, title: "title"))
+
+    refute_selector("div[class='']")
+  end
+
+  def test_does_not_render_primer_layout_classes_as_attributes
+    render_inline(Primer::BaseComponent.new(tag: :div, my: 4))
+
+    refute_selector("[my='4']")
+  end
+
+  def test_renders_as_a_link
+    render_inline(Primer::BaseComponent.new(tag: :a, href: "http://google.com"))
+
+    assert_selector("a[href='http://google.com']")
+  end
+
+  # We were calling tag.send(as), passing in :p ended up calling `p`, aka `puts`
+  # Due to how Rails uses method_missing in TagHelper. See Slack convo:
+  # https://github.slack.com/archives/C0HV3F37A/p1556216733019500
+  def test_renders_as_a_paragraph
+    render_inline(Primer::BaseComponent.new(tag: :p))
+
+    refute_text("[")
+  end
+
+  def test_renders_data_attributes
+    render_inline(Primer::BaseComponent.new(tag: :div, data: { foo: "bar" }))
+
+    assert_selector("[data-foo='bar']")
+  end
+
+  def test_renders_test_selector
+    render_inline(Primer::BaseComponent.new(tag: :div, test_selector: "bar"))
+
+    refute_selector("[test_selector='bar']")
+    assert_selector("[data-test-selector='bar']")
+  end
+
+  def test_renders_height_attribute
+    render_inline(Primer::BaseComponent.new(tag: :div, height: 30))
+
+    assert_selector("div[height=30]")
+  end
+
+  def test_renders_width_attribute
+    render_inline(Primer::BaseComponent.new(tag: :div, width: 30))
+
+    assert_selector("div[width=30]")
+  end
+
+  def test_does_not_render_height_as_attribute_if_value_is_class
+    render_inline(Primer::BaseComponent.new(tag: :div, height: :fill))
+
+    refute_selector("div[height='fill']")
+    assert_selector("div.height-fill")
+  end
+
+  def test_does_not_render_width_as_attribute_if_value_is_class
+    render_inline(Primer::BaseComponent.new(tag: :div, width: :fill))
+
+    refute_selector("div[width='fill']")
+    assert_selector("div.width-fill")
+  end
+end

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class Primer::BlankslateComponentTest < Minitest::Test
+class BlankslateComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_title

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -9,7 +9,7 @@ class PrimerComponentTest < Minitest::Test
     # Components with any arguments necessary to make them render
     components_with_args = [
       [Primer::BaseComponent, { tag: :div }],
-      [Primer::BlankslateComponent, { title: "Foo" }]
+      [Primer::BlankslateComponent, { title: "Foo" }],
       [Primer::BorderBoxComponent, {}, proc { |component| component.slot(:header) { "Foo" }  }],
       [Primer::BoxComponent, {}],
       [Primer::BreadcrumbComponent, {}, proc { |component| component.slot(:item) { "Foo" } }],

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -9,6 +9,7 @@ class PrimerComponentTest < Minitest::Test
     # Components with any arguments necessary to make them render
     components_with_args = [
       [Primer::BaseComponent, { tag: :div }],
+      [Primer::BlankslateComponent, { title: "Foo" }]
       [Primer::BorderBoxComponent, {}, proc { |component| component.slot(:header) { "Foo" }  }],
       [Primer::BoxComponent, {}],
       [Primer::BreadcrumbComponent, {}, proc { |component| component.slot(:item) { "Foo" } }],

--- a/test/components/stories/primer/blankslate_component_stories.rb
+++ b/test/components/stories/primer/blankslate_component_stories.rb
@@ -7,6 +7,7 @@ class Primer::BlankslateComponentStories < ViewComponent::Storybook::Stories
     controls do
       icon "shield"
       title "It looks like we have discovered a vulnerability"
+      icon_height 64
     end
   end
 

--- a/test/components/stories/primer/blankslate_component_stories.rb
+++ b/test/components/stories/primer/blankslate_component_stories.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Primer::BlankslateComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:icon) do
+    controls do
+      icon "shield"
+      title "It looks like we have discovered a vulnerability"
+    end
+  end
+
+  story(:image_src) do
+    controls do
+      image_src "https://github.githubassets.com/images/modules/site/features/security-icon.svg"
+      image_alt "Security - secure vault"
+      title "Millions of teams trust GitHub to keep their work safe"
+    end
+  end
+
+  story(:description) do
+    controls do
+      title "It looks like we have discovered a vulnerability"
+      description "Millions of teams trust GitHub to keep their work safe"
+    end
+  end
+
+  story(:button) do
+    controls do
+      title "It looks like we have discovered a vulnerability"
+      button_text "Fix issue"
+      button_url "#"
+    end
+  end
+
+  story(:link) do
+    controls do
+      title "It looks like we have discovered a vulnerability"
+      link_text "Fix issue"
+      link_url "#"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the blank slate component from our primer dotcom components.

## Storybook
<img width="940" alt="Screen Shot 2020-08-11 at 4 23 03 PM" src="https://user-images.githubusercontent.com/11095731/89945203-01145d80-dbef-11ea-9352-c56803394924.png">
