### PR TITLE
Add Storybook Story to Breadcrumb Component

### DIFF
--- a/stories/primer/breadcrumb_component_stories.rb
+++ b/stories/primer/breadcrumb_component_stories.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Primer::BreadcrumbComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:breadcrumb) do
+    content do |component|
+      component.slot(:item, selected: false) { "Breadcrumb Item one" }
+      component.slot(:item, href: "https://github.com/") { "Breadcrumb Item two" }
+    end
+  end
+end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -83,9 +83,9 @@ class PrimerComponentTest < Minitest::Test
 
   def test_components_storybook_count
 
+    # Should be Should be deprecated each time a new storybook is added to a component
     # Should be incremented if a new view component is added without a storybook
-    # Should be incremented if a new view component is added without a storybook
-    expected_missing_stories = 12
+    expected_missing_stories = 11
 
     expected_components_count = COMPONENTS_WITH_ARGS.length
 

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -85,7 +85,7 @@ class PrimerComponentTest < Minitest::Test
 
     # Should be Should be deprecated each time a new storybook is added to a component
     # Should be incremented if a new view component is added without a storybook
-    expected_missing_stories = 11
+    expected_missing_stories = 10
 
     expected_components_count = COMPONENTS_WITH_ARGS.length
 


### PR DESCRIPTION
- This PR adds a [storybook story](https://github.com/jonspalmer/view_component_storybook) to the [Breadcrumb Component:](https://github.com/primer/view_components/blob/main/app/components/primer/breadcrumb_component.rb)

<img width="900" alt="Screen Shot 2020-10-19 at 5 17 25 PM" src="https://user-images.githubusercontent.com/18093541/96471190-57c19780-122f-11eb-8070-e4238e0a1c0e.png">



cc/ @joelhawksley @aellispierce