### PR TITLE
Include statuses.json file in build

### DIFF
--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/statuses.json"]
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency     "octicons_helper", [">= 9.0.0", "< 13.0.0"]


### PR DESCRIPTION
Follow up to https://github.com/primer/view_components/pull/214, this
change includes the statuses.json file in the gemspec so it should be
packaged with the gem when it's installed so consumers can use it if
they wish.