### PR TITLE
Update @primer/gatsby-theme-doctocat to use main branch

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
       resolve: '@primer/gatsby-theme-doctocat',
       options: {
         defaultBranch: 'main',
-        repoRootPath: 'docs',
+        repoRootPath: './docs',
       },
     },
   ],

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -10,6 +10,7 @@ module.exports = {
       resolve: '@primer/gatsby-theme-doctocat',
       options: {
         defaultBranch: 'main',
+        repoRootPath: 'docs',
       },
     },
   ],

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -5,6 +5,13 @@ module.exports = {
     description: 'ViewComponents for the Primer Design System',
     imageUrl: "https://user-images.githubusercontent.com/10384315/53922681-2f6d3100-402a-11e9-9719-5d1811c8110a.png"
   },
-  plugins: ['@primer/gatsby-theme-doctocat'],
+  plugins: [
+    {
+      resolve: '@primer/gatsby-theme-doctocat',
+      options: {
+        defaultBranch: 'main',
+      },
+    },
+  ],
   pathPrefix: '/view-components',
 }


### PR DESCRIPTION
The "Edit this page on GitHub" links in the footers were 404ing because they defaulted to master.

This config change should make the footers point at the right url using `main`