### PR TITLE
Fix deprecated colors in the docs

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/head.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/head.js
@@ -17,7 +17,7 @@ function Head(props) {
       <meta property="og:description" content={description} />
       <meta property="og:image" content={siteMetadata.imageUrl} />
       <meta property="twitter:card" content="summary_large_image" />
-      <link href="https://unpkg.com/@primer/css-next@canary/dist/primer.css" rel="stylesheet" />
+      <link href="https://unpkg.com/@primer/css-next@0.0.0-7e7b125/dist/primer.css" rel="stylesheet" />
     </Helmet>
   )
 }


### PR DESCRIPTION
In https://github.com/primer/css/pull/1235 all the deprecated colors got removed to prepare for a Primer CSS `16.0.0` release. To make sure that the docs for Primer ViewComponents still look ok, this PR changes Primer CSS to a pinned version (that still includes the deprecated colors).

Before | After
--- | ---
![Screen Shot 2021-03-08 at 15 57 40](https://user-images.githubusercontent.com/378023/110286805-dc6b5180-8028-11eb-8aa9-418072e94216.png) | ![Screen Shot 2021-03-08 at 15 58 18](https://user-images.githubusercontent.com/378023/110286809-dd9c7e80-8028-11eb-98f7-38d16be18b70.png)

Example: [Deprecated Labels](https://primer.style/view-components/components/label#deprecated-schemes)

### Alternative

Some of the deprecated classes (like `.Label--orange`) will still [exist on dotcom](https://github.com/github/github/pull/172699) until we find a good replacement. So an alternative to this PR could also be to keep `@primer/css-next@canary` but remove the mentions of the deprecated colors. For example remove this part:

https://github.com/primer/view_components/blob/3bc834471a005819e85b22442449e36e71d0ab0b/app/components/primer/label_component.rb#L40-L42

So it can still be used on dotcom (for now) but it's undocumented.