### PR TITLE
Pass down inline styles in ProgressBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+* Allow inline styles on ProgressBar item slots
+    *emplums*
 
 * Updated the invalid class name error message
     *emplums*

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -52,13 +52,14 @@ module Primer
       include ClassNameHelper
       attr_reader :kwargs
 
-      def initialize(percentage: 0, bg: :green, **kwargs)
+      def initialize(percentage: 0, bg: :green, style: "", **kwargs)
         @percentage = percentage
         @kwargs = kwargs
+        @style = style
 
         @kwargs[:tag] = :span
         @kwargs[:bg] = bg
-        @kwargs[:style] = "width: #{@percentage}%;"
+        @kwargs[:style] = @style + "width: #{@percentage}%;"
         @kwargs[:classes] = class_names("Progress-item", @kwargs[:classes])
       end
     end

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -52,7 +52,7 @@ module Primer
       include ClassNameHelper
       attr_reader :kwargs
 
-      def initialize(percentage: 0, bg: :green, style: "", **kwargs)
+      def initialize(percentage: 0, bg: :green, **kwargs)
         @percentage = percentage
         @kwargs = kwargs
         @style = style

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -55,11 +55,10 @@ module Primer
       def initialize(percentage: 0, bg: :green, **kwargs)
         @percentage = percentage
         @kwargs = kwargs
-        @style = style
 
         @kwargs[:tag] = :span
         @kwargs[:bg] = bg
-        @kwargs[:style] = "width: #{@percentage}%; #{@kwargs[:style]}"
+        @kwargs[:style] = "width: #{@percentage}%;#{@kwargs[:style]}"
         @kwargs[:classes] = class_names("Progress-item", @kwargs[:classes])
       end
     end

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -59,7 +59,7 @@ module Primer
 
         @kwargs[:tag] = :span
         @kwargs[:bg] = bg
-        @kwargs[:style] = @style + "width: #{@percentage}%;"
+        @kwargs[:style] = "width: #{@percentage}%; #{@kwargs[:style]}"
         @kwargs[:classes] = class_names("Progress-item", @kwargs[:classes])
       end
     end

--- a/test/components/progress_bar_component_test.rb
+++ b/test/components/progress_bar_component_test.rb
@@ -65,6 +65,6 @@ class Primer::ProgressBarComponentTest < Minitest::Test
     render_inline(Primer::ProgressBarComponent.new) do |component|
       component.slot(:item, bg: :blue, style: "transition: width .2s ease-out;")
     end
-    assert_selector("[style='transition: width .2s ease-out;width: 0%;']")
+    assert_selector("[style='width: 0%;transition: width .2s ease-out;']")
   end
 end

--- a/test/components/progress_bar_component_test.rb
+++ b/test/components/progress_bar_component_test.rb
@@ -61,10 +61,10 @@ class Primer::ProgressBarComponentTest < Minitest::Test
     assert_selector("span.Progress .Progress-item.bg-yellow-8")
   end
 
-  def allows_inline_styles_on_slots
+  def test_allows_inline_styles_on_slots
     render_inline(Primer::ProgressBarComponent.new) do |component|
       component.slot(:item, bg: :blue, style: "transition: width .2s ease-out;")
     end
-    assert_selector("[style='transition: widdddth .2s ease-out;']")
+    assert_selector("[style='transition: width .2s ease-out;']")
   end
 end

--- a/test/components/progress_bar_component_test.rb
+++ b/test/components/progress_bar_component_test.rb
@@ -60,4 +60,11 @@ class Primer::ProgressBarComponentTest < Minitest::Test
 
     assert_selector("span.Progress .Progress-item.bg-yellow-8")
   end
+
+  def allows_inline_styles_on_slots
+    render_inline(Primer::ProgressBarComponent.new) do |component|
+      component.slot(:item, bg: :blue, style: "transition: width .2s ease-out;")
+    end
+    assert_selector("[style='transition: widdddth .2s ease-out;']")
+  end
 end

--- a/test/components/progress_bar_component_test.rb
+++ b/test/components/progress_bar_component_test.rb
@@ -65,6 +65,6 @@ class Primer::ProgressBarComponentTest < Minitest::Test
     render_inline(Primer::ProgressBarComponent.new) do |component|
       component.slot(:item, bg: :blue, style: "transition: width .2s ease-out;")
     end
-    assert_selector("[style='transition: width .2s ease-out;']")
+    assert_selector("[style='transition: width .2s ease-out;width: 0%;']")
   end
 end


### PR DESCRIPTION
This PR allows users to pass down inline styles in the ProgressBar component for ProgressBar item slots - this allows people to animate the progress bar when needed. This is used in the files viewed progress bar in the PR review process: 
![image](https://user-images.githubusercontent.com/8960591/91208314-dfbb7300-e6be-11ea-9601-f8678fbb82b2.png)


I think this opens up a broader question on whether or not we should allow inline styles on other components - my hunch is that we should only allow it on a as needed basis for now, to keep the component API a little more strict/opinionated.