### PR TITLE
Update `bg:` to use functional colors

### DIFF
--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -9,7 +9,7 @@ module Primer
     #   <%= render(Primer::BoxComponent.new) { "Your content here" } %>
     #
     # @example Color and padding
-    #   <%= render(Primer::BoxComponent.new(bg: :gray, p: 3)) { "Hello world" } %>
+    #   <%= render(Primer::BoxComponent.new(bg: :tertiary, p: 3)) { "Hello world" } %>
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(**system_arguments)

--- a/app/components/primer/flex_component.rb
+++ b/app/components/primer/flex_component.rb
@@ -36,31 +36,31 @@ module Primer
     ALLOWED_DIRECTIONS = [DEFAULT_DIRECTION, :column, :column_reverse, :row, :row_reverse].freeze
 
     # @example Default
-    #   <%= render(Primer::FlexComponent.new(bg: :gray)) do %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+    #   <%= render(Primer::FlexComponent.new(bg: :tertiary)) do %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
     #   <% end %>
     #
     # @example Justify center
-    #   <%= render(Primer::FlexComponent.new(justify_content: :center, bg: :gray)) do %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+    #   <%= render(Primer::FlexComponent.new(justify_content: :center, bg: :tertiary)) do %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
     #   <% end %>
     #
     # @example Align end
-    #   <%= render(Primer::FlexComponent.new(align_items: :end, bg: :gray)) do %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+    #   <%= render(Primer::FlexComponent.new(align_items: :end, bg: :tertiary)) do %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
     #   <% end %>
     #
     # @example Direction column
-    #   <%= render(Primer::FlexComponent.new(direction: :column, bg: :gray)) do %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+    #   <%= render(Primer::FlexComponent.new(direction: :column, bg: :tertiary)) do %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+    #     <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
     #   <% end %>
     #
     # @param justify_content [Symbol] Use this param to distribute space between and around flex items along the main axis of the container. <%= one_of(Primer::FlexComponent::JUSTIFY_CONTENT_OPTIONS) %>

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -11,7 +11,7 @@ module Primer
     # @param percentage [Integer] The percent complete
     # @param bg [Symbol] The background color
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
-    renders_many :items, lambda { |percentage: 0, bg: :green, **system_arguments|
+    renders_many :items, lambda { |percentage: 0, bg: :success_inverse, **system_arguments|
       percentage = percentage
       system_arguments = system_arguments
 
@@ -39,19 +39,19 @@ module Primer
     #
     # @example Small
     #   <%= render(Primer::ProgressBarComponent.new(size: :small)) do |component| %>
-    #     <% component.item(bg: :blue_4, percentage: 50) %>
+    #     <% component.item(bg: :info_inverse, percentage: 50) %>
     #   <% end %>
     #
     # @example Large
     #   <%= render(Primer::ProgressBarComponent.new(size: :large)) do |component| %>
-    #     <% component.item(bg: :red_4, percentage: 75) %>
+    #     <% component.item(bg: :danger_inverse, percentage: 75) %>
     #   <% end %>
     #
     # @example Multiple items
     #   <%= render(Primer::ProgressBarComponent.new) do |component| %>
     #     <% component.item(percentage: 10) %>
-    #     <% component.item(bg: :blue_4, percentage: 20) %>
-    #     <% component.item(bg: :red_4, percentage: 30) %>
+    #     <% component.item(bg: :info_inverse, percentage: 20) %>
+    #     <% component.item(bg: :danger_inverse, percentage: 30) %>
     #   <% end %>
     #
     # @param size [Symbol] <%= one_of(Primer::ProgressBarComponent::SIZE_OPTIONS) %> Increases height.

--- a/app/components/primer/text_component.rb
+++ b/app/components/primer/text_component.rb
@@ -7,7 +7,7 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::TextComponent.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
-    #   <%= render(Primer::TextComponent.new(tag: :p, color: :danger)) { "Danger Text" } %>
+    #   <%= render(Primer::TextComponent.new(tag: :p, color: :text_danger)) { "Danger Text" } %>
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(**system_arguments)

--- a/app/components/primer/text_component.rb
+++ b/app/components/primer/text_component.rb
@@ -7,7 +7,7 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::TextComponent.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
-    #   <%= render(Primer::TextComponent.new(tag: :p, color: :red_5)) { "Red Text" } %>
+    #   <%= render(Primer::TextComponent.new(tag: :p, color: :danger)) { "Danger Text" } %>
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(**system_arguments)

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -41,7 +41,7 @@ module Primer
     #   <div style="padding-left: 60px">
     #     <%= render(Primer::TimelineItemComponent.new) do |component| %>
     #       <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    #       <% component.badge(bg: :success_inverse, color: :white, icon: :check) %>
+    #       <% component.badge(bg: :success_inverse, color: :text_white, icon: :check) %>
     #       <% component.body { "Success!" } %>
     #     <% end %>
     #   </div>

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -41,7 +41,7 @@ module Primer
     #   <div style="padding-left: 60px">
     #     <%= render(Primer::TimelineItemComponent.new) do |component| %>
     #       <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    #       <% component.badge(bg: :green, color: :white, icon: :check) %>
+    #       <% component.badge(bg: :success_inverse, color: :white, icon: :check) %>
     #       <% component.body { "Success!" } %>
     #     <% end %>
     #   </div>

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -199,7 +199,7 @@ module Primer
           if val.to_s.start_with?("#")
             memo[:styles] << "background-color: #{val};"
           else
-            memo[:classes] << "bg-#{val.to_s.dasherize}"
+            memo[:classes] << Primer::Classify::FunctionalBackgroundColors.color(val)
           end
         elsif key == COLOR_KEY
           memo[:classes] << Primer::Classify::FunctionalTextColors.color(val)

--- a/app/lib/primer/classify/cache.rb
+++ b/app/lib/primer/classify/cache.rb
@@ -50,8 +50,13 @@ module Primer
           )
 
           preload(
-            keys: [Primer::Classify::COLOR_KEY, Primer::Classify::BG_KEY],
+            keys: [Primer::Classify::COLOR_KEY],
             values: [*Primer::Classify::FunctionalTextColors::OPTIONS, *Primer::Classify::FunctionalTextColors::DEPRECATED_OPTIONS]
+          )
+
+          preload(
+            keys: [Primer::Classify::BG_KEY],
+            values: [*Primer::Classify::FunctionalBackgroundColors::OPTIONS, *Primer::Classify::FunctionalBackgroundColors::DEPRECATED_OPTIONS]
           )
 
           preload(

--- a/app/lib/primer/classify/functional_background_colors.rb
+++ b/app/lib/primer/classify/functional_background_colors.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Primer
+  class Classify
+    # Background specific functional colors
+    # https://primer-css-git-mkt-color-modes-docs-primer.vercel.app/css/support/v16-migration#background
+    class FunctionalBackgroundColors < FunctionalColors
+      FUNCTIONAL_OPTIONS = {
+        primary: :primary,
+        secondary: :secondary,
+        tertiary: :tertiary,
+        canvas: :canvas,
+        canvas_inset: :canvas_inset,
+        canvas_inverse: :canvas_inverse,
+        info: :info,
+        info_inverse: :info_inverse,
+        success: :success,
+        success_inverse: :success_inverse,
+        warning: :warning,
+        warning_inverse: :warning_inverse,
+        danger_inverse: :danger_inverse,
+        overlay: :overlay
+      }.freeze
+
+      MAPPINGS = {
+        white: FUNCTIONAL_OPTIONS[:primary],
+        gray_light: FUNCTIONAL_OPTIONS[:secondary],
+        gray: FUNCTIONAL_OPTIONS[:tertiary],
+        gray_dark: FUNCTIONAL_OPTIONS[:canvas_inverse],
+        blue_light: FUNCTIONAL_OPTIONS[:info],
+        blue: FUNCTIONAL_OPTIONS[:info_inverse],
+        green_light: FUNCTIONAL_OPTIONS[:success],
+        green: FUNCTIONAL_OPTIONS[:success_inverse],
+        yellow_light: FUNCTIONAL_OPTIONS[:warning],
+        yellow: FUNCTIONAL_OPTIONS[:warning_inverse],
+        red_light: FUNCTIONAL_OPTIONS[:danger],
+        red: FUNCTIONAL_OPTIONS[:danger_inverse]
+      }.freeze
+
+      OPTIONS = FUNCTIONAL_OPTIONS.values.freeze
+      OPTIONS_WITHOUT_MAPPINGS = [:purple_light, :purple, :yellow_dark, :orange, :pink].freeze
+      DEPRECATED_OPTIONS = [*MAPPINGS.keys, *OPTIONS_WITHOUT_MAPPINGS].freeze
+
+      class << self
+        def color(val)
+          functional_color(
+            key: "bg",
+            value: val,
+            mappings: MAPPINGS,
+            non_functional_prefix: "bg",
+            functional_prefix: "bg-",
+            functional_options: OPTIONS,
+            options_without_mappigs: OPTIONS_WITHOUT_MAPPINGS
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/lib/primer/classify/functional_background_colors.rb
+++ b/app/lib/primer/classify/functional_background_colors.rb
@@ -45,11 +45,12 @@ module Primer
       class << self
         def color(val)
           functional_color(
-            key: "bg",
+            key: "background",
             value: val,
             mappings: MAPPINGS,
             non_functional_prefix: "bg",
-            functional_prefix: "bg-",
+            functional_prefix: "color-bg",
+            number_prefix: "bg",
             functional_options: OPTIONS,
             options_without_mappigs: OPTIONS_WITHOUT_MAPPINGS
           )

--- a/app/lib/primer/classify/functional_background_colors.rb
+++ b/app/lib/primer/classify/functional_background_colors.rb
@@ -18,6 +18,7 @@ module Primer
         success_inverse: :success_inverse,
         warning: :warning,
         warning_inverse: :warning_inverse,
+        danger: :danger,
         danger_inverse: :danger_inverse,
         overlay: :overlay
       }.freeze

--- a/app/lib/primer/classify/functional_border_colors.rb
+++ b/app/lib/primer/classify/functional_border_colors.rb
@@ -39,7 +39,8 @@ module Primer
             value: val,
             mappings: MAPPINGS,
             non_functional_prefix: "border",
-            functional_prefix: "border-",
+            functional_prefix: "color-border",
+            number_prefix: "border",
             functional_options: OPTIONS,
             options_without_mappigs: OPTIONS_WITHOUT_MAPPINGS
           )

--- a/app/lib/primer/classify/functional_border_colors.rb
+++ b/app/lib/primer/classify/functional_border_colors.rb
@@ -3,6 +3,7 @@
 module Primer
   class Classify
     # Border specific functional colors
+    # https://primer-css-git-mkt-color-modes-docs-primer.vercel.app/css/support/v16-migration#border
     class FunctionalBorderColors < FunctionalColors
       FUNCTIONAL_OPTIONS = {
         primary: :primary,

--- a/app/lib/primer/classify/functional_colors.rb
+++ b/app/lib/primer/classify/functional_colors.rb
@@ -15,7 +15,8 @@ module Primer
         # @param value [String|Symbol] Option value.
         # @param mappings [Hash] A `color` => `functional_color` mapping hash.
         # @param non_functional_prefix [String] The prefix to use for the non-functional color classes. E.g. "text" would create "text-value".
-        # @param functional_prefix [String] The prefix to use for the functional color classes. E.g. "text-" would create "color-text-value".
+        # @param functional_prefix [String] The prefix to use for the functional color classes. E.g. "color-text" would create "color-text-value".
+        # @param number_prefix [String] The prefix to use for colors ending with number. E.g. "text" would create "text-value-1".
         # @param functional_options [Array] All the acceptable functional values.
         # @param options_without_mappigs [Array] Non functional values that don't have an associated functional color.
         def functional_color(
@@ -24,11 +25,13 @@ module Primer
           mappings:,
           non_functional_prefix:,
           functional_prefix: "",
+          number_prefix: "",
           functional_options:,
           options_without_mappigs: []
         )
           # the value is a functional color
-          return "color-#{functional_prefix}#{value.to_s.dasherize}" if ends_with_number?(value) || functional_options.include?(value)
+          return "#{number_prefix}-#{value.to_s.dasherize}" if ends_with_number?(value)
+          return "#{functional_prefix}-#{value.to_s.dasherize}" if functional_options.include?(value)
           # if the app still allows non functional colors
           return "#{non_functional_prefix}-#{value.to_s.dasherize}" unless force_functional_colors?
 
@@ -39,7 +42,7 @@ module Primer
 
             ActiveSupport::Deprecation.warn("#{key} #{value} is deprecated. Please use #{functional_color} instead.") unless Rails.env.production? || silence_color_deprecations?
 
-            return "color-#{functional_prefix}#{functional_color.to_s.dasherize}"
+            return "#{functional_prefix}-#{functional_color.to_s.dasherize}"
           end
 
           raise ArgumentError, "#{key} #{value} does not exist." unless Rails.env.production?

--- a/app/lib/primer/classify/functional_text_colors.rb
+++ b/app/lib/primer/classify/functional_text_colors.rb
@@ -50,6 +50,8 @@ module Primer
             value: val,
             mappings: MAPPINGS,
             non_functional_prefix: "text",
+            functional_prefix: "color",
+            number_prefix: "color",
             functional_options: OPTIONS,
             options_without_mappigs: OPTIONS_WITHOUT_MAPPINGS
           )

--- a/app/lib/primer/classify/functional_text_colors.rb
+++ b/app/lib/primer/classify/functional_text_colors.rb
@@ -3,6 +3,7 @@
 module Primer
   class Classify
     # Text specific functional colors.
+    # https://primer-css-git-mkt-color-modes-docs-primer.vercel.app/css/support/v16-migration#text
     class FunctionalTextColors < FunctionalColors
       FUNCTIONAL_OPTIONS = {
         primary: :text_primary,

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -23,10 +23,10 @@ A basic wrapper component for most layout related needs.
 
 ### Color and padding
 
-<Example src="<div class='bg-gray p-3'>Hello world</div>" />
+<Example src="<div class='color-bg-tertiary p-3'>Hello world</div>" />
 
 ```erb
-<%= render(Primer::BoxComponent.new(bg: :gray, p: 3)) { "Hello world" } %>
+<%= render(Primer::BoxComponent.new(bg: :tertiary, p: 3)) { "Hello world" } %>
 ```
 
 ## Arguments

--- a/docs/content/components/flex.md
+++ b/docs/content/components/flex.md
@@ -18,49 +18,49 @@ Boxes](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/
 
 ### Default
 
-<Example src="<div class='bg-gray d-flex'>  <div class='border p-5 bg-gray-light'>Item 1</div>  <div class='border p-5 bg-gray-light'>Item 2</div>  <div class='border p-5 bg-gray-light'>Item 3</div></div>" />
+<Example src="<div class='color-bg-tertiary d-flex'>  <div class='border p-5 color-bg-secondary'>Item 1</div>  <div class='border p-5 color-bg-secondary'>Item 2</div>  <div class='border p-5 color-bg-secondary'>Item 3</div></div>" />
 
 ```erb
-<%= render(Primer::FlexComponent.new(bg: :gray)) do %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+<%= render(Primer::FlexComponent.new(bg: :tertiary)) do %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
 <% end %>
 ```
 
 ### Justify center
 
-<Example src="<div class='flex-justify-center bg-gray d-flex'>  <div class='border p-5 bg-gray-light'>Item 1</div>  <div class='border p-5 bg-gray-light'>Item 2</div>  <div class='border p-5 bg-gray-light'>Item 3</div></div>" />
+<Example src="<div class='flex-justify-center color-bg-tertiary d-flex'>  <div class='border p-5 color-bg-secondary'>Item 1</div>  <div class='border p-5 color-bg-secondary'>Item 2</div>  <div class='border p-5 color-bg-secondary'>Item 3</div></div>" />
 
 ```erb
-<%= render(Primer::FlexComponent.new(justify_content: :center, bg: :gray)) do %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+<%= render(Primer::FlexComponent.new(justify_content: :center, bg: :tertiary)) do %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
 <% end %>
 ```
 
 ### Align end
 
-<Example src="<div class='flex-items-end bg-gray d-flex'>  <div class='border p-5 bg-gray-light'>Item 1</div>  <div class='border p-5 bg-gray-light'>Item 2</div>  <div class='border p-5 bg-gray-light'>Item 3</div></div>" />
+<Example src="<div class='flex-items-end color-bg-tertiary d-flex'>  <div class='border p-5 color-bg-secondary'>Item 1</div>  <div class='border p-5 color-bg-secondary'>Item 2</div>  <div class='border p-5 color-bg-secondary'>Item 3</div></div>" />
 
 ```erb
-<%= render(Primer::FlexComponent.new(align_items: :end, bg: :gray)) do %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+<%= render(Primer::FlexComponent.new(align_items: :end, bg: :tertiary)) do %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
 <% end %>
 ```
 
 ### Direction column
 
-<Example src="<div class='bg-gray flex-column d-flex'>  <div class='border p-5 bg-gray-light'>Item 1</div>  <div class='border p-5 bg-gray-light'>Item 2</div>  <div class='border p-5 bg-gray-light'>Item 3</div></div>" />
+<Example src="<div class='color-bg-tertiary flex-column d-flex'>  <div class='border p-5 color-bg-secondary'>Item 1</div>  <div class='border p-5 color-bg-secondary'>Item 2</div>  <div class='border p-5 color-bg-secondary'>Item 3</div></div>" />
 
 ```erb
-<%= render(Primer::FlexComponent.new(direction: :column, bg: :gray)) do %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 1" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 2" } %>
-  <%= render(Primer::BoxComponent.new(p: 5, bg: :gray_light, classes: "border")) { "Item 3" } %>
+<%= render(Primer::FlexComponent.new(direction: :column, bg: :tertiary)) do %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 1" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 2" } %>
+  <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
 <% end %>
 ```
 

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -15,7 +15,7 @@ Use ProgressBar to visualize task completion.
 
 ### Default
 
-<Example src="<span class='Progress '>    <span style='width: 25%;' class='Progress-item bg-green'></span></span>" />
+<Example src="<span class='Progress '>    <span style='width: 25%;' class='Progress-item color-bg-success-inverse'></span></span>" />
 
 ```erb
 <%= render(Primer::ProgressBarComponent.new) do |component| %>
@@ -25,33 +25,33 @@ Use ProgressBar to visualize task completion.
 
 ### Small
 
-<Example src="<span class='Progress Progress--small '>    <span style='width: 50%;' class='Progress-item bg-blue-4'></span></span>" />
+<Example src="<span class='Progress Progress--small '>    <span style='width: 50%;' class='Progress-item color-bg-info-inverse'></span></span>" />
 
 ```erb
 <%= render(Primer::ProgressBarComponent.new(size: :small)) do |component| %>
-  <% component.item(bg: :blue_4, percentage: 50) %>
+  <% component.item(bg: :info_inverse, percentage: 50) %>
 <% end %>
 ```
 
 ### Large
 
-<Example src="<span class='Progress Progress--large '>    <span style='width: 75%;' class='Progress-item bg-red-4'></span></span>" />
+<Example src="<span class='Progress Progress--large '>    <span style='width: 75%;' class='Progress-item color-bg-danger-inverse'></span></span>" />
 
 ```erb
 <%= render(Primer::ProgressBarComponent.new(size: :large)) do |component| %>
-  <% component.item(bg: :red_4, percentage: 75) %>
+  <% component.item(bg: :danger_inverse, percentage: 75) %>
 <% end %>
 ```
 
 ### Multiple items
 
-<Example src="<span class='Progress '>    <span style='width: 10%;' class='Progress-item bg-green'></span>    <span style='width: 20%;' class='Progress-item bg-blue-4'></span>    <span style='width: 30%;' class='Progress-item bg-red-4'></span></span>" />
+<Example src="<span class='Progress '>    <span style='width: 10%;' class='Progress-item color-bg-success-inverse'></span>    <span style='width: 20%;' class='Progress-item color-bg-info-inverse'></span>    <span style='width: 30%;' class='Progress-item color-bg-danger-inverse'></span></span>" />
 
 ```erb
 <%= render(Primer::ProgressBarComponent.new) do |component| %>
   <% component.item(percentage: 10) %>
-  <% component.item(bg: :blue_4, percentage: 20) %>
-  <% component.item(bg: :red_4, percentage: 30) %>
+  <% component.item(bg: :info_inverse, percentage: 20) %>
+  <% component.item(bg: :danger_inverse, percentage: 30) %>
 <% end %>
 ```
 

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -15,11 +15,11 @@ The Text component is a wrapper component that will apply typography styles to t
 
 ### Default
 
-<Example src="<p class='text-bold'>Bold Text</p><p class='color-red-5'>Red Text</p>" />
+<Example src="<p class='text-bold'>Bold Text</p><p class='color-text-danger'>Danger Text</p>" />
 
 ```erb
 <%= render(Primer::TextComponent.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
-<%= render(Primer::TextComponent.new(tag: :p, color: :red_5)) { "Red Text" } %>
+<%= render(Primer::TextComponent.new(tag: :p, color: :text_danger)) { "Danger Text" } %>
 ```
 
 ## Arguments

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -15,13 +15,13 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 
 ### Default
 
-<Example src="<div style='padding-left: 60px'>  <div class='TimelineItem '>  <img src='https://github.com/github.png' alt='github' size='40' height='40' width='40' class='TimelineItem-avatar avatar '></img>  <div class='TimelineItem-badge bg-green color-text-white'><svg class='octicon octicon-check' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></div>  <div class='TimelineItem-body '>Success!</div></div></div>" />
+<Example src="<div style='padding-left: 60px'>  <div class='TimelineItem '>  <img src='https://github.com/github.png' alt='github' size='40' height='40' width='40' class='TimelineItem-avatar avatar '></img>  <div class='TimelineItem-badge color-bg-success-inverse color-text-white'><svg class='octicon octicon-check' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></div>  <div class='TimelineItem-body '>Success!</div></div></div>" />
 
 ```erb
 <div style="padding-left: 60px">
   <%= render(Primer::TimelineItemComponent.new) do |component| %>
     <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    <% component.badge(bg: :green, color: :white, icon: :check) %>
+    <% component.badge(bg: :success_inverse, color: :white, icon: :check) %>
     <% component.body { "Success!" } %>
   <% end %>
 </div>

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -21,7 +21,7 @@ Use `TimelineItem` to display items on a vertical timeline, connected by badge e
 <div style="padding-left: 60px">
   <%= render(Primer::TimelineItemComponent.new) do |component| %>
     <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    <% component.badge(bg: :success_inverse, color: :white, icon: :check) %>
+    <% component.badge(bg: :success_inverse, color: :text_white, icon: :check) %>
     <% component.body { "Success!" } %>
   <% end %>
 </div>

--- a/stories/primer/progress_bar_component_stories.rb
+++ b/stories/primer/progress_bar_component_stories.rb
@@ -9,7 +9,7 @@ class Primer::ProgressBarComponentStories < ViewComponent::Storybook::Stories
     end
 
     content do |component|
-      component.item(bg: :green, percentage: 10)
+      component.item(bg: :success_inverse, percentage: 10)
     end
   end
 end

--- a/stories/primer/timeline_item_component_stories.rb
+++ b/stories/primer/timeline_item_component_stories.rb
@@ -10,7 +10,7 @@ class Primer::TimelineItemComponentStories < ViewComponent::Storybook::Stories
 
     content do |component|
       component.avatar(src: "https://github.com/github.png", alt: "github")
-      component.badge(bg: :green, color: :white, icon: :check)
+      component.badge(bg: :success_inverse, color: :white, icon: :check)
       component.body { "Success" }
     end
   end

--- a/stories/primer/timeline_item_component_stories.rb
+++ b/stories/primer/timeline_item_component_stories.rb
@@ -10,7 +10,7 @@ class Primer::TimelineItemComponentStories < ViewComponent::Storybook::Stories
 
     content do |component|
       component.avatar(src: "https://github.com/github.png", alt: "github")
-      component.badge(bg: :success_inverse, color: :white, icon: :check)
+      component.badge(bg: :success_inverse, color: :text_white, icon: :check)
       component.body { "Success" }
     end
   end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations 114 do
+    assert_allocations 121 do
       Primer::Classify.call(**@values)
     end
   ensure

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations 121 do
+    assert_allocations 115 do
       Primer::Classify.call(**@values)
     end
   ensure

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -8,7 +8,7 @@ class BenchClassify < Minitest::Benchmark
     @values = {
       align_items: :center,
       align_self: :center,
-      bg: :blue,
+      bg: :info,
       border: :top,
       box_shadow: true,
       col: 1,

--- a/test/components/progress_bar_component_test.rb
+++ b/test/components/progress_bar_component_test.rb
@@ -51,10 +51,10 @@ class Primer::ProgressBarComponentTest < Minitest::Test
 
   def test_renders_background_colors
     render_inline(Primer::ProgressBarComponent.new) do |component|
-      component.item(bg: :red)
+      component.item(bg: :danger)
     end
 
-    assert_selector("span.Progress .Progress-item.bg-red")
+    assert_selector("span.Progress .Progress-item.color-bg-danger")
   end
 
   def test_renders_non_standard_background_colors

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -211,9 +211,98 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_bg
+    with_force_functional_colors(false) do
+      assert_generated_class("bg-blue-5",       { bg: :blue_5 })
+      assert_generated_class("bg-gray-9",       { bg: :gray_9 })
+      assert_generated_class("bg-purple-3",     { bg: :purple_3 })
+
+      assert_generated_class("bg-white", { bg: :white })
+      assert_generated_class("bg-gray-light", { bg: :gray_light })
+      assert_generated_class("bg-gray", { bg: :gray })
+      assert_generated_class("bg-gray-dark", { bg: :gray_dark })
+      assert_generated_class("bg-blue-light", { bg: :blue_light })
+      assert_generated_class("bg-blue", { bg: :blue })
+      assert_generated_class("bg-green-light", { bg: :green_light })
+      assert_generated_class("bg-green", { bg: :green })
+      assert_generated_class("bg-yellow-light", { bg: :yellow_light })
+      assert_generated_class("bg-yellow", { bg: :yellow })
+      assert_generated_class("bg-red-light", { bg: :red_light })
+      assert_generated_class("bg-red", { bg: :red })
+      assert_generated_class("bg-purple-light", { bg: :purple_light })
+      assert_generated_class("bg-purple", { bg: :purple })
+      assert_generated_class("bg-yellow-dark", { bg: :yellow_dark })
+      assert_generated_class("bg-orange", { bg: :orange })
+      assert_generated_class("bg-pink", { bg: :pink })
+
+      assert_generated_class("color-bg-primary", { bg: :primary })
+      assert_generated_class("color-bg-secondary", { bg: :secondary })
+      assert_generated_class("color-bg-tertiary", { bg: :tertiary })
+      assert_generated_class("color-bg-canvas", { bg: :canvas })
+      assert_generated_class("color-bg-canvas-inset", { bg: :canvas_inset })
+      assert_generated_class("color-bg-canvas-inverse", { bg: :canvas_inverse })
+      assert_generated_class("color-bg-info", { bg: :info })
+      assert_generated_class("color-bg-info-inverse", { bg: :info_inverse })
+      assert_generated_class("color-bg-success", { bg: :success })
+      assert_generated_class("color-bg-success-inverse", { bg: :success_inverse })
+      assert_generated_class("color-bg-warning", { bg: :warning })
+      assert_generated_class("color-bg-warning-inverse", { bg: :warning_inverse })
+      assert_generated_class("color-bg-danger", { bg: :danger })
+      assert_generated_class("color-bg-danger-inverse", { bg: :danger_inverse })
+      assert_generated_class("color-bg-overlay", { bg: :overlay })
+    end
+  end
+
+  def test_bg_enforcing_functional_colors
     assert_generated_class("bg-blue-5",       { bg: :blue_5 })
     assert_generated_class("bg-gray-9",       { bg: :gray_9 })
     assert_generated_class("bg-purple-3",     { bg: :purple_3 })
+
+    assert_generated_class("bg-purple-light", { bg: :purple_light })
+    assert_generated_class("bg-purple", { bg: :purple })
+    assert_generated_class("bg-yellow-dark", { bg: :yellow_dark })
+    assert_generated_class("bg-orange", { bg: :orange })
+    assert_generated_class("bg-pink", { bg: :pink })
+
+    assert_generated_class("bg-white", { bg: :white })
+    assert_generated_class("color-bg-primary", { bg: :primary })
+
+    assert_generated_class("bg-gray-light", { bg: :gray_light })
+    assert_generated_class("color-bg-secondary", { bg: :secondary })
+
+    assert_generated_class("bg-gray", { bg: :gray })
+    assert_generated_class("color-bg-tertiary", { bg: :tertiary })
+
+    assert_generated_class("color-bg-canvas", { bg: :canvas })
+    assert_generated_class("color-bg-canvas-inset", { bg: :canvas_inset })
+
+    assert_generated_class("bg-gray-dark", { bg: :gray_dark })
+    assert_generated_class("color-bg-canvas-inverse", { bg: :canvas_inverse })
+
+    assert_generated_class("bg-blue-light", { bg: :blue_light })
+    assert_generated_class("color-bg-info", { bg: :info })
+
+    assert_generated_class("bg-blue", { bg: :blue })
+    assert_generated_class("color-bg-info-inverse", { bg: :info_inverse })
+
+    assert_generated_class("bg-green-light", { bg: :green_light })
+    assert_generated_class("color-bg-success", { bg: :success })
+
+    assert_generated_class("bg-green", { bg: :green })
+    assert_generated_class("color-bg-success-inverse", { bg: :success_inverse })
+
+    assert_generated_class("bg-yellow-light", { bg: :yellow_light })
+    assert_generated_class("color-bg-warning", { bg: :warning })
+
+    assert_generated_class("bg-yellow", { bg: :yellow })
+    assert_generated_class("color-bg-warning-inverse", { bg: :warning_inverse })
+
+    assert_generated_class("bg-red-light", { bg: :red_light })
+    assert_generated_class("color-bg-danger", { bg: :danger })
+
+    assert_generated_class("bg-red", { bg: :red })
+    assert_generated_class("color-bg-danger-inverse", { bg: :danger_inverse })
+
+    assert_generated_class("color-bg-overlay", { bg: :overlay })
   end
 
   def test_text_align

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -263,46 +263,51 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("bg-orange", { bg: :orange })
     assert_generated_class("bg-pink", { bg: :pink })
 
-    assert_generated_class("bg-white", { bg: :white })
+    assert_generated_class("color-bg-primary", { bg: :white })
     assert_generated_class("color-bg-primary", { bg: :primary })
 
-    assert_generated_class("bg-gray-light", { bg: :gray_light })
+    assert_generated_class("color-bg-secondary", { bg: :gray_light })
     assert_generated_class("color-bg-secondary", { bg: :secondary })
 
-    assert_generated_class("bg-gray", { bg: :gray })
+    assert_generated_class("color-bg-tertiary", { bg: :gray })
     assert_generated_class("color-bg-tertiary", { bg: :tertiary })
+
+    assert_generated_class("color-bg-canvas-inverse", { bg: :gray_dark })
+    assert_generated_class("color-bg-canvas-inverse", { bg: :canvas_inverse })
+
+    assert_generated_class("color-bg-info", { bg: :blue_light })
+    assert_generated_class("color-bg-info", { bg: :info })
+
+    assert_generated_class("color-bg-info-inverse", { bg: :blue })
+    assert_generated_class("color-bg-info-inverse", { bg: :info_inverse })
+
+    assert_generated_class("color-bg-success", { bg: :green_light })
+    assert_generated_class("color-bg-success", { bg: :success })
+
+    assert_generated_class("color-bg-success-inverse", { bg: :green })
+    assert_generated_class("color-bg-success-inverse", { bg: :success_inverse })
+
+    assert_generated_class("color-bg-warning", { bg: :yellow_light })
+    assert_generated_class("color-bg-warning", { bg: :warning })
+
+    assert_generated_class("color-bg-warning-inverse", { bg: :yellow })
+    assert_generated_class("color-bg-warning-inverse", { bg: :warning_inverse })
+
+    assert_generated_class("color-bg-danger", { bg: :red_light })
+    assert_generated_class("color-bg-danger", { bg: :danger })
+
+    assert_generated_class("color-bg-danger-inverse", { bg: :red })
+    assert_generated_class("color-bg-danger-inverse", { bg: :danger_inverse })
 
     assert_generated_class("color-bg-canvas", { bg: :canvas })
     assert_generated_class("color-bg-canvas-inset", { bg: :canvas_inset })
-
-    assert_generated_class("bg-gray-dark", { bg: :gray_dark })
-    assert_generated_class("color-bg-canvas-inverse", { bg: :canvas_inverse })
-
-    assert_generated_class("bg-blue-light", { bg: :blue_light })
-    assert_generated_class("color-bg-info", { bg: :info })
-
-    assert_generated_class("bg-blue", { bg: :blue })
-    assert_generated_class("color-bg-info-inverse", { bg: :info_inverse })
-
-    assert_generated_class("bg-green-light", { bg: :green_light })
-    assert_generated_class("color-bg-success", { bg: :success })
-
-    assert_generated_class("bg-green", { bg: :green })
-    assert_generated_class("color-bg-success-inverse", { bg: :success_inverse })
-
-    assert_generated_class("bg-yellow-light", { bg: :yellow_light })
-    assert_generated_class("color-bg-warning", { bg: :warning })
-
-    assert_generated_class("bg-yellow", { bg: :yellow })
-    assert_generated_class("color-bg-warning-inverse", { bg: :warning_inverse })
-
-    assert_generated_class("bg-red-light", { bg: :red_light })
-    assert_generated_class("color-bg-danger", { bg: :danger })
-
-    assert_generated_class("bg-red", { bg: :red })
-    assert_generated_class("color-bg-danger-inverse", { bg: :danger_inverse })
-
     assert_generated_class("color-bg-overlay", { bg: :overlay })
+
+    err = assert_raises ArgumentError do
+      Primer::Classify.call(bg: :not_a_color)
+    end
+
+    assert_equal("background not_a_color does not exist.", err.message)
   end
 
   def test_text_align


### PR DESCRIPTION
Follow up on https://github.com/primer/view_components/pull/331

Updates adds functional color mappings to `bg:`, updating every internal use to the correct mappings.

Also updated the base `Primer::Classify::FunctionalColors` to receive a `number_prefix` since numbered colors (like `gray_5`) were treated differently between `text` and `background`:

```
color: :gray_5 => "color-gray-5"
bg: :gray_5 => "bg-gray-5"
```

Those classes still exist in PrimerCSS v16, so it is a good idea to keep them working properly :)