### PR TITLE
Allow passing the icon name as a positional argument to `OcticonComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Allow passing the icon name as a positional argument in `OcticonComponent`.
+* Allow passing the icon name as a positional argument to `OcticonComponent`.
 
     *Manuel Puyol*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Allow passing the icon name as a positional argument in `OcticonComponent`.
+
+    *Manuel Puyol*
+
 * Promote `TimeAgoComponent` to beta.
 
     *Manuel Puyol*

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -2,7 +2,7 @@
   <% if spinner.present? %>
     <%= spinner %>
   <% elsif @icon.present? %>
-    <%= primer_octicon icon: @icon, size: @icon_size, classes: "blankslate-icon" %>
+    <%= primer_octicon @icon, size: @icon_size, classes: "blankslate-icon" %>
   <% elsif @image_src.present? && @image_alt.present? %>
     <%= image_tag "#{@image_src}", class: "mb-3", size: "56x56", alt: "#{@image_alt}" %>
   <% end %>

--- a/app/components/primer/flash_component.html.erb
+++ b/app/components/primer/flash_component.html.erb
@@ -1,9 +1,9 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <%= primer_octicon icon: @icon if @icon %>
+  <%= primer_octicon @icon if @icon %>
   <%= content %>
   <% if @dismissible %>
     <button class="flash-close js-flash-close" type="button" aria-label="Close">
-      <%= primer_octicon icon: "x" %>
+      <%= primer_octicon "x" %>
     </button>
   <% end %>
 

--- a/app/components/primer/menu_component.rb
+++ b/app/components/primer/menu_component.rb
@@ -42,11 +42,11 @@ module Primer
     #       Item 1
     #     <% end %>
     #     <% c.item(href: "#url") do %>
-    #       <%= render(Primer::OcticonComponent.new(icon: "check")) %>
+    #       <%= render(Primer::OcticonComponent.new("check")) %>
     #       With Icon
     #     <% end %>
     #     <% c.item(href: "#url") do %>
-    #       <%= render(Primer::OcticonComponent.new(icon: "check")) %>
+    #       <%= render(Primer::OcticonComponent.new("check")) %>
     #       With Icon and Counter
     #       <%= render(Primer::CounterComponent.new(count: 25)) %>
     #     <% end %>

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -22,12 +22,12 @@ module Primer
       # Icon to be rendered in the Tab left.
       #
       # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::OcticonComponent) %>.
-      renders_one :icon, lambda { |**system_arguments|
+      renders_one :icon, lambda { |icon = nil, **system_arguments|
         system_arguments[:classes] = class_names(
           @icon_classes,
           system_arguments[:classes]
         )
-        Primer::OcticonComponent.new(**system_arguments)
+        Primer::OcticonComponent.new(icon, **system_arguments)
       }
 
       # The Tab's text.
@@ -52,11 +52,11 @@ module Primer
       #
       # @example With icons and counters
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.icon(icon: :star) %>
+      #     <% c.icon(:star) %>
       #     <% c.text { "Tab" } %>
       #   <% end %>
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.icon(icon: :star) %>
+      #     <% c.icon(:star) %>
       #     <% c.text { "Tab" } %>
       #     <% c.counter(count: 10) %>
       #   <% end %>

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -18,19 +18,20 @@ module Primer
     SIZE_OPTIONS = SIZE_MAPPINGS.keys
 
     # @example Default
+    #   <%= render(Primer::OcticonComponent.new("check")) %>
     #   <%= render(Primer::OcticonComponent.new(icon: "check")) %>
     #
     # @example Medium
-    #   <%= render(Primer::OcticonComponent.new(icon: "people", size: :medium)) %>
+    #   <%= render(Primer::OcticonComponent.new("people", size: :medium)) %>
     #
     # @example Large
-    #   <%= render(Primer::OcticonComponent.new(icon: "x", size: :large)) %>
+    #   <%= render(Primer::OcticonComponent.new("x", size: :large)) %>
     #
     # @param icon [String] Name of [Octicon](https://primer.style/octicons/) to use.
     # @param size [Symbol] <%= one_of(Primer::OcticonComponent::SIZE_MAPPINGS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(icon:, size: SIZE_DEFAULT, **system_arguments)
-      @icon = icon
+    def initialize(icon_name = nil, icon: nil, size: SIZE_DEFAULT, **system_arguments)
+      @icon = icon_name || icon
       @system_arguments = system_arguments
 
       @system_arguments[:class] = Primer::Classify.call(**@system_arguments)[:class]

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -77,7 +77,7 @@ module Primer
 
       def call
         render(Primer::BaseComponent.new(**@system_arguments)) do
-          render(Primer::OcticonComponent.new(icon: @icon))
+          render(Primer::OcticonComponent.new(@icon))
         end
       end
     end

--- a/app/lib/primer/view_helper.rb
+++ b/app/lib/primer/view_helper.rb
@@ -12,8 +12,8 @@ module Primer
     }.freeze
 
     HELPERS.each do |name, component|
-      define_method "primer_#{name}" do |**component_args, &block|
-        render component.constantize.new(**component_args), &block
+      define_method "primer_#{name}" do |*args, **kwargs, &block|
+        render component.constantize.new(*args, **kwargs), &block
       end
     end
   end

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -42,7 +42,7 @@ Add an `icon` to give additional context. Refer to the [Octicons](https://primer
 
 Add a [SpinnerComponent](https://primer.style/view-components/components/spinner) to the blankslate in place of an icon.
 
-<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='anim-rotate mb-3'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
+<Example src="<div class='blankslate '>    <svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='mb-3 anim-rotate'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>    <h3 class='mb-1'>Title</h3>    <p>Description</p>  </div>" />
 
 ```erb
 <%= render Primer::BlankslateComponent.new(

--- a/docs/content/components/menu.md
+++ b/docs/content/components/menu.md
@@ -26,11 +26,11 @@ Use menus to create vertical lists of navigational links.
     Item 1
   <% end %>
   <% c.item(href: "#url") do %>
-    <%= render(Primer::OcticonComponent.new(icon: "check")) %>
+    <%= render(Primer::OcticonComponent.new("check")) %>
     With Icon
   <% end %>
   <% c.item(href: "#url") do %>
-    <%= render(Primer::OcticonComponent.new(icon: "check")) %>
+    <%= render(Primer::OcticonComponent.new("check")) %>
     With Icon and Counter
     <%= render(Primer::CounterComponent.new(count: 25)) %>
   <% end %>

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -15,9 +15,10 @@ Renders an [Octicon](https://primer.style/octicons/) with [System arguments](/sy
 
 ### Default
 
-<Example src="<svg class='octicon octicon-check' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>" />
+<Example src="<svg class='octicon octicon-check' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg><svg class='octicon octicon-check' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>" />
 
 ```erb
+<%= render(Primer::OcticonComponent.new("check")) %>
 <%= render(Primer::OcticonComponent.new(icon: "check")) %>
 ```
 
@@ -26,7 +27,7 @@ Renders an [Octicon](https://primer.style/octicons/) with [System arguments](/sy
 <Example src="<svg class='octicon octicon-people' height='32' viewBox='0 0 24 24' version='1.1' width='32' aria-hidden='true'><path fill-rule='evenodd' d='M3.5 8a5.5 5.5 0 118.596 4.547 9.005 9.005 0 015.9 8.18.75.75 0 01-1.5.045 7.5 7.5 0 00-14.993 0 .75.75 0 01-1.499-.044 9.005 9.005 0 015.9-8.181A5.494 5.494 0 013.5 8zM9 4a4 4 0 100 8 4 4 0 000-8z'></path><path d='M17.29 8c-.148 0-.292.01-.434.03a.75.75 0 11-.212-1.484 4.53 4.53 0 013.38 8.097 6.69 6.69 0 013.956 6.107.75.75 0 01-1.5 0 5.193 5.193 0 00-3.696-4.972l-.534-.16v-1.676l.41-.209A3.03 3.03 0 0017.29 8z'></path></svg>" />
 
 ```erb
-<%= render(Primer::OcticonComponent.new(icon: "people", size: :medium)) %>
+<%= render(Primer::OcticonComponent.new("people", size: :medium)) %>
 ```
 
 ### Large
@@ -34,13 +35,13 @@ Renders an [Octicon](https://primer.style/octicons/) with [System arguments](/sy
 <Example src="<svg class='octicon octicon-x' height='64' viewBox='0 0 24 24' version='1.1' width='64' aria-hidden='true'><path fill-rule='evenodd' d='M5.72 5.72a.75.75 0 011.06 0L12 10.94l5.22-5.22a.75.75 0 111.06 1.06L13.06 12l5.22 5.22a.75.75 0 11-1.06 1.06L12 13.06l-5.22 5.22a.75.75 0 01-1.06-1.06L10.94 12 5.72 6.78a.75.75 0 010-1.06z'></path></svg>" />
 
 ```erb
-<%= render(Primer::OcticonComponent.new(icon: "x", size: :large)) %>
+<%= render(Primer::OcticonComponent.new("x", size: :large)) %>
 ```
 
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `icon` | `String` | N/A | Name of [Octicon](https://primer.style/octicons/) to use. |
+| `icon` | `String` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
 | `size` | `Symbol` | `:small` | One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`). |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -15,7 +15,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Default
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='32' height='32' class='anim-rotate'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new) %>
@@ -23,7 +23,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Small
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='16' height='16' class='anim-rotate'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :small)) %>
@@ -31,7 +31,7 @@ Use Primer::SpinnerComponent to let users know that content is being loaded.
 
 ### Large
 
-<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='anim-rotate '>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
+<Example src="<svg style='box-sizing: content-box; color: var(--color-icon-primary);' viewBox='0 0 16 16' fill='none' width='64' height='64' class='anim-rotate'>  <circle cx='8' cy='8' r='7' stroke='currentColor' stroke-opacity='0.25' stroke-width='2' vector-effect='non-scaling-stroke' />  <path d='M15 8a7.002 7.002 0 00-7-7' stroke='currentColor' stroke-width='2' stroke-linecap='round' vector-effect='non-scaling-stroke' /></svg>" />
 
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :large)) %>

--- a/docs/content/components/tab.md
+++ b/docs/content/components/tab.md
@@ -33,11 +33,11 @@ and `Primer::UnderlineNavComponent` and should not be used by itself.
 
 ```erb
 <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-  <% c.icon(icon: :star) %>
+  <% c.icon(:star) %>
   <% c.text { "Tab" } %>
 <% end %>
 <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-  <% c.icon(icon: :star) %>
+  <% c.icon(:star) %>
   <% c.text { "Tab" } %>
   <% c.counter(count: 10) %>
 <% end %>

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -6,73 +6,79 @@ class PrimerOcticonComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_octicon_by_providing_icon_as_only_argument
+    render_inline(Primer::OcticonComponent.new(:star))
+
+    assert_selector(".octicon.octicon-star")
+  end
+
+  def test_renders_octicon_by_providing_icon_as_keyword_argument
     render_inline(Primer::OcticonComponent.new(icon: :star))
 
     assert_selector(".octicon.octicon-star")
   end
 
   def test_renders_octicon_by_providing_icon_as_symbol_argument
-    render_inline(Primer::OcticonComponent.new(icon: :star))
+    render_inline(Primer::OcticonComponent.new(:star))
 
     assert_selector(".octicon.octicon-star")
   end
 
   def test_renders_aria_hidden_true_by_default
-    render_inline(Primer::OcticonComponent.new(icon: :star))
+    render_inline(Primer::OcticonComponent.new(:star))
 
     assert_selector("[aria-hidden='true']")
   end
 
   def test_renders_aria_label_attribute
-    render_inline(Primer::OcticonComponent.new(icon: :star, aria: { label: "star-label" }))
+    render_inline(Primer::OcticonComponent.new(:star, aria: { label: "star-label" }))
 
     assert_selector("[aria-label='star-label']")
   end
 
   def test_renders_style_argument
-    render_inline(Primer::OcticonComponent.new(icon: :star, style: "margin-left: 100px"))
+    render_inline(Primer::OcticonComponent.new(:star, style: "margin-left: 100px"))
 
     assert_selector("[style='margin-left: 100px']")
   end
 
   def test_renders_default_size_small
-    render_inline(Primer::OcticonComponent.new(icon: :star))
+    render_inline(Primer::OcticonComponent.new(:star))
 
     assert_selector("[height='16']")
   end
 
   def test_renders_the_provided_size
-    render_inline(Primer::OcticonComponent.new(icon: :star, size: :large))
+    render_inline(Primer::OcticonComponent.new(:star, size: :large))
 
     assert_selector("[height='64']")
   end
 
   def test_renders_small_if_invalid_size_is_passed
-    render_inline(Primer::OcticonComponent.new(icon: :star, size: :grande))
+    render_inline(Primer::OcticonComponent.new(:star, size: :grande))
 
     assert_selector("[height='16']")
   end
 
   def test_renders_with_overridden_height_and_width_despite_given_a_size
-    render_inline(Primer::OcticonComponent.new(icon: :star, size: :large, height: 33, width: 47))
+    render_inline(Primer::OcticonComponent.new(:star, size: :large, height: 33, width: 47))
 
     assert_selector('[height="33"][width="47"]')
   end
 
   def test_renders_classes_passed_in
-    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo"))
+    render_inline(Primer::OcticonComponent.new(:star, classes: "foo"))
 
     assert_selector(".foo")
   end
 
   def test_renders_classes_passed_in_along_with_primer_class
-    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo", my: 4))
+    render_inline(Primer::OcticonComponent.new(:star, classes: "foo", my: 4))
 
     assert_selector(".foo.my-4")
   end
 
   def test_does_not_render_classify_attributes_as_html_attributes
-    render_inline(Primer::OcticonComponent.new(icon: :star, classes: "foo", display: [:none]))
+    render_inline(Primer::OcticonComponent.new(:star, classes: "foo", display: [:none]))
 
     refute_selector('[classes="foo"]')
     refute_selector('[display="none"]')
@@ -83,7 +89,7 @@ class PrimerOcticonComponentTest < Minitest::Test
   end
 
   def test_renders_test_selector
-    render_inline(Primer::OcticonComponent.new(icon: :star, test_selector: "bar"))
+    render_inline(Primer::OcticonComponent.new(:star, test_selector: "bar"))
 
     refute_selector("[test_selector='bar']")
     assert_selector("[data-test-selector='bar']")

--- a/test/primer/view_helper_test.rb
+++ b/test/primer/view_helper_test.rb
@@ -26,4 +26,10 @@ class Primer::ViewHelperTest < Minitest::Test
 
     assert_selector(".octicon.octicon-star")
   end
+
+  def test_renders_octicon_using_positional_argument
+    primer_octicon :star
+
+    assert_selector(".octicon.octicon-star")
+  end
 end


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/394

This will allow:
```rb
Primer::OcticonComponent.new(icon: :x)
Primer::OcticonComponent.new(:x)
primer_octicon(icon: :x)
primer_octicon(:x)
```