### PR TITLE
Add support for functional color classes to `color`:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add support for functional colors to `color` system argument.
+
+    *Jake Shorty*
+
 * Add `border_radius` system argument.
 
     *Ash Guillaume*

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -76,7 +76,7 @@ module Primer
     #
     # @param underline [Boolean] Whether text should be underlined.
     #
-    # @param color [Symbol] Text color. <%= one_of([:blue, :red, :gray_light, :gray, :gray_dark, :green, :orange, :orange_light, :purple, :pink, :white, :inherit]) %> Note: this API is subject to change as we move to functional colors.
+    # @param color [Symbol] Text color. <%= one_of([:blue, :red, :gray_light, :gray, :gray_dark, :green, :orange, :orange_light, :purple, :pink, :white, :inherit, :text_primary, :text_secondary, :text_tertiary, :text_link, :text_success, :text_warning, :text_danger, :icon_primary, :icon_secondary, :icon_tertiary, :icon_info, :icon_success, :icon_warning, :icon_danger]) %>
     # @param bg [String, Symbol] Background color. Accepts either a hex value as a String or a color name as a Symbol.
     #
     # @param box_shadow [Boolean, Symbol] Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %>

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -71,7 +71,7 @@ System arguments include most HTML attributes. For example:
 | `float` | `Symbol` | One of `:left` and `:right`. |
 | `col` | `Integer` | Number of columns. |
 | `underline` | `Boolean` | Whether text should be underlined. |
-| `color` | `Symbol` | Text color. One of `:blue`, `:red`, `:gray_light`, `:gray`, `:gray_dark`, `:green`, `:orange`, `:orange_light`, `:purple`, `:pink`, `:white`, or `:inherit`. Note: this API is subject to change as we move to functional colors. |
+| `color` | `Symbol` | Text color. One of `:blue`, `:red`, `:gray_light`, `:gray`, `:gray_dark`, `:green`, `:orange`, `:orange_light`, `:purple`, `:pink`, `:white`, `:inherit`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, or `:icon_danger`. |
 | `bg` | `String, Symbol` | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
 | `box_shadow` | `Boolean, Symbol` | Box shadow. One of `true`, `:medium`, `:large`, `:extra_large`, or `:none`. |
 | `border` | `Symbol` | One of `:left`, `:top`, `:bottom`, `:right`, `:y`, or `:x`. |

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -202,11 +202,13 @@ module Primer
         elsif key == COLOR_KEY
           char_code = val[-1].ord
           # Does this string end in a character that is NOT a number?
-          memo[:classes] << if char_code >= 48 && char_code <= 57 # 48 is the charcode for 0; 57 is the charcode for 9
-                              "color-#{val.to_s.dasherize}"
-                            else
-                              "text-#{val.to_s.dasherize}"
-                            end
+          memo[:classes] <<
+            if (char_code >= 48 && char_code <= 57) || # 48 is the charcode for 0; 57 is the charcode for 9
+               val =~ /(primary|secondary|tertiary|link|success|warning|danger|info)/
+              "color-#{val.to_s.dasherize}"
+            else
+              "text-#{val.to_s.dasherize}"
+            end
         elsif key == DISPLAY_KEY
           memo[:classes] << "d#{breakpoint}-#{val.to_s.dasherize}"
         elsif key == VERTICAL_ALIGN_KEY

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -17,6 +17,7 @@ module Primer
 
     INVALID_CLASS_NAME_PREFIXES =
       (["bg-", "color-", "text-", "d-", "v-align-", "wb-", "text-", "box-shadow-"] + CONCAT_KEYS.map { |k| "#{k}-" }).freeze
+    FUNCTIONAL_COLOR_REGEX = /(primary|secondary|tertiary|link|success|warning|danger|info)/.freeze
 
     COLOR_KEY = :color
     BG_KEY = :bg
@@ -204,7 +205,7 @@ module Primer
           # Does this string end in a character that is NOT a number?
           memo[:classes] <<
             if (char_code >= 48 && char_code <= 57) || # 48 is the charcode for 0; 57 is the charcode for 9
-               val =~ /(primary|secondary|tertiary|link|success|warning|danger|info)/
+               FUNCTIONAL_COLOR_REGEX.match?(val)
               "color-#{val.to_s.dasherize}"
             else
               "text-#{val.to_s.dasherize}"

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -134,6 +134,21 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("color-blue-5",       { color: :blue_5 })
     assert_generated_class("color-gray-9",       { color: :gray_9 })
     assert_generated_class("color-purple-3",     { color: :purple_3 })
+
+    assert_generated_class("color-text-primary",   { color: :text_primary })
+    assert_generated_class("color-text-secondary", { color: :text_secondary })
+    assert_generated_class("color-text-tertiary",  { color: :text_tertiary })
+    assert_generated_class("color-text-link",      { color: :text_link })
+    assert_generated_class("color-text-success",   { color: :text_success })
+    assert_generated_class("color-text-warning",   { color: :text_warning })
+    assert_generated_class("color-text-danger",    { color: :text_danger })
+    assert_generated_class("color-icon-primary",   { color: :icon_primary })
+    assert_generated_class("color-icon-secondary", { color: :icon_secondary })
+    assert_generated_class("color-icon-tertiary",  { color: :icon_tertiary })
+    assert_generated_class("color-icon-info",      { color: :icon_info })
+    assert_generated_class("color-icon-success",   { color: :icon_success })
+    assert_generated_class("color-icon-warning",   { color: :icon_warning })
+    assert_generated_class("color-icon-danger",    { color: :icon_danger })
   end
 
   def test_bg


### PR DESCRIPTION
Prior to this change, color values supplied to the `color:` system argument are always classified with a `text-` prefix (`color: :my_color` becoming `text-my-color`).

This breaks with new functional color classes, where in some cases, a `color-` or other prefix is desired instead. This PR adds support for functional icon and text colors, a subset from the migration mapping at https://github.com/primer/css/blob/mkt/color-modes-docs/docs/content/support/v16-migration.mdx.