### PR TITLE
Fix zeitwerk autoload integration

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - main
-  
+
 
 jobs:
   build-docs:
@@ -21,12 +21,12 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: vendor/bundle
-          key: gems-build-rails-main-ruby-2.7.x-${{ hashFiles('**/Gemfile.lock') }}
+          key: gems-build-docs-${{ hashFiles('**/Gemfile.lock') }}
       - name: Generate docs and statuses
         run: |
           gem install bundler:2.2.9
           bundle config path vendor/bundle
-          bundle update
+          bundle install --jobs 4 --retry 3
           bundle exec rake docs:build
           bundle exec rake statuses:dump
       - name: Commit & Push Docs Data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix zeitwerk autoload integration.
+
+    *Manuel Puyol*
+
 * **Breaking change**: Upgrade `ProgressBarComponent` to use Slots V2.
 
   *Simon Taranto*

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -9,7 +9,7 @@ module Primer
     include FetchOrFallbackHelper
     include OcticonsHelper
     include JoinStyleArgumentsHelper
-    include ViewHelper::DSL
+    include ViewHelper::Dsl
     include ViewHelper
 
     # sourced from https://primer.style/doctocat/usage/front-matter#status

--- a/app/lib/primer/view_helper/dsl.rb
+++ b/app/lib/primer/view_helper/dsl.rb
@@ -10,10 +10,10 @@ module Primer
     # Example:
     #
     # class MyComponent < ViewComponent::Base
-    #   include Primer::ViewHelper::DSL
+    #   include Primer::ViewHelper::Dsl
     #   view_helper :my_component
     # end
-    module DSL
+    module Dsl
       extend ActiveSupport::Concern
 
       class ViewHelperAlreadyDefined < StandardError; end

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -16,7 +16,7 @@ Bundler.require(*Rails.groups)
 
 module Demo
   class Application < Rails::Application
-    config.load_defaults 6.0
+    config.load_defaults 6.0 if Rails.version.to_i >= 6
 
     # Initialize configuration defaults for originally generated Rails version.
     config.view_component_storybook.show_stories = true

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -16,6 +16,8 @@ Bundler.require(*Rails.groups)
 
 module Demo
   class Application < Rails::Application
+    config.load_defaults 6.0
+
     # Initialize configuration defaults for originally generated Rails version.
     config.view_component_storybook.show_stories = true
     config.view_component.show_previews = true

--- a/demo/test/components/previews/primer/counter_component_preview.rb
+++ b/demo/test/components/previews/primer/counter_component_preview.rb
@@ -1,5 +1,7 @@
-class CounterComponentPreview < ViewComponent::Preview
-  def default
-    render(Primer::CounterComponent.new(count: 2))
+module Primer
+  class CounterComponentPreview < ViewComponent::Preview
+    def default
+      render(Primer::CounterComponent.new(count: 2))
+    end
   end
 end

--- a/demo/test/components/previews/primer/tab_nav_component_preview.rb
+++ b/demo/test/components/previews/primer/tab_nav_component_preview.rb
@@ -1,9 +1,11 @@
-class TabNavComponentPreview < ViewComponent::Preview
-  def default
-    render(Primer::TabNavComponent.new(with_panel: true)) do |c|
-      c.tab(selected: true, title: "Tab 1") { "Panel 1" }
-      c.tab(title: "Tab 2") { "Panel 2" }
-      c.tab(title: "Tab 3") { "Panel 3" }
+module Primer
+  class TabNavComponentPreview < ViewComponent::Preview
+    def default
+      render(Primer::TabNavComponent.new(with_panel: true)) do |c|
+        c.tab(selected: true, title: "Tab 1") { "Panel 1" }
+        c.tab(title: "Tab 2") { "Panel 2" }
+        c.tab(title: "Tab 3") { "Panel 3" }
+      end
     end
   end
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,7 +5,7 @@ require "capybara/rails"
 require "capybara/minitest"
 require "capybara/cuprite"
 
-Ferrum::Browser.new(process_timeout: 5)
+Ferrum::Browser.new(process_timeout: 10)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :cuprite, using: :chrome, screen_size: [1400, 1400]

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,6 +13,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def with_preview(preview_name)
     component_uri = self.class.name.gsub("Test", "").gsub("Integration", "").underscore
 
-    visit("/rails/view_components/#{component_uri}/#{preview_name}")
+    visit("/rails/view_components/primer/#{component_uri}/#{preview_name}")
   end
 end

--- a/test/primer/dsl/view_helper_test.rb
+++ b/test/primer/dsl/view_helper_test.rb
@@ -3,14 +3,14 @@
 require "test_helper"
 
 class TestComponent < ViewComponent::Base
-  include Primer::ViewHelper::DSL
+  include Primer::ViewHelper::Dsl
 end
 
 class OtherTestComponent < ViewComponent::Base
-  include Primer::ViewHelper::DSL
+  include Primer::ViewHelper::Dsl
 end
 
-class Primer::ViewHelper::DSLTest < Minitest::Test
+class Primer::ViewHelper::DslTest < Minitest::Test
   def test_register_view_helpers
     assert_respond_to(TestComponent, :view_helper)
 
@@ -22,7 +22,7 @@ class Primer::ViewHelper::DSLTest < Minitest::Test
   def test_raises_if_helper_already_defined
     OtherTestComponent.view_helper :test
 
-    err = assert_raises Primer::ViewHelper::DSL::ViewHelperAlreadyDefined do
+    err = assert_raises Primer::ViewHelper::Dsl::ViewHelperAlreadyDefined do
       OtherTestComponent.view_helper :test
     end
 


### PR DESCRIPTION
zeitwerk expected `app/lib/primer/view_helper/dsl.rb` to declare `Primer::ViewHelper::Dsl` instead of `Primer::ViewHelper::DSL`.

In this PR I rename the module and activate zeitwerk in the demo app to catch other errors like this one earlier