### PR TITLE
Cache common Primer values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,27 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
+  benchmark:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-build-bench-ruby-2.7-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Build and test with Rake
+      run: |
+        gem install bundler:1.17.3
+        bundle config path vendor/bundle
+        bundle update
+        bundle exec rake bench
+      env:
+        RAILS_VERSION: main
   test:
     needs: lint
     runs-on: ubuntu-latest
@@ -67,6 +88,7 @@ jobs:
         bundle exec rake
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}
+        COVERAGE: 1
     - name: Upload coverage results
       uses: actions/upload-artifact@master
       if: always()

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,6 @@ Style/MultipleComparison:
 
 Rails/RakeEnvironment:
   Enabled: false
+
+Style/SymbolArray:
+  Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,10 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    allocation_tracer (0.6.3)
     ansi (1.5.0)
     ast (2.4.2)
+    benchmark-ips (2.8.4)
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -235,6 +237,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  allocation_tracer (~> 0.6.3)
+  benchmark-ips (~> 2.8.4)
   bootsnap (>= 1.4.2)
   capybara (~> 3)
   listen (~> 3.0)

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,12 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+Rake::TestTask.new(:bench) do |t|
+  t.libs << "test"
+  t.test_files = FileList["test/benchmarks/**/bench_*.rb"]
+  t.verbose = true
+end
+
 YARD::Rake::YardocTask.new
 
 namespace :coverage do

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "classify/cache"
+
 module Primer
   # :nodoc:
   class Classify
@@ -166,10 +168,10 @@ module Primer
             raise ArgumentError, "#{key} does not support responsive values" unless RESPONSIVE_KEYS.include?(key)
 
             value.each_with_index do |val, index|
-              extract_value(memo, key, val, BREAKPOINTS[index])
+              Primer::Classify::Cache.read(memo, key, val, BREAKPOINTS[index]) || extract_value(memo, key, val, BREAKPOINTS[index])
             end
           else
-            extract_value(memo, key, value, BREAKPOINTS[0])
+            Primer::Classify::Cache.read(memo, key, value, BREAKPOINTS[0]) || extract_value(memo, key, value, BREAKPOINTS[0])
           end
         end
 
@@ -194,7 +196,7 @@ module Primer
             memo[:classes] << css_class
           end
         elsif key == BG_KEY
-          if val.to_s.starts_with?("#")
+          if val.to_s.start_with?("#")
             memo[:styles] << "background-color: #{val};"
           else
             memo[:classes] << "bg-#{val.to_s.dasherize}"
@@ -265,5 +267,7 @@ module Primer
         end
       end
     end
+
+    Cache.preload!
   end
 end

--- a/lib/primer/classify/cache.rb
+++ b/lib/primer/classify/cache.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Primer
+  class Classify
+    # :nodoc:
+    class Cache
+      # rubocop:disable Style/MutableConstant
+      LOOKUP = {}
+      # rubocop:enable Style/MutableConstant
+
+      class <<self
+        def read(memo, key, val, breakpoint)
+          value = LOOKUP.dig(breakpoint, key, val)
+          memo[:classes] << value if value
+        end
+
+        def clear!
+          LOOKUP.clear
+        end
+
+        def preload!
+          preload(
+            keys: Primer::Classify::MARGIN_DIRECTION_KEYS,
+            values: [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6]
+          )
+
+          preload(
+            keys: (Primer::Classify::SPACING_KEYS - Primer::Classify::MARGIN_DIRECTION_KEYS),
+            values: [0, 1, 2, 3, 4, 5, 6]
+          )
+
+          preload(
+            keys: Primer::Classify::DIRECTION_KEY,
+            values: [:row, :column]
+          )
+
+          preload(
+            keys: Primer::Classify::JUSTIFY_CONTENT_KEY,
+            values: [:flex_start, :flex_end, :center, :space_between, :space_around]
+          )
+
+          preload(
+            keys: Primer::Classify::ALIGN_ITEMS_KEY,
+            values: [:flex_start, :flex_end, :center, :baseline, :stretch]
+          )
+
+          preload(
+            keys: Primer::Classify::DISPLAY_KEY,
+            values: [:flex, :block, :inline_block, :inline_flex, :none, :table, :table_cell]
+          )
+
+          preload(
+            keys: [Primer::Classify::COLOR_KEY, Primer::Classify::BG_KEY],
+            values: [:blue, :gray_dark, :gray, :gray_light, :red, :orange, :orange_light, :yellow, :green, :purple, :white, :pink]
+          )
+
+          preload(
+            keys: Primer::Classify::VERTICAL_ALIGN_KEY,
+            values: [:baseline, :top, :middle, :bottom, :text_top, :text_bottom]
+          )
+
+          preload(
+            keys: Primer::Classify::WORD_BREAK_KEY,
+            values: [:break_all]
+          )
+
+          preload(
+            keys: :text_align,
+            values: [:left, :center, :right]
+          )
+
+          preload(
+            keys: :font_weight,
+            values: [:bold, :light, :normal]
+          )
+
+          preload(
+            keys: Primer::Classify::FLEX_KEY,
+            values: [1, :auto]
+          )
+
+          preload(
+            keys: [Primer::Classify::FLEX_GROW_KEY, Primer::Classify::FLEX_SHRINK_KEY],
+            values: [0]
+          )
+
+          preload(
+            keys: [Primer::Classify::ALIGN_SELF_KEY],
+            values: [:auto, :start, :end, :center, :baseline, :stretch]
+          )
+
+          preload(
+            keys: [Primer::Classify::WIDTH_KEY, Primer::Classify::HEIGHT_KEY],
+            values: [:fit, :fill]
+          )
+
+          preload(
+            keys: Primer::Classify::BOX_SHADOW_KEY,
+            values: [true, :medium, :large, :extra_large, :none]
+          )
+
+          preload(
+            keys: Primer::Classify::VISIBILITY_KEY,
+            values: [:hidden, :visible]
+          )
+        end
+
+        def preload(keys:, values:)
+          BREAKPOINTS.each do |breakpoint|
+            Array(keys).each do |key|
+              values.each do |value|
+                classes = { classes: [] }
+                Primer::Classify.send(:extract_value, classes, key, value, breakpoint)
+
+                LOOKUP[breakpoint] ||= {}
+                LOOKUP[breakpoint][key] ||= {}
+                LOOKUP[breakpoint][key][value] = classes[:classes].first
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -30,6 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "octicons_helper", [">= 9.0.0", "< 12.0.0"]
   spec.add_runtime_dependency     "rails", [">= 5.0.0", "< 7.0"]
   spec.add_runtime_dependency     "view_component", [">= 2.0.0", "< 3.0"]
+  spec.add_development_dependency "allocation_tracer", "~> 0.6.3"
+  spec.add_development_dependency "benchmark-ips", "~> 2.8.4"
   spec.add_development_dependency "listen", "~> 3.0"
   spec.add_development_dependency "minitest", "= 5.6.0"
   spec.add_development_dependency "pry"

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "minitest/benchmark"
+require "test_helper"
+
+class BenchClassify < Minitest::Benchmark
+  def setup
+    @values = {
+      align_items: :center,
+      align_self: :center,
+      bg: :blue,
+      border: :top,
+      box_shadow: true,
+      col: 1,
+      color: :red,
+      flex: 1,
+      float: :left,
+      font_weight: :bold,
+      font_size: 1,
+      height: :fit,
+      justify_content: :flex_start,
+      m: 1,
+      p: 4,
+      position: :relative,
+      text_align: :left,
+      visibility: :hidden,
+      width: :fit,
+      underline: true,
+      vertical_align: :baseline,
+      direction: [:row, :column],
+      display: [:flex, :block, :inline_block, nil],
+      word_break: :break_all,
+      flex_grow: 0,
+      flex_shrink: 0
+    }
+  end
+
+  def bench_allocations_without_cache
+    # Preload cache, warm up benchmark
+    Primer::Classify::Cache.clear!
+    Primer::Classify.call(**@values)
+
+    assert_allocations 114 do
+      Primer::Classify.call(**@values)
+    end
+  ensure
+    Primer::Classify::Cache.preload!
+  end
+
+  def bench_allocations_with_cache
+    Primer::Classify::Cache.preload!
+    Primer::Classify.call(**@values)
+
+    assert_allocations 40 do
+      Primer::Classify.call(**@values)
+    end
+  end
+
+  private
+
+  def assert_allocations(count)
+    GC.disable
+    total_start = GC.stat[:total_allocated_objects]
+    yield
+    total_end = GC.stat[:total_allocated_objects]
+    GC.enable
+
+    total = total_end - total_start
+
+    assert_equal count, total, "Expected between #{count} allocations, got #{total} allocations."
+  end
+end

--- a/test/primer/classify/cache_test.rb
+++ b/test/primer/classify/cache_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PrimerClassifyCacheTest < Minitest::Test
+  def test_clear_clears_the_cache
+    Primer::Classify::Cache.clear!
+
+    assert_empty Primer::Classify::Cache::LOOKUP
+  ensure
+    Primer::Classify::Cache.preload!
+  end
+end

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -299,38 +299,6 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("bg-blue text-center float-left ml-1 ", { classes: "bg-blue text-center float-left ml-1" })
   end
 
-  def test_limits_allocations
-    # Warm up allocations
-    values = {
-      align_items: :center,
-      align_self: :center,
-      bg: :blue,
-      border: :top,
-      box_shadow: true,
-      col: 1,
-      color: :red,
-      flex: 1,
-      float: :left,
-      font_weight: :bold,
-      font_size: 1,
-      height: :fit,
-      justify_content: :flex_start,
-      m: 1,
-      p: 4,
-      position: :relative,
-      text_align: :left,
-      visibility: :hidden,
-      width: :fit,
-      underline: true,
-      vertical_align: true
-    }
-    Primer::Classify.call(**values)
-
-    assert_allocations 87, within: 4 do
-      Primer::Classify.call(**values)
-    end
-  end
-
   private
 
   def assert_generated_class(generated_class_name, input)
@@ -339,17 +307,5 @@ class PrimerClassifyTest < Minitest::Test
 
   def refute_generated_class(input)
     assert_nil(Primer::Classify.call(**input)[:class])
-  end
-
-  def assert_allocations(count, within:)
-    GC.disable
-    total_start = GC.stat[:total_allocated_objects]
-    yield
-    total_end = GC.stat[:total_allocated_objects]
-    GC.enable
-
-    total = total_end - total_start
-
-    assert_in_delta count, total, within, "Expected between #{count - within} and #{count + within} allocations. Got #{total}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,9 +4,11 @@ require "pry"
 require "simplecov"
 require "simplecov-console"
 
-SimpleCov.start do
-  command_name "rails#{ENV['RAILS_VERSION']}-ruby#{ENV['RUBY_VERSION']}" if ENV["RUBY_VERSION"]
-  formatter SimpleCov::Formatter::Console
+if ENV["COVERAGE"] == "1"
+  SimpleCov.start do
+    command_name "rails#{ENV['RAILS_VERSION']}-ruby#{ENV['RUBY_VERSION']}" if ENV["RUBY_VERSION"]
+    formatter SimpleCov::Formatter::Console
+  end
 end
 
 require "bundler/setup"


### PR DESCRIPTION
* Add `Primer::Classify::Cache` class for preloading common primer classes
* Use `Primer::Classify::Cache` when available in `Primer::Classify`
* Add benchmark tests to avoid having to give imprecise counts due to
  differences in Ruby/Rails versions
* Add CI for running benchmarks against Rails main, Ruby 2.7
* Only run simplecov if `COVERAGE=1` in your environment

This takes us from 114 allocations when not cached, down to 40 allocations when cached. There's probably a lot more work that could be done here, like catching new keys that `Classify` supports and tracking that we're caching them correctly.

Co-authored with @kenyonj 