### PR TITLE
Add Storybook for State Component

### DIFF
--- a/app/components/primer/state_component.rb
+++ b/app/components/primer/state_component.rb
@@ -37,12 +37,12 @@ module Primer
     )
       @kwargs = kwargs
       @kwargs[:title] = title
-      @kwargs[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, TAG_DEFAULT)
+      @kwargs[:tag] = fetch_or_fallback(TAG_OPTIONS, tag.to_sym, TAG_DEFAULT)
       @kwargs[:classes] = class_names(
         @kwargs[:classes],
         "State",
-        COLOR_MAPPINGS[fetch_or_fallback(COLOR_OPTIONS, color, COLOR_DEFAULT)],
-        SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)]
+        COLOR_MAPPINGS[fetch_or_fallback(COLOR_OPTIONS, color.to_sym, COLOR_DEFAULT)],
+        SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size.to_sym, SIZE_DEFAULT)]
       )
     end
 

--- a/stories/primer/state_component_stories.rb
+++ b/stories/primer/state_component_stories.rb
@@ -7,7 +7,7 @@ class Primer::StateComponentStories < ViewComponent::Storybook::Stories
     controls do
       title "this is the title"
       select(:color, Primer::StoriesHelper.array_to_options(Primer::StateComponent::COLOR_OPTIONS), :default)
-      select(:size, Primer::StoriesHelper.array_to_options(Primer::StateComponent::SIZE_MAPPINGS.keys), :default)
+      select(:size, Primer::StoriesHelper.array_to_options(Primer::StateComponent::SIZE_OPTIONS), :default)
       select(:tag, Primer::StoriesHelper.array_to_options(Primer::StateComponent::TAG_OPTIONS), :span)
     end
 

--- a/stories/primer/state_component_stories.rb
+++ b/stories/primer/state_component_stories.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Primer::StateComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:state) do
+    controls do
+      title "this is the title"
+      select(:color, Primer::StoriesHelper.array_to_options(Primer::StateComponent::COLOR_OPTIONS), :default)
+      select(:size, Primer::StoriesHelper.array_to_options(Primer::StateComponent::SIZE_MAPPINGS.keys), :default)
+      select(:tag, Primer::StoriesHelper.array_to_options(Primer::StateComponent::TAG_OPTIONS), :span)
+    end
+
+    content do
+      "This is a state!"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds [storybook support]( https://github.com/jonspalmer/view_component_storybook) for the State Component. 

<img width="848" alt="Screen Shot 2020-09-16 at 12 46 49 PM" src="https://user-images.githubusercontent.com/18093541/93367632-bb186e00-f81a-11ea-9442-060efcf162f9.png">

cc/ @joelhawksley @aellispierce @jonspalmer
