### PR TITLE
Reduce time spent in Primer::BaseComponent test selector

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -112,7 +112,7 @@ module Primer
       @result = Primer::Classify.call(**system_arguments.merge(classes: classes))
 
       # Filter out Primer keys so they don't get assigned as HTML attributes
-      @content_tag_args = add_test_selector(system_arguments).except(*Primer::Classify::VALID_KEYS)
+      @content_tag_args = add_test_selector(system_arguments).except(*Primer::Classify::VALID_KEYS + [TEST_SELECTOR_TAG])
     end
 
     def call
@@ -127,7 +127,7 @@ module Primer
         args[:data][TEST_SELECTOR_TAG] = args[TEST_SELECTOR_TAG]
       end
 
-      args.except(TEST_SELECTOR_TAG)
+      args
     end
   end
 end

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -116,7 +116,7 @@ module Primer
     end
 
     def call
-      content_tag(@tag, content, @content_tag_args.merge(@result))
+      content_tag(@tag, content, @content_tag_args.merge!(@result))
     end
 
     private

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -57,7 +57,7 @@ class BenchClassify < Minitest::Benchmark
   end
 
   def bench_allocations_for_base_component
-    assert_allocations 103 do
+    assert_allocations 100 do
       component = Primer::BaseComponent.new(tag: :div, classes: @values)
 
       component.call

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -56,6 +56,14 @@ class BenchClassify < Minitest::Benchmark
     end
   end
 
+  def bench_allocations_for_base_component
+    assert_allocations 103 do
+      component = Primer::BaseComponent.new(tag: :div, classes: @values)
+
+      component.call
+    end
+  end
+
   private
 
   def assert_allocations(count)

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -57,7 +57,7 @@ class BenchClassify < Minitest::Benchmark
   end
 
   def bench_allocations_for_base_component
-    assert_allocations 100 do
+    assert_allocations 98 do
       component = Primer::BaseComponent.new(tag: :div, classes: @values)
 
       component.call


### PR DESCRIPTION
When we initialize `Primer::BaseComponent`, we are calling `except` on the
args hash twice. Once is to remove a test selector and the other is to
remove classify related keys.

This change experiments with calling except only once. We allocate a new
array to generate the list to exclude but should allocate only one
additional hash due to calling except once instead of twice. We will allocate the same number of objects (we are trading a hash for an array) but we should spend less time processing the hash since we'll only call `except` on it once.

We also save an allocation by `s/merge/merge!` when we pass the params to `content_tag`.