### PR TITLE
add YARD & docs for CounterComponent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.25)
     zeitwerk (2.4.0)
 
 PLATFORMS
@@ -239,6 +240,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   view_component_storybook (~> 0.4.0)
   webpacker (~> 5.0)
+  yard (~> 0.9.25)
 
 BUNDLED WITH
    1.17.3

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Remember that restarting the Rails server is necessary to see changes, as the ge
 To minimize the number of restarts, we recommend checking the component in Storybook first, and then when it's in a good state,
 you can check it in your app.
 
+### Documentation
+
+Document components with [YARD](https://yardoc.org/). Docs are published to [RubyDoc.info](https://rubydoc.info/github/primer/view_components).
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/app/components/primer/counter_component.rb
+++ b/app/components/primer/counter_component.rb
@@ -9,6 +9,13 @@ module Primer
       :light_gray => "Counter Counter--gray-light",
     }.freeze
 
+    # @param count [Integer, Float::INFINITY, nil] The number to be displayed (e.x. # of issues, pull requests)
+    # @param scheme [Symbol] Color scheme. One of `SCHEME_MAPPINGS.keys`.
+    # @param limit [Integer] Maximum value to display. (e.x. if count == 6,000 and limit == 5000, counter will display "5,000+")
+    # @param hide_if_zero [Boolean] If true, a `hidden` attribute is added to the counter if `count` is zero.
+    # @param text [String] Text to display instead of count.
+    # @param round [Boolean] Whether to apply our standard rounding logic to value.
+    # @param kwargs [Hash] Style arguments to be passed to Primer::Classify
     def initialize(
       count: 0,
       scheme: DEFAULT_SCHEME,

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -36,4 +36,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-github", "~> 0.13.0"
   spec.add_development_dependency "simplecov", "~> 0.18.0"
   spec.add_development_dependency "simplecov-console", "~> 0.7.2"
+  spec.add_development_dependency "yard", "~> 0.9.25"
 end


### PR DESCRIPTION
This PR introduces documentation for our components, written in [YARD](https://yardoc.org/). 

If we like this approach, I'd recommend that we look into a tool like [yardstick](https://github.com/dkubb/yardstick) to ensure our documentation is complete.

cc @manuelpuyol 