### PR TITLE
Apply all avatar classes to the link wrapper if applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,6 @@
 
     *Keith Cirkel* & *Clay Miller*
 
-* **Breaking change**: Updates `PopoverComponent` to use Slots V2.
-
-    *Manuel Puyol*
-
 * Fix `AvatarComponent` to apply classes to the link wrapper if present.
 
     *Steve Richert*
@@ -41,6 +37,10 @@
 * Fix `AvatarComponent` to apply the `avatar-small` class rather than `avatar--small`.
 
     *Steve Richert*
+
+* **Breaking change**: Updates `PopoverComponent` to use Slots V2.
+
+    *Manuel Puyol*
 
 ## 0.0.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
 
     *Manuel Puyol*
 
+* Fix `AvatarComponent` to apply classes to the link wrapper if present.
+
+    *Steve Richert*
+
 ## 0.0.27
 
 * Promote `BreadcrumbComponent` and `ProgressBarComponent` to beta status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
     *Steve Richert*
 
+* Fix `AvatarComponent` to apply the `avatar-small` class rather than `avatar--small`.
+
+    *Steve Richert*
+
 ## 0.0.27
 
 * Promote `BreadcrumbComponent` and `ProgressBarComponent` to beta status.

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -34,17 +34,25 @@ module Primer
       @system_arguments[:height] = size
       @system_arguments[:width] = size
 
-      @system_arguments[:classes] = class_names(
-        system_arguments[:classes],
-        "avatar" => !href,
+      avatar_class_names = class_names(
+        "avatar",
         "avatar--small" => size < SMALL_THRESHOLD,
         "circle" => !square
       )
+
+      if @href
+        @link_arguments = { href: href, classes: avatar_class_names }
+      else
+        @system_arguments[:classes] = class_names(
+          system_arguments[:classes],
+          avatar_class_names
+        )
+      end
     end
 
     def call
       if @href
-        render(Primer::LinkComponent.new(href: @href, classes: "avatar")) do
+        render(Primer::LinkComponent.new(**@link_arguments)) do
           render(Primer::BaseComponent.new(**@system_arguments)) { content }
         end
       else

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -24,33 +24,32 @@ module Primer
     # @param square [Boolean] Used to create a square avatar.
     # @param href [String] The URL to link to. If used, component will be wrapped by an `<a>` tag.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(src:, alt:, size: 20, square: false, href: nil, classes: nil, **image_arguments)
+    def initialize(src:, alt:, size: 20, square: false, href: nil, **system_arguments)
       @href = href
+      @system_arguments = system_arguments
+      @system_arguments[:tag] = :img
+      @system_arguments[:src] = src
+      @system_arguments[:alt] = alt
+      @system_arguments[:size] = size
+      @system_arguments[:height] = size
+      @system_arguments[:width] = size
 
-      @image_arguments = image_arguments
-      @image_arguments[:tag] = :img
-      @image_arguments[:src] = src
-      @image_arguments[:alt] = alt
-      @image_arguments[:size] = size
-      @image_arguments[:height] = size
-      @image_arguments[:width] = size
-
-      @avatar_classes = class_names(
+      @system_arguments[:classes] = class_names(
+        system_arguments[:classes],
         "avatar",
         "avatar-small" => size < SMALL_THRESHOLD,
-        "circle" => !square
+        "circle" => !square,
+        "lh-0" => !!href # Addresses a overflow issue with linked avatars
       )
-
-      @all_classes = class_names(classes, @avatar_classes)
     end
 
     def call
       if @href
-        render(Primer::LinkComponent.new(href: @href, classes: @all_classes)) do
-          render(Primer::BaseComponent.new(classes: @avatar_classes, **@image_arguments)) { content }
+        render(Primer::LinkComponent.new(href: @href, classes: @system_arguments[:classes])) do
+          render(Primer::BaseComponent.new(**@system_arguments.except(:classes))) { content }
         end
       else
-        render(Primer::BaseComponent.new(classes: @all_classes, **@image_arguments)) { content }
+        render(Primer::BaseComponent.new(**@system_arguments)) { content }
       end
     end
   end

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -33,6 +33,7 @@ module Primer
       @system_arguments[:size] = size
       @system_arguments[:height] = size
       @system_arguments[:width] = size
+
       @system_arguments[:classes] = class_names(
         system_arguments[:classes],
         "avatar",
@@ -47,7 +48,7 @@ module Primer
           render(Primer::BaseComponent.new(**@system_arguments.except(:classes))) { content }
         end
       else
-        render(Primer::BaseComponent.new(classes: @classes, **@system_arguments)) { content }
+        render(Primer::BaseComponent.new(**@system_arguments)) { content }
       end
     end
   end

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -37,7 +37,7 @@ module Primer
 
       @avatar_classes = class_names(
         "avatar",
-        "avatar--small" => size < SMALL_THRESHOLD,
+        "avatar-small" => size < SMALL_THRESHOLD,
         "circle" => !square
       )
 

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -34,29 +34,21 @@ module Primer
       @system_arguments[:height] = size
       @system_arguments[:width] = size
 
-      avatar_class_names = class_names(
+      @classes = class_names(
+        system_arguments.delete(:classes),
         "avatar",
         "avatar--small" => size < SMALL_THRESHOLD,
         "circle" => !square
       )
-
-      if @href
-        @link_arguments = { href: href, classes: avatar_class_names }
-      else
-        @system_arguments[:classes] = class_names(
-          system_arguments[:classes],
-          avatar_class_names
-        )
-      end
     end
 
     def call
       if @href
-        render(Primer::LinkComponent.new(**@link_arguments)) do
+        render(Primer::LinkComponent.new(classes: @classes, href: @href)) do
           render(Primer::BaseComponent.new(**@system_arguments)) { content }
         end
       else
-        render(Primer::BaseComponent.new(**@system_arguments)) { content }
+        render(Primer::BaseComponent.new(classes: @classes, **@system_arguments)) { content }
       end
     end
   end

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -33,9 +33,8 @@ module Primer
       @system_arguments[:size] = size
       @system_arguments[:height] = size
       @system_arguments[:width] = size
-
-      @classes = class_names(
-        system_arguments.delete(:classes),
+      @system_arguments[:classes] = class_names(
+        system_arguments[:classes],
         "avatar",
         "avatar--small" => size < SMALL_THRESHOLD,
         "circle" => !square
@@ -44,8 +43,8 @@ module Primer
 
     def call
       if @href
-        render(Primer::LinkComponent.new(classes: @classes, href: @href)) do
-          render(Primer::BaseComponent.new(**@system_arguments)) { content }
+        render(Primer::LinkComponent.new(href: @href, classes: @system_arguments[:classes])) do
+          render(Primer::BaseComponent.new(**@system_arguments.except(:classes))) { content }
         end
       else
         render(Primer::BaseComponent.new(classes: @classes, **@system_arguments)) { content }

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -39,7 +39,7 @@ module Primer
         "avatar",
         "avatar-small" => size < SMALL_THRESHOLD,
         "circle" => !square,
-        "lh-0" => !!href # Addresses a overflow issue with linked avatars
+        "lh-0" => !!href # Addresses an overflow issue with linked avatars
       )
     end
 

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -39,7 +39,7 @@ module Primer
         "avatar",
         "avatar-small" => size < SMALL_THRESHOLD,
         "circle" => !square,
-        "lh-0" => !!href # Addresses an overflow issue with linked avatars
+        "lh-0" => href # Addresses an overflow issue with linked avatars
       )
     end
 

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -24,31 +24,33 @@ module Primer
     # @param square [Boolean] Used to create a square avatar.
     # @param href [String] The URL to link to. If used, component will be wrapped by an `<a>` tag.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(src:, alt:, size: 20, square: false, href: nil, **system_arguments)
+    def initialize(src:, alt:, size: 20, square: false, href: nil, classes: nil, **image_arguments)
       @href = href
-      @system_arguments = system_arguments
-      @system_arguments[:tag] = :img
-      @system_arguments[:src] = src
-      @system_arguments[:alt] = alt
-      @system_arguments[:size] = size
-      @system_arguments[:height] = size
-      @system_arguments[:width] = size
 
-      @system_arguments[:classes] = class_names(
-        system_arguments[:classes],
+      @image_arguments = image_arguments
+      @image_arguments[:tag] = :img
+      @image_arguments[:src] = src
+      @image_arguments[:alt] = alt
+      @image_arguments[:size] = size
+      @image_arguments[:height] = size
+      @image_arguments[:width] = size
+
+      @avatar_classes = class_names(
         "avatar",
         "avatar--small" => size < SMALL_THRESHOLD,
         "circle" => !square
       )
+
+      @all_classes = class_names(classes, @avatar_classes)
     end
 
     def call
       if @href
-        render(Primer::LinkComponent.new(href: @href, classes: @system_arguments[:classes])) do
-          render(Primer::BaseComponent.new(**@system_arguments.except(:classes))) { content }
+        render(Primer::LinkComponent.new(href: @href, classes: @all_classes)) do
+          render(Primer::BaseComponent.new(classes: @avatar_classes, **@image_arguments)) { content }
         end
       else
-        render(Primer::BaseComponent.new(**@system_arguments)) { content }
+        render(Primer::BaseComponent.new(classes: @all_classes, **@image_arguments)) { content }
       end
     end
   end

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -33,7 +33,7 @@ for organizations or any other non-human avatars.
 
 ### Link
 
-<Example src="<a href='#' class='avatar avatar-small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img></a>" />
+<Example src="<a href='#' class='avatar avatar-small circle lh-0 '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20'></img></a>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -33,7 +33,7 @@ for organizations or any other non-human avatars.
 
 ### Link
 
-<Example src="<a href='#' class='avatar '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar--small circle '></img></a>" />
+<Example src="<a href='#' class='avatar avatar--small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20'></img></a>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -17,7 +17,7 @@ for organizations or any other non-human avatars.
 
 ### Default
 
-<Example src="<img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>" />
+<Example src="<img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>
@@ -25,7 +25,7 @@ for organizations or any other non-human avatars.
 
 ### Square
 
-<Example src="<img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small '></img>" />
+<Example src="<img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small '></img>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", square: true)) %>
@@ -33,7 +33,7 @@ for organizations or any other non-human avatars.
 
 ### Link
 
-<Example src="<a href='#' class='avatar avatar--small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img></a>" />
+<Example src="<a href='#' class='avatar avatar-small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img></a>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -33,7 +33,7 @@ for organizations or any other non-human avatars.
 
 ### Link
 
-<Example src="<a href='#' class='avatar avatar--small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20'></img></a>" />
+<Example src="<a href='#' class='avatar avatar--small circle '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img></a>" />
 
 ```erb
 <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -15,7 +15,7 @@ Use AvatarStack to stack multiple avatars together.
 
 ### Default
 
-<Example src="<div class='AvatarStack AvatarStack--three-plus '>  <div class='AvatarStack-body '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img></div></div>" />
+<Example src="<div class='AvatarStack AvatarStack--three-plus '>  <div class='AvatarStack-body '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img></div></div>" />
 
 ```erb
 <%= render(Primer::AvatarStackComponent.new) do |c| %>
@@ -27,7 +27,7 @@ Use AvatarStack to stack multiple avatars together.
 
 ### Align right
 
-<Example src="<div class='AvatarStack AvatarStack--right AvatarStack--three-plus '>  <div class='AvatarStack-body '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img></div></div>" />
+<Example src="<div class='AvatarStack AvatarStack--right AvatarStack--three-plus '>  <div class='AvatarStack-body '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img></div></div>" />
 
 ```erb
 <%= render(Primer::AvatarStackComponent.new(align: :right)) do |c| %>
@@ -39,7 +39,7 @@ Use AvatarStack to stack multiple avatars together.
 
 ### With tooltip
 
-<Example src="<div class='AvatarStack AvatarStack--three-plus '>  <div aria-label='This is a tooltip!' class='AvatarStack-body tooltipped tooltipped-n '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar--small circle '></img></div></div>" />
+<Example src="<div class='AvatarStack AvatarStack--three-plus '>  <div aria-label='This is a tooltip!' class='AvatarStack-body tooltipped tooltipped-n '>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img>        <div class='avatar avatar-more'></div>      <img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img></div></div>" />
 
 ```erb
 <%= render(Primer::AvatarStackComponent.new(tooltipped: true, body_arguments: { label: 'This is a tooltip!' })) do |c| %>

--- a/stories/primer/avatar_stack_component_stories.rb
+++ b/stories/primer/avatar_stack_component_stories.rb
@@ -39,4 +39,16 @@ class Primer::AvatarStackComponentStories < ViewComponent::Storybook::Stories
       component.avatar(src: "https://github.com/github.png", alt: "github")
     end
   end
+
+  story(:linked) do
+    controls do
+      select(:align, Primer::AvatarStackComponent::ALIGN_OPTIONS, Primer::AvatarStackComponent::ALIGN_DEFAULT)
+    end
+
+    content do |component|
+      component.avatar(href: "#", src: "https://github.com/github.png", alt: "github")
+      component.avatar(href: "#", src: "https://github.com/github.png", alt: "github")
+      component.avatar(href: "#", src: "https://github.com/github.png", alt: "github")
+    end
+  end
 end

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -60,7 +60,8 @@ class PrimerAvatarComponentTest < Minitest::Test
 
     assert_selector("a.avatar") do |(a)|
       assert_equal("#given-href", a["href"])
-      assert_selector("img.avatar")
+      assert_selector("img")
+      refute_selector("img.avatar")
     end
   end
 
@@ -68,7 +69,8 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#"))
 
     assert_selector("a.avatar.circle") do
-      assert_selector("img.avatar.circle")
+      assert_selector("img")
+      refute_selector("img.circle")
     end
   end
 
@@ -76,7 +78,7 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", square: true))
 
     assert_selector("a.avatar") do
-      assert_selector("img.avatar")
+      assert_selector("img")
     end
     refute_selector(".circle")
   end
@@ -85,7 +87,8 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD - 1))
 
     assert_selector("a.avatar.avatar-small") do
-      assert_selector("img.avatar.avatar-small")
+      assert_selector("img")
+      refute_selector("img.avatar-small")
     end
   end
 
@@ -93,7 +96,7 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD + 1))
 
     assert_selector("a.avatar") do
-      assert_selector("img.avatar")
+      assert_selector("img")
     end
     refute_selector(".avatar-small")
   end
@@ -102,9 +105,18 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", classes: "custom-class"))
 
     assert_selector("a.avatar.custom-class") do
-      assert_selector("img.avatar")
+      assert_selector("img")
+      refute_selector("img.custom-class")
     end
-    refute_selector("img.custom-class")
+  end
+
+  def test_clears_link_wrapper_line_height
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#"))
+
+    assert_selector("a.lh-0") do
+      assert_selector("img")
+      refute_selector("img.lh-0")
+    end
   end
 
   def test_status

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -26,14 +26,14 @@ class PrimerAvatarComponentTest < Minitest::Test
   def test_defaults_adds_small_modifier_when_size_is_less_than_threshold
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", size: Primer::AvatarComponent::SMALL_THRESHOLD - 1))
 
-    assert_selector("img.avatar.avatar--small")
+    assert_selector("img.avatar.avatar-small")
   end
 
   def test_defaults_does_not_add_small_modifier_when_size_is_greater_than_threshold
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", size: Primer::AvatarComponent::SMALL_THRESHOLD + 1))
 
     assert_selector("img.avatar")
-    refute_selector(".avatar--small")
+    refute_selector(".avatar-small")
   end
 
   def test_adds_custom_classes
@@ -84,8 +84,8 @@ class PrimerAvatarComponentTest < Minitest::Test
   def test_adds_small_modifier_to_link_wrapper_when_size_is_less_than_threshold
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD - 1))
 
-    assert_selector("a.avatar.avatar--small") do
-      assert_selector("img.avatar.avatar--small")
+    assert_selector("a.avatar.avatar-small") do
+      assert_selector("img.avatar.avatar-small")
     end
   end
 
@@ -95,7 +95,7 @@ class PrimerAvatarComponentTest < Minitest::Test
     assert_selector("a.avatar") do
       assert_selector("img.avatar")
     end
-    refute_selector(".avatar--small")
+    refute_selector(".avatar-small")
   end
 
   def test_adds_custom_classes_to_link_wrapper

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -50,9 +50,10 @@ class PrimerAvatarComponentTest < Minitest::Test
   end
 
   def test_renders_link_wrapper
-    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#"))
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#given-href"))
 
-    assert_selector("a.avatar") do
+    assert_selector("a.avatar") do |(a)|
+      assert_equal("#given-href", a["href"])
       assert_selector("img")
     end
     refute_selector("img.avatar")

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -94,6 +94,15 @@ class PrimerAvatarComponentTest < Minitest::Test
     refute_selector(".avatar--small")
   end
 
+  def test_adds_custom_classes_to_link_wrapper
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", classes: "custom-class"))
+
+    assert_selector("a.avatar.custom-class") do
+      assert_selector("img")
+    end
+    refute_selector("img.custom-class")
+  end
+
   def test_status
     assert_component_state(Primer::AvatarComponent, :beta)
   end

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -60,25 +60,23 @@ class PrimerAvatarComponentTest < Minitest::Test
 
     assert_selector("a.avatar") do |(a)|
       assert_equal("#given-href", a["href"])
-      assert_selector("img")
+      assert_selector("img.avatar")
     end
-    refute_selector("img.avatar")
   end
 
   def test_defaults_circle_link_wrapper
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#"))
 
     assert_selector("a.avatar.circle") do
-      assert_selector("img")
+      assert_selector("img.avatar.circle")
     end
-    refute_selector("img.avatar")
   end
 
   def test_squared_link_wrapper
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", square: true))
 
     assert_selector("a.avatar") do
-      assert_selector("img")
+      assert_selector("img.avatar")
     end
     refute_selector(".circle")
   end
@@ -87,16 +85,15 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD - 1))
 
     assert_selector("a.avatar.avatar--small") do
-      assert_selector("img")
+      assert_selector("img.avatar.avatar--small")
     end
-    refute_selector("img.avatar")
   end
 
   def test_does_not_add_small_modifier_to_link_wrapper_when_size_is_greater_than_threshold
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD + 1))
 
     assert_selector("a.avatar") do
-      assert_selector("img")
+      assert_selector("img.avatar")
     end
     refute_selector(".avatar--small")
   end
@@ -105,7 +102,7 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", classes: "custom-class"))
 
     assert_selector("a.avatar.custom-class") do
-      assert_selector("img")
+      assert_selector("img.avatar")
     end
     refute_selector("img.custom-class")
   end

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -36,6 +36,12 @@ class PrimerAvatarComponentTest < Minitest::Test
     refute_selector(".avatar--small")
   end
 
+  def test_adds_custom_classes
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", classes: "custom-class"))
+
+    assert_selector("img.avatar.custom-class")
+  end
+
   def test_sets_size_height_and_width
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", size: 50))
 

--- a/test/components/avatar_component_test.rb
+++ b/test/components/avatar_component_test.rb
@@ -46,7 +46,7 @@ class PrimerAvatarComponentTest < Minitest::Test
     render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", square: true))
 
     assert_selector("img.avatar")
-    refute_selector(".CircleBadge")
+    refute_selector(".circle")
   end
 
   def test_renders_link_wrapper
@@ -56,6 +56,42 @@ class PrimerAvatarComponentTest < Minitest::Test
       assert_selector("img")
     end
     refute_selector("img.avatar")
+  end
+
+  def test_defaults_circle_link_wrapper
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#"))
+
+    assert_selector("a.avatar.circle") do
+      assert_selector("img")
+    end
+    refute_selector("img.avatar")
+  end
+
+  def test_squared_link_wrapper
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", square: true))
+
+    assert_selector("a.avatar") do
+      assert_selector("img")
+    end
+    refute_selector(".circle")
+  end
+
+  def test_adds_small_modifier_to_link_wrapper_when_size_is_less_than_threshold
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD - 1))
+
+    assert_selector("a.avatar.avatar--small") do
+      assert_selector("img")
+    end
+    refute_selector("img.avatar")
+  end
+
+  def test_does_not_add_small_modifier_to_link_wrapper_when_size_is_greater_than_threshold
+    render_inline(Primer::AvatarComponent.new(src: "https://github.com/github.png", alt: "github", href: "#", size: Primer::AvatarComponent::SMALL_THRESHOLD + 1))
+
+    assert_selector("a.avatar") do
+      assert_selector("img")
+    end
+    refute_selector(".avatar--small")
   end
 
   def test_status


### PR DESCRIPTION
If an `href` argument is specified, the `AvatarComponent` wraps the `img` element in an `a` element, applying the `avatar` class to the `a` instead. These changes make sure that the other optional avatar-related classes like `avatar--small` and `circle` are also applied to the `a` (if present) rather than the `img`. Otherwise, you get a square `a` around a circle `img`.

| Before | After |
|:---:|:---:|
| <img width="58" alt="Screen Shot 2021-03-11 at 9 24 04 AM" src="https://user-images.githubusercontent.com/34264/110811613-d5c12200-8254-11eb-9c32-3a9433a1802d.png"> | <img width="58" alt="Screen Shot 2021-03-11 at 9 24 43 AM" src="https://user-images.githubusercontent.com/34264/110811617-d659b880-8254-11eb-9f04-5315e4eb5fa5.png"> |
