### PR TITLE
Clean up hash arg related deprecation warnings

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -113,7 +113,7 @@ module Primer
     end
 
     def call
-      content_tag(@tag, content, **@content_tag_args.merge(@result))
+      content_tag(@tag, content, { **@content_tag_args.merge(@result) })
     end
 
     private

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -39,7 +39,7 @@ module Primer
     end
 
     def call
-      octicon(@icon, **@system_arguments)
+      octicon(@icon, { **@system_arguments })
     end
   end
 end


### PR DESCRIPTION
This change explicitly passes hashes when splatted to avoid warnings
like:

```
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
./Users/srt32/src/github.com/github/view_components/vendor/bundle/ruby/2.6.0/gems/actionview-6.0.3.3/lib/action_view/helpers/tag_helper.rb:270: warning: in `content_tag': the last argument was passed as a single Hash
/Users/srt32/src/github.com/github/view_components/app/components/primer/base_component.rb:116: warning: although a splat keyword arguments here
...................................
```