### PR TITLE
Add nav item for dropdown menu docs

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -22,6 +22,8 @@
       url: /components/button
     - title: Counter
       url: /components/counter
+    - title: DropdownMenu
+      url: /components/dropdownmenu
     - title: Flash
       url: /components/flash
     - title: Label


### PR DESCRIPTION
Fast follow to https://github.com/primer/view_components/pull/180.

This change adds the nav entry for the new docs page.