### PR TITLE
Update OcticonComponent to correctly deal with test_selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix `OcticonComponent` not rendering `data-test-selector` correctly.
+
+    *Manuel Puyol*
+
 * **Breaking change**: Upgrade `LayoutComponent` to use Slots V2.
 
     *Simon Taranto*

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -37,7 +37,8 @@ module Primer
   # | `style` | `String` | Inline styles. |
   # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
   class BaseComponent < Primer::Component
-    TEST_SELECTOR_TAG = :test_selector
+    include TestSelectorHelper
+
     # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
     #
     # @param m [Integer] Margin. <%= one_of((-6..6).to_a) %>
@@ -121,17 +122,6 @@ module Primer
 
     def self.status
       Primer::Component::STATUSES[:beta]
-    end
-
-    private
-
-    def add_test_selector(args)
-      if args.key?(TEST_SELECTOR_TAG) && !Rails.env.production?
-        args[:data] ||= {}
-        args[:data][TEST_SELECTOR_TAG] = args[TEST_SELECTOR_TAG]
-      end
-
-      args.except(TEST_SELECTOR_TAG)
     end
   end
 end

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -5,7 +5,8 @@ module Primer
   class OcticonComponent < Primer::Component
     view_helper :octicon
 
-    include Primer::ClassNameHelper
+    include ClassNameHelper
+    include TestSelectorHelper
     include OcticonsHelper
 
     SIZE_DEFAULT = :small
@@ -38,7 +39,7 @@ module Primer
       # Filter out classify options to prevent them from becoming invalid html attributes.
       # Note height and width are both classify options and valid html attributes.
       octicon_helper_options = @system_arguments.slice(:height, :width)
-      @system_arguments = @system_arguments.except(*Primer::Classify::VALID_KEYS, :classes).merge(octicon_helper_options)
+      @system_arguments = add_test_selector(@system_arguments).except(*Primer::Classify::VALID_KEYS, :classes).merge(octicon_helper_options)
     end
 
     def call

--- a/app/lib/primer/test_selector_helper.rb
+++ b/app/lib/primer/test_selector_helper.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Primer
+  module TestSelectorHelper
+    TEST_SELECTOR_TAG = :test_selector
+
+    def add_test_selector(args)
+      if args.key?(TEST_SELECTOR_TAG) && !Rails.env.production?
+        args[:data] ||= {}
+        args[:data][TEST_SELECTOR_TAG] = args[TEST_SELECTOR_TAG]
+      end
+
+      args.except(TEST_SELECTOR_TAG)
+    end
+  end
+end

--- a/app/lib/primer/test_selector_helper.rb
+++ b/app/lib/primer/test_selector_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module Primer
+  # Module to allow components to deal with the `test_selector` argument.
+  # It will only add the selector if env is not Production.
+  #
+  # test_selecotr: "foo" => data-test-selector="foo"
   module TestSelectorHelper
     TEST_SELECTOR_TAG = :test_selector
 

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -6,7 +6,7 @@ class PrimerOcticonComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_octicon_by_providing_icon_as_only_argument
-    render_inline(Primer::OcticonComponent.new(icon: "star"))
+    render_inline(Primer::OcticonComponent.new(icon: :star))
 
     assert_selector(".octicon.octicon-star")
   end
@@ -18,61 +18,61 @@ class PrimerOcticonComponentTest < Minitest::Test
   end
 
   def test_renders_aria_hidden_true_by_default
-    render_inline(Primer::OcticonComponent.new(icon: "star"))
+    render_inline(Primer::OcticonComponent.new(icon: :star))
 
     assert_selector("[aria-hidden='true']")
   end
 
   def test_renders_aria_label_attribute
-    render_inline(Primer::OcticonComponent.new(icon: "star", aria: { label: "star-label" }))
+    render_inline(Primer::OcticonComponent.new(icon: :star, aria: { label: "star-label" }))
 
     assert_selector("[aria-label='star-label']")
   end
 
   def test_renders_style_argument
-    render_inline(Primer::OcticonComponent.new(icon: "star", style: "margin-left: 100px"))
+    render_inline(Primer::OcticonComponent.new(icon: :star, style: "margin-left: 100px"))
 
     assert_selector("[style='margin-left: 100px']")
   end
 
   def test_renders_default_size_small
-    render_inline(Primer::OcticonComponent.new(icon: "star"))
+    render_inline(Primer::OcticonComponent.new(icon: :star))
 
     assert_selector("[height='16']")
   end
 
   def test_renders_the_provided_size
-    render_inline(Primer::OcticonComponent.new(icon: "star", size: :large))
+    render_inline(Primer::OcticonComponent.new(icon: :star, size: :large))
 
     assert_selector("[height='64']")
   end
 
   def test_renders_small_if_invalid_size_is_passed
-    render_inline(Primer::OcticonComponent.new(icon: "star", size: :grande))
+    render_inline(Primer::OcticonComponent.new(icon: :star, size: :grande))
 
     assert_selector("[height='16']")
   end
 
   def test_renders_with_overridden_height_and_width_despite_given_a_size
-    render_inline(Primer::OcticonComponent.new(icon: "star", size: :large, height: 33, width: 47))
+    render_inline(Primer::OcticonComponent.new(icon: :star, size: :large, height: 33, width: 47))
 
     assert_selector('[height="33"][width="47"]')
   end
 
   def test_renders_classes_passed_in
-    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo"))
+    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo"))
 
     assert_selector(".foo")
   end
 
   def test_renders_classes_passed_in_along_with_primer_class
-    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", my: 4))
+    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo", my: 4))
 
     assert_selector(".foo.my-4")
   end
 
   def test_does_not_render_classify_attributes_as_html_attributes
-    render_inline(Primer::OcticonComponent.new(icon: "star", classes: "foo", display: [:none]))
+    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo", display: [:none]))
 
     refute_selector('[classes="foo"]')
     refute_selector('[display="none"]')
@@ -80,5 +80,12 @@ class PrimerOcticonComponentTest < Minitest::Test
 
   def test_status
     assert_component_state(Primer::OcticonComponent, :beta)
+  end
+
+  def test_renders_test_selector
+    render_inline(Primer::OcticonComponent.new(icon: :star, test_selector: "bar"))
+
+    refute_selector("[test_selector='bar']")
+    assert_selector("[data-test-selector='bar']")
   end
 end


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/321

Extracts `TestSelectorHelper` to be used by `Octicon` and `Base`