### PR TITLE
update primerCSS to use @16.0.0-rc.873c0d1

### DIFF
--- a/demo/app/views/layouts/application.html.erb
+++ b/demo/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
     <title>Demo</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <link href="https://unpkg.com/@primer/css-next@canary/dist/primer.css" rel="stylesheet" />
+    <link href="https://unpkg.com/@primer/css@16.0.0-rc.873c0d1/dist/primer.css" rel="stylesheet" />
 
     <%= javascript_include_tag "primer_view_components", type: "module" %>
   </head>

--- a/demo/app/views/layouts/storybook_centered_preview.html.erb
+++ b/demo/app/views/layouts/storybook_centered_preview.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>ActionView::Component Storybook Preview</title>
 
-    <link href="https://unpkg.com/@primer/css-next@canary/dist/primer.css" rel="stylesheet" />
+    <link href="https://unpkg.com/@primer/css@16.0.0-rc.873c0d1/dist/primer.css" rel="stylesheet" />
     <% if Rails.env.development? %>
       <%= javascript_include_tag "primer_view_components", host: "localhost:4000" %>
     <% else %>

--- a/demo/app/views/layouts/storybook_preview.html.erb
+++ b/demo/app/views/layouts/storybook_preview.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>ActionView::Component Storybook Preview</title>
 
-    <link href="https://unpkg.com/@primer/css-next@canary/dist/primer.css" rel="stylesheet" />
+    <link href="https://unpkg.com/@primer/css@16.0.0-rc.873c0d1/dist/primer.css" rel="stylesheet" />
     <% if Rails.env.development? %>
       <%= javascript_include_tag "primer_view_components", host: "localhost:4000" %>
     <% else %>

--- a/docs/src/@primer/gatsby-theme-doctocat/components/head.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/head.js
@@ -17,7 +17,7 @@ function Head(props) {
       <meta property="og:description" content={description} />
       <meta property="og:image" content={siteMetadata.imageUrl} />
       <meta property="twitter:card" content="summary_large_image" />
-      <link href="https://unpkg.com/@primer/css-next@canary/dist/primer.css" rel="stylesheet" />
+      <link href="https://unpkg.com/@primer/css@16.0.0-rc.873c0d1/dist/primer.css" rel="stylesheet" />
       <script src="https://unpkg.com/@primer/view-components@latest/app/assets/javascripts/primer_view_components.js"></script>
     </Helmet>
   )


### PR DESCRIPTION
Since PrimerCSS now has rc1 for v16, we should use it instead of `css-next`