### PR TITLE
rename kwargs to system_arguments

### DIFF
--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -15,25 +15,25 @@ module Primer
     # @param alt [String] Passed through to alt on img tag
     # @param size [Integer] Adds the avatar-small class if less than 24
     # @param square [Boolean] Used to create a square avatar.
-    def initialize(src:, alt:, size: 20, square: false, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :img
-      @kwargs[:src] = src
-      @kwargs[:alt] = alt
-      @kwargs[:size] = size
-      @kwargs[:height] = size
-      @kwargs[:width] = size
+    def initialize(src:, alt:, size: 20, square: false, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :img
+      @system_arguments[:src] = src
+      @system_arguments[:alt] = alt
+      @system_arguments[:size] = size
+      @system_arguments[:height] = size
+      @system_arguments[:width] = size
 
-      @kwargs[:classes] = class_names(
+      @system_arguments[:classes] = class_names(
         "avatar",
-        kwargs[:classes],
+        system_arguments[:classes],
         "avatar--small" => size < SMALL_THRESHOLD,
         "CircleBadge" => !square
       )
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -59,12 +59,12 @@ module Primer
     # @param font_size [String] <%= one_of(["00", "0", "1", "2", "3", "4", "5", "6"]) %>
     # @param tag [Symbol] HTML tag name to be passed to `tag.send`
     # @param classes [String] CSS class name value to be concatenated with generated Primer CSS classes
-    def initialize(tag:, classes: nil, **kwargs)
+    def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag
-      @result = Primer::Classify.call(**kwargs.merge(classes: classes))
+      @result = Primer::Classify.call(**system_arguments.merge(classes: classes))
 
       # Filter out Primer keys so they don't get assigned as HTML attributes
-      @content_tag_args = add_test_selector(kwargs).except(*Primer::Classify::VALID_KEYS)
+      @content_tag_args = add_test_selector(system_arguments).except(*Primer::Classify::VALID_KEYS)
     end
 
     def call

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if @icon.present? %>
     <%= render(Primer::OcticonComponent.new(
       icon: @icon,

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -87,12 +87,12 @@ module Primer
       large: false,
       spacious: false,
 
-      **kwargs
+      **system_arguments
     )
-      @kwargs = kwargs
-      @kwargs[:tag] ||= :div
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments = system_arguments
+      @system_arguments[:tag] ||= :div
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "blankslate",
         "blankslate-narrow": narrow,
         "blankslate-large": large,

--- a/app/components/primer/border_box_component.html.erb
+++ b/app/components/primer/border_box_component.html.erb
@@ -1,25 +1,25 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if header %>
-    <%= render Primer::BaseComponent.new(**header.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**header.system_arguments) do %>
       <%= header.content %>
     <% end %>
   <% end %>
   <% if body %>
-    <%= render Primer::BaseComponent.new(**body.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**body.system_arguments) do %>
       <%= body.content %>
     <% end %>
   <% end %>
   <% if rows.any? %>
     <ul>
       <% rows.each do |row| %>
-        <%= render Primer::BaseComponent.new(**row.kwargs) do %>
+        <%= render Primer::BaseComponent.new(**row.system_arguments) do %>
           <%= row.content %>
         <% end %>
       <% end %>
     </ul>
   <% end %>
   <% if footer %>
-    <%= render Primer::BaseComponent.new(**footer.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**footer.system_arguments) do %>
       <%= footer.content %>
     <% end %>
   <% end %>

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -20,13 +20,13 @@ module Primer
     #     component.slot(:footer) { "Footer" }
     #   end %>
     #
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :div
-      @kwargs[:classes] = class_names(
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :div
+      @system_arguments[:classes] = class_names(
         "Box",
-        kwargs[:classes]
+        system_arguments[:classes]
       )
     end
 
@@ -35,53 +35,53 @@ module Primer
     end
 
     class Header < Primer::Slot
-      attr_reader :kwargs
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+      attr_reader :system_arguments
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "Box-header",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end
 
     class Body < Primer::Slot
-      attr_reader :kwargs
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+      attr_reader :system_arguments
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "Box-body",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end
 
     class Footer < Primer::Slot
-      attr_reader :kwargs
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+      attr_reader :system_arguments
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "Box-footer",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end
 
     class Row < Primer::Slot
-      attr_reader :kwargs
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :li
-        @kwargs[:classes] = class_names(
+      attr_reader :system_arguments
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :li
+        @system_arguments[:classes] = class_names(
           "Box-row",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -3,14 +3,14 @@
 module Primer
   # A basic wrapper component for most layout related needs.
   class BoxComponent < Primer::Component
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :div
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :div
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/breadcrumb_component.html.erb
+++ b/app/components/primer/breadcrumb_component.html.erb
@@ -1,8 +1,8 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <ol>
     <% items.each do |item| %>
       <%# The <li> and <a> need to be on the same line to prevent unwanted whitespace %>
-      <%= render Primer::BaseComponent.new(**item.kwargs) do %><%- if item.href.present? %><a href="<%= item.href %>"><%= item.content %></a><%- else %><%= item.content %><%- end %><%- end %>
+      <%= render Primer::BaseComponent.new(**item.system_arguments) do %><%- if item.href.present? %><a href="<%= item.href %>"><%= item.content %></a><%- else %><%= item.content %><%- end %><%- end %>
     <% end %>
   </ol>
 <% end %>

--- a/app/components/primer/breadcrumb_component.rb
+++ b/app/components/primer/breadcrumb_component.rb
@@ -14,11 +14,11 @@ module Primer
     #     <% component.slot(:item, selected: true) do %>Team<% end %>
     #   <% end %>
     #
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :nav
-      @kwargs[:aria] = { label: "Breadcrumb" }
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :nav
+      @system_arguments[:aria] = { label: "Breadcrumb" }
     end
 
     def render?
@@ -27,18 +27,18 @@ module Primer
 
     # _Note: if both `href` and `selected: true` are passed in, `href` will be ignored and the item will not be rendered as a link._
     class BreadcrumbItem < Primer::Slot
-      attr_reader :href, :kwargs
+      attr_reader :href, :system_arguments
 
       # @param href [String] The URL to link to.
       # @param selected [Boolean] Whether or not the item is selected and not rendered as a link.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(href: nil, selected: false, **kwargs)
-        @href, @kwargs = href, kwargs
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(href: nil, selected: false, **system_arguments)
+        @href, @system_arguments = href, system_arguments
 
         @href = nil if selected
-        @kwargs[:tag] = :li
-        @kwargs[:"aria-current"] = "page" if selected
-        @kwargs[:classes] = "breadcrumb-item #{@kwargs[:classes]}"
+        @system_arguments[:tag] = :li
+        @system_arguments[:"aria-current"] = "page" if selected
+        @system_arguments[:classes] = "breadcrumb-item #{@system_arguments[:classes]}"
       end
     end
   end

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -48,20 +48,20 @@ module Primer
       tag: DEFAULT_TAG,
       type: DEFAULT_TYPE,
       group_item: false,
-      **kwargs
+      **system_arguments
     )
-      @kwargs = kwargs
-      @kwargs[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
 
-      if @kwargs[:tag] == :a
-        @kwargs[:role] = :button
+      if @system_arguments[:tag] == :a
+        @system_arguments[:role] = :button
       else
-        @kwargs[:type] = type
+        @system_arguments[:type] = type
       end
 
-      @kwargs[:classes] = class_names(
+      @system_arguments[:classes] = class_names(
         "btn",
-        kwargs[:classes],
+        system_arguments[:classes],
         BUTTON_TYPE_MAPPINGS[fetch_or_fallback(BUTTON_TYPE_OPTIONS, button_type, DEFAULT_BUTTON_TYPE)],
         VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)],
         "BtnGroup-item" => group_item
@@ -69,7 +69,7 @@ module Primer
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/counter_component.rb
+++ b/app/components/primer/counter_component.rb
@@ -20,7 +20,7 @@ module Primer
     # @param hide_if_zero [Boolean] If true, a `hidden` attribute is added to the counter if `count` is zero.
     # @param text [String] Text to display instead of count.
     # @param round [Boolean] Whether to apply our standard rounding logic to value.
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(
       count: 0,
       scheme: DEFAULT_SCHEME,
@@ -28,23 +28,23 @@ module Primer
       hide_if_zero: false,
       text: "",
       round: false,
-      **kwargs
+      **system_arguments
     )
-      @count, @limit, @hide_if_zero, @text, @round, @kwargs = count, limit, hide_if_zero, text, round, kwargs
+      @count, @limit, @hide_if_zero, @text, @round, @system_arguments = count, limit, hide_if_zero, text, round, system_arguments
 
-      @kwargs[:title] = title
-      @kwargs[:tag] = :span
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments[:title] = title
+      @system_arguments[:tag] = :span
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)]
       )
       if count == 0 && hide_if_zero
-        @kwargs[:hidden] = true
+        @system_arguments[:hidden] = true
       end
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { value }
+      render(Primer::BaseComponent.new(**@system_arguments)) { value }
     end
 
     private

--- a/app/components/primer/details_component.html.erb
+++ b/app/components/primer/details_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <%= render summary.component do %>
     <%= summary.content %>
   <% end %>

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -19,11 +19,11 @@ module Primer
     with_slot :body, class_name: "Body"
     with_slot :summary, class_name: "Summary"
 
-    def initialize(overlay: NO_OVERLAY, reset: false, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :details
-      @kwargs[:classes] = class_names(
-        kwargs[:classes],
+    def initialize(overlay: NO_OVERLAY, reset: false, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :details
+      @system_arguments[:classes] = class_names(
+        system_arguments[:classes],
         OVERLAY_MAPPINGS[fetch_or_fallback(OVERLAY_MAPPINGS.keys, overlay, NO_OVERLAY)],
         "details-reset" => reset
       )
@@ -34,29 +34,29 @@ module Primer
     end
 
     class Summary < Primer::Slot
-      def initialize(button: true, **kwargs)
+      def initialize(button: true, **system_arguments)
         @button = button
 
-        @kwargs = kwargs
-        @kwargs[:tag] = :summary
-        @kwargs[:role] = "button"
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :summary
+        @system_arguments[:role] = "button"
       end
 
       def component
-        return Primer::BaseComponent.new(**@kwargs) unless @button
+        return Primer::BaseComponent.new(**@system_arguments) unless @button
 
-        Primer::ButtonComponent.new(**@kwargs)
+        Primer::ButtonComponent.new(**@system_arguments)
       end
     end
 
     class Body < Primer::Slot
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] ||= :div
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] ||= :div
       end
 
       def component
-        Primer::BaseComponent.new(**@kwargs)
+        Primer::BaseComponent.new(**@system_arguments)
       end
     end
   end

--- a/app/components/primer/dropdown_menu_component.html.erb
+++ b/app/components/primer/dropdown_menu_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if @header.present? %>
     <div class="dropdown-header">
       <%= @header %>

--- a/app/components/primer/dropdown_menu_component.rb
+++ b/app/components/primer/dropdown_menu_component.rb
@@ -11,14 +11,14 @@ module Primer
     DIRECTION_DEFAULT = :se
     DIRECTION_OPTIONS = [DIRECTION_DEFAULT, :sw, :w, :e, :ne, :s]
 
-    def initialize(direction: DIRECTION_DEFAULT, scheme: SCHEME_DEFAULT, header: nil, **kwargs)
-      @header, @direction, @kwargs = header, direction, kwargs
+    def initialize(direction: DIRECTION_DEFAULT, scheme: SCHEME_DEFAULT, header: nil, **system_arguments)
+      @header, @direction, @system_arguments = header, direction, system_arguments
 
-      @kwargs[:tag] = "details-menu"
-      @kwargs[:role] = "menu"
+      @system_arguments[:tag] = "details-menu"
+      @system_arguments[:role] = "menu"
 
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "dropdown-menu",
         "dropdown-menu-#{fetch_or_fallback(DIRECTION_OPTIONS, direction, DIRECTION_DEFAULT)}",
         SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, SCHEME_DEFAULT)]

--- a/app/components/primer/flash_component.html.erb
+++ b/app/components/primer/flash_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <%= render(Primer::OcticonComponent.new(icon: @icon)) if @icon %>
   <%= content %>
   <% if @dismissible %>
@@ -7,7 +7,7 @@
     </button>
   <% end %>
   <% if actions.present? %>
-    <%= render Primer::BaseComponent.new(**actions.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**actions.system_arguments) do %>
       <%= actions.content %>
     <% end %>
   <% end %>

--- a/app/components/primer/flash_component.rb
+++ b/app/components/primer/flash_component.rb
@@ -42,31 +42,31 @@ module Primer
     # @param dismissible [Boolean] Whether the component can be dismissed with an X button.
     # @param icon [String] Name of Octicon icon to use.
     # @param variant [Symbol] <%= one_of(Primer::FlashComponent::VARIANT_MAPPINGS.keys) %>
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(full: false, spacious: false, dismissible: false, icon: nil, variant: DEFAULT_VARIANT, **kwargs)
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(full: false, spacious: false, dismissible: false, icon: nil, variant: DEFAULT_VARIANT, **system_arguments)
       @icon = icon
       @dismissible = dismissible
-      @kwargs = kwargs
-      @kwargs[:tag] = :div
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :div
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "flash",
         VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_MAPPINGS.keys, variant, DEFAULT_VARIANT)],
         "flash-full": full
       )
-      @kwargs[:mb] ||= spacious ? 4 : nil
+      @system_arguments[:mb] ||= spacious ? 4 : nil
     end
 
     class Actions < ViewComponent::Slot
       include ClassNameHelper
 
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(@kwargs[:classes], "flash-action")
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "flash-action")
       end
     end
   end

--- a/app/components/primer/flex_component.rb
+++ b/app/components/primer/flex_component.rb
@@ -37,7 +37,7 @@ module Primer
       flex_wrap: FLEX_WRAP_DEFAULT,
       align_items: ALIGN_ITEMS_DEFAULT,
       direction: nil,
-      **kwargs
+      **system_arguments
     )
       @align_items = fetch_or_fallback(ALIGN_ITEMS_OPTIONS, align_items, ALIGN_ITEMS_DEFAULT)
       @justify_content = fetch_or_fallback(JUSTIFY_CONTENT_OPTIONS, justify_content, JUSTIFY_CONTENT_DEFAULT)
@@ -51,13 +51,13 @@ module Primer
           DEFAULT_DIRECTION
         end
 
-      @kwargs = kwargs.merge({ direction: @direction }.compact)
-      @kwargs[:classes] = class_names(@kwargs[:classes], component_class_names)
-      @kwargs[:display] = fetch_or_fallback(INLINE_OPTIONS, inline, INLINE_DEFAULT) ? :inline_flex : :flex
+      @system_arguments = system_arguments.merge({ direction: @direction }.compact)
+      @system_arguments[:classes] = class_names(@system_arguments[:classes], component_class_names)
+      @system_arguments[:display] = fetch_or_fallback(INLINE_OPTIONS, inline, INLINE_DEFAULT) ? :inline_flex : :flex
     end
 
     def call
-      render(Primer::BoxComponent.new(**@kwargs)) { content }
+      render(Primer::BoxComponent.new(**@system_arguments)) { content }
     end
 
     private

--- a/app/components/primer/flex_item_component.rb
+++ b/app/components/primer/flex_item_component.rb
@@ -5,17 +5,17 @@ module Primer
     FLEX_AUTO_DEFAULT = false
     FLEX_AUTO_ALLOWED_VALUES = [FLEX_AUTO_DEFAULT, true]
 
-    def initialize(flex_auto: FLEX_AUTO_DEFAULT, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:classes] =
+    def initialize(flex_auto: FLEX_AUTO_DEFAULT, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:classes] =
         class_names(
-          @kwargs[:classes],
+          @system_arguments[:classes],
           "flex-auto" => fetch_or_fallback(FLEX_AUTO_ALLOWED_VALUES, flex_auto, FLEX_AUTO_DEFAULT)
         )
     end
 
     def call
-      render(Primer::BoxComponent.new(**@kwargs)) { content }
+      render(Primer::BoxComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/heading_component.rb
+++ b/app/components/primer/heading_component.rb
@@ -2,13 +2,13 @@
 
 module Primer
   class HeadingComponent < Primer::Component
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] ||= :h1
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] ||= :h1
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -44,22 +44,22 @@ module Primer
     # @param title [String] `title` attribute for the component element.
     # @param scheme [Symbol] <%= one_of(Primer::LabelComponent::SCHEME_OPTIONS) %>
     # @param variant [Symbol] <%= one_of(Primer::LabelComponent::VARIANT_OPTIONS) %>
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(title:, scheme: nil, variant: nil, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:bg] = :blue if scheme.nil?
-      @kwargs[:tag] ||= :span
-      @kwargs[:title] = title
-      @kwargs[:classes] = class_names(
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(title:, scheme: nil, variant: nil, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:bg] = :blue if scheme.nil?
+      @system_arguments[:tag] ||= :span
+      @system_arguments[:title] = title
+      @system_arguments[:classes] = class_names(
         "Label",
-        kwargs[:classes],
+        system_arguments[:classes],
         SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_OPTIONS, scheme)],
         VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant)]
       )
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/layout_component.html.erb
+++ b/app/components/primer/layout_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(Primer::FlexComponent.new(**@kwargs)) do %>
+<%= render(Primer::FlexComponent.new(**@system_arguments)) do %>
   <% if @side == :left %>
     <%= render Primer::BaseComponent.new(tag: :div, classes: "flex-shrink-0", col: (@responsive ? [12, nil, @sidebar_col] : @sidebar_col), mb: (@responsive ? [4, nil, 0] : nil)) do %>
       <%= sidebar %>

--- a/app/components/primer/layout_component.rb
+++ b/app/components/primer/layout_component.rb
@@ -27,16 +27,16 @@ module Primer
     # @param responsive [Boolean] Whether to collapse layout to a single column at smaller widths.
     # @param side [Symbol] Which side to display the sidebar on. <%= one_of(Primer::LayoutComponent::ALLOWED_SIDES) %>
     # @param sidebar_col [Integer] Sidebar column width.
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(responsive: false, side: DEFAULT_SIDE, sidebar_col: DEFAULT_SIDEBAR_COL, **kwargs)
-      @kwargs = kwargs
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(responsive: false, side: DEFAULT_SIDE, sidebar_col: DEFAULT_SIDEBAR_COL, **system_arguments)
+      @system_arguments = system_arguments
       @side = fetch_or_fallback(ALLOWED_SIDES, side, DEFAULT_SIDE)
       @responsive = responsive
-      @kwargs[:classes] = class_names(
+      @system_arguments[:classes] = class_names(
         "gutter-condensed gutter-lg",
-        @kwargs[:classes]
+        @system_arguments[:classes]
       )
-      @kwargs[:direction] = responsive ? [:column, nil, :row] : nil
+      @system_arguments[:direction] = responsive ? [:column, nil, :row] : nil
 
       @sidebar_col = fetch_or_fallback(ALLOWED_SIDEBAR_COLS, sidebar_col, DEFAULT_SIDEBAR_COL)
       @main_col = MAX_COL - @sidebar_col

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -11,19 +11,19 @@ module Primer
     #
     # @param href [String] URL to be used for the Link
     # @param muted [Boolean] Uses light gray for Link color, and blue on hover
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(href:, muted: false, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :a
-      @kwargs[:href] = href
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(href:, muted: false, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :a
+      @system_arguments[:href] = href
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "muted-link" => fetch_or_fallback([true, false], muted, false)
       )
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -25,21 +25,21 @@ module Primer
     #
     # @param icon [String] Name of [Octicon](https://primer.style/octicons/) to use.
     # @param size [Symbol] <%= one_of(Primer::OcticonComponent::SIZE_MAPPINGS) %>
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(icon:, size: SIZE_DEFAULT, **kwargs)
-      @icon, @kwargs = icon, kwargs
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(icon:, size: SIZE_DEFAULT, **system_arguments)
+      @icon, @system_arguments = icon, system_arguments
 
-      @kwargs[:class] = Primer::Classify.call(**@kwargs)[:class]
-      @kwargs[:height] ||= SIZE_MAPPINGS[size]
+      @system_arguments[:class] = Primer::Classify.call(**@system_arguments)[:class]
+      @system_arguments[:height] ||= SIZE_MAPPINGS[size]
 
       # Filter out classify options to prevent them from becoming invalid html attributes.
       # Note height and width are both classify options and valid html attributes.
-      octicon_helper_options = @kwargs.slice(:height, :width)
-      @kwargs = @kwargs.except(*Primer::Classify::VALID_KEYS, :classes).merge(octicon_helper_options)
+      octicon_helper_options = @system_arguments.slice(:height, :width)
+      @system_arguments = @system_arguments.except(*Primer::Classify::VALID_KEYS, :classes).merge(octicon_helper_options)
     end
 
     def call
-      octicon(@icon, **@kwargs)
+      octicon(@icon, **@system_arguments)
     end
   end
 end

--- a/app/components/primer/popover_component.html.erb
+++ b/app/components/primer/popover_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <%= render body.component do %>
     <% if heading %>
       <%= render heading.component do %>

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -40,17 +40,17 @@ module Primer
     #     <% end %>
     #   <% end %>
     #
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] ||= :div
-      @kwargs[:classes] = class_names(
-        kwargs[:classes],
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] ||= :div
+      @system_arguments[:classes] = class_names(
+        system_arguments[:classes],
         "Popover"
       )
-      @kwargs[:position] ||= :relative
-      @kwargs[:right] = false unless kwargs.key?(:right)
-      @kwargs[:left] = false unless kwargs.key?(:left)
+      @system_arguments[:position] ||= :relative
+      @system_arguments[:right] = false unless system_arguments.key?(:right)
+      @system_arguments[:left] = false unless system_arguments.key?(:left)
     end
 
     def render?
@@ -58,15 +58,15 @@ module Primer
     end
 
     class Heading < ViewComponent::Slot
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:mb] ||= 2
-        @kwargs[:tag] ||= :h4
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:mb] ||= 2
+        @system_arguments[:tag] ||= :h4
       end
 
       def component
-        Primer::HeadingComponent.new(**@kwargs)
+        Primer::HeadingComponent.new(**@system_arguments)
       end
     end
 
@@ -89,24 +89,24 @@ module Primer
 
       # @param caret [Symbol] <%= one_of(Primer::PopoverComponent::Body::CARET_MAPPINGS.keys) %>
       # @param large [Boolean] Whether to use the large version of the component.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(caret: CARET_DEFAULT, large: false, **kwargs)
-        @kwargs = kwargs
-        @kwargs[:classes] = class_names(
-          kwargs[:classes],
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(caret: CARET_DEFAULT, large: false, **system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:classes] = class_names(
+          system_arguments[:classes],
           "Popover-message Box",
           CARET_MAPPINGS[fetch_or_fallback(CARET_MAPPINGS.keys, caret, CARET_DEFAULT)],
           "Popover-message--large" => large
         )
-        @kwargs[:p] ||= 4
-        @kwargs[:mt] ||= 2
-        @kwargs[:mx] ||= :auto
-        @kwargs[:text_align] ||= :left
-        @kwargs[:box_shadow] ||= :large
+        @system_arguments[:p] ||= 4
+        @system_arguments[:mt] ||= 2
+        @system_arguments[:mx] ||= :auto
+        @system_arguments[:text_align] ||= :left
+        @system_arguments[:box_shadow] ||= :large
       end
 
       def component
-        Primer::BoxComponent.new(**@kwargs)
+        Primer::BoxComponent.new(**@system_arguments)
       end
     end
   end

--- a/app/components/primer/progress_bar_component.html.erb
+++ b/app/components/primer/progress_bar_component.html.erb
@@ -1,5 +1,5 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% items.each do |item| %>
-    <%= render Primer::BaseComponent.new(**item.kwargs) %>
+    <%= render Primer::BaseComponent.new(**item.system_arguments) %>
   <% end %>
 <% end %>

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -39,15 +39,15 @@ module Primer
     #   <% end %>
     #
     # @param size [Symbol] <%= one_of(Primer::ProgressBarComponent::SIZE_OPTIONS) %> Increases height.
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(size: SIZE_DEFAULT, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(size: SIZE_DEFAULT, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "Progress",
         SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)]
       )
-      @kwargs[:tag] = :span
+      @system_arguments[:tag] = :span
 
     end
 
@@ -57,19 +57,19 @@ module Primer
 
     class Item < ViewComponent::Slot
       include ClassNameHelper
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
       # @param percentage [Integer] Percentage completion of item.
       # @param bg [Symbol] Color of item.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(percentage: 0, bg: :green, **kwargs)
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(percentage: 0, bg: :green, **system_arguments)
         @percentage = percentage
-        @kwargs = kwargs
+        @system_arguments = system_arguments
 
-        @kwargs[:tag] = :span
-        @kwargs[:bg] = bg
-        @kwargs[:style] = "width: #{@percentage}%;"
-        @kwargs[:classes] = class_names("Progress-item", @kwargs[:classes])
+        @system_arguments[:tag] = :span
+        @system_arguments[:bg] = bg
+        @system_arguments[:style] = "width: #{@percentage}%;"
+        @system_arguments[:classes] = class_names("Progress-item", @system_arguments[:classes])
       end
     end
   end

--- a/app/components/primer/spinner_component.html.erb
+++ b/app/components/primer/spinner_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
   <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke">
     <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="1s" repeatCount="indefinite" />

--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -26,14 +26,14 @@ module Primer
     #   <%= render(Primer::SpinnerComponent.new(size: :large)) %>
     #
     # @param size [Symbol] <%= one_of(Primer::SpinnerComponent::SIZE_MAPPINGS) %>
-    def initialize(size: DEFAULT_SIZE, style: DEFAULT_STYLE, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :svg
-      @kwargs[:width] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
-      @kwargs[:height] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
-      @kwargs[:viewBox] = "0 0 16 16"
-      @kwargs[:fill] = :none
-      @kwargs[:style] = DEFAULT_STYLE unless style.nil?
+    def initialize(size: DEFAULT_SIZE, style: DEFAULT_STYLE, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :svg
+      @system_arguments[:width] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
+      @system_arguments[:height] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
+      @system_arguments[:viewBox] = "0 0 16 16"
+      @system_arguments[:fill] = :none
+      @system_arguments[:style] = DEFAULT_STYLE unless style.nil?
     end
   end
 end

--- a/app/components/primer/state_component.rb
+++ b/app/components/primer/state_component.rb
@@ -39,19 +39,19 @@ module Primer
     # @param color [Symbol] Background color. <%= one_of(Primer::StateComponent::COLOR_OPTIONS) %>
     # @param tag [Symbol] HTML tag for element. <%= one_of(Primer::StateComponent::TAG_OPTIONS) %>
     # @param size [Symbol] <%= one_of(Primer::StateComponent::SIZE_OPTIONS) %>
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(
       title:,
       color: COLOR_DEFAULT,
       tag: TAG_DEFAULT,
       size: SIZE_DEFAULT,
-      **kwargs
+      **system_arguments
     )
-      @kwargs = kwargs
-      @kwargs[:title] = title
-      @kwargs[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, TAG_DEFAULT)
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments = system_arguments
+      @system_arguments[:title] = title
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, TAG_DEFAULT)
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "State",
         COLOR_MAPPINGS[fetch_or_fallback(COLOR_OPTIONS, color, COLOR_DEFAULT)],
         SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)]
@@ -59,7 +59,7 @@ module Primer
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/subhead_component.html.erb
+++ b/app/components/primer/subhead_component.html.erb
@@ -1,16 +1,16 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if heading.present? %>
-    <%= render Primer::BaseComponent.new(**heading.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**heading.system_arguments) do %>
       <%= heading.content %>
     <% end %>
   <% end %>
   <% if actions.present? %>
-    <%= render Primer::BaseComponent.new(**actions.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**actions.system_arguments) do %>
       <%= actions.content %>
     <% end %>
   <% end %>
   <% if description.present? %>
-    <%= render Primer::BaseComponent.new(**description.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**description.system_arguments) do %>
       <%= description.content %>
     <% end %>
   <% end %>

--- a/app/components/primer/subhead_component.rb
+++ b/app/components/primer/subhead_component.rb
@@ -48,19 +48,19 @@ module Primer
     #
     # @param spacious [Boolean] Whether to add spacing to the Subhead.
     # @param hide_border [Boolean] Whether to hide the border under the heading.
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(spacious: false, hide_border: false, **kwargs)
-      @kwargs = kwargs
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(spacious: false, hide_border: false, **system_arguments)
+      @system_arguments = system_arguments
 
-      @kwargs[:tag] = :div
-      @kwargs[:classes] =
+      @system_arguments[:tag] = :div
+      @system_arguments[:classes] =
         class_names(
-          @kwargs[:classes],
+          @system_arguments[:classes],
           "Subhead hx_Subhead--responsive",
           "Subhead--spacious": spacious,
           "border-bottom-0": hide_border
         )
-      @kwargs[:mb] ||= hide_border ? 0 : nil
+      @system_arguments[:mb] ||= hide_border ? 0 : nil
     end
 
     def render?
@@ -70,15 +70,15 @@ module Primer
     class Heading < ViewComponent::Slot
       include ClassNameHelper
 
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
       # @param danger [Boolean] Whether to style the heading as dangerous.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(danger: false, **kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] ||= :div
-        @kwargs[:classes] = class_names(
-          @kwargs[:classes],
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(danger: false, **system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] ||= :div
+        @system_arguments[:classes] = class_names(
+          @system_arguments[:classes],
           "Subhead-heading",
           "Subhead-heading--danger": danger
         )
@@ -88,26 +88,26 @@ module Primer
     class Actions < ViewComponent::Slot
       include ClassNameHelper
 
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(@kwargs[:classes], "Subhead-actions")
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "Subhead-actions")
       end
     end
 
     class Description < ViewComponent::Slot
       include ClassNameHelper
 
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(@kwargs[:classes], "Subhead-description")
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(@system_arguments[:classes], "Subhead-description")
       end
     end
   end

--- a/app/components/primer/text_component.rb
+++ b/app/components/primer/text_component.rb
@@ -7,14 +7,14 @@ module Primer
     #   <%= render(Primer::TextComponent.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
     #   <%= render(Primer::TextComponent.new(tag: :p, color: :red_5)) { "Red Text" } %>
     #
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] ||= :span
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(**system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] ||= :span
     end
 
     def call
-      render(Primer::BaseComponent.new(**@kwargs)) { content }
+      render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
   end
 end

--- a/app/components/primer/timeline_item_component.html.erb
+++ b/app/components/primer/timeline_item_component.html.erb
@@ -1,16 +1,16 @@
-<%= render Primer::BaseComponent.new(**kwargs) do %>
+<%= render Primer::BaseComponent.new(**system_arguments) do %>
   <% if avatar %>
-    <%= render Primer::AvatarComponent.new(alt: avatar.alt, src: avatar.src, size: avatar.size, square: avatar.square, **avatar.kwargs) %>
+    <%= render Primer::AvatarComponent.new(alt: avatar.alt, src: avatar.src, size: avatar.size, square: avatar.square, **avatar.system_arguments) %>
   <% end %>
 
   <% if badge %>
-    <%= render Primer::BaseComponent.new(**badge.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**badge.system_arguments) do %>
       <%= octicon badge.icon %>
     <% end %>
   <% end %>
 
   <% if body %>
-    <%= render Primer::BaseComponent.new(**body.kwargs) do %>
+    <%= render Primer::BaseComponent.new(**body.system_arguments) do %>
       <%= body.content %>
     <% end %>
   <% end %>

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -9,7 +9,7 @@ module Primer
     with_slot :badge, class_name: "Badge"
     with_slot :body, class_name: "Body"
 
-    attr_reader :kwargs
+    attr_reader :system_arguments
 
     # @example 75|Default
     #   <div style="padding-left: 60px">
@@ -21,14 +21,14 @@ module Primer
     #   </div>
     #
     # @param condensed [Boolean] Reduce the vertical padding and remove the background from the badge item. Most commonly used in commits.
-    # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(condensed: false, **kwargs)
-      @kwargs = kwargs
-      @kwargs[:tag] = :div
-      @kwargs[:classes] = class_names(
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    def initialize(condensed: false, **system_arguments)
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :div
+      @system_arguments[:classes] = class_names(
         "TimelineItem",
         condensed ? "TimelineItem--condensed" : "",
-        kwargs[:classes]
+        system_arguments[:classes]
       )
     end
 
@@ -37,55 +37,55 @@ module Primer
     end
 
     class Avatar < Primer::Slot
-      attr_reader :kwargs, :alt, :src, :size, :square
+      attr_reader :system_arguments, :alt, :src, :size, :square
 
       # @param alt [String] Alt text for avatar image.
       # @param src [String] Src attribute for avatar image.
       # @param size [Integer] Image size.
       # @param square [Boolean] Whether to round the edges of the image.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(alt: nil, src: nil, size: 40, square: true, **kwargs)
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(alt: nil, src: nil, size: 40, square: true, **system_arguments)
         @alt = alt
         @src = src
         @size = size
         @square = square
 
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "TimelineItem-avatar",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end
 
     class Badge < Primer::Slot
-      attr_reader :kwargs, :icon
+      attr_reader :system_arguments, :icon
 
       # @param icon [String] Name of [Octicon](https://primer.style/octicons/) to use.
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(icon: nil, **kwargs)
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(icon: nil, **system_arguments)
         @icon = icon
 
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "TimelineItem-badge",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end
 
     class Body < Primer::Slot
-      attr_reader :kwargs
+      attr_reader :system_arguments
 
-      # @param kwargs [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**kwargs)
-        @kwargs = kwargs
-        @kwargs[:tag] = :div
-        @kwargs[:classes] = class_names(
+      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      def initialize(**system_arguments)
+        @system_arguments = system_arguments
+        @system_arguments[:tag] = :div
+        @system_arguments[:classes] = class_names(
           "TimelineItem-body",
-          kwargs[:classes]
+          system_arguments[:classes]
         )
       end
     end

--- a/app/components/primer/underline_nav_component.html.erb
+++ b/app/components/primer/underline_nav_component.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(**@kwargs) do %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if actions && @align == :right %>
     <%= actions %>
   <% end %>

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -7,13 +7,13 @@ module Primer
 
     with_content_areas :body, :actions
 
-    def initialize(align: ALIGN_DEFAULT, **kwargs)
+    def initialize(align: ALIGN_DEFAULT, **system_arguments)
       @align = fetch_or_fallback(ALIGN_OPTIONS, align, ALIGN_DEFAULT)
 
-      @kwargs = kwargs
-      @kwargs[:tag] = :nav
-      @kwargs[:classes] = class_names(
-        @kwargs[:classes],
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :nav
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
         "UnderlineNav",
         "UnderlineNav--right" => @align == :right
       )

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -25,28 +25,28 @@ end %>
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `header` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `body` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `footer` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `row` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -8,4 +8,4 @@ A basic wrapper component for most layout related needs.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -22,7 +22,7 @@ Use breadcrumbs to display page hierarchy within a section of the site. All of t
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `item` slot
 
@@ -30,6 +30,6 @@ Use breadcrumbs to display page hierarchy within a section of the site. All of t
 | :- | :- | :- | :- |
 | `href` | `String` | `nil` | The URL to link to. |
 | `selected` | `Boolean` | `false` | Whether or not the item is selected and not rendered as a link. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 _Note: if both `href` and `selected: true` are passed in, `href` will be ignored and the item will not be rendered as a link._

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -24,4 +24,4 @@ Use Primer::CounterComponent to add a count to navigational elements and buttons
 | `hide_if_zero` | `Boolean` | `false` | If true, a `hidden` attribute is added to the counter if `count` is zero. |
 | `text` | `String` | `""` | Text to display instead of count. |
 | `round` | `Boolean` | `false` | Whether to apply our standard rounding logic to value. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -63,10 +63,10 @@ Use the Flash component to inform users of successful or pending actions.
 | `dismissible` | `Boolean` | `false` | Whether the component can be dismissed with an X button. |
 | `icon` | `String` | `nil` | Name of Octicon icon to use. |
 | `variant` | `Symbol` | `:default` | One of `:default`, `:warning`, `:danger`, or `:success`. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `actions` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -35,4 +35,4 @@ Use labels to add contextual metadata to a design.
 | `title` | `String` | N/A | `title` attribute for the component element. |
 | `scheme` | `Symbol` | `nil` | One of `:gray`, `:dark_gray`, `:yellow`, `:orange`, `:red`, `:green`, `:blue`, `:purple`, `:pink`, `:outline`, `:green_outline`, or `nil`. |
 | `variant` | `Symbol` | `nil` | One of `:large`, `:inline`, or `nil`. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -35,4 +35,4 @@ Use Layout to build a main/sidebar layout.
 | `responsive` | `Boolean` | `false` | Whether to collapse layout to a single column at smaller widths. |
 | `side` | `Symbol` | `:right` | Which side to display the sidebar on. One of `:right` and `:left`. |
 | `sidebar_col` | `Integer` | `3` | Sidebar column width. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -28,4 +28,4 @@ Use links for moving from one page to another. The Link component styles anchor 
 | :- | :- | :- | :- |
 | `href` | `String` | N/A | URL to be used for the Link |
 | `muted` | `Boolean` | `false` | Uses light gray for Link color, and blue on hover |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -36,4 +36,4 @@ Renders an [Octicon](https://primer.style/octicons/) with [System Arguments](/sy
 | :- | :- | :- | :- |
 | `icon` | `String` | N/A | Name of [Octicon](https://primer.style/octicons/) to use. |
 | `size` | `Symbol` | `:small` | One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`). |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -57,13 +57,13 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `heading` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `body` slot
 
@@ -71,4 +71,4 @@ By default, the popover renders with absolute positioning, meaning it should usu
 | :- | :- | :- | :- |
 | `caret` | `Symbol` | `CARET_DEFAULT` | One of `:top`, `:bottom`, `:bottom_right`, `:bottom_left`, `:left`, `:left_bottom`, `:left_top`, `:right`, `:right_bottom`, `:right_top`, `:top_left`, or `:top_right`. |
 | `large` | `Boolean` | `false` | Whether to use the large version of the component. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -53,7 +53,7 @@ Use ProgressBar to visualize task completion.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `size` | `Symbol` | `:default` | One of `:default`, `:small`, or `:large`. Increases height. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `item` slot
 
@@ -61,4 +61,4 @@ Use ProgressBar to visualize task completion.
 | :- | :- | :- | :- |
 | `percentage` | `Integer` | `0` | Percentage completion of item. |
 | `bg` | `Symbol` | `:green` | Color of item. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -42,4 +42,4 @@ Component for rendering the status of an item.
 | `color` | `Symbol` | `:default` | Background color. One of `:default`, `:green`, `:red`, or `:purple`. |
 | `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span`, `:div`, or `:a`. |
 | `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -64,23 +64,23 @@ Use the Subhead component for page headings.
 | :- | :- | :- | :- |
 | `spacious` | `Boolean` | `false` | Whether to add spacing to the Subhead. |
 | `hide_border` | `Boolean` | `false` | Whether to hide the border under the heading. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `heading` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `danger` | `Boolean` | `false` | Whether to style the heading as dangerous. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `actions` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `description` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -19,4 +19,4 @@ The Text component is a wrapper component that will apply typography styles to t
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -25,7 +25,7 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `condensed` | `Boolean` | `false` | Reduce the vertical padding and remove the background from the badge item. Most commonly used in commits. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `avatar` slot
 
@@ -35,17 +35,17 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 | `src` | `String` | `nil` | Src attribute for avatar image. |
 | `size` | `Integer` | `40` | Image size. |
 | `square` | `Boolean` | `true` | Whether to round the edges of the image. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `badge` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `icon` | `String` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
 
 ### `body` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -60,7 +60,7 @@ class PrimerComponentTest < Minitest::Test
       render_component(component, { "data-ga-click": "Foo,bar" }.merge(args), proc)
       assert_selector("[data-ga-click='Foo,bar']", visible: false)
 
-      # Ensure all slots accept Primer kwargs
+      # Ensure all slots accept Primer system_arguments
       if component.slots.any?
         render_inline(component.new(**args)) do |c|
           component.slots.each do |slot_name, slot_attributes|


### PR DESCRIPTION
This PR renames the `kwargs` argument in the codebase to `system_arguments`, making the purpose of the argument clear.