### PR TITLE
Allow no box-sizing style for SpinnerComponent

### DIFF
--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -11,6 +11,9 @@ module Primer
       :large => 64,
     }.freeze
     SIZE_OPTIONS = SIZE_MAPPINGS.keys
+    # Setting `box-sizing: content-box` allows consumers to add padding
+    # to the spinner without shrinking the icon
+    DEFAULT_STYLE = "box-sizing: content-box; color: var(--color-icon-primary);"
 
     #
     # @example 48|Default
@@ -23,16 +26,14 @@ module Primer
     #   <%= render(Primer::SpinnerComponent.new(size: :large)) %>
     #
     # @param size [Symbol] <%= one_of(Primer::SpinnerComponent::SIZE_OPTIONS) %>
-    def initialize(size: DEFAULT_SIZE, **kwargs)
+    def initialize(size: DEFAULT_SIZE, style: DEFAULT_STYLE, **kwargs)
       @kwargs = kwargs
       @kwargs[:tag] = :svg
       @kwargs[:width] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @kwargs[:height] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @kwargs[:viewBox] = "0 0 16 16"
       @kwargs[:fill] = :none
-      # Setting `box-sizing: content-box` allows consumers to add padding
-      # to the spinner without shrinking the icon
-      @kwargs[:style] = "box-sizing: content-box; color: var(--color-icon-primary);"
+      @kwargs[:style] = DEFAULT_STYLE unless style.nil?
     end
   end
 end

--- a/test/components/spinner_component_test.rb
+++ b/test/components/spinner_component_test.rb
@@ -28,4 +28,16 @@ class PrimerSpinnerComponentTest < Minitest::Test
 
     assert_selector("svg[height=64][width=64]")
   end
+
+  def test_defaults_to_box_sizing_style
+    render_inline(Primer::SpinnerComponent.new)
+
+    assert_selector("[style='box-sizing: content-box; color: var(--color-icon-primary);']")
+  end
+
+  def test_no_box_sizing_style
+    render_inline(Primer::SpinnerComponent.new(style: nil))
+
+    assert_no_selector("style")
+  end
 end


### PR DESCRIPTION
### Summary

This adds the option to disable adding the `box-sizing` style to the `SpinnerCompnent` added in https://github.com/primer/view_components/pull/107

Having a style causes CSP errors as we don't allow inline stlyes over at https://github.com/github/helphub/issues/925. We don't need to add padding to the spinner so the ability to disable this style is needed. 

@colebemis Let me know if this sounds alright or you recommend another approach? 