### PR TITLE
Exclude Ruby 2.5 and 2.6 from using Rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
         exclude:
           - rails_version: main
             ruby_version: 2.4.x
+          - rails_version: main
+            ruby_version: 2.5.x
+          - rails_version: main
+            ruby_version: 2.6.x
           - rails_version: 6.0.0
             ruby_version: 2.4.x
     steps:


### PR DESCRIPTION
Rails main is now requiring Ruby 2.7+ which is causing Ruby 2.5 and 2.6
builds to fail.
