### PR TITLE
Primer::OcticonComponent classify options are leaking as invalid html attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 0.0.9
+
+* BREAKING CHANGE: OcticonComponent no longer accepts `class` parameter; use `classes` instead.
+
+    *heynan0*
+
 ## 0.0.8
 
 * Add support for border margins, such as: `border_top: 0`.

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -3,7 +3,7 @@
     <%= render(Primer::OcticonComponent.new(
       icon: @icon,
       size: @icon_size,
-      class: "blankslate-icon"
+      classes: "blankslate-icon"
     )) %>
   <% end %>
 

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -15,9 +15,10 @@ module Primer
 
     def initialize(icon:, size: SIZE_DEFAULT, **kwargs)
       @icon, @kwargs = icon, kwargs
-
+      classes = class_names(@kwargs.delete(:class), @kwargs.delete(:classes))
+      @kwargs[:class] = class_names(Primer::Classify.call(**@kwargs)[:class], classes)
+      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS)
       @kwargs[:height] = SIZE_MAPPINGS[size]
-      @kwargs[:class] = class_names(@kwargs[:class], Primer::Classify.call(**@kwargs)[:class])
     end
 
     def call

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -16,13 +16,13 @@ module Primer
     def initialize(icon:, size: SIZE_DEFAULT, **kwargs)
       @icon, @kwargs = icon, kwargs
 
-      @kwargs[:class] = class_names(Primer::Classify.call(**@kwargs)[:class], @kwargs.delete(:classes))
+      @kwargs[:class] = Primer::Classify.call(**@kwargs)[:class]
       @kwargs[:height] ||= SIZE_MAPPINGS[size]
 
       # Filter out classify options to prevent them from becoming invalid html attributes.
       # Note height and width are both classify options and valid html attributes.
       octicon_helper_options = @kwargs.slice(:height, :width)
-      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS).merge(octicon_helper_options)
+      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS, :classes).merge(octicon_helper_options)
     end
 
     def call

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -15,10 +15,15 @@ module Primer
 
     def initialize(icon:, size: SIZE_DEFAULT, **kwargs)
       @icon, @kwargs = icon, kwargs
+
       classes = class_names(@kwargs.delete(:class), @kwargs.delete(:classes))
       @kwargs[:class] = class_names(Primer::Classify.call(**@kwargs)[:class], classes)
-      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS)
-      @kwargs[:height] = SIZE_MAPPINGS[size]
+      @kwargs[:height] ||= SIZE_MAPPINGS[size]
+
+      # Filter out classify options to prevent them from becoming invalid html attributes.
+      # Note height and width are both classify options and valid html attributes.
+      octicon_helper_options = @kwargs.slice(:height, :width)
+      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS).merge(octicon_helper_options)
     end
 
     def call

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -16,8 +16,7 @@ module Primer
     def initialize(icon:, size: SIZE_DEFAULT, **kwargs)
       @icon, @kwargs = icon, kwargs
 
-      classes = class_names(@kwargs.delete(:class), @kwargs.delete(:classes))
-      @kwargs[:class] = class_names(Primer::Classify.call(**@kwargs)[:class], classes)
+      @kwargs[:class] = class_names(Primer::Classify.call(**@kwargs)[:class], @kwargs.delete(:classes))
       @kwargs[:height] ||= SIZE_MAPPINGS[size]
 
       # Filter out classify options to prevent them from becoming invalid html attributes.

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -53,6 +53,12 @@ class PrimerOcticonComponentTest < Minitest::Test
     assert_selector("[height='16']")
   end
 
+  def test_renders_with_overridden_height_and_width_despite_given_a_size
+    render_inline(Primer::OcticonComponent.new(icon: "star", size: :large, height: 33, width: 47))
+
+    assert_selector('[height="33"][width="47"]')
+  end
+
   def test_renders_class_passed_in
     render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo"))
 

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -78,7 +78,7 @@ class PrimerOcticonComponentTest < Minitest::Test
   end
 
   def test_does_not_render_classify_attributes_as_html_attributes
-    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", my: 4, display: [:none]))
+    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", display: [:none]))
 
     refute_selector('[classes="foo"][display="none"]')
   end

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -86,6 +86,7 @@ class PrimerOcticonComponentTest < Minitest::Test
   def test_does_not_render_classify_attributes_as_html_attributes
     render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", display: [:none]))
 
-    refute_selector('[classes="foo"][display="none"]')
+    refute_selector('[classes="foo"]')
+    refute_selector('[display="none"]')
   end
 end

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -59,9 +59,27 @@ class PrimerOcticonComponentTest < Minitest::Test
     assert_selector(".foo")
   end
 
+  def test_renders_classes_passed_in
+    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo"))
+
+    assert_selector(".foo")
+  end
+
   def test_renders_class_passed_in_along_with_primer_class
     render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo", my: 4))
 
     assert_selector(".foo.my-4")
+  end
+
+  def test_renders_concatenated_class_and_classes_passed_in
+    render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo", classes: "bar"))
+
+    assert_selector(".foo.bar")
+  end
+
+  def test_does_not_render_classify_attributes_as_html_attributes
+    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", my: 4, display: [:none]))
+
+    refute_selector('[classes="foo"][display="none"]')
   end
 end

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -59,28 +59,16 @@ class PrimerOcticonComponentTest < Minitest::Test
     assert_selector('[height="33"][width="47"]')
   end
 
-  def test_renders_class_passed_in
-    render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo"))
-
-    assert_selector(".foo")
-  end
-
   def test_renders_classes_passed_in
     render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo"))
 
     assert_selector(".foo")
   end
 
-  def test_renders_class_passed_in_along_with_primer_class
-    render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo", my: 4))
+  def test_renders_classes_passed_in_along_with_primer_class
+    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", my: 4))
 
     assert_selector(".foo.my-4")
-  end
-
-  def test_renders_concatenated_class_and_classes_passed_in
-    render_inline(Primer::OcticonComponent.new(icon: "star", class: "foo", classes: "bar"))
-
-    assert_selector(".foo.bar")
   end
 
   def test_does_not_render_classify_attributes_as_html_attributes


### PR DESCRIPTION
Before: `Primer::OcticonComponent` is leaking Classify attributes into the HTML element attributes. These attributes are invalid. See screenshot below (`classes`, `display`).

<img width="627" alt="Screen Shot 2020-10-05 at 3 39 57 PM" src="https://user-images.githubusercontent.com/58703271/95247840-3ee6ca00-07cb-11eb-85ed-b75a9d59183b.png">

After:

* ~~Passed in `class` and `classes` arguments are concatenated into one and show under html `class` attribute.~~
  * Update: now, only `classes` option is supported. `class` will no longer work.
* Classify attributes are filtered out before passing options to octicon helper, preventing any leakage into invalid html attributes. 


<img width="625" alt="Screen Shot 2020-10-06 at 12 02 25 PM" src="https://user-images.githubusercontent.com/58703271/95248352-0a274280-07cc-11eb-96ab-c5443eefb8b2.png">
legend for screenshot immediately above

* red: from classify options: `d-none d-sm-inline`
* ~~green: from `class`: `abc`~~ (update not shown in screenshot: no longer supported)
* cyan: from `classes`: `UnderlineN2322av-octicon`