### PR TITLE
Update puma to 4.3.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rake", "~> 12.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version
 # Use Puma as the app server
-gem "puma", "~> 4.1"
+gem "puma", "~> 4.3.6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -230,7 +230,7 @@ DEPENDENCIES
   primer_view_components!
   pry
   pry-rails
-  puma (~> 4.1)
+  puma (~> 4.3.6)
   rails (= 6.0.3.3)
   rake (~> 12.0)
   rubocop (= 0.74)

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -8,7 +8,7 @@ gem "rake", "~> 12.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version
 # Use Puma as the app server
-gem "puma", "~> 4.1"
+gem "puma", "~> 4.3.6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.0"
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.5)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -195,7 +195,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   primer_view_components!
   pry-rails
-  puma (~> 4.1)
+  puma (~> 4.3.6)
   rails (= 6.0.3.3)
   rake (~> 12.0)
   spring


### PR DESCRIPTION
To avoid compilation problem in `puma` 4.3.5 with Xcode 12

(Reference https://github.com/puma/puma/pull/2314)

```
compiling puma_http11.c
puma_http11.c:203:22: error: implicitly declaring library function 'isspace' with type 'int (int)' [-Werror,-Wimplicit-function-declaration]
  while (vlen > 0 && isspace(value[vlen - 1])) vlen--;
                     ^
puma_http11.c:203:22: note: include the header <ctype.h> or explicitly provide a declaration for 'isspace'
1 error generated.
make: *** [puma_http11.o] Error 1
```