### PR TITLE
Fix bug where DetailsComponent summary was always a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix `DetailsComponent` summary always being rendered as a `btn`.
+
+    *Manuel Puyol*
+
 * **Breaking change**: Upgrade `LayoutComponent` to use Slots V2.
 
     *Simon Taranto*

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -16,12 +16,11 @@ module Primer
     #
     # @param button [Boolean] Whether to render the Summary as a button or not.
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
-    renders_one :summary, lambda { |button = true, **system_arguments|
-      system_arguments = system_arguments
+    renders_one :summary, lambda { |button: true, **system_arguments|
       system_arguments[:tag] = :summary
       system_arguments[:role] = "button"
 
-      Primer::BaseComponent.new(**system_arguments) unless button
+      return Primer::BaseComponent.new(**system_arguments) unless button
 
       Primer::ButtonComponent.new(**system_arguments)
     }

--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -57,9 +57,23 @@ class PrimerDetailsComponentTest < Minitest::Test
     assert_selector("summary.btn")
   end
 
-  def test_falls_back_to_defaults_when_invalid_button_and_overlay_are_passed
+  def test_does_not_render_btn_if_button_false
+    render_inline(Primer::DetailsComponent.new) do |component|
+      component.summary(button: false) do
+        "Summary"
+      end
+      component.body do
+        "Body"
+      end
+    end
+
+    assert_selector("summary")
+    refute_selector(".btn")
+  end
+
+  def test_falls_back_to_defaults_when_invalid_overlay_is_passed
     without_fetch_or_fallback_raises do
-      render_inline(Primer::DetailsComponent.new(button: :foo, overlay: :bar)) do |component|
+      render_inline(Primer::DetailsComponent.new(overlay: :bar)) do |component|
         component.summary { "Summary" }
         component.body { "Body" }
       end


### PR DESCRIPTION
`button` wasn't a keyword argument and was always true without early return