### PR TITLE
Ignore built gems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 demo/public/packs/
 demo/tmp/
 demo/config/master.key
+primer_view_components*.gem


### PR DESCRIPTION
This updates the .gitignore such that when you build a new gem via `gem build primer_view_components.gemspec` and it ends up in the root directory of the repo, it's still ignored.