### PR TITLE
Add test to limit allocations of `Primer::Classify`

### DIFF
--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -154,7 +154,8 @@ module Primer
       # Example usage:
       # extract_hash({ mt: 4, py: 2 }) => "mt-4 py-2"
       def extract_hash(styles_hash)
-        out = styles_hash.each_with_object({ classes: [], styles: [] }) do |(key, value), memo|
+        memo = { classes: [], styles: [] }
+        styles_hash.each do |key, value|
           next unless VALID_KEYS.include?(key)
 
           if value.is_a?(Array) && !RESPONSIVE_KEYS.include?(key)
@@ -245,9 +246,9 @@ module Primer
         end
 
         {
-          classes: out[:classes].join(" "),
-          styles: out[:styles].join(" ")
-        }.merge(out.except(:classes, :styles))
+          classes: memo[:classes].join(" "),
+          styles: memo[:styles].join(" ")
+        }.merge(memo.except(:classes, :styles))
       end
     end
   end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -113,10 +113,12 @@ module Primer
       def call(classes: "", style: nil, **args)
         extracted_results = extract_hash(args)
 
-        {
-          class: [validated_class_names(classes), extracted_results[:classes]].compact.join(" ").presence,
-          style: [extracted_results[:styles], style].compact.join("").presence,
-        }.merge(extracted_results.except(:classes, :styles))
+        extracted_results[:class] = [validated_class_names(classes), extracted_results[:classes]].compact.join(" ").presence
+        extracted_results[:style] = [extracted_results[:styles], style].compact.join("").presence
+        extracted_results.delete(:classes)
+        extracted_results.delete(:styles)
+
+        extracted_results
       end
 
       private

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -3,7 +3,6 @@
 module Primer
   class Classify
     MARGIN_DIRECTION_KEYS = [:mt, :ml, :mb, :mr]
-    MARGIN_DIRECTION_KEY_VALUES = [:mt, :ml, :mb, :mr].map { |k| [k, k.to_s.dasherize] }.to_h.freeze
     SPACING_KEYS = ([:m, :my, :mx, :p, :py, :px, :pt, :pl, :pb, :pr] + MARGIN_DIRECTION_KEYS).freeze
     DIRECTION_KEY = :direction
     JUSTIFY_CONTENT_KEY = :justify_content
@@ -80,7 +79,10 @@ module Primer
     }.freeze
     BORDER_KEYS = [:border, :border_color].freeze
     BORDER_MARGIN_KEYS = [:border_top, :border_bottom, :border_left, :border_right].freeze
+<<<<<<< HEAD
     BORDER_RADIUS_KEY = :border_radius
+=======
+>>>>>>> c5fb29f (38 allocations)
     TYPOGRAPHY_KEYS = [:font_size].freeze
     VALID_KEYS = (
       CONCAT_KEYS +
@@ -114,10 +116,15 @@ module Primer
       def call(classes: "", style: nil, **args)
         extracted_results = extract_hash(args)
 
-        extracted_results[:class] = [validated_class_names(classes), extracted_results[:classes]].compact.join(" ").presence
-        extracted_results[:style] = [extracted_results[:styles], style].compact.join("").presence
-        extracted_results.delete(:classes)
-        extracted_results.delete(:styles)
+        extracted_results[:class] = [
+          validated_class_names(classes),
+          extracted_results.delete(:classes)
+        ].compact.join(" ").presence
+
+        extracted_results[:style] = [
+          extracted_results.delete(:styles),
+          style
+        ].compact.join("").presence
 
         extracted_results
       end
@@ -172,7 +179,7 @@ module Primer
           end
         end
 
-        memo[:classes] = memo[:classes].join(" ") # 1 allocation
+        memo[:classes] = memo[:classes].join(" ")
 
         memo
       end
@@ -198,10 +205,12 @@ module Primer
             memo[:classes] << "bg-#{val.to_s.dasherize}"
           end
         elsif key == COLOR_KEY
-          if val[-1] !~ /\D/
+          char_code = val[-1].ord
+          # Does this string end in a character that is NOT a number?
+          if char_code < 48 || char_code > 57 # 48 is the charcode for 0; 57 is the charcode for 9
             memo[:classes] << "color-#{val.to_s.dasherize}"
           else
-            memo[:classes] << "text-#{val.to_s.dasherize}" # 2 allocations
+            memo[:classes] << "text-#{val.to_s.dasherize}"
           end
         elsif key == DISPLAY_KEY
           memo[:classes] << "d#{breakpoint}-#{val.to_s.dasherize}"
@@ -210,9 +219,9 @@ module Primer
         elsif key == WORD_BREAK_KEY
           memo[:classes] << "wb-#{val.to_s.dasherize}"
         elsif BORDER_KEYS.include?(key)
-          memo[:classes] << "border-#{val.to_s.dasherize}" # 2 allocations
+          memo[:classes] << "border-#{val.to_s.dasherize}"
         elsif BORDER_MARGIN_KEYS.include?(key)
-          memo[:classes] << "#{BORDER_MARGIN_KEY_VALUES[key]}-#{val}"
+          memo[:classes] << "#{key.to_s.dasherize}-#{val}"
         elsif key == BORDER_RADIUS_KEY
           memo[:classes] << "rounded-#{val}"
         elsif key == DIRECTION_KEY
@@ -229,10 +238,10 @@ module Primer
         elsif key == FLEX_SHRINK_KEY
           memo[:classes] << "flex-shrink-#{val}"
         elsif key == ALIGN_SELF_KEY
-          memo[:classes] << "flex-self-#{val}" # 2 allocations
+          memo[:classes] << "flex-self-#{val}"
         elsif key == WIDTH_KEY || key == HEIGHT_KEY
           if val == :fit || val == :fill
-            memo[:classes] << "#{key}-#{val}" # 3 allocations
+            memo[:classes] << "#{key}-#{val}"
           else
             memo[key] = val
           end
@@ -241,7 +250,7 @@ module Primer
         elsif TYPOGRAPHY_KEYS.include?(key)
           memo[:classes] << "f#{val.to_s.dasherize}"
         elsif MARGIN_DIRECTION_KEYS.include?(key) && val < 0
-          memo[:classes] << "#{MARGIN_DIRECTION_KEY_VALUES[key]}#{breakpoint}-n#{val.abs}"
+          memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
         elsif key == BOX_SHADOW_KEY
           if val == true
             memo[:classes] << "box-shadow"
@@ -249,9 +258,9 @@ module Primer
             memo[:classes] << "box-shadow-#{val.to_s.dasherize}"
           end
         elsif key == VISIBILITY_KEY
-          memo[:classes] << "v-#{val.to_s.dasherize}" # 2 allocations
+          memo[:classes] << "v-#{val.to_s.dasherize}"
         else
-          memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}" # 4 allocations
+          memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
         end
       end
     end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -244,10 +244,10 @@ module Primer
           end
         end
 
-        {
-          classes: memo[:classes].join(" "),
-          styles: memo[:styles].join(" ")
-        }.merge(memo.except(:classes, :styles))
+        memo[:classes] = memo[:classes].join(" ")
+        memo[:styles] = memo[:styles].join(" ")
+
+        memo
       end
     end
   end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -156,7 +156,7 @@ module Primer
       # Example usage:
       # extract_hash({ mt: 4, py: 2 }) => "mt-4 py-2"
       def extract_hash(styles_hash)
-        memo = { classes: [], styles: [] }
+        memo = { classes: [], styles: String.new }
         styles_hash.each do |key, value|
           next unless VALID_KEYS.include?(key)
 

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -173,7 +173,6 @@ module Primer
               end
             end
 
-            dasherized_val = val.to_s.dasherize
             breakpoint = BREAKPOINTS[index]
 
             if BOOLEAN_MAPPINGS.has_key?(key)
@@ -184,28 +183,28 @@ module Primer
               if val.to_s.starts_with?("#")
                 memo[:styles] << "background-color: #{val};"
               else
-                memo[:classes] << "bg-#{dasherized_val}"
+                memo[:classes] << "bg-#{val.to_s.dasherize}"
               end
             elsif key == COLOR_KEY
               if val.to_s.chars.last !~ /\D/
-                memo[:classes] << "color-#{dasherized_val}"
+                memo[:classes] << "color-#{val.to_s.dasherize}"
               else
-                memo[:classes] << "text-#{dasherized_val}"
+                memo[:classes] << "text-#{val.to_s.dasherize}"
               end
             elsif key == DISPLAY_KEY
-              memo[:classes] << "d#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "d#{breakpoint}-#{val.to_s.dasherize}"
             elsif key == VERTICAL_ALIGN_KEY
-              memo[:classes] << "v-align-#{dasherized_val}"
+              memo[:classes] << "v-align-#{val.to_s.dasherize}"
             elsif key == WORD_BREAK_KEY
-              memo[:classes] << "wb-#{dasherized_val}"
+              memo[:classes] << "wb-#{val.to_s.dasherize}"
             elsif BORDER_KEYS.include?(key)
-              memo[:classes] << "border-#{dasherized_val}"
+              memo[:classes] << "border-#{val.to_s.dasherize}"
             elsif BORDER_MARGIN_KEYS.include?(key)
               memo[:classes] << "#{key.to_s.dasherize}-#{val}"
             elsif key == BORDER_RADIUS_KEY
               memo[:classes] << "rounded-#{val}"
             elsif key == DIRECTION_KEY
-              memo[:classes] << "flex#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "flex#{breakpoint}-#{val.to_s.dasherize}"
             elsif key == JUSTIFY_CONTENT_KEY
               formatted_value = val.to_s.gsub(/(flex\_|space\_)/, "")
               memo[:classes] << "flex#{breakpoint}-justify-#{formatted_value}"
@@ -226,21 +225,21 @@ module Primer
                 memo[key] = val
               end
             elsif TEXT_KEYS.include?(key)
-              memo[:classes] << "text-#{dasherized_val}"
+              memo[:classes] << "text-#{val.to_s.dasherize}"
             elsif TYPOGRAPHY_KEYS.include?(key)
-              memo[:classes] << "f#{dasherized_val}"
+              memo[:classes] << "f#{val.to_s.dasherize}"
             elsif MARGIN_DIRECTION_KEYS.include?(key) && val < 0
               memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
             elsif key == BOX_SHADOW_KEY
               if val == true
                 memo[:classes] << "box-shadow"
               else
-                memo[:classes] << "box-shadow-#{dasherized_val}"
+                memo[:classes] << "box-shadow-#{val.to_s.dasherize}"
               end
             elsif key == VISIBILITY_KEY
-              memo[:classes] << "v-#{dasherized_val}"
+              memo[:classes] << "v-#{val.to_s.dasherize}"
             else
-              memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{dasherized_val}"
+              memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
             end
           end
         end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -188,7 +188,7 @@ module Primer
                 memo[:classes] << "bg-#{val.to_s.dasherize}"
               end
             elsif key == COLOR_KEY
-              if val.to_s.chars.last !~ /\D/
+              if val[-1] !~ /\D/ # 9 allocations
                 memo[:classes] << "color-#{val.to_s.dasherize}"
               else
                 memo[:classes] << "text-#{val.to_s.dasherize}"

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -3,6 +3,7 @@
 module Primer
   class Classify
     MARGIN_DIRECTION_KEYS = [:mt, :ml, :mb, :mr]
+    MARGIN_DIRECTION_KEY_VALUES = [:mt, :ml, :mb, :mr].map { |k| [k, k.to_s.dasherize] }.to_h.freeze
     SPACING_KEYS = ([:m, :my, :mx, :p, :py, :px, :pt, :pl, :pb, :pr] + MARGIN_DIRECTION_KEYS).freeze
     DIRECTION_KEY = :direction
     JUSTIFY_CONTENT_KEY = :justify_content
@@ -160,11 +161,9 @@ module Primer
         styles_hash.each do |key, value|
           next unless VALID_KEYS.include?(key)
 
-          if value.is_a?(Array) && !RESPONSIVE_KEYS.include?(key)
-            raise ArgumentError, "#{key} does not support responsive values"
-          end
-
           if value.is_a?(Array)
+            raise ArgumentError, "#{key} does not support responsive values" if !RESPONSIVE_KEYS.include?(key)
+
             value.each_with_index do |val, index|
               extract_value(memo, key, val, BREAKPOINTS[index])
             end
@@ -209,7 +208,6 @@ module Primer
         elsif key == VERTICAL_ALIGN_KEY
           memo[:classes] << "v-align-#{val.to_s.dasherize}"
         elsif key == WORD_BREAK_KEY
-          puts "here"
           memo[:classes] << "wb-#{val.to_s.dasherize}"
         elsif BORDER_KEYS.include?(key)
           memo[:classes] << "border-#{val.to_s.dasherize}" # 2 allocations

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -207,7 +207,7 @@ module Primer
         elsif key == COLOR_KEY
           char_code = val[-1].ord
           # Does this string end in a character that is NOT a number?
-          if char_code < 48 || char_code > 57 # 48 is the charcode for 0; 57 is the charcode for 9
+          if char_code >= 48 && char_code <= 57 # 48 is the charcode for 0; 57 is the charcode for 9
             memo[:classes] << "color-#{val.to_s.dasherize}"
           else
             memo[:classes] << "text-#{val.to_s.dasherize}"

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -188,7 +188,7 @@ module Primer
                 memo[:classes] << "bg-#{val.to_s.dasherize}"
               end
             elsif key == COLOR_KEY
-              if val[-1] !~ /\D/ # 9 allocations
+              if val[-1] !~ /\D/
                 memo[:classes] << "color-#{val.to_s.dasherize}"
               else
                 memo[:classes] << "text-#{val.to_s.dasherize}"
@@ -246,8 +246,7 @@ module Primer
           end
         end
 
-        memo[:classes] = memo[:classes].join(" ")
-        memo[:styles] = memo[:styles].join(" ")
+        memo[:classes] = memo[:classes].join(" ") # 1 allocation
 
         memo
       end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -79,10 +79,7 @@ module Primer
     }.freeze
     BORDER_KEYS = [:border, :border_color].freeze
     BORDER_MARGIN_KEYS = [:border_top, :border_bottom, :border_left, :border_right].freeze
-<<<<<<< HEAD
     BORDER_RADIUS_KEY = :border_radius
-=======
->>>>>>> c5fb29f (38 allocations)
     TYPOGRAPHY_KEYS = [:font_size].freeze
     VALID_KEYS = (
       CONCAT_KEYS +

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 70 do
+    assert_allocations 65 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -290,7 +290,7 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_limits_allocations
-    assert_allocations 0 do
+    assert_allocations 93 do
       Primer::Classify.call(align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red }
     Primer::Classify.call(**values)
 
-    assert_allocations 82 do
+    assert_allocations 77 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 71 do
+    assert_allocations 70 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -290,7 +290,7 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_limits_allocations
-    assert_allocations 93 do
+    assert_allocations 81 do
       Primer::Classify.call(align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 41 do
+    assert_allocations 41, within: 3 do
       Primer::Classify.call(**values)
     end
   end
@@ -309,7 +309,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_nil(Primer::Classify.call(**input)[:class])
   end
 
-  def assert_allocations(count, msg = nil, &block)
+  def assert_allocations(count, within:, &block)
     GC.disable
     total_start = GC.stat[:total_allocated_objects]
     yield
@@ -318,6 +318,6 @@ class PrimerClassifyTest < Minitest::Test
 
     total = total_end - total_start
 
-    assert_equal count, total, msg
+    assert_in_delta count, total, within, "Expected between #{count - within} and #{count + within} allocations. Got #{total}"
   end
 end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -290,8 +290,12 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_limits_allocations
-    assert_allocations 81 do
-      Primer::Classify.call(align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red)
+    # Warm up allocations
+    values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red }
+    Primer::Classify.call(**values)
+
+    assert_allocations 82 do
+      Primer::Classify.call(**values)
     end
   end
 

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -306,9 +306,11 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def assert_allocations(count, msg = nil, &block)
+    GC.disable
     total_start = GC.stat[:total_allocated_objects]
     yield
     total_end = GC.stat[:total_allocated_objects]
+    GC.enable
 
     total = total_end - total_start
 

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red }
     Primer::Classify.call(**values)
 
-    assert_allocations 77 do
+    assert_allocations 71 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 41, within: 3 do
+    assert_allocations 38, within: 0 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -291,10 +291,10 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_limits_allocations
     # Warm up allocations
-    values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red }
+    values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 71 do
+    assert_allocations 77 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -291,10 +291,32 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_limits_allocations
     # Warm up allocations
-    values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
+    values = {
+      align_items: :center,
+      align_self: :center,
+      bg: :blue,
+      border: :top,
+      box_shadow: true,
+      col: 1,
+      color: :red,
+      flex: 1,
+      float: :left,
+      font_weight: :bold,
+      font_size: 1,
+      height: :fit,
+      justify_content: :flex_start,
+      m: 1,
+      p: 4,
+      position: :relative,
+      text_align: :left,
+      visibility: :hidden,
+      width: :fit,
+      underline: true,
+      vertical_align: true,
+    }
     Primer::Classify.call(**values)
 
-    assert_allocations 38, within: 4 do
+    assert_allocations 87, within: 4 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 38, within: 0 do
+    assert_allocations 38, within: 4 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 77 do
+    assert_allocations 71 do
       Primer::Classify.call(**values)
     end
   end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -289,11 +289,29 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("bg-blue text-center float-left ml-1 ",  { classes: "bg-blue text-center float-left ml-1" })
   end
 
+  def test_limits_allocations
+    assert_allocations 0 do
+      Primer::Classify.call(align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red)
+    end
+  end
+
+  private
+
   def assert_generated_class(generated_class_name, input)
     assert_equal(generated_class_name, Primer::Classify.call(**input)[:class])
   end
 
   def refute_generated_class(input)
     assert_nil(Primer::Classify.call(**input)[:class])
+  end
+
+  def assert_allocations(count, msg = nil, &block)
+    total_start = GC.stat[:total_allocated_objects]
+    yield
+    total_end = GC.stat[:total_allocated_objects]
+
+    total = total_end - total_start
+
+    assert_equal count, total, msg
   end
 end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -294,7 +294,7 @@ class PrimerClassifyTest < Minitest::Test
     values = { align_self: :center, width: :fit, p: 4, m: 1, border: :top, box_shadow: true, color: :red, visibility: :hidden}
     Primer::Classify.call(**values)
 
-    assert_allocations 65 do
+    assert_allocations 41 do
       Primer::Classify.call(**values)
     end
   end


### PR DESCRIPTION
Reduce allocations from 97 to 38 when using a "basic" `Primer::Classify#call` implementation.

closes part of https://github.com/primer/view_components/issues/155