### PR TITLE
Update CONTRIBUTING docs to point to ./script/setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 ## Submitting a pull request
 
 0. [Fork](https://github.com/primer/view_components/fork) and clone the repository
-0. Configure and install the dependencies: `bundle`
+0. Configure and install the dependencies: `./script/setup`
 0. Make sure the tests pass on your machine: `bundle exec rake`
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass

--- a/script/setup
+++ b/script/setup
@@ -5,7 +5,7 @@ bundle install --path vendor/bundle
 
 # Set up demo
 pushd demo
-bundle install
+bundle install --path vendor/bundle
 yarn install
 popd
 


### PR DESCRIPTION
This change also updates the `bundle` step in the script to vendor gems
(which are gitignored) so the user is not prompted for a password to
place the gems in the home dir.