### PR TITLE
YARD extension for slots

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -239,7 +239,7 @@ namespace :docs do
             f.puts("### `#{slot_documentation.name.to_s.capitalize}`")
             f.puts
 
-            unless slot_documentation.base_docstring.blank?
+            if slot_documentation.base_docstring.present?
               f.puts(slot_documentation.base_docstring)
               f.puts
             end

--- a/app/components/primer/button_group_component.rb
+++ b/app/components/primer/button_group_component.rb
@@ -7,7 +7,7 @@ module Primer
 
     # Required list of buttons to be rendered.
     #
-    # @param kwargs [Hash] the same arguments as <%= link_to_component(Primer::ButtonComponent) %>
+    # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::ButtonComponent) %>.
     renders_many :buttons, ->(**kwargs) { Primer::ButtonComponent.new(group_item: true, **kwargs) }
 
     # @example 50|Default

--- a/app/components/primer/button_group_component.rb
+++ b/app/components/primer/button_group_component.rb
@@ -5,6 +5,9 @@ module Primer
   class ButtonGroupComponent < Primer::Component
     include ViewComponent::SlotableV2
 
+    # Required list of buttons to be rendered.
+    #
+    # @param kwargs [Hash] the same arguments as <%= link_to_component(Primer::ButtonComponent) %>
     renders_many :buttons, ->(**kwargs) { Primer::ButtonComponent.new(group_item: true, **kwargs) }
 
     # @example 50|Default

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -38,4 +38,4 @@ Required list of buttons to be rendered.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | the same arguments as [Button](/components/button) |
+| `kwargs` | `Hash` | N/A | The same arguments as [Button](/components/button). |

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -29,3 +29,13 @@ end %>
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Buttons`
+
+Required list of buttons to be rendered.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | the same arguments as [Button](/components/button) |

--- a/lib/yard/renders_many_handler.rb
+++ b/lib/yard/renders_many_handler.rb
@@ -1,0 +1,16 @@
+module YARD
+  class RendersOneHandler < YARD::Handlers::Ruby::Base
+    handles method_call(:renders_many)
+    namespace_only
+
+    process do
+      name = statement.parameters.first.jump(:tstring_content, :ident).source
+      object = YARD::CodeObjects::MethodObject.new(namespace, name)
+      register(object)
+      parse_block(statement.last, :owner => object)
+
+      object.dynamic = true
+      object[:renders_many] = true
+    end
+  end
+end

--- a/lib/yard/renders_many_handler.rb
+++ b/lib/yard/renders_many_handler.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 module YARD
-  class RendersOneHandler < YARD::Handlers::Ruby::Base
+  # YARD Handler to parse `renders_many` calls.
+  class RendersManyHandler < YARD::Handlers::Ruby::Base
     handles method_call(:renders_many)
     namespace_only
 
@@ -7,7 +10,7 @@ module YARD
       name = statement.parameters.first.jump(:tstring_content, :ident).source
       object = YARD::CodeObjects::MethodObject.new(namespace, name)
       register(object)
-      parse_block(statement.last, :owner => object)
+      parse_block(statement.last, owner: object)
 
       object.dynamic = true
       object[:renders_many] = true

--- a/lib/yard/renders_one_handler.rb
+++ b/lib/yard/renders_one_handler.rb
@@ -1,0 +1,16 @@
+module YARD
+  class RendersOneHandler < YARD::Handlers::Ruby::Base
+    handles method_call(:renders_one)
+    namespace_only
+
+    process do
+      name = statement.parameters.first.jump(:tstring_content, :ident).source
+      object = YARD::CodeObjects::MethodObject.new(namespace, name)
+      register(object)
+      parse_block(statement.last, :owner => object)
+
+      object.dynamic = true
+      object[:renders_one] = true
+    end
+  end
+end

--- a/lib/yard/renders_one_handler.rb
+++ b/lib/yard/renders_one_handler.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 module YARD
+  # YARD Handler to parse `renders_one` calls.
   class RendersOneHandler < YARD::Handlers::Ruby::Base
     handles method_call(:renders_one)
     namespace_only
@@ -7,7 +10,7 @@ module YARD
       name = statement.parameters.first.jump(:tstring_content, :ident).source
       object = YARD::CodeObjects::MethodObject.new(namespace, name)
       register(object)
-      parse_block(statement.last, :owner => object)
+      parse_block(statement.last, owner: object)
 
       object.dynamic = true
       object[:renders_one] = true


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/188

- Adds a way to document slots by creating handlers for `renders_one` and `renders_many` calls.
- Adds a method to create links between components in the doc.
- Adds documentation to `ButtonGroup#buttons` slot

![image](https://user-images.githubusercontent.com/11280312/107410735-4f89b280-6ad3-11eb-90d8-eb07301b3b5e.png)
