### PR TITLE
Add docs and stories for DropdownMenu component

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,6 +99,7 @@ namespace :docs do
       Primer::BreadcrumbComponent,
       Primer::ButtonComponent,
       Primer::CounterComponent,
+      Primer::DropdownMenuComponent,
       Primer::FlashComponent,
       Primer::LabelComponent,
       Primer::LayoutComponent,

--- a/app/components/primer/dropdown_menu_component.rb
+++ b/app/components/primer/dropdown_menu_component.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module Primer
+  # DropdownMenus are lightweight context menus for housing navigation and actions.
+  # They're great for instances where you don't need the full power (and code)
+  # of the select menu.
   class DropdownMenuComponent < Primer::Component
     SCHEME_DEFAULT = :default
     SCHEME_MAPPINGS = {
@@ -11,6 +14,29 @@ module Primer
     DIRECTION_DEFAULT = :se
     DIRECTION_OPTIONS = [DIRECTION_DEFAULT, :sw, :w, :e, :ne, :s]
 
+    # @example 200|With a header
+    #   <div style="margin-bottom: 150px">
+    #     <%= render(Primer::DetailsComponent.new(overlay: :default, reset: true, position: :relative)) do |c| %>
+    #       <% c.slot(:summary) do %>
+    #         Dropdown
+    #       <% end %>
+    #
+    #       <% c.slot(:body) do %>
+    #         <%= render(Primer::DropdownMenuComponent.new(header: "Options")) do %>
+    #           <ul>
+    #             <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    #             <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    #             <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+    #           </ul>
+    #         <% end %>
+    #       <% end %>
+    #     <% end %>
+    #   </div>
+    #
+    # @param direction [Symbol] <%= one_of(Primer::DropdownMenuComponent::DIRECTION_OPTIONS) %>
+    # @param scheme [Symbol] Pass :dark for dark mode theming
+    # @param header [String] Optional string to display as the header
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(direction: DIRECTION_DEFAULT, scheme: SCHEME_DEFAULT, header: nil, **system_arguments)
       @header, @direction, @system_arguments = header, direction, system_arguments
 

--- a/demo/app/views/layouts/storybook_centered_preview.html.erb
+++ b/demo/app/views/layouts/storybook_centered_preview.html.erb
@@ -7,7 +7,7 @@
   </head>
 
   <body>
-    <div class="d-flex flex-justify-center">
+    <div class="d-flex flex-justify-center" style="position:relative">
       <%= yield %>
     </div>
   </body>

--- a/docs/content/components/dropdownmenu.md
+++ b/docs/content/components/dropdownmenu.md
@@ -1,0 +1,46 @@
+---
+title: DropdownMenu
+status: Experimental
+source: https://github.com/primer/view_components/tree/main/app/components/primer/dropdown_menu_component.rb
+---
+
+<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
+
+DropdownMenus are lightweight context menus for housing navigation and actions.
+They're great for instances where you don't need the full power (and code)
+of the select menu.
+
+## Examples
+
+### With a header
+
+<iframe style="width: 100%; border: 0px; height: 200px;" srcdoc="<html><head><link href='https://unpkg.com/@primer/css/dist/primer.css' rel='stylesheet'></head><body><div style='margin-bottom: 150px'>  <details class='details-overlay details-reset position-relative'>  <summary role='button' type='button' class='btn '>    Dropdown</summary>  <div>    <details-menu role='menu' class='dropdown-menu dropdown-menu-se '>    <div class='dropdown-header'>      Options    </div>          <ul>          <li><a class='dropdown-item' href='#url'>Dropdown item</a></li>          <li><a class='dropdown-item' href='#url'>Dropdown item</a></li>          <li><a class='dropdown-item' href='#url'>Dropdown item</a></li>        </ul></details-menu></div></details></div></body></html>"></iframe>
+
+```erb
+<div style="margin-bottom: 150px">
+  <%= render(Primer::DetailsComponent.new(overlay: :default, reset: true, position: :relative)) do |c| %>
+    <% c.slot(:summary) do %>
+      Dropdown
+    <% end %>
+
+    <% c.slot(:body) do %>
+      <%= render(Primer::DropdownMenuComponent.new(header: "Options")) do %>
+        <ul>
+          <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+          <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+          <li><a class="dropdown-item" href="#url">Dropdown item</a></li>
+        </ul>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>
+```
+
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `direction` | `Symbol` | `:se` | One of `:se`, `:sw`, `:w`, `:e`, `:ne`, or `:s`. |
+| `scheme` | `Symbol` | `:default` | Pass :dark for dark mode theming |
+| `header` | `String` | `nil` | Optional string to display as the header |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/stories/primer/dropdown_menu_stories.rb
+++ b/stories/primer/dropdown_menu_stories.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Primer::DropdownMenuComponentStories < ViewComponent::Storybook::Stories
+  layout "storybook_centered_preview"
+
+  story(:with_header) do
+    controls do
+      select(:direction, Primer::DropdownMenuComponent::DIRECTION_OPTIONS, Primer::DropdownMenuComponent::DIRECTION_DEFAULT)
+      select(:scheme, Primer::DropdownMenuComponent::SCHEME_MAPPINGS.keys, Primer::DropdownMenuComponent::SCHEME_DEFAULT)
+      header "Header"
+    end
+
+    content do |component|
+      "<ul><li><a class='dropdown-item'>Turkey sandwich</a></li></ul>".html_safe
+    end
+  end
+end


### PR DESCRIPTION
This change adds docs and a storybook entry for the
DropdownMenuComponent.

We really should add a `DropdownComponent` that wraps this existing
component via a slot but for now we are targeting full docs so we will
commit this as at this point.

![image](https://user-images.githubusercontent.com/2181356/106650224-e42e6680-654f-11eb-9247-5663f741f5e9.png)

![image](https://user-images.githubusercontent.com/2181356/106650246-ea244780-654f-11eb-9324-9dfcb7443b27.png)
