### PR TITLE
Simplify hash argument

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -116,7 +116,7 @@ module Primer
     end
 
     def call
-      content_tag(@tag, content, { **@content_tag_args.merge(@result) })
+      content_tag(@tag, content, @content_tag_args.merge(@result))
     end
 
     private


### PR DESCRIPTION
Just a quick cleanup to simplify how we pass a hash to content_tag.