### PR TITLE
Vendor gems for the demo app

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    primer_view_components (0.0.16)
+    primer_view_components (0.0.17)
       octicons_helper (>= 9.0.0, < 12.0.0)
       rails (>= 5.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)
@@ -105,10 +105,10 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    octicons (11.1.0)
+    octicons (11.2.0)
       nokogiri (>= 1.6.3.1)
-    octicons_helper (11.1.0)
-      octicons (= 11.1.0)
+    octicons_helper (11.2.0)
+      octicons (= 11.2.0)
       rails
     pry (0.13.1)
       coderay (~> 1.1)

--- a/demo/bin/setup
+++ b/demo/bin/setup
@@ -17,7 +17,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
-  system("bundle check") || system!("bundle install")
+  system("bundle check") || system!("bundle install --path vendor/bundle")
 
   # Install JavaScript dependencies
   # system('bin/yarn')


### PR DESCRIPTION
As a follow up to https://github.com/primer/view_components/pull/170,
this change vendors gems when the demo app gets set up.

This change allows for `./script/setup` to run without needing the user
to fill out a password if the home dir is protected. This should make
setup easier for some users.

The PVC dep also got bumped, which seems like a good thing.