### PR TITLE
Apply Link--muted instead of muted-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Update `LinkComponent` to use `Link--muted` instead of `muted-link`.
+
+    *Manuel Puyol*
+
 * Promote `DetailsComponent`, `TextComponent`, `TimelineItemComponent`, and
   `PopoverComponent` to beta status.
 

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -20,7 +20,7 @@ module Primer
       @system_arguments[:href] = href
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
-        "muted-link" => fetch_or_fallback_boolean(muted, false)
+        "Link--muted" => fetch_or_fallback_boolean(muted, false)
       )
     end
 

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -23,7 +23,7 @@ Use links for moving from one page to another. The Link component styles anchor 
 
 ### Muted
 
-<Example src="<a href='http://www.google.com' class='muted-link '>Link</a>" />
+<Example src="<a href='http://www.google.com' class='Link--muted '>Link</a>" />
 
 ```erb
 <%= render(Primer::LinkComponent.new(href: "http://www.google.com", muted: true)) { "Link" } %>

--- a/test/components/link_component_test.rb
+++ b/test/components/link_component_test.rb
@@ -9,7 +9,7 @@ class PrimerLinkComponentTest < Minitest::Test
     render_inline(Primer::LinkComponent.new(href: "http://joe-jonas-shirtless.com")) { "content" }
 
     assert_text("content")
-    refute_selector(".muted-link")
+    refute_selector(".Link--muted")
   end
 
   def test_renders_as_a_link
@@ -21,7 +21,7 @@ class PrimerLinkComponentTest < Minitest::Test
   def test_renders_primer_classes
     render_inline(Primer::LinkComponent.new(href: "http://google.com", mr: 3, muted: true)) { "content" }
 
-    assert_selector(".mr-3.muted-link")
+    assert_selector(".mr-3.Link--muted")
   end
 
   def test_defaults_muted_to_false
@@ -29,13 +29,13 @@ class PrimerLinkComponentTest < Minitest::Test
       render_inline(Primer::LinkComponent.new(href: "http://google.com", muted: nil)) { "content" }
     end
 
-    refute_selector(".muted-link")
+    refute_selector(".Link--muted")
   end
 
   def test_renders_muted_and_custom_css_class
     render_inline(Primer::LinkComponent.new(href: "http://google.com", classes: "foo", muted: true)) { "content" }
 
-    assert_selector(".foo.muted-link")
+    assert_selector(".foo.Link--muted")
   end
 
   def test_status


### PR DESCRIPTION
PrimerCSS v16 removed `muted-link` in favor of `Link--muted`