### PR TITLE
Add Storybook Story to Progress Bar Component 

### DIFF
--- a/stories/primer/progress_bar_component_stories.rb
+++ b/stories/primer/progress_bar_component_stories.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Primer::ProgressBarComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:progress_bar) do
+    controls do
+      select(:size, Primer::ProgressBarComponent::SIZE_MAPPINGS.keys, :small)
+    end
+
+    content do |component|
+      component.slot(:item, bg: :green, percentage: 10)
+    end
+  end
+end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -83,9 +83,9 @@ class PrimerComponentTest < Minitest::Test
 
   def test_components_storybook_count
 
+    # Should be deprecated each time a new storybook is added to a component
     # Should be incremented if a new view component is added without a storybook
-    # Should be incremented if a new view component is added without a storybook
-    expected_missing_stories = 12
+    expected_missing_stories = 11
 
     expected_components_count = COMPONENTS_WITH_ARGS.length
 

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -85,7 +85,7 @@ class PrimerComponentTest < Minitest::Test
 
     # Should be deprecated each time a new storybook is added to a component
     # Should be incremented if a new view component is added without a storybook
-    expected_missing_stories = 11
+    expected_missing_stories = 10
 
     expected_components_count = COMPONENTS_WITH_ARGS.length
 


### PR DESCRIPTION
- This PR adds a [storybook story](https://github.com/jonspalmer/view_component_storybook) to the [Progress Bar Component:](https://github.com/primer/view_components/blob/main/app/components/primer/progress_bar_component.rb)

<img width="1078" alt="Screen Shot 2020-10-19 at 4 22 18 PM" src="https://user-images.githubusercontent.com/18093541/96464106-b97e0380-1227-11eb-926c-c361658ddf1e.png">

cc/ @joelhawksley @aellispierce