### PR TITLE
Install docs dependencies in setup script

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -3,10 +3,13 @@
 # Gems
 bundle install --path vendor/bundle
 
-# NPM packages
-cd demo
+# Set up demo
+pushd demo
 bundle install
 yarn install
+popd
 
-# back to root
-cd ../
+# Set up docs
+pushd docs
+yarn install
+popd


### PR DESCRIPTION
The first time I ran `script/dev` it failed because the npm dependencies for the docs were not installed. This PR updates the `script/setup` script to install docs npm dependencies.