### PR TITLE
update CounterComponent to use functional colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Update `CounterComponent` to accept functional schemes `primary` and `secondary`. Deprecate `gray` and `light_gray` schemes.
+
+    *Manuel Puyol*
+
 * Add `force_functional_colors` option to convert colors to functional. This change includes a deprecation warning in non-production environments that warns about non functional color usage.
 
     *Manuel Puyol*

--- a/app/components/primer/counter_component.rb
+++ b/app/components/primer/counter_component.rb
@@ -7,17 +7,26 @@ module Primer
 
     DEFAULT_SCHEME = :default
     SCHEME_MAPPINGS = {
-      DEFAULT_SCHEME => "Counter",
-      :gray => "Counter Counter--gray",
-      :light_gray => "Counter Counter--gray-light"
+      DEFAULT_SCHEME => "",
+      :primary => "Counter--primary",
+      :secondary => "Counter--secondary",
+      # deprecated
+      :gray => "Counter--primary",
+      :light_gray => "Counter--secondary"
     }.freeze
+    DEPRECATED_SCHEME_OPTIONS = [:gray, :light_gray].freeze
+    SCHEME_OPTIONS = (SCHEME_MAPPINGS.keys - DEPRECATED_SCHEME_OPTIONS).freeze
 
     #
     # @example Default
     #   <%= render(Primer::CounterComponent.new(count: 25)) %>
     #
+    # @example Schemes
+    #   <%= render(Primer::CounterComponent.new(count: 25, scheme: :primary)) %>
+    #   <%= render(Primer::CounterComponent.new(count: 25, scheme: :secondary)) %>
+    #
     # @param count [Integer, Float::INFINITY, nil] The number to be displayed (e.x. # of issues, pull requests)
-    # @param scheme [Symbol] Color scheme. One of `SCHEME_MAPPINGS.keys`.
+    # @param scheme [Symbol] Color scheme. <%= one_of(Primer::CounterComponent::SCHEME_OPTIONS) %>
     # @param limit [Integer, nil] Maximum value to display. Pass `nil` for no limit. (e.x. if `count` == 6,000 and `limit` == 5000, counter will display "5,000+")
     # @param hide_if_zero [Boolean] If true, a `hidden` attribute is added to the counter if `count` is zero.
     # @param text [String] Text to display instead of count.
@@ -43,8 +52,9 @@ module Primer
       @system_arguments[:title] = title
       @system_arguments[:tag] = :span
       @system_arguments[:classes] = class_names(
+        "Counter",
         @system_arguments[:classes],
-        SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)]
+        SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME, deprecated_values: DEPRECATED_SCHEME_OPTIONS)]
       )
       @system_arguments[:hidden] = true if count == 0 && hide_if_zero # rubocop:disable Style/NumericPredicate
     end

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -21,12 +21,21 @@ Use Primer::CounterComponent to add a count to navigational elements and buttons
 <%= render(Primer::CounterComponent.new(count: 25)) %>
 ```
 
+### Schemes
+
+<Example src="<span title='25' class='Counter Counter--primary '>25</span><span title='25' class='Counter Counter--secondary '>25</span>" />
+
+```erb
+<%= render(Primer::CounterComponent.new(count: 25, scheme: :primary)) %>
+<%= render(Primer::CounterComponent.new(count: 25, scheme: :secondary)) %>
+```
+
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `count` | `Integer, Float::INFINITY, nil` | `0` | The number to be displayed (e.x. # of issues, pull requests) |
-| `scheme` | `Symbol` | `:default` | Color scheme. One of `SCHEME_MAPPINGS.keys`. |
+| `scheme` | `Symbol` | `:default` | Color scheme. One of `:default`, `:primary`, or `:secondary`. |
 | `limit` | `Integer, nil` | `5_000` | Maximum value to display. Pass `nil` for no limit. (e.x. if `count` == 6,000 and `limit` == 5000, counter will display "5,000+") |
 | `hide_if_zero` | `Boolean` | `false` | If true, a `hidden` attribute is added to the counter if `count` is zero. |
 | `text` | `String` | `""` | Text to display instead of count. |

--- a/stories/primer/counter_component_stories.rb
+++ b/stories/primer/counter_component_stories.rb
@@ -6,7 +6,7 @@ class Primer::CounterComponentStories < ViewComponent::Storybook::Stories
   story(:counter) do
     controls do
       count 0
-      select(:scheme, Primer::CounterComponent::SCHEME_MAPPINGS.keys, :gray)
+      select(:scheme, Primer::CounterComponent::SCHEME_MAPPINGS.keys, :primary)
       limit 5000
       hide_if_zero false
       round false

--- a/test/components/counter_component_test.rb
+++ b/test/components/counter_component_test.rb
@@ -105,9 +105,18 @@ class CounterComponentTest < Minitest::Test
   end
 
   def test_renders_with_the_css_class_scheme_mapping_to_the_provided_scheme
+    render_inline(Primer::CounterComponent.new(count: 20, scheme: :primary))
+
+    assert_selector(".Counter.Counter--primary")
+    assert_selector("[title='20']", text: "20")
+  end
+
+  def test_renders_with_the_css_class_scheme_mapping_to_the_provided_deprecated_scheme
+    ActiveSupport::Deprecation.expects(:warn).with("gray is deprecated and will be removed in a future version.").once
+
     render_inline(Primer::CounterComponent.new(count: 20, scheme: :gray))
 
-    assert_selector(".Counter.Counter--gray")
+    assert_selector(".Counter.Counter--primary")
     assert_selector("[title='20']", text: "20")
   end
 


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/352
Based on https://primer-css-git-mkt-color-modes-docs-primer.vercel.app/css/support/v16-migration#counters

CounterComponent now accepts `primary` and `secondary`, deprecating `gray` and `light_gray`

![image](https://user-images.githubusercontent.com/11280312/110703944-0011d180-81ba-11eb-8eae-220ee4d3fa61.png)
