### PR TITLE
Allow customizing summary classes in DetailsComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
     *simurai*
 
+* Add more styling control over `summary` in DetailsComponent
+
+    *Sarah Vessels*
+
 # 0.0.5
 
 * Add support for box_shadow

--- a/app/components/primer/details_component.html.erb
+++ b/app/components/primer/details_component.html.erb
@@ -1,6 +1,8 @@
 <%= render Primer::BaseComponent.new(**@kwargs) do %>
-  <%= render Primer::BaseComponent.new(**@summary_kwargs) do %>
-    <%= summary %>
+  <%= render summary.component do %>
+    <%= summary.content %>
   <% end %>
-  <%= body %>
+  <%= render body.component do %>
+    <%= body.content %>
+  <% end %>
 <% end %>

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -2,11 +2,12 @@
 
 module Primer
   #
-  # overlay - options are `none`, `default` and `dark`. Dictates the type of overlay to render with.
-  # button - options are `default` and `reset`. default will make the target a default primer ``.btn`
-  #          reset will remove all styles from the <summary> element.
+  # overlay - options are `none`, `default` and `dark`. Dictates the type of page overlay to render with.
+  # reset - Boolean; true will result in `details-reset` on the details element
   #
   class DetailsComponent < Primer::Component
+    include ViewComponent::Slotable
+
     OVERLAY_DEFAULT = :none
     OVERLAY_MAPPINGS = {
       OVERLAY_DEFAULT => "",
@@ -14,25 +15,48 @@ module Primer
       :dark => "details-overlay details-overlay-dark",
     }.freeze
 
-    BUTTON_DEFAULT = :default
-    BUTTON_RESET = :reset
-    BUTTON_OPTIONS = [BUTTON_DEFAULT, BUTTON_RESET]
+    attr_reader :reset
+    with_slot :summary, class_name: "Summary"
+    with_slot :body, class_name: "Body"
 
-    with_content_areas :summary, :body
-
-    def initialize(overlay: OVERLAY_DEFAULT, button: BUTTON_DEFAULT, **kwargs)
-      @button = fetch_or_fallback(BUTTON_OPTIONS, button, BUTTON_DEFAULT)
-
+    def initialize(overlay: OVERLAY_DEFAULT, reset: false, **kwargs)
       @kwargs = kwargs
       @kwargs[:tag] = :details
+      @reset = reset
       @kwargs[:classes] = class_names(
         kwargs[:classes],
         OVERLAY_MAPPINGS[fetch_or_fallback(OVERLAY_MAPPINGS.keys, overlay, OVERLAY_DEFAULT)],
-        "details-reset" => @button == BUTTON_RESET
+        "details-reset" => @reset
       )
+    end
 
-      @summary_kwargs = { tag: :summary, role: "button" }
-      @summary_kwargs[:classes] = "btn" if @button == BUTTON_DEFAULT
+    def render?
+      summary.present? && body.present?
+    end
+
+    class Summary < ViewComponent::Slot
+      def initialize(**kwargs)
+        @kwargs = kwargs
+        @kwargs[:mb] ||= 2
+        @kwargs[:tag] ||= :summary
+        @kwargs[:role] ||= "button" if @kwargs[:tag] == :summary
+        @kwargs[:classes] ||= "btn"
+      end
+
+      def component
+        Primer::BaseComponent.new(**@kwargs)
+      end
+    end
+
+    class Body < ViewComponent::Slot
+      def initialize(**kwargs)
+        @kwargs = kwargs
+        @kwargs[:tag] ||= :div
+      end
+
+      def component
+        Primer::BaseComponent.new(**@kwargs)
+      end
     end
   end
 end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -16,7 +16,10 @@ class PrimerComponentTest < Minitest::Test
       [Primer::BreadcrumbComponent, {}, proc { |component| component.slot(:item) { "Foo" } }],
       [Primer::ButtonComponent, {}],
       [Primer::CounterComponent, { count: 1 }],
-      [Primer::DetailsComponent, {}],
+      [Primer::DetailsComponent, {}, proc do |component|
+        component.slot(:summary)
+        component.slot(:body)
+      end],
       [Primer::DropdownMenuComponent, {}],
       [Primer::FlexComponent, {}],
       [Primer::FlexItemComponent, { flex_auto: true }],

--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -68,6 +68,21 @@ class PrimerDetailsComponentTest < Minitest::Test
     end
 
     assert_selector("summary.btn-link.ml-3")
+    refute_selector("summary.btn")
+  end
+
+  def test_allows_summary_without_classes
+    render_inline(Primer::DetailsComponent.new) do |component|
+      component.slot(:summary, classes: "") do
+        "Summary"
+      end
+      component.slot(:body) do
+        "Body"
+      end
+    end
+
+    assert_selector("summary")
+    refute_selector("summary.btn")
   end
 
   def test_falls_back_to_defaults_when_invalid_overlay_is_passed

--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -7,10 +7,10 @@ class PrimerDetailsComponentTest < Minitest::Test
 
   def test_overlay_default_renders_details_overlay
     render_inline(Primer::DetailsComponent.new(overlay: :default)) do |component|
-      component.with(:summary) do
+      component.slot(:summary) do
         "Summary"
       end
-      component.with(:body) do
+      component.slot(:body) do
         "Body"
       end
     end
@@ -20,10 +20,10 @@ class PrimerDetailsComponentTest < Minitest::Test
 
   def test_overlay_dark_renders_details_overlay_dark
     render_inline(Primer::DetailsComponent.new(overlay: :dark)) do |component|
-      component.with(:summary) do
+      component.slot(:summary) do
         "Summary"
       end
-      component.with(:body) do
+      component.slot(:body) do
         "Body"
       end
     end
@@ -31,12 +31,12 @@ class PrimerDetailsComponentTest < Minitest::Test
     assert_selector("details.details-overlay.details-overlay-dark")
   end
 
-  def test_renders_details_reset_when_reseting_the_button_style
-    render_inline(Primer::DetailsComponent.new(button: :reset)) do |component|
-      component.with(:summary) do
+  def test_renders_details_reset_when_reset_true
+    render_inline(Primer::DetailsComponent.new(reset: true)) do |component|
+      component.slot(:summary) do
         "Summary"
       end
-      component.with(:body) do
+      component.slot(:body) do
         "Body"
       end
     end
@@ -46,10 +46,10 @@ class PrimerDetailsComponentTest < Minitest::Test
 
   def test_default_component_renders_btn_summary
     render_inline(Primer::DetailsComponent.new) do |component|
-      component.with(:summary) do
+      component.slot(:summary) do
         "Summary"
       end
-      component.with(:body) do
+      component.slot(:body) do
         "Body"
       end
     end
@@ -57,11 +57,24 @@ class PrimerDetailsComponentTest < Minitest::Test
     assert_selector("summary.btn")
   end
 
-  def test_falls_back_to_defaults_when_invalid_button_and_overlay_are_passed
+  def test_allows_summary_customization
+    render_inline(Primer::DetailsComponent.new) do |component|
+      component.slot(:summary, classes: "btn-link", ml: 3) do
+        "Summary"
+      end
+      component.slot(:body) do
+        "Body"
+      end
+    end
+
+    assert_selector("summary.btn-link.ml-3")
+  end
+
+  def test_falls_back_to_defaults_when_invalid_overlay_is_passed
     without_fetch_or_fallback_raises do
-      render_inline(Primer::DetailsComponent.new(button: :foo, overlay: :bar)) do |component|
-        component.with(:summary) { "Summary" }
-        component.with(:body) { "Body" }
+      render_inline(Primer::DetailsComponent.new(overlay: :bar)) do |component|
+        component.slot(:summary) { "Summary" }
+        component.slot(:body) { "Body" }
       end
     end
 


### PR DESCRIPTION
This converts the content areas in DetailsComponent to be slots so that you can better customize them. I found myself wanting to use `btn-link` on the summary instead of `btn` but this didn't appear possible before.