### PR TITLE
Update `box_shadow:` to use functional classes

### DIFF
--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -252,7 +252,7 @@ module Primer
           memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
         elsif key == BOX_SHADOW_KEY
           memo[:classes] << if val == true
-                              "box-shadow"
+                              "color-shadow-small"
                             elsif val == :none
                               "box-shadow-none"
                             else

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -253,8 +253,10 @@ module Primer
         elsif key == BOX_SHADOW_KEY
           memo[:classes] << if val == true
                               "box-shadow"
+                            elsif val == :none
+                              "box-shadow-none"
                             else
-                              "box-shadow-#{val.to_s.dasherize}"
+                              "color-shadow-#{val.to_s.dasherize}"
                             end
         elsif key == VISIBILITY_KEY
           memo[:classes] << "v-#{val.to_s.dasherize}"

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -253,7 +253,7 @@ module Primer
         elsif key == BOX_SHADOW_KEY
           memo[:classes] << if val == true
                               "color-shadow-small"
-                            elsif val == :none
+                            elsif val == :none || val.blank?
                               "box-shadow-none"
                             else
                               "color-shadow-#{val.to_s.dasherize}"

--- a/app/lib/primer/classify/cache.rb
+++ b/app/lib/primer/classify/cache.rb
@@ -96,7 +96,7 @@ module Primer
 
           preload(
             keys: Primer::Classify::BOX_SHADOW_KEY,
-            values: [true, :medium, :large, :extra_large, :none]
+            values: [true, :small, :medium, :large, :extra_large, :none]
           )
 
           preload(

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -17,7 +17,7 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 ### Default
 
-<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box p-4 mt-2 mx-auto text-left box-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the Popover body.</div></div>" />
+<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the Popover body.</div></div>" />
 
 ```erb
 <%= render Primer::PopoverComponent.new do |component| %>
@@ -32,7 +32,7 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 ### Large
 
-<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--large p-4 mt-2 mx-auto text-left box-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the large Popover body.</div></div>" />
+<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--large p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the large Popover body.</div></div>" />
 
 ```erb
 <%= render Primer::PopoverComponent.new do |component| %>
@@ -47,7 +47,7 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 ### Caret position
 
-<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--left p-4 mt-2 mx-auto text-left box-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the large Popover body.</div></div>" />
+<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--left p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the large Popover body.</div></div>" />
 
 ```erb
 <%= render Primer::PopoverComponent.new do |component| %>

--- a/test/components/popover_component_test.rb
+++ b/test/components/popover_component_test.rb
@@ -17,7 +17,7 @@ class PrimerPopoverComponentTest < Minitest::Test
 
     assert_selector("div.Popover.right-0.left-0")
     assert_selector("div.Popover div.Popover-message h4.mb-2", text: "My header")
-    assert_selector("div.Popover div.Popover-message.Box.box-shadow-large", text: "My body")
+    assert_selector("div.Popover div.Popover-message.Box.color-shadow-large", text: "My body")
   end
 
   def test_allows_customization

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -323,7 +323,7 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_box_shadow
     assert_generated_class("color-shadow-small",       { box_shadow: true })
-    assert_generated_class("color-shadow-small",       { box_shadow: true })
+    assert_generated_class("color-shadow-small",       { box_shadow: :small })
     assert_generated_class("color-shadow-medium",      { box_shadow: :medium })
     assert_generated_class("color-shadow-large",       { box_shadow: :large })
     assert_generated_class("color-shadow-extra-large", { box_shadow: :extra_large })

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -228,11 +228,13 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_box_shadow
-    assert_generated_class("box-shadow",             { box_shadow: true })
-    assert_generated_class("box-shadow-medium",      { box_shadow: :medium })
-    assert_generated_class("box-shadow-large",       { box_shadow: :large })
-    assert_generated_class("box-shadow-extra-large", { box_shadow: :extra_large })
-    assert_generated_class("box-shadow-none",        { box_shadow: :none })
+    assert_generated_class("color-shadow-small",       { box_shadow: true })
+    assert_generated_class("color-shadow-small",       { box_shadow: true })
+    assert_generated_class("color-shadow-medium",      { box_shadow: :medium })
+    assert_generated_class("color-shadow-large",       { box_shadow: :large })
+    assert_generated_class("color-shadow-extra-large", { box_shadow: :extra_large })
+    assert_generated_class("box-shadow-none",          { box_shadow: :none })
+    assert_generated_class("box-shadow-none",          { box_shadow: false })
   end
 
   def test_col


### PR DESCRIPTION
according to https://primer-css-git-mkt-color-modes-docs-primer.vercel.app/css/support/v16-migration#shadow the mapping is 1:1, so we can simply change the classes