### PR TITLE
Blankslate SlotsV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* **Breaking change**: Upgrade `BlankslateComponent` to use SlotsV2.
+
+    *Manuel Puyol*
+
 ## 0.0.20
 
 * Fix bug when empty string was passed to Classify.

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,6 +1,6 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if spinner.present? %>
-    <%= render spinner.component %>
+    <%= spinner %>
   <% elsif @icon.present? %>
     <%= render(Primer::OcticonComponent.new(
       icon: @icon,

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -8,10 +8,10 @@ module Primer
     # Optional Spinner.
     #
     # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::SpinnerComponent) %>.
-    renders_one :spinner, ->(**system_arguments) do
+    renders_one :spinner, lambda { |**system_arguments|
       system_arguments[:mb] ||= 3
       Primer::SpinnerComponent.new(**system_arguments)
-    end
+    }
 
     #
     # @example auto|Basic

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -3,9 +3,15 @@
 module Primer
   # Use Primer::BlankslateComponent when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
   class BlankslateComponent < Primer::Component
-    include ViewComponent::Slotable
+    include ViewComponent::SlotableV2
 
-    with_slot :spinner, class_name: "Spinner"
+    # Optional Spinner.
+    #
+    # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::SpinnerComponent) %>.
+    renders_one :spinner, ->(**system_arguments) do
+      system_arguments[:mb] ||= 3
+      Primer::SpinnerComponent.new(**system_arguments)
+    end
 
     #
     # @example auto|Basic
@@ -26,7 +32,7 @@ module Primer
     #     title: "Title",
     #     description: "Description",
     #   ) do |component| %>
-    #     <% component.slot(:spinner, size: :large) %>
+    #     <% component.spinner(size: :large) %>
     #   <% end %>
     #
     # @example auto|Custom content|Pass custom content as a block in place of `description`.
@@ -123,20 +129,6 @@ module Primer
       @button_classes = button_classes
       @link_text = link_text
       @link_url = link_url
-    end
-
-    # :nodoc:
-    class Spinner < Primer::Slot
-      # @param size [Symbol] <%= one_of(Primer::SpinnerComponent::SIZE_MAPPINGS) %>
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**system_arguments)
-        @system_arguments = system_arguments
-        @system_arguments[:mb] ||= 3
-      end
-
-      def component
-        Primer::SpinnerComponent.new(**@system_arguments)
-      end
     end
   end
 end

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -46,7 +46,7 @@ Add a [SpinnerComponent](https://primer.style/view-components/components/spinner
   title: "Title",
   description: "Description",
 ) do |component| %>
-  <% component.slot(:spinner, size: :large) %>
+  <% component.spinner(size: :large) %>
 <% end %>
 ```
 
@@ -134,9 +134,12 @@ There are a few variations of how the Blankslate appears: `narrow` adds a maximu
 | `large` | `Boolean` | `false` | Increases the font size. |
 | `spacious` | `Boolean` | `false` | Adds extra padding. |
 
-### `spinner` slot
+## Slots
+
+### `Spinner`
+
+Optional Spinner.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `size` | `Symbol` | N/A | One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`). |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+| `kwargs` | `Hash` | N/A | The same arguments as [Spinner](/components/spinner). |

--- a/stories/primer/blankslate_component_stories.rb
+++ b/stories/primer/blankslate_component_stories.rb
@@ -26,7 +26,7 @@ class Primer::BlankslateComponentStories < ViewComponent::Storybook::Stories
     end
 
     content do |component|
-      component.slot(:spinner)
+      component.spinner
     end
   end
 

--- a/stories/primer/blankslate_component_stories.rb
+++ b/stories/primer/blankslate_component_stories.rb
@@ -25,8 +25,8 @@ class Primer::BlankslateComponentStories < ViewComponent::Storybook::Stories
       description "We’re currently mirroring this repository. It should take anywhere from a few minutes to a couple of hours depending on the size of the repository."
     end
 
-    content do |component|
-      component.spinner
+    content do |c|
+      c.spinner(size: :large)
     end
   end
 

--- a/test/components/blankslate_component_test.rb
+++ b/test/components/blankslate_component_test.rb
@@ -29,7 +29,7 @@ class BlankslateComponentTest < Minitest::Test
 
   def test_renders_a_blankslate_component_with_a_spinner_component
     render_inline(Primer::BlankslateComponent.new(title: "Title")) do |component|
-      component.slot(:spinner, test_selector: "blankslate-spinner")
+      component.spinner(test_selector: "blankslate-spinner")
     end
 
     assert_selector(".blankslate [data-test-selector='blankslate-spinner']")


### PR DESCRIPTION
This PR updates Blankslate to use SlotsV2

Before:
```erb
<%= render Primer::BlankslateComponent.new(title: "Title", description: "Description") do |component| %>
  <% component.slot(:spinner, size: :large) %>
<% end %>
```

now

```erb
<%= render Primer::BlankslateComponent.new(title: "Title", description: "Description") do |component| %>
  <% component.spinner(size: :large) %>
<% end %>
```