### PR TITLE
Build docs on Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,33 +87,6 @@ jobs:
       with:
         name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - name: Setup Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
-    - name: Generate and diff docs
-      run: |
-        gem install bundler:2.2.9
-        bundle config path vendor/bundle
-        bundle update
-        bundle exec rake docs:build
-
-        if [ $(git ls-files -m | grep docs\/content | wc -l) -gt 0 ] ; then
-          echo "======================================================================="
-          echo "👋! There are changes in the docs/ directory. Please run bundle exec rake docs:build and commit the diff."
-          echo "======================================================================="
-          exit 1
-        fi
-
-        exit 0
   coverage:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # TODO - change me to main
-      - st-build-docs
+      - st-build-docs-in-actions
 
 jobs:
     runs-on: ubuntu-latest
@@ -31,4 +31,4 @@ jobs:
           git config --local user.name "Actions Auto Build"
           git add -f docs static/statuses.json
           git commit -m "docs: build docs" || true
-          git push --force origin HEAD:refs/heads/main
+          git push --force origin HEAD:refs/heads/st-build-docs-in-actions

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,8 +3,7 @@ name: Docs Build
 on:
   push:
     branches:
-      # TODO - change me to main
-      - st-build-docs-in-actions
+      - main
 
 jobs:
     runs-on: ubuntu-latest
@@ -31,4 +30,4 @@ jobs:
           git config --local user.name "Actions Auto Build"
           git add -f docs static/statuses.json
           git commit -m "docs: build docs" || true
-          git push --force origin HEAD:refs/heads/st-build-docs-in-actions
+          git push --force origin HEAD:refs/heads/main

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,34 @@
+name: Docs Build
+
+on:
+  push:
+    branches:
+      # TODO - change me to main
+      - st-build-docs
+
+jobs:
+    runs-on: ubuntu-latest
+    name: Build Docs
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 2.7.x
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+    - name: Generate docs and statuses
+      run: |
+        gem install bundler:2.2.9
+        bundle config path vendor/bundle
+        bundle update
+        bundle exec rake docs:build
+        bundle exec rake statuses:dump
+      - name: Commit & Push Docs Data
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Actions Auto Build"
+          git add -f docs static/statuses.json
+          git commit -m "docs: build docs" || true
+          git push --force origin HEAD:refs/heads/main


### PR DESCRIPTION
closes https://github.com/primer/view_components/issues/247

This change adds a workflow that will build the docs and statuses.json file on each push to `main`. It will then commit and push the changes directly to main.

This means that devs no longer have to build the docs (if they don't want to) since we'll automatically keep them up to date once a PR merges.

This change also removes the previously added CI check for the docs being stale.