### PR TITLE
CI build for confirming docs are up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle update
         bundle exec rake docs:build
 
         git ls-files -m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,12 @@ jobs:
         bundle update
         bundle exec rake docs:build
 
-        git ls-files -m
-        git ls-files -m | grep docs\/content
-
         if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
           echo "There are changes in the docs/ directory. Please run `rake docs:build` and commit the diff."
           exit 1
         fi
+
+        exit 0
   coverage:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,28 @@ jobs:
       with:
         name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Generate and diff docs
+      run: |
+        gem install bundler:2.2.9
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+        bundle exec rake docs:build
+        if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
+          echo "There are changes in the docs/ directory. Please run `rake docs:build` and commit the diff."
+          exit 1
+        fi
   coverage:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake docs:build
+
+        git ls-files -m
+        git ls-files -m | grep docs\/content
+
         if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
           echo "There are changes in the docs/ directory. Please run `rake docs:build` and commit the diff."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         bundle exec rake docs:build
 
         if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
-          echo "There are changes in the docs/ directory. Please run `rake docs:build` and commit the diff."
+          echo "👋! There are changes in the docs/ directory. Please run bundle exec rake docs:build and commit the diff."
           exit 1
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
         bundle exec rake docs:build
 
         if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
+          echo "======================================================================="
           echo "👋! There are changes in the docs/ directory. Please run bundle exec rake docs:build and commit the diff."
+          echo "======================================================================="
           exit 1
         fi
 

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -51,7 +51,7 @@ Use AvatarStack to stack multiple avatars together.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. |
-| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not |
+| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not. |
 | `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -51,7 +51,7 @@ Use AvatarStack to stack multiple avatars together.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. |
-| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not. |
+| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not |
 | `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 


### PR DESCRIPTION
This change adds an action that checks that the docs/content directory is up to date. This avoids us commiting docs changes without running the docs:build step that writes out the markdown.

You can see example failure in action in https://github.com/primer/view_components/pull/243/checks?check_run_id=1923206585.

It looks like this:

![image](https://user-images.githubusercontent.com/2181356/108287191-a7fe2700-7147-11eb-940c-3f276dd0bd83.png)
