### PR TITLE
Fix popover with HTML body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Fix `Popover` bug where body was only returning the last line of the HTML.
+
+    *Manuel Puyol, Blake Williams*
+
 ## 0.0.30
 
 * Make `color:`, `bg:` and `border_color:` accept string values.

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -39,7 +39,7 @@ module Primer
     # @param caret [Symbol] <%= one_of(Primer::PopoverComponent::CARET_MAPPINGS.keys) %>
     # @param large [Boolean] Whether to use the large version of the component.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_one :body, lambda { |caret: CARET_DEFAULT, large: false, **system_arguments|
+    renders_one :body, lambda { |caret: CARET_DEFAULT, large: false, **system_arguments, &block|
       system_arguments[:classes] = class_names(
         system_arguments[:classes],
         "Popover-message Box",
@@ -54,7 +54,7 @@ module Primer
 
       # This is a hack to allow the parent to set the slot's content
       @body_arguments = system_arguments
-      ContentComponent.new
+      view_context.capture { block&.call }
     }
 
     # @example Default
@@ -123,12 +123,6 @@ module Primer
 
     def body_component
       Primer::BoxComponent.new(**@body_arguments)
-    end
-
-    class ContentComponent < ViewComponent::Base
-      def call
-        content
-      end
     end
   end
 end

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -39,7 +39,7 @@ module Primer
     # @param caret [Symbol] <%= one_of(Primer::PopoverComponent::CARET_MAPPINGS.keys) %>
     # @param large [Boolean] Whether to use the large version of the component.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_one :body, lambda { |caret: CARET_DEFAULT, large: false, **system_arguments, &block|
+    renders_one :body, lambda { |caret: CARET_DEFAULT, large: false, **system_arguments|
       system_arguments[:classes] = class_names(
         system_arguments[:classes],
         "Popover-message Box",
@@ -54,7 +54,7 @@ module Primer
 
       # This is a hack to allow the parent to set the slot's content
       @body_arguments = system_arguments
-      block&.call
+      ContentComponent.new
     }
 
     # @example Default
@@ -83,7 +83,24 @@ module Primer
     #       Activity feed
     #     <% end %>
     #     <% component.body(caret: :left) do %>
-    #       This is the large Popover body.
+    #       This is the Popover body.
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example With HTML body
+    #   <%= render Primer::PopoverComponent.new do |component| %>
+    #     <% component.heading do %>
+    #       Activity feed
+    #     <% end %>
+    #     <% component.body(caret: :left) do %>
+    #       <p> This is the Popover body.</p>
+    #       <div>
+    #         This is using HTML.
+    #         <ul>
+    #           <li>Thing #1</li>
+    #           <li>Thing #2</li>
+    #         </ul>
+    #       </div>
     #     <% end %>
     #   <% end %>
     #
@@ -106,6 +123,12 @@ module Primer
 
     def body_component
       Primer::BoxComponent.new(**@body_arguments)
+    end
+
+    class ContentComponent < ViewComponent::Base
+      def call
+        content
+      end
     end
   end
 end

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -47,7 +47,7 @@ By default, the popover renders with absolute positioning, meaning it should usu
 
 ### Caret position
 
-<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--left p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the large Popover body.</div></div>" />
+<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--left p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        This is the Popover body.</div></div>" />
 
 ```erb
 <%= render Primer::PopoverComponent.new do |component| %>
@@ -55,7 +55,29 @@ By default, the popover renders with absolute positioning, meaning it should usu
     Activity feed
   <% end %>
   <% component.body(caret: :left) do %>
-    This is the large Popover body.
+    This is the Popover body.
+  <% end %>
+<% end %>
+```
+
+### With HTML body
+
+<Example src="<div class='Popover position-relative right-0 left-0'>  <div class='Popover-message Box Popover-message--left p-4 mt-2 mx-auto text-left color-shadow-large'>    <h4 class='mb-2'>    Activity feed</h4>        <p> This is the Popover body.</p>    <div>      This is using HTML.      <ul>        <li>Thing #1</li>        <li>Thing #2</li>      </ul>    </div></div></div>" />
+
+```erb
+<%= render Primer::PopoverComponent.new do |component| %>
+  <% component.heading do %>
+    Activity feed
+  <% end %>
+  <% component.body(caret: :left) do %>
+    <p> This is the Popover body.</p>
+    <div>
+      This is using HTML.
+      <ul>
+        <li>Thing #1</li>
+        <li>Thing #2</li>
+      </ul>
+    </div>
   <% end %>
 <% end %>
 ```


### PR DESCRIPTION
Running `block.call` was only returning the last line of the HTML as content.
This was probably caused because we were evaluating the content before rendering the component.
To fix that, we have to run `view_context.capture`