### PR TITLE
Add Storybook Story to UnderlineNav Component

### DIFF
--- a/stories/primer/underline_nav_component_stories.rb
+++ b/stories/primer/underline_nav_component_stories.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Primer::UnderlineNavComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_preview"
+
+  story(:underline_nav) do
+    controls do
+      select(:align, Primer::UnderlineNavComponent::ALIGN_OPTIONS, :left)
+    end
+
+    content do |component|
+      component.with(:body) { "body" }
+    end
+  end
+end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -95,7 +95,6 @@ class PrimerComponentTest < Minitest::Test
         "subhead_component",
         "flex_item_component",
         "dropdown_menu_component",
-        "underline_nav_component",
         "base_component",
         "flex_component",
       ]


### PR DESCRIPTION
- This PR adds a [storybook story](https://github.com/jonspalmer/view_component_storybook) to the [Underline Nav Component:](https://github.com/primer/view_components/blob/main/app/components/primer/underline_nav_component.rb)

<img width="920" alt="Screen Shot 2020-10-20 at 4 32 41 PM" src="https://user-images.githubusercontent.com/18093541/96601447-5016f700-12f2-11eb-81ee-10b6de84815c.png">

cc/ @joelhawksley @aellispierce