### PR TITLE
Make docs-build action work and push to the PR branch

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,10 +1,6 @@
 name: Docs Build
 
-on:
-  push:
-    branches:
-      - main
-      - srt32-patch-1
+on: [push, pull_request]
 
 jobs:
   build-docs:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -33,4 +33,4 @@ jobs:
           git config --local user.name "Actions Auto Build"
           git add -f docs static/statuses.json
           git commit -m "docs: build docs" || true
-          git push --force origin HEAD:refs/heads/main
+          git push --force origin HEAD

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -29,4 +29,4 @@ jobs:
           git config --local user.name "Actions Auto Build"
           git add -f docs static/statuses.json
           git commit -m "docs: build docs" || true
-          git push --force origin HEAD
+          git push

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,6 @@
 name: Docs Build
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build-docs:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,6 +1,10 @@
 name: Docs Build
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
+  
 
 jobs:
   build-docs:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,7 +7,7 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -6,24 +6,26 @@ on:
       - main
 
 jobs:
-    runs-on: ubuntu-latest
+  build-docs:
     name: Build Docs
-    - uses: actions/checkout@master
-    - name: Setup Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.7.x
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
-    - name: Generate docs and statuses
-      run: |
-        gem install bundler:2.2.9
-        bundle config path vendor/bundle
-        bundle update
-        bundle exec rake docs:build
-        bundle exec rake statuses:dump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Generate docs and statuses
+        run: |
+          gem install bundler:2.2.9
+          bundle config path vendor/bundle
+          bundle update
+          bundle exec rake docs:build
+          bundle exec rake statuses:dump
       - name: Commit & Push Docs Data
         run: |
           git config --local user.email "actions@github.com"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build-docs:
-    name: Build Docs
+    name: Build Docs 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build-docs:
-    name: Build Docs 
+    name: Build Docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - srt32-patch-1
 
 jobs:
   build-docs:

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -16,11 +16,11 @@ module Primer
     # @example auto|Link
     #   <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>
     #
-    # @param src [String] The source url of the avatar image
-    # @param alt [String] Passed through to alt on img tag
-    # @param size [Integer] Adds the avatar-small class if less than 24
+    # @param src [String] The source url of the avatar image.
+    # @param alt [String] Passed through to alt on img tag.
+    # @param size [Integer] Adds the avatar-small class if less than 24.
     # @param square [Boolean] Used to create a square avatar.
-    # @param href [String] The URL to link to. If used, component will be wrapped by an `<a>` tag
+    # @param href [String] The URL to link to. If used, component will be wrapped by an `<a>` tag.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(src:, alt:, size: 20, square: false, href: nil, **system_arguments)
       @href = href

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -40,9 +40,9 @@ for organizations or any other non-human avatars.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `src` | `String` | N/A | The source url of the avatar image |
-| `alt` | `String` | N/A | Passed through to alt on img tag |
-| `size` | `Integer` | `20` | Adds the avatar-small class if less than 24 |
+| `src` | `String` | N/A | The source url of the avatar image. |
+| `alt` | `String` | N/A | Passed through to alt on img tag. |
+| `size` | `Integer` | `20` | Adds the avatar-small class if less than 24. |
 | `square` | `Boolean` | `false` | Used to create a square avatar. |
-| `href` | `String` | `nil` | The URL to link to. If used, component will be wrapped by an `<a>` tag |
+| `href` | `String` | `nil` | The URL to link to. If used, component will be wrapped by an `<a>` tag. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |


### PR DESCRIPTION
Follow up to https://github.com/primer/view_components/pull/252

The previous attempt was broken.  To avoid branch protection rule errors on main, now we commit the changes to the current PR branch (on push). We can choose to make this build required once we're happy with it so devs can't forget to commit the docs and also can't write broken docs.

