### PR TITLE
add support for responsive floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # main
 
+* Add support for responsive `float` style arguments.
+
+    *Joel Hawksley*
+
 * Add components:
     * Avatar
     * Blankslate

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -8,7 +8,7 @@ module Primer
     JUSTIFY_CONTENT_KEY = :justify_content
     ALIGN_ITEMS_KEY = :align_items
     DISPLAY_KEY = :display
-    RESPONSIVE_KEYS = ([DISPLAY_KEY, DIRECTION_KEY, JUSTIFY_CONTENT_KEY, ALIGN_ITEMS_KEY, :col] + SPACING_KEYS).freeze
+    RESPONSIVE_KEYS = ([DISPLAY_KEY, DIRECTION_KEY, JUSTIFY_CONTENT_KEY, ALIGN_ITEMS_KEY, :col, :float] + SPACING_KEYS).freeze
     BREAKPOINTS = ["", "-sm", "-md", "-lg"]
 
     # Keys where we can simply translate { key: value } into ".key-value"

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -192,6 +192,7 @@ class PrimerClassifyTest < Minitest::Test
   def test_responsive
     assert_generated_class("p-4",  { p: [4] })
     assert_generated_class("p-4 p-sm-3",  { p: [4, 3] })
+    assert_generated_class("float-left float-md-right",  { float: [:left, nil, :right] })
     assert_generated_class("d-flex d-sm-block",  { display: [:flex, :block] })
     assert_generated_class("d-flex d-md-block",  { display: [:flex, nil, :block] })
     assert_generated_class("flex-row flex-sm-column",  { direction: [:row, :column] })


### PR DESCRIPTION
Primer CSS supports responsive floats,
and now Primer ViewComponents do too!

See https://primer.style/css/utilities/layout#responsive-floats