### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,26 +56,18 @@ jobs:
     strategy:
       matrix:
         rails_version: [5.2.3, 6.0.0, main]
-        ruby_version: [2.4.x, 2.5.x, 2.6.x, 2.7.x]
+        ruby_version: [2.5.x, 2.6.x, 2.7.x]
         exclude:
-          - rails_version: main
-            ruby_version: 2.4.x
           - rails_version: main
             ruby_version: 2.5.x
           - rails_version: main
             ruby_version: 2.6.x
-          - rails_version: 6.0.0
-            ruby_version: 2.4.x
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby
       uses: actions/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby_version }}
-    - name: Update rubygems when testing with Ruby 2.4.x
-      if: startsWith(matrix.ruby_version, '2.4')
-      run: |
-        gem update --system --no-document
     - uses: actions/cache@v2
       with:
         path: vendor/bundle

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "ViewComponents for the Primer Design System"
   spec.homepage      = "https://github.com/primer/view_components"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.


### PR DESCRIPTION
close https://github.com/primer/view_components/issues/211

2.4 is EOL at this point.