### PR TITLE
Add docs page for migrating from Primer CSS

### DIFF
--- a/docs/content/migration.md
+++ b/docs/content/migration.md
@@ -10,9 +10,8 @@ stable status.
 
 | Primer CSS Class | ViewComponent |
 |------------------|---------------|
-| `State`                   | `Primer::StateComponent`              |
-| `breadcrumb-item`         | `Primer::BreadcrumbComponent`         |
-| `Counter`                 | `Primer::CounterComponent`            |
-| `Subhead`                 | `Primer::SubheadComponent`            |
-| `blankslate`              | `Primer::BlankslateComponent`         |
-| `octocat-spinner`         | `Primer::SpinnerComponent`            |
+| [`State`](https://primer.style/css/components/labels#states)             | [`Primer::StateComponent`](https://primer.style/view-components/components/state)              |
+| [`breadcrumb-item`](https://primer.style/css/components/breadcrumb)      | [`Primer::BreadcrumbComponent`](https://primer.style/view-components/components/breadcrumb)    |
+| [`Counter`](https://primer.style/css/stickersheet/labels#counters)       | [`Primer::CounterComponent`](https://primer.style/view-components/components/counter)          |
+| [`Subhead`](https://primer.style/css/components/subhead)                 | [`Primer::SubheadComponent`](https://primer.style/view-components/components/subhead)          |
+| [`blankslate`](https://primer.style/css/components/blankslate)           | [`Primer::BlankslateComponent`](https://primer.style/view-components/components/blankslate)    |

--- a/docs/content/migration.md
+++ b/docs/content/migration.md
@@ -1,0 +1,18 @@
+---
+title: Migrate from Primer CSS
+---
+
+Many Primer CSS use cases are supported by Primer ViewComponents.
+
+When migrating from Primer CSS classes to ViewComponents, use this mapping to
+help guide your implementation. This list includes components currently in
+stable status.
+
+| Primer CSS Class | ViewComponent |
+|------------------|---------------|
+| `State`                   | `Primer::StateComponent`              |
+| `breadcrumb-item`         | `Primer::BreadcrumbComponent`         |
+| `Counter`                 | `Primer::CounterComponent`            |
+| `Subhead`                 | `Primer::SubheadComponent`            |
+| `blankslate`              | `Primer::BlankslateComponent`         |
+| `octocat-spinner`         | `Primer::SpinnerComponent`            |

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -5,6 +5,8 @@
       url: /contributing
     - title: System arguments
       url: /system-arguments
+    - title: Migration
+      url: /migration
 - title: Components
   url: /components
   children:


### PR DESCRIPTION
closes https://github.com/github/design-systems/issues/1352

This change adds a new docs page to help consumers migrate from Primer
CSS to ViewComponents.

![image](https://user-images.githubusercontent.com/2181356/112345929-1b391280-8c8b-11eb-9323-712359649c33.png)
