### PR TITLE
Add log statement on docs:build when component has no examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       run: |
         gem install bundler:1.17.3
         bundle config path vendor/bundle
+        bundle config git.allow_insecure true
         bundle update
         bundle exec rake
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       run: |
         gem install bundler:1.17.3
         bundle config path vendor/bundle
-        bundle config git.allow_insecure true
         bundle update
         bundle exec rake
       env:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ rails_version = "#{ENV['RAILS_VERSION'] || '6.0.3.3'}"
 
 gem "rake", "~> 12.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem "rails", rails_version == "main" ? { github: "rails/rails" } : rails_version
+gem "rails", rails_version == "main" ? { git: "https://github.com/rails/rails", ref: "main" } : rails_version
 # Use Puma as the app server
 gem "puma", "~> 4.3.6"
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker

--- a/Rakefile
+++ b/Rakefile
@@ -113,6 +113,8 @@ namespace :docs do
       Primer::TimelineItemComponent
     ]
 
+    components_without_examples = []
+
     components.each do |component|
       documentation = registry.get(component.name)
 
@@ -134,6 +136,8 @@ namespace :docs do
         if initialize_method.tags(:example).any?
           f.puts("## Examples")
           f.puts
+        else
+          components_without_examples << component
         end
 
         initialize_method.tags(:example).each do |tag|
@@ -244,6 +248,10 @@ namespace :docs do
     end
 
     puts "Markdown compiled."
+
+    if components_without_examples.any?
+      puts "The following components have no examples defined: #{components_without_examples.map(&:name).join(", ")}. Consider adding an example?"
+    end
   end
 end
 


### PR DESCRIPTION
We'd like to make sure all components have documented examples.

This change adds a log statement to the end of `docs:build` that will
list out the components missing examples.

If I remove the examples from `BoxComponent`, for example, I'll see this
statement:

```
Converting YARD documentation to Markdown files.
Markdown compiled.
The following components have no examples defined: Primer::BoxComponent. Consider adding an example?
```