### PR TITLE
Adjust spinner to use CSS animations instead of SMIL.

### DIFF
--- a/app/components/primer/spinner_component.html.erb
+++ b/app/components/primer/spinner_component.html.erb
@@ -1,4 +1,4 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
-  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" class="anim-rotate-360" style="transform-origin: 8px 8px;" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" class="anim-rotate" style="transform-origin: 8px 8px;" />
 <% end %>

--- a/app/components/primer/spinner_component.html.erb
+++ b/app/components/primer/spinner_component.html.erb
@@ -1,4 +1,4 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
-  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" class="anim-rotate" style="transform-origin: 8px 8px;" />
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
 <% end %>

--- a/app/components/primer/spinner_component.html.erb
+++ b/app/components/primer/spinner_component.html.erb
@@ -1,6 +1,4 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" />
-  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke">
-    <animateTransform attributeName="transform" type="rotate" from="0 8 8" to="360 8 8" dur="1s" repeatCount="indefinite" />
-  </path>
+  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" class="anim-rotate-360" style="transform-origin: 8px 8px;" />
 <% end %>

--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -31,10 +31,7 @@ module Primer
       @system_arguments = system_arguments
       @system_arguments[:tag] = :svg
       @system_arguments[:style] ||= DEFAULT_STYLE
-      @system_arguments[:classes] = class_names(
-        @system_arguments[:classes],
-        "anim-rotate"
-      )
+      @system_arguments[:animation] = :rotate
       @system_arguments[:width] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @system_arguments[:height] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @system_arguments[:viewBox] = "0 0 16 16"

--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -31,6 +31,10 @@ module Primer
       @system_arguments = system_arguments
       @system_arguments[:tag] = :svg
       @system_arguments[:style] ||= DEFAULT_STYLE
+      @system_arguments[:classes] = class_names(
+        @system_arguments[:classes],
+        "anim-rotate"
+      )
       @system_arguments[:width] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @system_arguments[:height] = SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
       @system_arguments[:viewBox] = "0 0 16 16"

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -42,7 +42,7 @@ Add an `icon` to give additional context. Refer to the [Octicons](https://primer
 
 Add a [SpinnerComponent](https://primer.style/view-components/components/spinner) to the blankslate in place of an icon.
 
-<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
+<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
 
 ```erb
 <%= render Primer::BlankslateComponent.new(

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -42,7 +42,7 @@ Add an `icon` to give additional context. Refer to the [Octicons](https://primer
 
 Add a [SpinnerComponent](https://primer.style/view-components/components/spinner) to the blankslate in place of an icon.
 
-<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
+<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='anim-rotate mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
 
 ```erb
 <%= render Primer::BlankslateComponent.new(

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -42,7 +42,7 @@ Add an `icon` to give additional context. Refer to the [Octicons](https://primer
 
 Add a [SpinnerComponent](https://primer.style/view-components/components/spinner) to the blankslate in place of an icon.
 
-<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke'>    <animateTransform attributeName='transform' type='rotate' from='0 8 8' to='360 8 8' dur='1s' repeatCount='indefinite' />  </path></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
+<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
 
 ```erb
 <%= render Primer::BlankslateComponent.new(

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -15,7 +15,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Default
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new) %>
@@ -23,7 +23,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Small
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :small)) %>
@@ -31,7 +31,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Large
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :large)) %>

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -15,7 +15,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Default
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new) %>
@@ -23,7 +23,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Small
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :small)) %>
@@ -31,7 +31,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Large
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :large)) %>

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -15,7 +15,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Default
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke'>    <animateTransform attributeName='transform' type='rotate' from='0 8 8' to='360 8 8' dur='1s' repeatCount='indefinite' />  </path></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new) %>
@@ -23,7 +23,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Small
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke'>    <animateTransform attributeName='transform' type='rotate' from='0 8 8' to='360 8 8' dur='1s' repeatCount='indefinite' />  </path></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :small)) %>
@@ -31,7 +31,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Large
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke'>    <animateTransform attributeName='transform' type='rotate' from='0 8 8' to='360 8 8' dur='1s' repeatCount='indefinite' />  </path></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' class='anim-rotate-360' style='transform-origin: 8px 8px;' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :large)) %>


### PR DESCRIPTION
The current implementation of `SpinnerComponent` uses an SVG with SMIL animations to render a spinner that spins indefinitely. This unfortunately triggers a [bug in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=1039243) that is very frustrating for users, where a page with SVGs with infinitely-repeating SMIL animations that is placed in the background will trigger a linear task to emit, then run, events for each frame that would have been run, as soon as the page is returned to the foreground. This execution is linear to the number of SVGs with repeating SMIL animations multiplied by the duration the tab is in the background. For GitHub.com webpages, this can take seconds, or even minutes, where the Chrome tab is frozen, or even locking up the entire OS if memory is limited.

This PR adjusts the SpinnerComponent to use a new `anim-rotate-360` CSS class that uses CSS animations to perform the same animation as the original SMIL `animateTransform` tag.

This PR is dependent on https://github.com/primer/css/pull/1251, which implements the CSS class itself.