### PR TITLE
Document the status of a given component

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,6 +124,9 @@ namespace :docs do
       File.open("docs/content/components/#{short_name.downcase}.md", "w") do |f|
         f.puts("---")
         f.puts("title: #{short_name}")
+        if component.status.present?
+          f.puts("status: #{component.status.to_s.capitalize}")
+        end
         f.puts("---")
         f.puts
         f.puts("<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->")
@@ -132,13 +135,6 @@ namespace :docs do
         f.puts
 
         initialize_method = documentation.meths.find(&:constructor?)
-
-        if component.status.present?
-          f.puts("## Status")
-          f.puts
-          f.puts(component.status.to_s.capitalize)
-          f.puts
-        end
 
         if initialize_method.tags(:example).any?
           f.puts("## Examples")

--- a/Rakefile
+++ b/Rakefile
@@ -127,9 +127,7 @@ namespace :docs do
       File.open("docs/content/components/#{short_name.downcase}.md", "w") do |f|
         f.puts("---")
         f.puts("title: #{short_name}")
-        if component.status.present?
-          f.puts("status: #{component.status.to_s.capitalize}")
-        end
+        f.puts("status: #{component.status.to_s.capitalize}")
         f.puts("---")
         f.puts
         f.puts("<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->")

--- a/Rakefile
+++ b/Rakefile
@@ -133,6 +133,13 @@ namespace :docs do
 
         initialize_method = documentation.meths.find(&:constructor?)
 
+        if component.status.present?
+          f.puts("## Status")
+          f.puts
+          f.puts(component.status.to_s.capitalize)
+          f.puts
+        end
+
         if initialize_method.tags(:example).any?
           f.puts("## Examples")
           f.puts

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -20,7 +20,7 @@ module Primer
     end
 
     def self.status
-      :released
+      Primer::Component::STATUSES[:released]
     end
   end
 end

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -20,7 +20,7 @@ module Primer
     end
 
     def self.status
-      Primer::Component::STATUSES[:released]
+      Primer::Component::STATUSES[:stable]
     end
   end
 end

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -18,5 +18,9 @@ module Primer
     def call
       render(Primer::BaseComponent.new(**@system_arguments)) { content }
     end
+
+    def self.status
+      :released
+    end
   end
 end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -8,10 +8,12 @@ module Primer
     include OcticonsHelper
     include JoinStyleArgumentsHelper
 
+    # sourced from https://primer.style/doctocat/usage/front-matter#status
     STATUSES = {
+      deprecated: :deprecated,
+      review: :review,
       experimental: :experimental,
-      beta: :beta,
-      recommended: :recommended,
+      new: :new,
       stable: :stable,
     }
 

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -8,12 +8,12 @@ module Primer
     include OcticonsHelper
     include JoinStyleArgumentsHelper
 
-    STATUSES = [
-      :experimental,
-      :beta,
-      :recommended,
-      :released,
-    ]
+    STATUSES = {
+      experimental: :experimental,
+      beta: :beta,
+      recommended: :recommended,
+      released: :released,
+    }
 
     def self.status
     end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -7,5 +7,15 @@ module Primer
     include FetchOrFallbackHelper
     include OcticonsHelper
     include JoinStyleArgumentsHelper
+
+    STATUSES = [
+      :experimental,
+      :beta,
+      :recommended,
+      :released,
+    ]
+
+    def self.status
+    end
   end
 end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -12,7 +12,7 @@ module Primer
       experimental: :experimental,
       beta: :beta,
       recommended: :recommended,
-      released: :released,
+      stable: :stable,
     }
 
     def self.status

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -16,6 +16,7 @@ module Primer
     }
 
     def self.status
+      STATUSES[:experimental]
     end
   end
 end

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -1,5 +1,6 @@
 ---
 title: Avatar
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -1,5 +1,6 @@
 ---
 title: Blankslate
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -1,5 +1,6 @@
 ---
 title: BorderBox
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -1,14 +1,11 @@
 ---
 title: Box
+status: Released
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
 A basic wrapper component for most layout related needs.
-
-## Status
-
-Released
 
 ## Examples
 

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -1,6 +1,6 @@
 ---
 title: Box
-status: Released
+status: Stable
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -6,6 +6,10 @@ title: Box
 
 A basic wrapper component for most layout related needs.
 
+## Status
+
+Released
+
 ## Examples
 
 ### Default

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -1,5 +1,6 @@
 ---
 title: Breadcrumb
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -1,5 +1,6 @@
 ---
 title: Button
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -1,5 +1,6 @@
 ---
 title: Counter
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -1,5 +1,6 @@
 ---
 title: Flash
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -1,5 +1,6 @@
 ---
 title: Label
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -1,5 +1,6 @@
 ---
 title: Layout
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -1,5 +1,6 @@
 ---
 title: Link
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -1,5 +1,6 @@
 ---
 title: Octicon
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -1,5 +1,6 @@
 ---
 title: Popover
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -1,5 +1,6 @@
 ---
 title: ProgressBar
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -1,5 +1,6 @@
 ---
 title: Spinner
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -1,5 +1,6 @@
 ---
 title: State
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -1,5 +1,6 @@
 ---
 title: Subhead
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -1,5 +1,6 @@
 ---
 title: Text
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -1,5 +1,6 @@
 ---
 title: TimelineItem
+status: Experimental
 ---
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->

--- a/test/components/box_component_test.rb
+++ b/test/components/box_component_test.rb
@@ -20,4 +20,8 @@ class PrimerBoxComponentTest < Minitest::Test
 
     assert_selector("div")
   end
+
+  def test_status
+    assert_equal Primer::BoxComponent.status, Primer::Component::STATUSES[:released]
+  end
 end

--- a/test/components/box_component_test.rb
+++ b/test/components/box_component_test.rb
@@ -22,6 +22,6 @@ class PrimerBoxComponentTest < Minitest::Test
   end
 
   def test_status
-    assert_equal Primer::BoxComponent.status, Primer::Component::STATUSES[:released]
+    assert_equal Primer::BoxComponent.status, Primer::Component::STATUSES[:stable]
   end
 end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -93,6 +93,10 @@ class PrimerComponentTest < Minitest::Test
     end
   end
 
+  def test_status_has_a_default
+    assert_equal Primer::Component.status, Primer::Component::STATUSES[:experimental]
+  end
+
   def test_components_storybook_coverage
     components = Dir[Rails.root.join("../app/components/primer/**/*.rb")].map { |path| path.gsub(".rb", "").split("/").last }
     stories = Dir[Rails.root.join("../stories/primer/**/*.rb")].map { |path| path.gsub("_stories.rb", "").split("/").last }


### PR DESCRIPTION
By default, a component has an experimental status and now we have the ability to
declare a status on each component, which gets rendered in the docs.

We can use this system to better inform consumers what they can expect
of a given component.

<img width="1136" alt="Screen Shot 2021-01-26 at 12 46 15 PM" src="https://user-images.githubusercontent.com/2181356/105896799-88eef800-5fd4-11eb-970c-9fa7b5afe437.png">
