### PR TITLE
Blankslate spacing

### DIFF
--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <% if @link_text.present? && @link_url.present? %>
-    <p class="mt-3">
+    <p>
       <%= link_to "#{@link_url}" do %><%= @link_text %><% end %>
     </p>
   <% end %>

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -16,7 +16,7 @@
   <%= content %>
 
   <% if @button_text.present? && @button_url.present? %>
-    <p><a class="btn <%= @button_classes %>" href="<%= @button_url %>"><%= @button_text %></a></p>
+    <a class="btn <%= @button_classes %>" href="<%= @button_url %>"><%= @button_text %></a>
   <% end %>
 
   <% if @link_text.present? && @link_url.present? %>

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -122,7 +122,7 @@ module Primer
       description: "",
       button_text: "",
       button_url: "",
-      button_classes: "btn-sm btn-primary",
+      button_classes: "btn-primary my-3",
       link_text: "",
       link_url: "",
 


### PR DESCRIPTION
This tweaks the spacing of the `BlankslateComponent` to better match the [Primer CSS version](https://primer.style/css/components/blankslate#basic-example). Also uses the default button size.

Before | After
--- | ---
![Screen Shot 2020-08-19 at 22 18 51](https://user-images.githubusercontent.com/378023/90640909-880aab00-e26b-11ea-8bee-376fc0501025.png) | ![Screen Shot 2020-08-19 at 22 25 01](https://user-images.githubusercontent.com/378023/90640916-89d46e80-e26b-11ea-8d0b-b16e5d7da448.png)
