### PR TITLE
Early return when classify value is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix bug when empty string was passed to Classify.
+
+    *Manuel Puyol*
+
 ## 0.0.19
 
 * Add support for functional colors to `color` system argument.

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -182,7 +182,7 @@ module Primer
       end
 
       def extract_value(memo, key, val, breakpoint)
-        return if val.nil?
+        return if val.nil? || val == ""
 
         if SPACING_KEYS.include?(key)
           if MARGIN_DIRECTION_KEYS.include?(key)

--- a/test/primer/classify_test.rb
+++ b/test/primer/classify_test.rb
@@ -118,6 +118,7 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_color
+    assert_generated_class(nil,                  { color: "" })
     assert_generated_class("text-blue",          { color: :blue })
     assert_generated_class("text-red",           { color: :red })
     assert_generated_class("text-gray-light",    { color: :gray_light })


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/251