### PR TITLE
Remove deprecated label examples from the docs

### DIFF
--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -37,10 +37,6 @@ module Primer
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
     #
-    # @example Deprecated schemes
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :orange)) { "Orange" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :purple)) { "Purple" } %>
-    #
     # @param title [String] `title` attribute for the component element.
     # @param scheme [Symbol] <%= one_of(Primer::LabelComponent::SCHEME_MAPPINGS.keys) %>
     # @param variant [Symbol] <%= one_of(Primer::LabelComponent::VARIANT_OPTIONS) %>

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -36,15 +36,6 @@ Use labels to add contextual metadata to a design.
 <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
 ```
 
-### Deprecated schemes
-
-<Example src="<span title='Label: Label' class='Label Label--orange '>Orange</span><span title='Label: Label' class='Label Label--purple '>Purple</span>" />
-
-```erb
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :orange)) { "Orange" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :purple)) { "Purple" } %>
-```
-
 ## Arguments
 
 | Name | Type | Default | Description |


### PR DESCRIPTION
This is a follow-up to #336. It removes the [deprecated label examples](https://primer.style/view-components/components/label#deprecated-schemes) that is currently broken.

![Screen Shot 2021-03-08 at 15 57 40](https://user-images.githubusercontent.com/378023/110286805-dc6b5180-8028-11eb-8aa9-418072e94216.png)

Ref https://github.com/primer/view_components/pull/336#issuecomment-793329057