### PR TITLE
DropdownMenuComponent when used with DetailsComponent must be a direct descendant 

### DIFF
--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -94,4 +94,18 @@ class PrimerDetailsComponentTest < Minitest::Test
     refute_selector("details")
     refute_selector("summary")
   end
+
+  def test_details_menu_is_direct_child
+    menu = render_inline(Primer::DropdownMenuComponent.new(direction: :w)) { "Body" }
+    render_inline(Primer::DetailsComponent.new) do |component|
+      component.slot(:summary, variant: :small, button_type: :primary) do
+        "Summary"
+      end
+      component.slot(:body) do
+        menu.to_s.html_safe
+      end
+    end
+
+    assert_selector("details > details-menu", visible: false)
+  end
 end


### PR DESCRIPTION
The `<details-menu>` custom element is required to be a direct descendant of `<details>` https://github.com/github/details-menu-element/blob/73048a145256e7fabf9e0a1799125de427942ab8/src/index.ts#L125

There is functionality that's missing in the combination of using `DetailsComponent` and `DropdownMenuComponent`. Take this example:

```ruby
    render(Primer::DetailsComponent.new) do |component|
      component.slot(:summary, variant: :small, button_type: :primary) do
        "Summary"
      end
      component.slot(:body) do
        render(Primer::DropdownMenuComponent.new(direction: :w)) { "Body" }
      end
    end
```

When rendered it produces a wrapping `<div>` tag for the body. This breaks close functionality built into the custom element. The requirement of a direct child `details > details-menu` is because there is instances where a `details-menu` contains a `details` element. **So the menu cannot close on click**

**What should be happening.gif**

![Untitled](https://user-images.githubusercontent.com/54012/94977309-08f4cd80-04cd-11eb-9aa1-6527bb9962fe.gif)

```html
<details open="">
    <summary aria-haspopup="menu" role="button">Best robot: <span data-menu-button="">Hubot</span></summary>
    <details-menu role="menu">
      <button type="button" role="menuitem" data-menu-button-text="">Hubot</button>
      <button type="button" role="menuitem" data-menu-button-text="">Bender</button>
      <button type="button" role="menuitem" data-menu-button-text="">BB-8</button>
    </details-menu>
  </details>
```


**What is happening.gif**

![Untitled 2](https://user-images.githubusercontent.com/54012/94977316-101bdb80-04cd-11eb-9358-76d6636e8fde.gif) 

```html
<details open="">
    <summary aria-haspopup="menu" role="button">Best robot: <span data-menu-button="">Hubot</span></summary>
    <div><details-menu role="menu">
      <button type="button" role="menuitem" data-menu-button-text="">Hubot</button>
      <button type="button" role="menuitem" data-menu-button-text="">Bender</button>
      <button type="button" role="menuitem" data-menu-button-text="">BB-8</button>
    </details-menu></div>
  </details>
```

### Ideas for fixing

* We could remove the wrapping primer element.
* Create a combo component DetailsMenuComponent that does the correct thing.