### PR TITLE
Do not build as many combinations of Ruby and Rails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,14 @@ jobs:
         rails_version: [5.2.3, 6.1.1, main]
         ruby_version: [2.5.x, 2.6.x, 2.7.x]
         exclude:
+          - rails_version: 5.2.3
+            ruby_version: 2.6.x
+          - rails_version: 5.2.3
+            ruby_version: 2.7.x
+          - rails_version: 6.1.1
+            ruby_version: 2.5.x
+          - rails_version: 6.1.1
+            ruby_version: 2.7.x
           - rails_version: main
             ruby_version: 2.5.x
           - rails_version: main


### PR DESCRIPTION
### What

Change our CI configuration to reduce the number of builds, limiting us to a single build per Ruby and Rails version.

### Why

Unlike ViewComponent, where we copied this configuration from, we don't have any Rails/Ruby version-specific code. Thus, testing against as many permutations as we were feels unnecessary, and can lead to build queuing when we're all working on the repo at the same time 😄 