### PR TITLE
Add functional functional color support to LabelComponent

### DIFF
--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -4,12 +4,12 @@ module Primer
   # Use labels to add contextual metadata to a design.
   class LabelComponent < Primer::Component
     NEW_SCHEME_MAPPINGS = {
-      primary: "Label--primary",
-      secondary: "Label--secondary",
-      info: "Label--info",
-      success: "Label--success",
-      warning: "Label--warning",
-      danger: "Label--danger"
+      primary: "Label--gray-darker",
+      secondary: "Label--gray",
+      info: "Label--blue",
+      success: "Label--green",
+      warning: "Label--yellow",
+      danger: "Label--red"
     }.freeze
 
     DEPRECATED_SCHEME_MAPPINGS = {

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -43,7 +43,7 @@ Component for rendering the status of an item.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `title` | `String` | N/A | `title` HTML attribute. |
-| `color` | `Symbol` | `:default` | Background color. One of `:default`, `:green`, `:red`, or `:purple`. |
+| `color` | `Symbol` | `:default` | Background color. One of `:open`, `:closed`, `:merged`, `:default`, `:green`, `:red`, or `:purple`. |
 | `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span`, `:div`, or `:a`. |
 | `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -43,7 +43,7 @@ Component for rendering the status of an item.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `title` | `String` | N/A | `title` HTML attribute. |
-| `color` | `Symbol` | `:default` | Background color. One of `:open`, `:closed`, `:merged`, `:default`, `:green`, `:red`, or `:purple`. |
+| `color` | `Symbol` | `:default` | Background color. One of `:default`, `:green`, `:red`, or `:purple`. |
 | `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span`, `:div`, or `:a`. |
 | `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/test/components/label_component_test.rb
+++ b/test/components/label_component_test.rb
@@ -20,7 +20,7 @@ class PrimerLabelComponentTest < Minitest::Test
   def test_supports_functional_schemes
     render_inline(Primer::LabelComponent.new(title: "foo", scheme: :danger)) { "private" }
 
-    assert_selector(".Label--danger")
+    assert_selector(".Label--red")
   end
 
   def test_falls_back_when_scheme_isn_t_valid


### PR DESCRIPTION
The color mapping is pulled from https://github.com/primer/css/blob/mkt/color-modes-docs/docs/content/support/v16-migration.mdx#labels

supports https://github.com/primer/view_components/issues/231

This change updates the internal CSS we use to use the existing classes
while full functional color support is implemented in Primer CSS.