### PR TITLE
Add action to sync Component status project board

### DIFF
--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -16,9 +16,6 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.7.x
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-build-docs-${{ hashFiles('**/Gemfile.lock') }}
       - name: Rewrite code
+        run: gem install graphql-client
         run: script/update-statuses-project.rb

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -10,6 +10,8 @@ jobs:
   build-docs:
     name: Update statuses project
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup Ruby

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -1,0 +1,24 @@
+name: Docs Build
+
+on:
+  push:
+    branches:
+      - master
+      - st-statuses-action
+
+jobs:
+  build-docs:
+    name: Update statuses project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-build-docs-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Rewrite code
+        run: script/update-statuses-project.rb

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -18,6 +18,6 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: 2.7.x
-      - name: Rewrite code
+      - name: Make updates
         run: gem install graphql-client
         run: script/update-statuses-project.rb

--- a/.github/workflows/statuses.yml
+++ b/.github/workflows/statuses.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - st-statuses-action
 
 jobs:
   build-docs:

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -73,18 +73,21 @@ class Project
   def self.create_card(note:, column_id:)
     response = Github::Client.query(CreateCard, variables: { note: note, projectColumnId: column_id })
     return unless response.errors.any?
+
     raise QueryExecutionError, response.errors[:data].join(", ")
   end
 
   def self.move_card(card_id:, column_id:)
     response = Github::Client.query(MoveCard, variables: { cardId: card_id, columnId: column_id })
     return unless response.errors.any?
+
     raise(QueryExecutionError, response.errors[:data].join(", "))
   end
 
   def self.fetch_columns
     response = Github::Client.query(ProjectQuery)
     return response.data.repository.project.columns unless response.errors.any?
+
     raise(QueryExecutionError, response.errors[:data].join(", "))
   end
 end

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -123,9 +123,9 @@ def move_card(card_id:, status:)
 end
 
 def create_card(component_name:, status:)
-  puts "create card with #{component_name} on #{status}"
-
   column_id = @column_mapping[status.downcase]
+
+  puts "create card with #{component_name} on #{status} on column #{column_id}"
 
   Project.create_card(note: component_name, column_id: column_id)
 end

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+#/ Usage: script/update-statuses-project
+# frozen_string_literal: true
+
+module Github
+  GITHUB_ACCESS_TOKEN = ENV['GITHUB_TOKEN']
+  URL = 'https://api.github.com/graphql'
+  HttpAdapter = GraphQL::Client::HTTP.new(URL) do
+    def headers(context)
+      {
+        "Authorization" => "Bearer #{GITHUB_ACCESS_TOKEN}",
+        "User-Agent" => 'Ruby'
+      }
+    end
+  end
+  Schema = GraphQL::Client.load_schema(HttpAdapter)
+  Client = GraphQL::Client.new(schema: Schema, execute: HttpAdapter)
+end
+
+class Project
+  ProjectQuery = Github::Client.parse <<-'GRAPHQL'
+    query {
+      repository(owner: "primer", name: "view_components") {
+        project(number: 3) {
+          columns(first: 100) {
+            nodes {
+              name
+              id
+              databaseId
+              cards {
+                nodes {
+                  id
+                  databaseId
+                  note
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+
+  def self.fetch_columns
+    response = Github::Client.query(ProjectQuery)
+
+    if response.errors.any?
+      raise QueryExecutionError.new(response.errors[:data].join(", "))
+    else
+      response.data.repository.project.columns
+    end
+  end
+end
+
+# fetch project columns
+# fetch cards
+
+columns = Project.fetch_columns
+
+puts columns
+
+# TODO: find missing cards
+# TODO: parse statuses.json
+# TODO: move cards on wrong column

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -84,8 +84,8 @@ class Project
 
   def self.fetch_columns
     response = Github::Client.query(ProjectQuery)
-    raise(QueryExecutionError, response.errors[:data].join(", ")) if response.errors.any?
-    response.data.repository.project.columns
+    return response.data.repository.project.columns unless response.errors.any?
+    raise(QueryExecutionError, response.errors[:data].join(", "))
   end
 end
 
@@ -102,7 +102,7 @@ def get_card(name_prefix:)
   @cards.find { |card| card.note.start_with?(name_prefix + NOTE_SEPARATOR) }
 end
 
-def on_correct_column(card_id:, status:)
+def on_correct_column?(card_id:, status:)
   card = @cards.find { |c| c.id == card_id }
   card.column.name.casecmp(status).zero?
 end
@@ -127,7 +127,7 @@ statuses_json.each do |component_name, component_status|
   card = get_card(name_prefix: component_name)
 
   if card
-    if !on_correct_column(card_id: card.id, status: component_status)
+    if !on_correct_column?(card_id: card.id, status: component_status)
       move_card(card_id: card.id, status: component_status)
     else
       puts "#{card.id} is on the right column. noop"

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -72,25 +72,19 @@ class Project
 
   def self.create_card(note:, column_id:)
     response = Github::Client.query(CreateCard, variables: { note: note, projectColumnId: column_id })
-
     return unless response.errors.any?
-
     raise QueryExecutionError, response.errors[:data].join(", ")
   end
 
   def self.move_card(card_id:, column_id:)
     response = Github::Client.query(MoveCard, variables: { cardId: card_id, columnId: column_id })
-
     return unless response.errors.any?
-
     raise(QueryExecutionError, response.errors[:data].join(", "))
   end
 
   def self.fetch_columns
     response = Github::Client.query(ProjectQuery)
-
     raise(QueryExecutionError, response.errors[:data].join(", ")) if response.errors.any?
-
     response.data.repository.project.columns
   end
 end
@@ -110,7 +104,6 @@ end
 
 def on_correct_column(card_id:, status:)
   card = @cards.find { |c| c.id == card_id }
-
   card.column.name.casecmp(status).zero?
 end
 

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -9,6 +9,7 @@ statuses = File.read(File.join(File.dirname(__FILE__), "../static/statuses.json"
 statuses_json = JSON.parse(statuses)
 
 class QueryExecutionError < StandardError; end
+NOTE_SEPERATOR = " --- "
 
 module Github
   GITHUB_ACCESS_TOKEN = ENV.fetch("GITHUB_TOKEN")
@@ -69,7 +70,7 @@ class Project
   GRAPHQL
 
   def self.create_card(note:, column_id:)
-    response = Github::Client.query(CreateCard, variables: { note: note, project_column_id: column_id })
+    response = Github::Client.query(CreateCard, variables: { note: note, projectColumnId: column_id })
 
     if response.errors.any?
       raise QueryExecutionError.new(response.errors[:data].join(", "))
@@ -77,7 +78,7 @@ class Project
   end
 
   def self.move_card(card_id:, column_id:)
-    response = Github::Client.query(MoveCard, variables: { card_id: card_id, column_id: column_id })
+    response = Github::Client.query(MoveCard, variables: { cardId: card_id, columnId: column_id })
 
     if response.errors.any?
       raise QueryExecutionError.new(response.errors[:data].join(", "))
@@ -105,7 +106,7 @@ end
 @cards = columns.map(&:cards).map(&:nodes).flatten
 
 def get_card(name_prefix:)
-  @cards.find { |card| card.note.start_with?(name_prefix) }
+  @cards.find { |card| card.note.start_with?(name_prefix + NOTE_SEPERATOR) }
 end
 
 def on_correct_column(card_id:, status:)
@@ -127,7 +128,7 @@ def create_card(component_name:, status:)
 
   puts "create card with #{component_name} on #{status} on column #{column_id}"
 
-  Project.create_card(note: component_name, column_id: column_id)
+  Project.create_card(note: component_name + NOTE_SEPERATOR, column_id: column_id)
 end
 
 statuses_json.each do |component_name, component_status|

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -75,7 +75,7 @@ class Project
 
     return unless response.errors.any?
 
-    raise QueryExecutionError.new(response.errors[:data].join(", "))
+    raise QueryExecutionError, response.errors[:data].join(", ")
   end
 
   def self.move_card(card_id:, column_id:)

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -2,6 +2,9 @@
 #/ Usage: script/update-statuses-project
 # frozen_string_literal: true
 
+require "graphql/client"
+require "graphql/client/http"
+
 module Github
   GITHUB_ACCESS_TOKEN = ENV['GITHUB_TOKEN']
   URL = 'https://api.github.com/graphql'
@@ -57,7 +60,7 @@ end
 
 columns = Project.fetch_columns
 
-puts columns
+puts columns.nodes.map(&:name)
 
 # TODO: find missing cards
 # TODO: parse statuses.json

--- a/script/update-statuses-project.rb
+++ b/script/update-statuses-project.rb
@@ -11,7 +11,7 @@ statuses_json = JSON.parse(statuses)
 class QueryExecutionError < StandardError; end
 
 module Github
-  GITHUB_ACCESS_TOKEN = ENV['GITHUB_TOKEN']
+  GITHUB_ACCESS_TOKEN = ENV.fetch("GITHUB_TOKEN")
   URL = 'https://api.github.com/graphql'
   HttpAdapter = GraphQL::Client::HTTP.new(URL) do
     def headers(context)


### PR DESCRIPTION
This action runs on pushes to main and updates the cards on https://github.com/primer/view_components/projects/3 so that they are on the correct column.

The "ideas" column is not under automation and people can add ideas there. The other status columns are used in automation and hold cards in their current status.

We use the <ComponentName --- > as an id on the card to keep track of them. We can add more info after this separator such as links to tracking issues. 

The script assumes a handful of things:

* the column names match the status names
* the card starts with the component name
* the project board number (3) is hardcoded

![image](https://user-images.githubusercontent.com/2181356/110996134-b7345700-8338-11eb-9485-f8b74508dcf7.png)
