### PR TITLE
Add `border_radius` system argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## main
 
-## 0.0.18
-
 * Add `border_radius` system argument.
 
     *Ash Guillaume*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.0.18
 
-* Add `rounded` tests
+* Add `border_radius` system argument.
 
     *Ash Guillaume*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 0.0.18
+
+* Add `rounded` tests
+
+    *Ash Guillaume*
+
 ## 0.0.17
 
 * Ensure all components support inline styles.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,4 +246,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,4 +246,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.1.4
+   1.17.3

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -86,6 +86,7 @@ module Primer
     # @param border_bottom [Integer] Set to `0` to remove the bottom border.
     # @param border_left [Integer] Set to `0` to remove the left border.
     # @param border_right [Integer] Set to `0` to remove the right border.
+    # @param border_radius [Integer] <%= one_of([0, 1, 2, 3]) %>
     #
     # @param font_size [String, Integer] <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %>
     # @param text_align [Symbol] Text alignment. <%= one_of([:left, :right, :center]) %>

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -80,6 +80,7 @@ System arguments include most HTML attributes. For example:
 | `border_bottom` | `Integer` | Set to `0` to remove the bottom border. |
 | `border_left` | `Integer` | Set to `0` to remove the left border. |
 | `border_right` | `Integer` | Set to `0` to remove the right border. |
+| `border_radius` | `Integer` | One of `0`, `1`, `2`, or `3`. |
 | `font_size` | `String, Integer` | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `text_align` | `Symbol` | Text alignment. One of `:left`, `:right`, or `:center`. |
 | `font_weight` | `Symbol` | Font weight. One of `:light`, `:normal`, or `:bold`. |

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -79,6 +79,7 @@ module Primer
     }.freeze
     BORDER_KEYS = [:border, :border_color].freeze
     BORDER_MARGIN_KEYS = [:border_top, :border_bottom, :border_left, :border_right].freeze
+    BORDER_RADIUS_KEY = :border_radius
     TYPOGRAPHY_KEYS = [:font_size].freeze
     VALID_KEYS = (
       CONCAT_KEYS +
@@ -88,6 +89,7 @@ module Primer
       TYPOGRAPHY_KEYS +
       TEXT_KEYS +
       [
+        BORDER_RADIUS_KEY,
         COLOR_KEY,
         BG_KEY,
         DISPLAY_KEY,
@@ -199,6 +201,8 @@ module Primer
               memo[:classes] << "border-#{dasherized_val}"
             elsif BORDER_MARGIN_KEYS.include?(key)
               memo[:classes] << "#{key.to_s.dasherize}-#{val}"
+            elsif key == BORDER_RADIUS_KEY
+              memo[:classes] << "rounded-#{val}"
             elsif key == DIRECTION_KEY
               memo[:classes] << "flex#{breakpoint}-#{dasherized_val}"
             elsif key == JUSTIFY_CONTENT_KEY

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -185,6 +185,13 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("border-black-fade", { border_color: :black_fade })
   end
 
+  def test_rounded
+    assert_generated_class("rounded-0", { rounded_0: 0})
+    assert_generated_class("rounded-1", { rounded_0: 1})
+    assert_generated_class("rounded-2", { rounded_0: 2})
+    assert_generated_class("rounded-3", { rounded_0: 3})
+  end
+
   def test_justify_content
     assert_generated_class("flex-justify-start", { justify_content: :flex_start })
     assert_generated_class("flex-justify-end", { justify_content: :flex_end })

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -186,10 +186,10 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_rounded
-    assert_generated_class("rounded-0", { rounded_0: 0})
-    assert_generated_class("rounded-1", { rounded_0: 1})
-    assert_generated_class("rounded-2", { rounded_0: 2})
-    assert_generated_class("rounded-3", { rounded_0: 3})
+    assert_generated_class("rounded-0", { border_radius: 0 })
+    assert_generated_class("rounded-1", { border_radius: 1 })
+    assert_generated_class("rounded-2", { border_radius: 2 })
+    assert_generated_class("rounded-3", { border_radius: 3 })
   end
 
   def test_justify_content


### PR DESCRIPTION
This PR adds tests for the `rounded` classes from Primer CSS.

**Note:** This is an ongoing PR that I am 🍐 ing with @joelhawksley on as a learning and development exercise.