### PR TITLE
Add large and spacious option to BlankslateComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # main
 
+* Add large and spacious option to BlankslateComponent
+
+    *simurai*
+
 # 0.0.5
 
 * Add support for box_shadow

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -98,6 +98,8 @@ module Primer
   # There are a few variations of how the Blankslate appears:
   #
   # - `narrow` (`Boolean` optional). Adds a maximum width.
+  # - `large` (`Boolean` optional). Increaeses the font size.
+  # - `spacious` (`Boolean` optional). Adds extra padding.
   #
   # ```ruby
   # <%= render Primer::BlankslateComponent.new(
@@ -106,6 +108,8 @@ module Primer
   #   description: "Wikis provide a place in your repository to lay out the roadmap of your project, show the current status, and document software better, together.",
   #
   #   narrow: true,
+  #   large: true,
+  #   spacious: true,
   # ) %>
   # ```
   class BlankslateComponent < Primer::Component
@@ -128,6 +132,8 @@ module Primer
 
       #variations
       narrow: false,
+      large: false,
+      spacious: false,
 
       **kwargs
     )
@@ -137,6 +143,8 @@ module Primer
         @kwargs[:classes],
         "blankslate",
         "blankslate-narrow": narrow,
+        "blankslate-large": large,
+        "blankslate-spacious": spacious,
       )
 
       @title_tag = title_tag

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -14,6 +14,8 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector("div.blankslate")
     assert_selector("h3", text: "Title")
     refute_selector(".blankslate-narrow")
+    refute_selector(".blankslate-large")
+    refute_selector(".blankslate-spacious")
   end
 
   def test_renders_a_blankslate_component_with_a_title_and_custom_tag
@@ -25,13 +27,17 @@ class BlankslateComponentTest < Minitest::Test
     assert_selector("h5", text: "Title")
   end
 
-  def test_renders_a_narrow_blankslate_component
+  def test_renders_a_narrow_large_and_spacious_blankslate_component
     result = render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       narrow: true,
+      large: true,
+      spacious: true,
     ))
 
     assert_selector(".blankslate.blankslate-narrow")
+    assert_selector(".blankslate.blankslate-large")
+    assert_selector(".blankslate.blankslate-spacious")
   end
 
   def test_renders_a_blankslate_component_with_an_icon


### PR DESCRIPTION
This was part of https://github.com/github/github/pull/151985, but that PR missed the move to `primer/view_components` so I'm adding it here.

It adds a `large` and `spacious` option to `Primer::BlankslateComponent`.

Before | After
--- | ---
![Screen Shot 2020-08-07 at 16 30 53](https://user-images.githubusercontent.com/378023/89620993-8932f400-d8cb-11ea-91a8-453779eba180.png) | ![Screen Shot 2020-08-07 at 16 31 05](https://user-images.githubusercontent.com/378023/89620995-8afcb780-d8cb-11ea-8354-b1b07a344c78.png)

I think with this change, we should have "API parity" with [Primer CSS](https://primer.style/css/components/blankslate).

### TODO

- [x] Add `large` option
- [x] Add `spacious` option
- [x] Update tests
- [x] Update CHANGELOG