### PR TITLE
Another pass at system arguments docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Rename `v` system argument to `visibility`.
+
+    *Joel Hawksley*
+
 ## 0.0.14
 
 * Add functional colors to Label.

--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ namespace :docs do
   end
 
   def link_to_system_arguments_docs
-    "[System Arguments](/system-arguments)"
+    "[System arguments](/system-arguments)"
   end
 
   def pretty_value(val)
@@ -213,11 +213,11 @@ namespace :docs do
       end
     end
 
-    # Build System Arguments docs from BaseComponent
+    # Build system arguments docs from BaseComponent
     documentation = registry.get(Primer::BaseComponent.name)
     File.open("docs/content/system-arguments.md", "w") do |f|
       f.puts("---")
-      f.puts("title: System Arguments")
+      f.puts("title: System arguments")
       f.puts("---")
       f.puts
       f.puts(documentation.base_docstring)
@@ -227,7 +227,7 @@ namespace :docs do
 
       f.puts("## Arguments")
       f.puts
-      f.puts("| Name | Type | Default | Description |")
+      f.puts("| Name | Type | Description |")
       f.puts("| :- | :- | :- |")
 
       initialize_method.tags(:param).each do |tag|

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -25,13 +25,14 @@ module Primer
   #
   # ## HTML attributes
   #
-  # System arguments sinclude most HTML attributes. For example:
+  # System arguments include most HTML attributes. For example:
   #
   # | Name | Type | Description |
   # | :- | :- | :- |
   # | `width` | `Integer` | Width. |
   # | `height` | `Integer` | Height. |
   # | `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
+  # | `aria` | `Hash` | Aria attributes. For example: `aria: { label: "foo" }` will render `aria-label='foo'`. |
   # | `title` | `String` | The `title` attribute. |
   # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
   class BaseComponent < Primer::Component

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -33,13 +33,13 @@ module Primer
     # @param ml [Integer] Margin left. <%= one_of((-6..6).to_a) %>
     # @param mx [Integer] Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %>
     # @param my [Integer] Vertical margins. <%= one_of((-6..6).to_a) %>
-    # @param m [Integer] Padding. <%= one_of((0..6).to_a) %>
-    # @param mt [Integer] Padding left. <%= one_of((0..6).to_a) %>
-    # @param mr [Integer] Padding right. <%= one_of((0..6).to_a) %>
-    # @param mb [Integer] Padding bottom. <%= one_of((0..6).to_a) %>
-    # @param ml [Integer] Padding left. <%= one_of((0..6).to_a) %>
-    # @param mx [Integer] Horizontal padding. <%= one_of((0..6).to_a) %>
-    # @param my [Integer] Vertical padding. <%= one_of((0..6).to_a) %>
+    # @param p [Integer] Padding. <%= one_of((0..6).to_a) %>
+    # @param pt [Integer] Padding left. <%= one_of((0..6).to_a) %>
+    # @param pr [Integer] Padding right. <%= one_of((0..6).to_a) %>
+    # @param pb [Integer] Padding bottom. <%= one_of((0..6).to_a) %>
+    # @param pl [Integer] Padding left. <%= one_of((0..6).to_a) %>
+    # @param px [Integer] Horizontal padding. <%= one_of((0..6).to_a) %>
+    # @param py [Integer] Vertical padding. <%= one_of((0..6).to_a) %>
     #
     # @param position [Symbol] <%= one_of([:relative, :absolute, :fixed]) %>
     #

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -78,7 +78,7 @@ module Primer
     # @param color [Symbol] Text color. <%= one_of([:blue, :red, :gray_light, :gray, :gray_dark, :green, :orange, :orange_light, :purple, :pink, :white, :inherit]) %> Note: this API is subject to change as we move to functional colors.
     # @param bg [String, Symbol] Background color. Accepts either a hex value as a String or a color name as a Symbol.
     #
-    # @param box_shadow [Boolean, Symbol] Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none])
+    # @param box_shadow [Boolean, Symbol] Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %>
     # @param border [Symbol] <%= one_of([:left, :top, :bottom, :right, :y, :x]) %>
     # @param border_color [Symbol] <%= one_of([:blue, :blue_light, :gray, :gray_dark, :green, :purple, :red, :red_light, :white, :yellow, :black_fade]) %> Note: this API is subject to change as we move to functional colors.
     # @param border_top [Integer] Set to `0` to remove the top border.

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -86,7 +86,7 @@ module Primer
     # @param border_left [Integer] Set to `0` to remove the left border.
     # @param border_right [Integer] Set to `0` to remove the right border.
     #
-    # @param font_size [String] <%= one_of(["00", "0", "1", "2", "3", "4", "5", "6"]) %>
+    # @param font_size [String, Integer] <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %>
     # @param text_align [Symbol] Text alignment. <%= one_of([:left, :right, :center]) %>
     # @param font_weight [Symbol] Font weight. <%= one_of([:light, :normal, :bold]) %>
     #

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Primer
-  # All Primer ViewComponents accept a standard set of options called System Arguments, mimicking the [styled-system API](https://styled-system.com/table) [used by Primer React](https://primer.style/components/system-props).
+  # All Primer ViewComponents accept a standard set of options called system arguments, mimicking the [styled-system API](https://styled-system.com/table) used by [Primer React](https://primer.style/components/system-props).
   #
-  # Under the hood, System Arguments are [mapped](https://github.com/primer/view_components/blob/main/lib/primer/classify.rb) to Primer CSS classes, with any remaining options passed to Rails' [`content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag).
+  # Under the hood, system arguments are [mapped](https://github.com/primer/view_components/blob/main/lib/primer/classify.rb) to Primer CSS classes, with any remaining options passed to Rails' [`content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag).
   #
   # ## Responsive values
   #
@@ -23,9 +23,21 @@ module Primer
   # <h1 class="mt-0 mt-lg-4 mt-xl-2">Hello world</h1>
   # ```
   #
+  # ## HTML attributes
+  #
+  # System arguments sinclude most HTML attributes. For example:
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `width` | `Integer` | Width. |
+  # | `height` | `Integer` | Height. |
+  # | `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
+  # | `title` | `String` | The `title` attribute. |
+  # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
   class BaseComponent < Primer::Component
     TEST_SELECTOR_TAG = :test_selector
-
+    # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
+    #
     # @param m [Integer] Margin. <%= one_of((-6..6).to_a) %>
     # @param mt [Integer] Margin left. <%= one_of((-6..6).to_a) %>
     # @param mr [Integer] Margin right. <%= one_of((-6..6).to_a) %>
@@ -50,15 +62,46 @@ module Primer
     #
     # @param display [Symbol] <%= one_of([:block, :none, :inline, :inline_block, :table, :table_cell]) %>
     #
+    # @param v [Symbol] Visibility. <%= one_of([:hidden, :visible]) %>
+    #
     # @param hide [Symbol] Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %>
     #
     # @param vertical_align [Symbol] <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %>
     #
     # @param float [Symbol] <%= one_of([:left, :right]) %>
     #
+    # @param col [Integer] Number of columns.
+    #
+    # @param underline [Boolean] Whether text should be underlined.
+    #
+    # @param color [Symbol] Text color. <%= one_of([:blue, :red, :gray_light, :gray, :gray_dark, :green, :orange, :orange_light, :purple, :pink, :white, :inherit]) %> Note: this API is subject to change as we move to functional colors.
+    # @param bg [String, Symbol] Background color. Accepts either a hex value as a String or a color name as a Symbol.
+    #
+    # @param box_shadow [Boolean, Symbol] Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none])
+    # @param border [Symbol] <%= one_of([:left, :top, :bottom, :right, :y, :x]) %>
+    # @param border_color [Symbol] <%= one_of([:blue, :blue_light, :gray, :gray_dark, :green, :purple, :red, :red_light, :white, :yellow, :black_fade]) %> Note: this API is subject to change as we move to functional colors.
+    # @param border_top [Integer] Set to `0` to remove the top border.
+    # @param border_bottom [Integer] Set to `0` to remove the bottom border.
+    # @param border_left [Integer] Set to `0` to remove the left border.
+    # @param border_right [Integer] Set to `0` to remove the right border.
+    #
     # @param font_size [String] <%= one_of(["00", "0", "1", "2", "3", "4", "5", "6"]) %>
-    # @param tag [Symbol] HTML tag name to be passed to `tag.send`
-    # @param classes [String] CSS class name value to be concatenated with generated Primer CSS classes
+    # @param text_align [Symbol] Text alignment. <%= one_of([:left, :right, :center]) %>
+    # @param font_weight [Symbol] Font weight. <%= one_of([:light, :normal, :bold]) %>
+    #
+    # @param flex [Integer, Symbol] <%= one_of([1, :auto]) %>
+    # @param flex_grow [Integer] To enable, set to `0`.
+    # @param flex_shrink [Integer] To enable, set to `0`.
+    # @param align_self [Symbol] <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %>
+    # @param justify_content [Symbol] <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %>
+    # @param align_items [Symbol] <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %>
+    # @param width [Symbol] <%= one_of([:fit, :fill]) %>
+    # @param height [Symbol] <%= one_of([:fit, :fill]) %>
+    #
+    # @param word_break [Symbol] Whether to break words on line breaks. Can only be `:break_all`.
+    #
+    # @param tag [Symbol] HTML tag name to be passed to `tag.send`.
+    # @param classes [String] CSS class name value to be concatenated with generated Primer CSS classes.
     def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag
       @result = Primer::Classify.call(**system_arguments.merge(classes: classes))

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -31,8 +31,8 @@ module Primer
   # | :- | :- | :- |
   # | `width` | `Integer` | Width. |
   # | `height` | `Integer` | Height. |
-  # | `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
-  # | `aria` | `Hash` | Aria attributes. For example: `aria: { label: "foo" }` will render `aria-label='foo'`. |
+  # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
+  # | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
   # | `title` | `String` | The `title` attribute. |
   # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
   class BaseComponent < Primer::Component

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    primer_view_components (0.0.13)
+    primer_view_components (0.0.14)
       octicons_helper (>= 9.0.0, < 12.0.0)
       rails (>= 5.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -25,28 +25,28 @@ end %>
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `header` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `body` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `footer` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `row` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -8,4 +8,4 @@ A basic wrapper component for most layout related needs.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -22,7 +22,7 @@ Use breadcrumbs to display page hierarchy within a section of the site. All of t
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `item` slot
 
@@ -30,6 +30,6 @@ Use breadcrumbs to display page hierarchy within a section of the site. All of t
 | :- | :- | :- | :- |
 | `href` | `String` | `nil` | The URL to link to. |
 | `selected` | `Boolean` | `false` | Whether or not the item is selected and not rendered as a link. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 _Note: if both `href` and `selected: true` are passed in, `href` will be ignored and the item will not be rendered as a link._

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -24,4 +24,4 @@ Use Primer::CounterComponent to add a count to navigational elements and buttons
 | `hide_if_zero` | `Boolean` | `false` | If true, a `hidden` attribute is added to the counter if `count` is zero. |
 | `text` | `String` | `""` | Text to display instead of count. |
 | `round` | `Boolean` | `false` | Whether to apply our standard rounding logic to value. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -63,10 +63,10 @@ Use the Flash component to inform users of successful or pending actions.
 | `dismissible` | `Boolean` | `false` | Whether the component can be dismissed with an X button. |
 | `icon` | `String` | `nil` | Name of Octicon icon to use. |
 | `variant` | `Symbol` | `:default` | One of `:default`, `:warning`, `:danger`, or `:success`. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `actions` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -35,4 +35,4 @@ Use labels to add contextual metadata to a design.
 | `title` | `String` | N/A | `title` attribute for the component element. |
 | `scheme` | `Symbol` | `nil` | One of `:gray`, `:dark_gray`, `:yellow`, `:orange`, `:red`, `:green`, `:blue`, `:purple`, `:pink`, `:outline`, or `:green_outline`. |
 | `variant` | `Symbol` | `nil` | One of `:large`, `:inline`, or `nil`. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -35,4 +35,4 @@ Use Layout to build a main/sidebar layout.
 | `responsive` | `Boolean` | `false` | Whether to collapse layout to a single column at smaller widths. |
 | `side` | `Symbol` | `:right` | Which side to display the sidebar on. One of `:right` and `:left`. |
 | `sidebar_col` | `Integer` | `3` | Sidebar column width. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -28,4 +28,4 @@ Use links for moving from one page to another. The Link component styles anchor 
 | :- | :- | :- | :- |
 | `href` | `String` | N/A | URL to be used for the Link |
 | `muted` | `Boolean` | `false` | Uses light gray for Link color, and blue on hover |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -2,7 +2,7 @@
 title: Octicon
 ---
 
-Renders an [Octicon](https://primer.style/octicons/) with [System Arguments](/system-arguments).
+Renders an [Octicon](https://primer.style/octicons/) with [System arguments](/system-arguments).
 
 ## Examples
 
@@ -36,4 +36,4 @@ Renders an [Octicon](https://primer.style/octicons/) with [System Arguments](/sy
 | :- | :- | :- | :- |
 | `icon` | `String` | N/A | Name of [Octicon](https://primer.style/octicons/) to use. |
 | `size` | `Symbol` | `:small` | One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`). |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -57,13 +57,13 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `heading` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `body` slot
 
@@ -71,4 +71,4 @@ By default, the popover renders with absolute positioning, meaning it should usu
 | :- | :- | :- | :- |
 | `caret` | `Symbol` | `CARET_DEFAULT` | One of `:top`, `:bottom`, `:bottom_right`, `:bottom_left`, `:left`, `:left_bottom`, `:left_top`, `:right`, `:right_bottom`, `:right_top`, `:top_left`, or `:top_right`. |
 | `large` | `Boolean` | `false` | Whether to use the large version of the component. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -53,7 +53,7 @@ Use ProgressBar to visualize task completion.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `size` | `Symbol` | `:default` | One of `:default`, `:small`, or `:large`. Increases height. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `item` slot
 
@@ -61,4 +61,4 @@ Use ProgressBar to visualize task completion.
 | :- | :- | :- | :- |
 | `percentage` | `Integer` | `0` | Percentage completion of item. |
 | `bg` | `Symbol` | `:green` | Color of item. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -42,4 +42,4 @@ Component for rendering the status of an item.
 | `color` | `Symbol` | `:default` | Background color. One of `:default`, `:green`, `:red`, or `:purple`. |
 | `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span`, `:div`, or `:a`. |
 | `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -64,23 +64,23 @@ Use the Subhead component for page headings.
 | :- | :- | :- | :- |
 | `spacious` | `Boolean` | `false` | Whether to add spacing to the Subhead. |
 | `hide_border` | `Boolean` | `false` | Whether to hide the border under the heading. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `heading` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `danger` | `Boolean` | `false` | Whether to style the heading as dangerous. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `actions` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `description` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -19,4 +19,4 @@ The Text component is a wrapper component that will apply typography styles to t
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -25,7 +25,7 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `condensed` | `Boolean` | `false` | Reduce the vertical padding and remove the background from the badge item. Most commonly used in commits. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `avatar` slot
 
@@ -35,17 +35,17 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 | `src` | `String` | `nil` | Src attribute for avatar image. |
 | `size` | `Integer` | `40` | Image size. |
 | `square` | `Boolean` | `true` | Whether to round the edges of the image. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `badge` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `icon` | `String` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `body` slot
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System Arguments](/system-arguments) |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -77,7 +77,7 @@ System arguments include most HTML attributes. For example:
 | `border_bottom` | `Integer` | Set to `0` to remove the bottom border. |
 | `border_left` | `Integer` | Set to `0` to remove the left border. |
 | `border_right` | `Integer` | Set to `0` to remove the right border. |
-| `font_size` | `String` | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `font_size` | `String, Integer` | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `text_align` | `Symbol` | Text alignment. One of `:left`, `:right`, or `:center`. |
 | `font_weight` | `Symbol` | Font weight. One of `:light`, `:normal`, or `:bold`. |
 | `flex` | `Integer, Symbol` | One of `1` and `:auto`. |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -26,13 +26,14 @@ Renders:
 
 ## HTML attributes
 
-System arguments sinclude most HTML attributes. For example:
+System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
 | `width` | `Integer` | Width. |
 | `height` | `Integer` | Height. |
 | `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
+| `aria` | `Hash` | Aria attributes. For example: `aria: { label: "foo" }` will render `aria-label='foo'`. |
 | `title` | `String` | The `title` attribute. |
 | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
 

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -32,8 +32,8 @@ System arguments include most HTML attributes. For example:
 | :- | :- | :- |
 | `width` | `Integer` | Width. |
 | `height` | `Integer` | Height. |
-| `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
-| `aria` | `Hash` | Aria attributes. For example: `aria: { label: "foo" }` will render `aria-label='foo'`. |
+| `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
+| `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
 | `title` | `String` | The `title` attribute. |
 | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
 

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -70,7 +70,7 @@ System arguments include most HTML attributes. For example:
 | `underline` | `Boolean` | Whether text should be underlined. |
 | `color` | `Symbol` | Text color. One of `:blue`, `:red`, `:gray_light`, `:gray`, `:gray_dark`, `:green`, `:orange`, `:orange_light`, `:purple`, `:pink`, `:white`, or `:inherit`. Note: this API is subject to change as we move to functional colors. |
 | `bg` | `String, Symbol` | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-| `box_shadow` | `Boolean, Symbol` | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) |
+| `box_shadow` | `Boolean, Symbol` | Box shadow. One of `true`, `:medium`, `:large`, `:extra_large`, or `:none`. |
 | `border` | `Symbol` | One of `:left`, `:top`, `:bottom`, `:right`, `:y`, or `:x`. |
 | `border_color` | `Symbol` | One of `:blue`, `:blue_light`, `:gray`, `:gray_dark`, `:green`, `:purple`, `:red`, `:red_light`, `:white`, `:yellow`, or `:black_fade`. Note: this API is subject to change as we move to functional colors. |
 | `border_top` | `Integer` | Set to `0` to remove the top border. |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -1,10 +1,10 @@
 ---
-title: System Arguments
+title: System arguments
 ---
 
-All Primer ViewComponents accept a standard set of options called System Arguments, mimicking the [styled-system API](https://styled-system.com/table) [used by Primer React](https://primer.style/components/system-props).
+All Primer ViewComponents accept a standard set of options called system arguments, mimicking the [styled-system API](https://styled-system.com/table) used by [Primer React](https://primer.style/components/system-props).
 
-Under the hood, System Arguments are [mapped](https://github.com/primer/view_components/blob/main/lib/primer/classify.rb) to Primer CSS classes, with any remaining options passed to Rails' [`content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag).
+Under the hood, system arguments are [mapped](https://github.com/primer/view_components/blob/main/lib/primer/classify.rb) to Primer CSS classes, with any remaining options passed to Rails' [`content_tag`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag).
 
 ## Responsive values
 
@@ -24,10 +24,23 @@ Renders:
 <h1 class="mt-0 mt-lg-4 mt-xl-2">Hello world</h1>
 ```
 
+## HTML attributes
+
+System arguments sinclude most HTML attributes. For example:
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `width` | `Integer` | Width. |
+| `height` | `Integer` | Height. |
+| `data` | `Hash` | Data attributes. For example: `data: { foo: :bar }` will render `data-foo='bar'`. |
+| `title` | `String` | The `title` attribute. |
+| `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
+
 ## Arguments
 
-| Name | Type | Default | Description |
+| Name | Type | Description |
 | :- | :- | :- |
+| `test_selector` | `String` | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
 | `m` | `Integer` | Margin. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mt` | `Integer` | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mr` | `Integer` | Margin right. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
@@ -48,9 +61,32 @@ Renders:
 | `bottom` | `Boolean` | If `false`, sets `bottom: 0`. |
 | `left` | `Boolean` | If `false`, sets `left: 0`. |
 | `display` | `Symbol` | One of `:block`, `:none`, `:inline`, `:inline_block`, `:table`, or `:table_cell`. |
+| `v` | `Symbol` | Visibility. One of `:hidden` and `:visible`. |
 | `hide` | `Symbol` | Hide the element at a specific breakpoint. One of `:sm`, `:md`, `:lg`, or `:xl`. |
 | `vertical_align` | `Symbol` | One of `:baseline`, `:top`, `:middle`, `:bottom`, `:text_top`, or `:text_bottom`. |
 | `float` | `Symbol` | One of `:left` and `:right`. |
+| `col` | `Integer` | Number of columns. |
+| `underline` | `Boolean` | Whether text should be underlined. |
+| `color` | `Symbol` | Text color. One of `:blue`, `:red`, `:gray_light`, `:gray`, `:gray_dark`, `:green`, `:orange`, `:orange_light`, `:purple`, `:pink`, `:white`, or `:inherit`. Note: this API is subject to change as we move to functional colors. |
+| `bg` | `String, Symbol` | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
+| `box_shadow` | `Boolean, Symbol` | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) |
+| `border` | `Symbol` | One of `:left`, `:top`, `:bottom`, `:right`, `:y`, or `:x`. |
+| `border_color` | `Symbol` | One of `:blue`, `:blue_light`, `:gray`, `:gray_dark`, `:green`, `:purple`, `:red`, `:red_light`, `:white`, `:yellow`, or `:black_fade`. Note: this API is subject to change as we move to functional colors. |
+| `border_top` | `Integer` | Set to `0` to remove the top border. |
+| `border_bottom` | `Integer` | Set to `0` to remove the bottom border. |
+| `border_left` | `Integer` | Set to `0` to remove the left border. |
+| `border_right` | `Integer` | Set to `0` to remove the right border. |
 | `font_size` | `String` | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `tag` | `Symbol` | HTML tag name to be passed to `tag.send` |
-| `classes` | `String` | CSS class name value to be concatenated with generated Primer CSS classes |
+| `text_align` | `Symbol` | Text alignment. One of `:left`, `:right`, or `:center`. |
+| `font_weight` | `Symbol` | Font weight. One of `:light`, `:normal`, or `:bold`. |
+| `flex` | `Integer, Symbol` | One of `1` and `:auto`. |
+| `flex_grow` | `Integer` | To enable, set to `0`. |
+| `flex_shrink` | `Integer` | To enable, set to `0`. |
+| `align_self` | `Symbol` | One of `:auto`, `:start`, `:end`, `:center`, `:baseline`, or `:stretch`. |
+| `justify_content` | `Symbol` | One of `:flex_start`, `:flex_end`, `:center`, `:space_between`, or `:space_around`. |
+| `align_items` | `Symbol` | One of `:flex_start`, `:flex_end`, `:center`, `:baseline`, or `:stretch`. |
+| `width` | `Symbol` | One of `:fit` and `:fill`. |
+| `height` | `Symbol` | One of `:fit` and `:fill`. |
+| `word_break` | `Symbol` | Whether to break words on line breaks. Can only be `:break_all`. |
+| `tag` | `Symbol` | HTML tag name to be passed to `tag.send`. |
+| `classes` | `String` | CSS class name value to be concatenated with generated Primer CSS classes. |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -35,13 +35,13 @@ Renders:
 | `ml` | `Integer` | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mx` | `Integer` | Horizontal margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
 | `my` | `Integer` | Vertical margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `m` | `Integer` | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mt` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mr` | `Integer` | Padding right. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mb` | `Integer` | Padding bottom. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `ml` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mx` | `Integer` | Horizontal padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `my` | `Integer` | Vertical padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `p` | `Integer` | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pt` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pr` | `Integer` | Padding right. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pb` | `Integer` | Padding bottom. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pl` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `px` | `Integer` | Horizontal padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `py` | `Integer` | Vertical padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `position` | `Symbol` | One of `:relative`, `:absolute`, or `:fixed`. |
 | `top` | `Boolean` | If `false`, sets `top: 0`. |
 | `right` | `Boolean` | If `false`, sets `right: 0`. |

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -3,7 +3,7 @@
   children:
     - title: Contributing
       url: /contributing
-    - title: System Arguments
+    - title: System arguments
       url: /system-arguments
 - title: Components
   url: /components

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -29,7 +29,7 @@ module Primer
     WIDTH_KEY = :width
     HEIGHT_KEY = :height
     BOX_SHADOW_KEY = :box_shadow
-
+    VISIBILITY_KEY = :visibility
 
     BOOLEAN_MAPPINGS = {
       underline: {
@@ -102,7 +102,8 @@ module Primer
         ALIGN_SELF_KEY,
         WIDTH_KEY,
         HEIGHT_KEY,
-        BOX_SHADOW_KEY
+        BOX_SHADOW_KEY,
+        VISIBILITY_KEY
       ]
     ).freeze
 
@@ -231,6 +232,8 @@ module Primer
               else
                 memo[:classes] << "box-shadow-#{dasherized_val}"
               end
+            elsif key == VISIBILITY_KEY
+              memo[:classes] << "v-#{dasherized_val}"
             else
               memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{dasherized_val}"
             end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -150,7 +150,6 @@ class PrimerClassifyTest < Minitest::Test
   def test_font_weight
     assert_generated_class("text-light",    { font_weight: :light })
     assert_generated_class("text-normal",   { font_weight: :normal })
-    assert_generated_class("text-semibold", { font_weight: :semibold })
     assert_generated_class("text-bold",     { font_weight: :bold })
   end
 
@@ -172,6 +171,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("border-bottom", { border: :bottom })
     assert_generated_class("border-right",  { border: :right })
     assert_generated_class("border-y",      { border: :y })
+    assert_generated_class("border-x",      { border: :x })
   end
 
   def test_border_margins

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -88,8 +88,8 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_v
-    assert_generated_class("v-hidden",  { v: :hidden })
-    assert_generated_class("v-visible", { v: :visible })
+    assert_generated_class("v-hidden",  { visibility: :hidden })
+    assert_generated_class("v-visible", { visibility: :visible })
   end
 
   def test_hide


### PR DESCRIPTION
This PR fills out the remaining gaps of our documentation for system arguments.

While what we have here isn't the most easily digested, it is more or less complete. I hope we can introduce a more friendly structure soon.

cc @yaili as I've addressed your capitalization concerns here 😄 
cc @kevinsawicki as I've added some examples based on your feedback. (Such as `hidden`, `data` attributes, etc)

Related: https://github.com/primer/view_components/issues/120