### PR TITLE
Add deprecated `orange` and `purple` schemes to `LabelComponent`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # CHANGELOG
 
 ## main
-  
+
+* Add deprecated `orange` and `purple` schemes to `LabelComponent`.
+
+    *Manuel Puyol*
+
 ## 0.0.24
 
 * Fix zeitwerk autoload integration.

--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -9,9 +9,11 @@ module Primer
       info: "Label--info",
       success: "Label--success",
       warning: "Label--warning",
-      danger: "Label--danger"
+      danger: "Label--danger",
+      # deprecated
+      orange: "Label--orange",
+      purple: "Label--purple"
     }.freeze
-
     SCHEME_OPTIONS = SCHEME_MAPPINGS.keys << nil
 
     VARIANT_MAPPINGS = {
@@ -32,6 +34,10 @@ module Primer
     # @example Variants
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
+    #
+    # @example Deprecated schemes
+    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :orange)) { "Orange" } %>
+    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :purple)) { "Purple" } %>
     #
     # @param title [String] `title` attribute for the component element.
     # @param scheme [Symbol] <%= one_of(Primer::LabelComponent::SCHEME_MAPPINGS.keys) %>

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -36,11 +36,20 @@ Use labels to add contextual metadata to a design.
 <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
 ```
 
+### Deprecated schemes
+
+<Example src="<span title='Label: Label' class='Label Label--orange '>Orange</span><span title='Label: Label' class='Label Label--purple '>Purple</span>" />
+
+```erb
+<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :orange)) { "Orange" } %>
+<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :purple)) { "Purple" } %>
+```
+
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `title` | `String` | N/A | `title` attribute for the component element. |
-| `scheme` | `Symbol` | `nil` | One of `:primary`, `:secondary`, `:info`, `:success`, `:warning`, or `:danger`. |
+| `scheme` | `Symbol` | `nil` | One of `:primary`, `:secondary`, `:info`, `:success`, `:warning`, `:danger`, `:orange`, or `:purple`. |
 | `variant` | `Symbol` | `nil` | One of `:large`, `:inline`, or `nil`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |


### PR DESCRIPTION
PrimerCSS functional colors does not cover `orange` and `purple`, so this PR brings them back until they decide what to do with it