### PR TITLE
Fix description for mt

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -41,7 +41,7 @@ module Primer
     # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
     #
     # @param m [Integer] Margin. <%= one_of((-6..6).to_a) %>
-    # @param mt [Integer] Margin left. <%= one_of((-6..6).to_a) %>
+    # @param mt [Integer] Margin top. <%= one_of((-6..6).to_a) %>
     # @param mr [Integer] Margin right. <%= one_of((-6..6).to_a) %>
     # @param mb [Integer] Margin bottom. <%= one_of((-6..6).to_a) %>
     # @param ml [Integer] Margin left. <%= one_of((-6..6).to_a) %>

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -46,7 +46,7 @@ System arguments include most HTML attributes. For example:
 | :- | :- | :- |
 | `test_selector` | `String` | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
 | `m` | `Integer` | Margin. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mt` | `Integer` | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mt` | `Integer` | Margin top. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mr` | `Integer` | Margin right. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mb` | `Integer` | Margin bottom. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `ml` | `Integer` | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |


### PR DESCRIPTION
`mt` describes margin top – instead of margin left.