### PR TITLE
Use rails@main in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-build-rails-master-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
     - name: Lint with Rubocop
       run: |
         gem install bundler:1.17.3
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: [5.2.3, 6.0.0, master]
+        rails_version: [5.2.3, 6.0.0, main]
         ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
         exclude:
-          - rails_version: master
+          - rails_version: main
             ruby_version: 2.4.x
           - rails_version: 6.0.0
             ruby_version: 2.4.x
@@ -83,7 +83,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-build-rails-master-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
     - name: Collate simplecov
       run: |
         gem install bundler:1.17.3

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ rails_version = "#{ENV['RAILS_VERSION'] || '6.0.3.3'}"
 
 gem "rake", "~> 12.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version
+gem "rails", rails_version == "main" ? { github: "rails/rails" } : rails_version
 # Use Puma as the app server
 gem "puma", "~> 4.3.6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker


### PR DESCRIPTION
rails/rails has updated the default branch to be main - https://twitter.com/dhh/status/1350091751789375490

I do believe this change will bust the cache in CI but I think that should be a one time hit.