### PR TITLE
Allow CORS in demo app (Storybook)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 rails_version = (ENV["RAILS_VERSION"] || "6.1.1").to_s
 
 gem "rake", "~> 12.0"
+gem "rack-cors"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", rails_version == "main" ? { git: "https://github.com/rails/rails", ref: "main" } : rails_version
 # Use Puma as the app server

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ source "https://rubygems.org"
 gemspec
 rails_version = (ENV["RAILS_VERSION"] || "6.1.1").to_s
 
-gem "rake", "~> 12.0"
 gem "rack-cors"
+gem "rake", "~> 12.0"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", rails_version == "main" ? { git: "https://github.com/rails/rails", ref: "main" } : rails_version
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -247,6 +249,7 @@ DEPENDENCIES
   pry
   pry-rails
   puma (~> 4.3.6)
+  rack-cors
   rails (= 6.1.1)
   rake (~> 12.0)
   rubocop (= 0.82)

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 rails_version = (ENV["RAILS_VERSION"] || "6.1.1").to_s
 
 gem "rake", "~> 12.0"
+gem "rack-cors"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", rails_version == "master" ? { github: "rails/rails" } : rails_version
 # Use Puma as the app server

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -201,6 +203,7 @@ DEPENDENCIES
   primer_view_components!
   pry-rails
   puma (~> 4.3.6)
+  rack-cors
   rails (= 6.1.1)
   rake (~> 12.0)
   spring

--- a/demo/config/initializers/cors.rb
+++ b/demo/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end


### PR DESCRIPTION
This will allow us to run [Storybook Composition](https://storybook.js.org/docs/react/workflows/storybook-composition) in a separate repo, accessing our PVC stories