### PR TITLE
Fix Ruby warnings

### DIFF
--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -36,7 +36,7 @@ class BlankslateComponentTest < Minitest::Test
   end
 
   def test_renders_a_narrow_large_and_spacious_blankslate_component
-    result = render_inline(Primer::BlankslateComponent.new(
+    render_inline(Primer::BlankslateComponent.new(
       title: "Title",
       narrow: true,
       large: true,

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -61,7 +61,7 @@ class PrimerComponentTest < Minitest::Test
       assert_selector("[data-ga-click='Foo,bar']", visible: false)
 
       # Ensure all slots accept Primer system_arguments
-      if component.slots.any?
+      if component.respond_to?(:slots) && component.slots.any?
         render_inline(component.new(**args)) do |c|
           component.slots.each do |slot_name, slot_attributes|
             c.slot(

--- a/test/primer/fetch_or_fallback_helper_test.rb
+++ b/test/primer/fetch_or_fallback_helper_test.rb
@@ -33,8 +33,8 @@ class Primer::FetchOrFallbackHelperTest < Minitest::Test
       fetch_or_fallback([1, 2, 3], 0, 1)
     end
 
-    assert_match /Expected one of: \[1, 2, 3\]/, error.message
-    assert_match /Got: 0/, error.message
-    assert_match /This will not raise in production, but will instead fallback to: 1/, error.message
+    assert_match(/Expected one of: \[1, 2, 3\]/, error.message)
+    assert_match(/Got: 0/, error.message)
+    assert_match(/This will not raise in production, but will instead fallback to: 1/, error.message)
   end
 end


### PR DESCRIPTION
This PR fixes a few Ruby warnings that were returned when running the test suite.

It also updates us to bundler `2.2.0`.