### PR TITLE
Promote SubheadComponent to Slots V2

### DIFF
--- a/app/components/primer/subhead_component.html.erb
+++ b/app/components/primer/subhead_component.html.erb
@@ -1,17 +1,5 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <% if heading.present? %>
-    <%= render Primer::BaseComponent.new(**heading.system_arguments) do %>
-      <%= heading.content %>
-    <% end %>
-  <% end %>
-  <% if actions.present? %>
-    <%= render Primer::BaseComponent.new(**actions.system_arguments) do %>
-      <%= actions.content %>
-    <% end %>
-  <% end %>
-  <% if description.present? %>
-    <%= render Primer::BaseComponent.new(**description.system_arguments) do %>
-      <%= description.content %>
-    <% end %>
-  <% end %>
+  <%= heading %>
+  <%= actions %>
+  <%= description %>
 <% end %>

--- a/app/components/primer/subhead_component.rb
+++ b/app/components/primer/subhead_component.rb
@@ -3,41 +3,67 @@
 module Primer
   # Use the Subhead component for page headings.
   class SubheadComponent < Primer::Component
-    include ViewComponent::Slotable
+    include ViewComponent::SlotableV2
 
-    with_slot :heading, class_name: "Heading"
-    with_slot :actions, class_name: "Actions"
-    with_slot :description, class_name: "Description"
+    # @param danger [Boolean] Whether to style the heading as dangerous.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    renders_one :heading, lambda { |danger: false, **system_arguments|
+      system_arguments[:tag] ||= :div
+      system_arguments[:classes] = class_names(
+        system_arguments[:classes],
+        "Subhead-heading",
+        "Subhead-heading--danger": danger
+      )
+
+
+      Primer::BaseComponent.new(**system_arguments)
+    }
+
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    renders_one :actions, lambda { |**system_arguments|
+      system_arguments[:tag] = :div
+      system_arguments[:classes] = class_names(system_arguments[:classes], "Subhead-actions")
+
+      Primer::BaseComponent.new(**system_arguments)
+    }
+
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    renders_one :description, lambda { |**system_arguments|
+      system_arguments[:tag] = :div
+      system_arguments[:classes] = class_names(system_arguments[:classes], "Subhead-description")
+
+      Primer::BaseComponent.new(**system_arguments)
+    }
 
     # @example Default
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.slot(:heading) do %>
+    #     <% component.heading do %>
     #       My Heading
     #     <% end %>
-    #     <% component.slot(:description) do %>
+    #     <% component.description do %>
     #       My Description
     #     <% end %>
     #   <% end %>
     #
     # @example Without border
     #   <%= render(Primer::SubheadComponent.new(hide_border: true)) do |component| %>
-    #     <% component.slot(:heading) do %>
+    #     <% component.heading do %>
     #       My Heading
     #     <% end %>
-    #     <% component.slot(:description) do %>
+    #     <% component.description do %>
     #       My Description
     #     <% end %>
     #   <% end %>
     #
     # @example With actions
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.slot(:heading) do %>
+    #     <% component.heading do %>
     #       My Heading
     #     <% end %>
-    #     <% component.slot(:description) do %>
+    #     <% component.description do %>
     #       My Description
     #     <% end %>
-    #     <% component.slot(:actions) do %>
+    #     <% component.actions do %>
     #       <%= render(
     #         Primer::ButtonComponent.new(
     #           tag: :a, href: "http://www.google.com", button_type: :danger
@@ -65,53 +91,6 @@ module Primer
 
     def render?
       heading.present?
-    end
-
-    # :nodoc:
-    class Heading < ViewComponent::Slot
-      include ClassNameHelper
-
-      attr_reader :system_arguments
-
-      # @param danger [Boolean] Whether to style the heading as dangerous.
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(danger: false, **system_arguments)
-        @system_arguments = system_arguments
-        @system_arguments[:tag] ||= :div
-        @system_arguments[:classes] = class_names(
-          @system_arguments[:classes],
-          "Subhead-heading",
-          "Subhead-heading--danger": danger
-        )
-      end
-    end
-
-    # :nodoc:
-    class Actions < ViewComponent::Slot
-      include ClassNameHelper
-
-      attr_reader :system_arguments
-
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**system_arguments)
-        @system_arguments = system_arguments
-        @system_arguments[:tag] = :div
-        @system_arguments[:classes] = class_names(@system_arguments[:classes], "Subhead-actions")
-      end
-    end
-
-    # :nodoc:
-    class Description < ViewComponent::Slot
-      include ClassNameHelper
-
-      attr_reader :system_arguments
-
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(**system_arguments)
-        @system_arguments = system_arguments
-        @system_arguments[:tag] = :div
-        @system_arguments[:classes] = class_names(@system_arguments[:classes], "Subhead-description")
-      end
     end
   end
 end

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -15,14 +15,14 @@ Use the Subhead component for page headings.
 
 ### Default
 
-<Example src="<div class='Subhead hx_Subhead--responsive '>    <div class='Subhead-heading '>      My Heading</div>    <div class='Subhead-description '>      My Description</div></div>" />
+<Example src="<div class='Subhead hx_Subhead--responsive '>  <div class='Subhead-heading '>    My Heading</div>    <div class='Subhead-description '>    My Description</div></div>" />
 
 ```erb
 <%= render(Primer::SubheadComponent.new) do |component| %>
-  <% component.slot(:heading) do %>
+  <% component.heading do %>
     My Heading
   <% end %>
-  <% component.slot(:description) do %>
+  <% component.description do %>
     My Description
   <% end %>
 <% end %>
@@ -30,14 +30,14 @@ Use the Subhead component for page headings.
 
 ### Without border
 
-<Example src="<div class='Subhead hx_Subhead--responsive border-bottom-0 mb-0'>    <div class='Subhead-heading '>      My Heading</div>    <div class='Subhead-description '>      My Description</div></div>" />
+<Example src="<div class='Subhead hx_Subhead--responsive border-bottom-0 mb-0'>  <div class='Subhead-heading '>    My Heading</div>    <div class='Subhead-description '>    My Description</div></div>" />
 
 ```erb
 <%= render(Primer::SubheadComponent.new(hide_border: true)) do |component| %>
-  <% component.slot(:heading) do %>
+  <% component.heading do %>
     My Heading
   <% end %>
-  <% component.slot(:description) do %>
+  <% component.description do %>
     My Description
   <% end %>
 <% end %>
@@ -45,17 +45,17 @@ Use the Subhead component for page headings.
 
 ### With actions
 
-<Example src="<div class='Subhead hx_Subhead--responsive '>    <div class='Subhead-heading '>      My Heading</div>    <div class='Subhead-actions '>      <a href='http://www.google.com' role='button' class='btn btn-danger '>Action</a></div>    <div class='Subhead-description '>      My Description</div></div>" />
+<Example src="<div class='Subhead hx_Subhead--responsive '>  <div class='Subhead-heading '>    My Heading</div>  <div class='Subhead-actions '>    <a href='http://www.google.com' role='button' class='btn btn-danger '>Action</a></div>  <div class='Subhead-description '>    My Description</div></div>" />
 
 ```erb
 <%= render(Primer::SubheadComponent.new) do |component| %>
-  <% component.slot(:heading) do %>
+  <% component.heading do %>
     My Heading
   <% end %>
-  <% component.slot(:description) do %>
+  <% component.description do %>
     My Description
   <% end %>
-  <% component.slot(:actions) do %>
+  <% component.actions do %>
     <%= render(
       Primer::ButtonComponent.new(
         tag: :a, href: "http://www.google.com", button_type: :danger
@@ -73,20 +73,28 @@ Use the Subhead component for page headings.
 | `hide_border` | `Boolean` | `false` | Whether to hide the border under the heading. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
-### `heading` slot
+## Slots
+
+### `Heading`
+
+
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `danger` | `Boolean` | `false` | Whether to style the heading as dangerous. |
+| `danger` | `Boolean` | N/A | Whether to style the heading as dangerous. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
-### `actions` slot
+### `Actions`
+
+
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
-### `description` slot
+### `Description`
+
+
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -46,7 +46,7 @@ class PrimerComponentTest < Minitest::Test
     [Primer::ProgressBarComponent, {}, proc { |component| component.slot(:item) }],
     [Primer::SpinnerComponent, {}],
     [Primer::StateComponent, { title: "Open" }],
-    [Primer::SubheadComponent, { heading: "Foo" }, proc { |component| component.slot(:heading) { "Foo" } }],
+    [Primer::SubheadComponent, { heading: "Foo" }, proc { |component| component.heading { "Foo" } }],
     [Primer::TabContainerComponent, {}, proc { "Foo" }],
     [Primer::TabNavComponent, {}, proc { |c| c.tab(title: "Foo", selected: true) }],
     [Primer::TextComponent, {}],

--- a/test/components/subhead_component_test.rb
+++ b/test/components/subhead_component_test.rb
@@ -13,7 +13,7 @@ class SubheadComponentTest < Minitest::Test
 
   def test_renders_heading
     render_inline(Primer::SubheadComponent.new) do |component|
-      component.slot(:heading, tag: :h2) { "Hello World" }
+      component.heading(tag: :h2) { "Hello World" }
     end
 
     assert_selector(".Subhead h2.Subhead-heading", text: "Hello World")
@@ -21,7 +21,7 @@ class SubheadComponentTest < Minitest::Test
 
   def test_render_dangerous_heading
     render_inline(Primer::SubheadComponent.new) do |component|
-      component.slot(:heading, danger: true) { "Hello World" }
+      component.heading(danger: true) { "Hello World" }
     end
 
     assert_selector(".Subhead .Subhead-heading--danger", text: "Hello World")
@@ -29,7 +29,7 @@ class SubheadComponentTest < Minitest::Test
 
   def test_render_without_border
     render_inline(Primer::SubheadComponent.new(hide_border: true)) do |component|
-      component.slot(:heading) { "Hello World" }
+      component.heading { "Hello World" }
     end
 
     assert_selector(".Subhead.border-bottom-0.mb-0", text: "Hello World")
@@ -37,7 +37,7 @@ class SubheadComponentTest < Minitest::Test
 
   def test_bottom_margin_can_be_overridden_when_border_is_hidden
     render_inline(Primer::SubheadComponent.new(hide_border: true, mb: 1)) do |component|
-      component.slot(:heading) { "Hello World" }
+      component.heading { "Hello World" }
     end
 
     assert_selector(".Subhead.border-bottom-0.mb-1", text: "Hello World")
@@ -45,8 +45,8 @@ class SubheadComponentTest < Minitest::Test
 
   def test_renders_actions
     render_inline(Primer::SubheadComponent.new(heading: "Hello world")) do |component|
-      component.slot(:heading) { "Hello World" }
-      component.slot(:actions) { "My Actions" }
+      component.heading { "Hello World" }
+      component.actions { "My Actions" }
     end
 
     assert_selector(".Subhead .Subhead-actions", text: "My Actions")
@@ -54,7 +54,7 @@ class SubheadComponentTest < Minitest::Test
 
   def test_handles_spacious
     render_inline(Primer::SubheadComponent.new(spacious: true)) do |component|
-      component.slot(:heading) { "Hello World" }
+      component.heading { "Hello World" }
     end
 
     assert_selector(".Subhead.Subhead--spacious .Subhead-heading", text: "Hello World")
@@ -62,8 +62,8 @@ class SubheadComponentTest < Minitest::Test
 
   def test_renders_a_description
     render_inline(Primer::SubheadComponent.new(heading: "Hello world")) do |component|
-      component.slot(:heading) { "Hello World" }
-      component.slot(:description) { "My Description" }
+      component.heading { "Hello World" }
+      component.description { "My Description" }
     end
 
     assert_selector(".Subhead .Subhead-description", text: "My Description")


### PR DESCRIPTION
Previously:

```
<%= render(Primer::SubheadComponent.new) do |component| %>
  <% component.slot(:heading) do %>
    My Heading
  <% end %>
  <% component.slot(:description) do %>
    My Description
  <% end %>
  <% component.slot(:actions) do %>
    <%= render(
      Primer::ButtonComponent.new(
        tag: :a, href: "http://www.google.com", button_type: :danger
      )
    ) { "Action" } %>
  <% end %>
<% end %>
```

And now:

```
<%= render(Primer::SubheadComponent.new) do |component| %>
  <% component.heading do %>
    My Heading
  <% end %>
  <% component.description do %>
    My Description
  <% end %>
  <% component.actions do %>
    <%= render(
      Primer::ButtonComponent.new(
        tag: :a, href: "http://www.google.com", button_type: :danger
      )
    ) { "Action" } %>
  <% end %>
<% end %>
```