### PR TITLE
Update border box example to use ERB blocks

### DIFF
--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -36,10 +36,7 @@ module Primer
     def initialize(**system_arguments)
       @system_arguments = system_arguments
       @system_arguments[:tag] = :div
-      @system_arguments[:classes] = class_names(
-        "Box",
-        system_arguments[:classes]
-      )
+      @system_arguments[:classes] = class_names("Box", system_arguments[:classes])
     end
 
     def render?

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -11,14 +11,26 @@ module Primer
     with_slot :row, collection: true, class_name: "Row"
 
     # @example 350|Header, body, rows, and footer
-    #   <%= render(Primer::BorderBoxComponent.new) do |component|
-    #     component.slot(:header) { "Header" }
-    #     component.slot(:body) { "Body" }
-    #     component.slot(:row) { "Row one" }
-    #     component.slot(:row) { "Row two" }
-    #     component.slot(:row) { "Row three" }
-    #     component.slot(:footer) { "Footer" }
-    #   end %>
+    #   <%= render(Primer::BorderBoxComponent.new) do |component| %>
+    #     <% component.slot(:header) do %>
+    #       Header
+    #     <% end %>
+    #     <% component.slot(:body) do %>
+    #       Body
+    #     <% end %>
+    #     <% component.slot(:row) do %>
+    #       Row one
+    #     <% end %>
+    #     <% component.slot(:row) do %>
+    #       Row two
+    #     <% end %>
+    #     <% component.slot(:row) do %>
+    #       Row three
+    #     <% end %>
+    #     <% component.slot(:footer) do %>
+    #       Footer
+    #     <% end %>
+    #   <% end %>
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(**system_arguments)

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -19,13 +19,12 @@ module Primer
     #       Body
     #     <% end %>
     #     <% component.slot(:row) do %>
-    #       Row one
+    #       <% if true %>
+    #         Row one
+    #       <% end %>
     #     <% end %>
     #     <% component.slot(:row) do %>
     #       Row two
-    #     <% end %>
-    #     <% component.slot(:row) do %>
-    #       Row three
     #     <% end %>
     #     <% component.slot(:footer) do %>
     #       Footer

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -15,14 +15,26 @@ BorderBox is a Box component with a border.
 <iframe style="width: 100%; border: 0px; height: 350px;" srcdoc="<html><head><link href='https://unpkg.com/@primer/css/dist/primer.css' rel='stylesheet'></head><body><div class='Box '>    <div class='Box-header '>      Header</div>    <div class='Box-body '>      Body</div>    <ul>        <li class='Box-row '>          Row one</li>        <li class='Box-row '>          Row two</li>        <li class='Box-row '>          Row three</li>    </ul>    <div class='Box-footer '>      Footer</div></div></body></html>"></iframe>
 
 ```erb
-<%= render(Primer::BorderBoxComponent.new) do |component|
-  component.slot(:header) { "Header" }
-  component.slot(:body) { "Body" }
-  component.slot(:row) { "Row one" }
-  component.slot(:row) { "Row two" }
-  component.slot(:row) { "Row three" }
-  component.slot(:footer) { "Footer" }
-end %>
+<%= render(Primer::BorderBoxComponent.new) do |component| %>
+  <% component.slot(:header) do %>
+    Header
+  <% end %>
+  <% component.slot(:body) do %>
+    Body
+  <% end %>
+  <% component.slot(:row) do %>
+    Row one
+  <% end %>
+  <% component.slot(:row) do %>
+    Row two
+  <% end %>
+  <% component.slot(:row) do %>
+    Row three
+  <% end %>
+  <% component.slot(:footer) do %>
+    Footer
+  <% end %>
+<% end %>
 ```
 
 ## Arguments

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -12,7 +12,7 @@ BorderBox is a Box component with a border.
 
 ### Header, body, rows, and footer
 
-<iframe style="width: 100%; border: 0px; height: 350px;" srcdoc="<html><head><link href='https://unpkg.com/@primer/css/dist/primer.css' rel='stylesheet'></head><body><div class='Box '>    <div class='Box-header '>      Header</div>    <div class='Box-body '>      Body</div>    <ul>        <li class='Box-row '>          Row one</li>        <li class='Box-row '>          Row two</li>        <li class='Box-row '>          Row three</li>    </ul>    <div class='Box-footer '>      Footer</div></div></body></html>"></iframe>
+<iframe style="width: 100%; border: 0px; height: 350px;" srcdoc="<html><head><link href='https://unpkg.com/@primer/css/dist/primer.css' rel='stylesheet'></head><body><div class='Box '>    <div class='Box-header '>      Header</div>    <div class='Box-body '>      Body</div>    <ul>        <li class='Box-row '>          Row one</li>        <li class='Box-row '>          Row two</li>    </ul>    <div class='Box-footer '>      Footer</div></div></body></html>"></iframe>
 
 ```erb
 <%= render(Primer::BorderBoxComponent.new) do |component| %>
@@ -23,13 +23,12 @@ BorderBox is a Box component with a border.
     Body
   <% end %>
   <% component.slot(:row) do %>
-    Row one
+    <% if true %>
+      Row one
+    <% end %>
   <% end %>
   <% component.slot(:row) do %>
     Row two
-  <% end %>
-  <% component.slot(:row) do %>
-    Row three
   <% end %>
   <% component.slot(:footer) do %>
     Footer


### PR DESCRIPTION
While the existing example here is correct, I think the suggested example is more useful to developers using this pattern, as it shows how to pass ERB to slots.