### PR TITLE
Fix storybook path not working without trailing slash

### DIFF
--- a/demo/.storybook/main.js
+++ b/demo/.storybook/main.js
@@ -3,4 +3,9 @@ module.exports = {
   addons: [
     '@storybook/addon-controls',
   ],
+  managerWebpack: async (config) => {
+    config.output.publicPath = "/view-components/stories/"
+
+    return config;
+  }
 };

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
   get '/', to: redirect('/view-components/stories/')
 
   get '/auto_complete', to: 'auto_complete_test#index'
+
+  get '/view-components/iframe.html', to: redirect('/view-components/stories/iframe.html')
 end


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/288

Storybook was building their `index.html` using relative paths for the js assets. With this change, they'll use absolute paths.
For some reason, I couldn't control `iframe.html` - used to render stories - so I just added a Rails redirect for that