### PR TITLE
Reset body style to use font-size: 16px

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/head.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/head.js
@@ -2,6 +2,13 @@ import React from 'react'
 import Helmet from 'react-helmet'
 import useSiteMetadata from '@primer/gatsby-theme-doctocat/src/use-site-metadata'
 
+// Reset PrimerCSS changing body font-size to 14px
+const bodyStyle = `
+  body {
+    font-size: 16px;
+  }
+`
+
 function Head(props) {
   const siteMetadata = useSiteMetadata()
   const title = props.title
@@ -19,6 +26,7 @@ function Head(props) {
       <meta property="twitter:card" content="summary_large_image" />
       <link href="https://unpkg.com/@primer/css@16.0.0-rc.873c0d1/dist/primer.css" rel="stylesheet" />
       <script src="https://unpkg.com/@primer/view-components@latest/app/assets/javascripts/primer_view_components.js"></script>
+      <style>{bodyStyle}</style>
     </Helmet>
   )
 }


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/377

Requiring PrimeCSS was changing the docs font-size to 14px. This is a quick fix to revert it back to 16px