### PR TITLE
Supress deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## main
 
+* Add `primer_time_ago` helper.
+
+    *Simon Taranto*
+
+* Add config to supress deprecation warnings.
+
+    *Manuel Puyol*
+
 ## 0.0.28
 
 * Update `CounterComponent` to accept functional schemes `primary` and `secondary`. Deprecate `gray` and `light_gray` schemes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
     *Simon Taranto*
 
-* Add config to supress deprecation warnings.
+* Add `silence_deprecations` config to supress deprecation warnings.
 
     *Manuel Puyol*
 

--- a/app/lib/primer/classify/functional_colors.rb
+++ b/app/lib/primer/classify/functional_colors.rb
@@ -40,7 +40,7 @@ module Primer
             # colors without functional mapping stay the same
             return "#{non_functional_prefix}-#{value.to_s.dasherize}" if functional_color.blank?
 
-            ActiveSupport::Deprecation.warn("#{key} #{value} is deprecated. Please use #{functional_color} instead.") unless Rails.env.production? || silence_color_deprecations?
+            ActiveSupport::Deprecation.warn("#{key} #{value} is deprecated. Please use #{functional_color} instead.") unless Rails.env.production? || silence_deprecations?
 
             return "#{functional_prefix}-#{functional_color.to_s.dasherize}"
           end
@@ -57,8 +57,8 @@ module Primer
           Rails.application.config.primer_view_components.force_functional_colors
         end
 
-        def silence_color_deprecations?
-          Rails.application.config.primer_view_components.silence_color_deprecations
+        def silence_deprecations?
+          Rails.application.config.primer_view_components.silence_deprecations
         end
       end
     end

--- a/app/lib/primer/fetch_or_fallback_helper.rb
+++ b/app/lib/primer/fetch_or_fallback_helper.rb
@@ -29,7 +29,7 @@ module Primer
       if allowed_values.include?(given_value)
         given_value
       elsif deprecated_values.include?(given_value)
-        ActiveSupport::Deprecation.warn("#{given_value} is deprecated and will be removed in a future version.") unless Rails.env.production?
+        ActiveSupport::Deprecation.warn("#{given_value} is deprecated and will be removed in a future version.") unless Rails.env.production? || silence_deprecations?
 
         given_value
       else
@@ -54,6 +54,10 @@ module Primer
       else
         fallback
       end
+    end
+
+    def silence_deprecations?
+      Rails.application.config.primer_view_components.silence_deprecations
     end
   end
 end

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -42,5 +42,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-  config.primer_view_components.silence_color_deprecations = true
+  config.primer_view_components.silence_deprecations = true
 end

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -14,7 +14,7 @@ module Primer
 
       config.primer_view_components = ActiveSupport::OrderedOptions.new
       config.primer_view_components.force_functional_colors = true
-      config.primer_view_components.silence_color_deprecations = false
+      config.primer_view_components.silence_deprecations = false
 
       initializer "primer_view_components.assets" do |app|
         app.config.assets.precompile += %w[primer_view_components] if app.config.respond_to?(:assets)

--- a/test/components/counter_component_test.rb
+++ b/test/components/counter_component_test.rb
@@ -112,8 +112,6 @@ class CounterComponentTest < Minitest::Test
   end
 
   def test_renders_with_the_css_class_scheme_mapping_to_the_provided_deprecated_scheme
-    ActiveSupport::Deprecation.expects(:warn).with("gray is deprecated and will be removed in a future version.").once
-
     render_inline(Primer::CounterComponent.new(count: 20, scheme: :gray))
 
     assert_selector(".Counter.Counter--primary")

--- a/test/components/label_component_test.rb
+++ b/test/components/label_component_test.rb
@@ -19,7 +19,6 @@ class PrimerLabelComponentTest < Minitest::Test
 
   def test_deprecated_schemes
     Primer::LabelComponent::DEPRECATED_SCHEME_OPTIONS.each do |scheme|
-      ActiveSupport::Deprecation.expects(:warn).with("#{scheme} is deprecated and will be removed in a future version.").once
       render_inline(Primer::LabelComponent.new(title: "foo", scheme: scheme)) { "scheme" }
     end
   end

--- a/test/lib/fetch_or_fallback_helper_test.rb
+++ b/test/lib/fetch_or_fallback_helper_test.rb
@@ -4,6 +4,7 @@ require "test_helper"
 
 class Primer::FetchOrFallbackHelperTest < Minitest::Test
   include Primer::FetchOrFallbackHelper
+  include Primer::ComponentTestHelpers
 
   def test_one_of
     Primer::FetchOrFallbackHelper.fallback_raises = false
@@ -21,8 +22,14 @@ class Primer::FetchOrFallbackHelperTest < Minitest::Test
   end
 
   def test_accepts_deprecated_values
-    ActiveSupport::Deprecation.expects(:warn).with("3 is deprecated and will be removed in a future version.").once
     assert_equal(fetch_or_fallback([1, 2], 3, deprecated_values: [3]), 3)
+  end
+
+  def test_warns_of_deprecation_if_not_silenced
+    with_silence_deprecations(false) do
+      ActiveSupport::Deprecation.expects(:warn).with("3 is deprecated and will be removed in a future version.").once
+      assert_equal(fetch_or_fallback([1, 2], 3, deprecated_values: [3]), 3)
+    end
   end
 
   def test_does_not_raise_in_production

--- a/test/test_helpers/component_test_helpers.rb
+++ b/test/test_helpers/component_test_helpers.rb
@@ -26,6 +26,14 @@ module Primer
       Primer::Classify::Cache.preload!
     end
 
+    def with_silence_deprecations(new_value)
+      old_value = Rails.application.config.primer_view_components.silence_deprecations
+      Rails.application.config.primer_view_components.silence_deprecations = new_value
+      yield
+    ensure
+      Rails.application.config.primer_view_components.silence_deprecations = old_value
+    end
+
     def assert_component_state(component, state)
       assert_equal component.status, Primer::Component::STATUSES[state]
     end


### PR DESCRIPTION
Renames `silence_color_deprecations` to `silence_deprecations` to control **all** deprecation warnings created by us