### PR TITLE
Update demo mimemagic and improve cuprite setup

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    primer_view_components (0.0.32)
+    primer_view_components (0.0.33)
       octicons_helper (>= 9.0.0, < 13.0.0)
       rails (>= 5.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)
@@ -101,7 +101,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -5,7 +5,7 @@ require "capybara/rails"
 require "capybara/minitest"
 require "capybara/cuprite"
 
-Ferrum::Browser.new(process_timeout: 10)
+Ferrum::Browser.new(process_timeout: 15)
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :cuprite, using: :chrome, screen_size: [1400, 1400]


### PR DESCRIPTION
`demo` was using the yanked version, which was breaking deploys
our cuprite setup was causing a lot of flaky errors, so I'm upping the timeout to 15s instead of 10 and extracting the setup into a support file