### PR TITLE
Output structured arg info

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -34,5 +34,6 @@ jobs:
           git config --local user.email "actions@github.com"
           git config --local user.name "Actions Auto Build"
           git add -f docs static/statuses.json
+          git add -f docs static/arguments.yml
           git commit -m "docs: build docs" || true
           git push

--- a/Rakefile
+++ b/Rakefile
@@ -254,9 +254,9 @@ namespace :docs do
 
           args << {
             "name" => tag.name,
-            "type" => tag.types.join(', '),
+            "type" => tag.types.join(", "),
             "default" => default,
-            "description" => view_context.render(inline: tag.text),
+            "description" => view_context.render(inline: tag.text)
           }
 
           f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
@@ -265,7 +265,7 @@ namespace :docs do
         component_args = {
           "component" => short_name,
           "source" => "https://github.com/primer/view_components/tree/main/app/components/primer/#{component.to_s.demodulize.underscore}.rb",
-          "parameters" => args,
+          "parameters" => args
         }
 
         args_for_components << component_args

--- a/Rakefile
+++ b/Rakefile
@@ -254,7 +254,7 @@ namespace :docs do
 
           args << {
             name: tag.name,
-            types: tag.types.join(', '),
+            type: tag.types.join(', '),
             default: default,
             description: view_context.render(inline: tag.text),
           }
@@ -263,8 +263,8 @@ namespace :docs do
         end
 
         component_args = {
-          component_name: short_name,
-          args: args,
+          component: short_name,
+          parameters: args,
         }
 
         args_for_components << component_args
@@ -309,7 +309,8 @@ namespace :docs do
       end
     end
 
-    puts args_for_components
+    require "yaml"
+    puts YAML.dump(args_for_components)
 
     # Build system arguments docs from BaseComponent
     documentation = registry.get(Primer::BaseComponent.name)

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require "rake/testtask"
 require "yard"
 require "yard/renders_one_handler"
 require "yard/renders_many_handler"
+require "yaml"
 
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
@@ -251,7 +252,6 @@ namespace :docs do
               "N/A"
             end
 
-
           args << {
             "name" => tag.name,
             "type" => tag.types.join(', '),
@@ -310,8 +310,9 @@ namespace :docs do
       end
     end
 
-    require "yaml"
-    puts YAML.dump(args_for_components)
+    File.open("static/arguments.yml", "w") do |f|
+      f.puts YAML.dump(args_for_components)
+    end
 
     # Build system arguments docs from BaseComponent
     documentation = registry.get(Primer::BaseComponent.name)

--- a/Rakefile
+++ b/Rakefile
@@ -253,19 +253,19 @@ namespace :docs do
 
 
           args << {
-            name: tag.name,
-            type: tag.types.join(', '),
-            default: default,
-            description: view_context.render(inline: tag.text),
+            "name" => tag.name,
+            "type" => tag.types.join(', '),
+            "default" => default,
+            "description" => view_context.render(inline: tag.text),
           }
 
           f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
         end
 
         component_args = {
-          component: short_name,
-          source: "https://github.com/primer/view_components/tree/main/app/components/primer/#{component.to_s.demodulize.underscore}.rb",
-          parameters: args,
+          "component" => short_name,
+          "source" => "https://github.com/primer/view_components/tree/main/app/components/primer/#{component.to_s.demodulize.underscore}.rb",
+          "parameters" => args,
         }
 
         args_for_components << component_args

--- a/Rakefile
+++ b/Rakefile
@@ -264,6 +264,7 @@ namespace :docs do
 
         component_args = {
           component: short_name,
+          source: "https://github.com/primer/view_components/tree/main/app/components/primer/#{component.to_s.demodulize.underscore}.rb",
           parameters: args,
         }
 

--- a/Rakefile
+++ b/Rakefile
@@ -171,6 +171,7 @@ namespace :docs do
     components_needing_docs = all_components - components
 
     components_without_examples = []
+    args_for_components = []
 
     components.each do |component|
       documentation = registry.get(component.name)
@@ -233,6 +234,7 @@ namespace :docs do
         f.puts("| Name | Type | Default | Description |")
         f.puts("| :- | :- | :- | :- |")
 
+        args = []
         initialize_method.tags(:param).each do |tag|
           params = tag.object.parameters.find { |param| [tag.name.to_s, tag.name.to_s + ":"].include?(param[0]) }
 
@@ -249,8 +251,23 @@ namespace :docs do
               "N/A"
             end
 
+
+          args << {
+            name: tag.name,
+            types: tag.types.join(', '),
+            default: default,
+            description: view_context.render(inline: tag.text),
+          }
+
           f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
         end
+
+        component_args = {
+          component_name: short_name,
+          args: args,
+        }
+
+        args_for_components << component_args
 
         # Slots V2 docs
         slot_v2_methods = documentation.meths.select { |x| x[:renders_one] || x[:renders_many] }
@@ -291,6 +308,8 @@ namespace :docs do
         end
       end
     end
+
+    puts args_for_components
 
     # Build system arguments docs from BaseComponent
     documentation = registry.get(Primer::BaseComponent.name)

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -1,0 +1,693 @@
+---
+- component: AutoComplete
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/auto_complete_component.rb
+  parameters:
+  - name: src
+    type: String
+    default: N/A
+    description: The route to query.
+  - name: id
+    type: String
+    default: N/A
+    description: Id of the list element.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: AutoCompleteItem
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/auto_complete_item_component.rb
+  parameters:
+  - name: value
+    type: String
+    default: N/A
+    description: Value of the item.
+  - name: selected
+    type: Boolean
+    default: "`false`"
+    description: Whether the item is selected.
+  - name: disabled
+    type: Boolean
+    default: "`false`"
+    description: Whether the item is disabled.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Avatar
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/avatar_component.rb
+  parameters:
+  - name: src
+    type: String
+    default: N/A
+    description: The source url of the avatar image.
+  - name: alt
+    type: String
+    default: N/A
+    description: Passed through to alt on img tag.
+  - name: size
+    type: Integer
+    default: "`20`"
+    description: Adds the avatar-small class if less than 24.
+  - name: square
+    type: Boolean
+    default: "`false`"
+    description: Used to create a square avatar.
+  - name: href
+    type: String
+    default: "`nil`"
+    description: The URL to link to. If used, component will be wrapped by an `<a>`
+      tag.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: AvatarStack
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/avatar_stack_component.rb
+  parameters:
+  - name: align
+    type: Symbol
+    default: "`:left`"
+    description: One of `:left` and `:right`.
+  - name: tooltipped
+    type: Boolean
+    default: "`false`"
+    description: Whether to add a tooltip to the stack or not.
+  - name: body_arguments
+    type: Hash
+    default: "`{}`"
+    description: Parameters to add to the Body. If `tooltipped` is set, has the same
+      arguments as [Tooltip](/components/tooltip).
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Blankslate
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/blankslate_component.rb
+  parameters:
+  - name: title
+    type: String
+    default: '`""`'
+    description: Text that appears in a larger bold font.
+  - name: title_tag
+    type: Symbol
+    default: "`:h3`"
+    description: HTML tag to use for title.
+  - name: icon
+    type: String
+    default: '`""`'
+    description: Octicon icon to use at top of component.
+  - name: icon_size
+    type: Symbol
+    default: "`:medium`"
+    description: One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`).
+  - name: image_src
+    type: String
+    default: '`""`'
+    description: Image to display.
+  - name: image_alt
+    type: String
+    default: '`" "`'
+    description: Alt text for image.
+  - name: description
+    type: String
+    default: '`""`'
+    description: Text that appears below the title. Typically a whole sentence.
+  - name: button_text
+    type: String
+    default: '`""`'
+    description: The text of the button.
+  - name: button_url
+    type: String
+    default: '`""`'
+    description: The URL where the user will be taken after clicking the button.
+  - name: button_classes
+    type: String
+    default: '`"btn-primary my-3"`'
+    description: Classes to apply to action button
+  - name: link_text
+    type: String
+    default: '`""`'
+    description: The text of the link.
+  - name: link_url
+    type: String
+    default: '`""`'
+    description: The URL where the user will be taken after clicking the link.
+  - name: narrow
+    type: Boolean
+    default: "`false`"
+    description: Adds a maximum width.
+  - name: large
+    type: Boolean
+    default: "`false`"
+    description: Increases the font size.
+  - name: spacious
+    type: Boolean
+    default: "`false`"
+    description: Adds extra padding.
+- component: BorderBox
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/border_box_component.rb
+  parameters:
+  - name: padding
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:condensed`, or `:spacious`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Box
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/box_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Breadcrumb
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/breadcrumb_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Button
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/button_component.rb
+  parameters:
+  - name: button_type
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:primary`, `:danger`, or `:outline`.
+  - name: variant
+    type: Symbol
+    default: "`:medium`"
+    description: One of `:small`, `:medium`, or `:large`.
+  - name: tag
+    type: Symbol
+    default: "`:button`"
+    description: One of `:button`, `:a`, or `:summary`.
+  - name: type
+    type: Symbol
+    default: "`:button`"
+    description: One of `:button`, `:reset`, or `:submit`.
+  - name: group_item
+    type: Boolean
+    default: "`false`"
+    description: Whether button is part of a ButtonGroup.
+- component: ButtonGroup
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/button_group_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: ButtonMarketing
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/button_marketing_component.rb
+  parameters:
+  - name: button_type
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:primary`, `:outline`, or `:transparent`.
+  - name: variant
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default` and `:large`.
+  - name: tag
+    type: Symbol
+    default: "`:button`"
+    description: One of `:button` and `:a`.
+  - name: type
+    type: Symbol
+    default: "`:button`"
+    description: One of `:button` and `:submit`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Counter
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/counter_component.rb
+  parameters:
+  - name: count
+    type: Integer, Float::INFINITY, nil
+    default: "`0`"
+    description: 'The number to be displayed (e.x. # of issues, pull requests)'
+  - name: scheme
+    type: Symbol
+    default: "`:default`"
+    description: Color scheme. One of `:default`, `:primary`, or `:secondary`.
+  - name: limit
+    type: Integer, nil
+    default: "`5_000`"
+    description: Maximum value to display. Pass `nil` for no limit. (e.x. if `count`
+      == 6,000 and `limit` == 5000, counter will display "5,000+")
+  - name: hide_if_zero
+    type: Boolean
+    default: "`false`"
+    description: If true, a `hidden` attribute is added to the counter if `count`
+      is zero.
+  - name: text
+    type: String
+    default: '`""`'
+    description: Text to display instead of count.
+  - name: round
+    type: Boolean
+    default: "`false`"
+    description: Whether to apply our standard rounding logic to value.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Details
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/details_component.rb
+  parameters:
+  - name: overlay
+    type: Symbol
+    default: "`:none`"
+    description: Dictates the type of overlay to render with. One of `:none`, `:default`,
+      or `:dark`.
+  - name: reset
+    type: Boolean
+    default: "`false`"
+    description: Defatuls to false. If set to true, it will remove the default caret
+      and remove style from the summary element
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Dropdown
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/dropdown_component.rb
+  parameters:
+  - name: overlay
+    type: Symbol
+    default: "`:default`"
+    description: One of `:none`, `:default`, or `:dark`.
+  - name: reset
+    type: Boolean
+    default: "`true`"
+    description: Whether to hide the default caret on the button
+  - name: summary_classes
+    type: String
+    default: '`""`'
+    description: Custom classes to add to the button
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: DropdownMenu
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/dropdown_menu_component.rb
+  parameters:
+  - name: direction
+    type: Symbol
+    default: "`:se`"
+    description: One of `:se`, `:sw`, `:w`, `:e`, `:ne`, or `:s`.
+  - name: scheme
+    type: Symbol
+    default: "`:default`"
+    description: Pass :dark for dark mode theming
+  - name: header
+    type: String
+    default: "`nil`"
+    description: Optional string to display as the header
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Flash
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/flash_component.rb
+  parameters:
+  - name: full
+    type: Boolean
+    default: "`false`"
+    description: Whether the component should take up the full width of the screen.
+  - name: spacious
+    type: Boolean
+    default: "`false`"
+    description: Whether to add margin to the bottom of the component.
+  - name: dismissible
+    type: Boolean
+    default: "`false`"
+    description: Whether the component can be dismissed with an X button.
+  - name: icon
+    type: String
+    default: "`nil`"
+    description: Name of Octicon icon to use.
+  - name: variant
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:warning`, `:danger`, or `:success`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Flex
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/flex_component.rb
+  parameters:
+  - name: justify_content
+    type: Symbol
+    default: "`JUSTIFY_CONTENT_DEFAULT`"
+    description: Use this param to distribute space between and around flex items
+      along the main axis of the container. One of `nil`, `:flex_start`, `:flex_end`,
+      `:center`, `:space_between`, or `:space_around`.
+  - name: inline
+    type: Boolean
+    default: "`false`"
+    description: Defaults to false.
+  - name: flex_wrap
+    type: Boolean
+    default: "`FLEX_WRAP_DEFAULT`"
+    description: Defaults to nil.
+  - name: align_items
+    type: Symbol
+    default: "`ALIGN_ITEMS_DEFAULT`"
+    description: Use this param to align items on the cross axis. One of `nil`, `:start`,
+      `:end`, `:center`, `:baseline`, or `:stretch`.
+  - name: direction
+    type: Symbol
+    default: "`nil`"
+    description: Use this param to define the orientation of the main axis (row or
+      column). By default, flex items will display in a row. One of `nil`, `:column`,
+      `:column_reverse`, `:row`, or `:row_reverse`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: FlexItem
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/flex_item_component.rb
+  parameters:
+  - name: flex_auto
+    type: Boolean
+    default: "`false`"
+    description: Fills available space and auto-sizes based on the content. Defaults
+      to false
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Heading
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/heading_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Label
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/label_component.rb
+  parameters:
+  - name: title
+    type: String
+    default: N/A
+    description: "`title` attribute for the component element."
+  - name: scheme
+    type: Symbol
+    default: "`nil`"
+    description: One of `:primary`, `:secondary`, `:info`, `:success`, `:warning`,
+      `:danger`, `:orange`, or `:purple`.
+  - name: variant
+    type: Symbol
+    default: "`nil`"
+    description: One of `:large`, `:inline`, or `nil`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Layout
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/layout_component.rb
+  parameters:
+  - name: responsive
+    type: Boolean
+    default: "`false`"
+    description: Whether to collapse layout to a single column at smaller widths.
+  - name: side
+    type: Symbol
+    default: "`:right`"
+    description: Which side to display the sidebar on. One of `:right` and `:left`.
+  - name: sidebar_col
+    type: Integer
+    default: "`3`"
+    description: Sidebar column width.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Link
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/link_component.rb
+  parameters:
+  - name: tag
+    type: String
+    default: "`:a`"
+    description: One of `:a` and `:span`.
+  - name: href
+    type: String
+    default: "`nil`"
+    description: URL to be used for the Link. Required if tag is `:a`. If the requirements
+      are not met an error will be raised in non production environments. In production,
+      an empty link element will be rendered.
+  - name: variant
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:primary`, or `:secondary`.
+  - name: muted
+    type: Boolean
+    default: "`false`"
+    description: Uses light gray for Link color, and blue on hover.
+  - name: underline
+    type: Boolean
+    default: "`true`"
+    description: Whether or not to underline the link.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Markdown
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/markdown_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Menu
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/menu_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Tab
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/tab_component.rb
+  parameters:
+  - name: selected
+    type: Boolean
+    default: "`false`"
+    description: Whether the Tab is selected or not.
+  - name: with_panel
+    type: Boolean
+    default: "`false`"
+    description: Whether the Tab has an associated panel.
+  - name: icon_classes
+    type: Boolean
+    default: '`""`'
+    description: Classes that must always be applied to icons.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Octicon
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/octicon_component.rb
+  parameters:
+  - name: icon
+    type: String
+    default: "`nil`"
+    description: Name of [Octicon](https://primer.style/octicons/) to use.
+  - name: size
+    type: Symbol
+    default: "`:small`"
+    description: One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`).
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Popover
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/popover_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: ProgressBar
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/progress_bar_component.rb
+  parameters:
+  - name: size
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default`, `:small`, or `:large`. Increases height.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: State
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/state_component.rb
+  parameters:
+  - name: title
+    type: String
+    default: N/A
+    description: "`title` HTML attribute."
+  - name: color
+    type: Symbol
+    default: "`:default`"
+    description: Background color. One of `:open`, `:closed`, `:merged`, `:default`,
+      `:green`, `:red`, or `:purple`.
+  - name: tag
+    type: Symbol
+    default: "`:span`"
+    description: HTML tag for element. One of `:span`, `:div`, or `:a`.
+  - name: size
+    type: Symbol
+    default: "`:default`"
+    description: One of `:default` and `:small`.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Spinner
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/spinner_component.rb
+  parameters:
+  - name: size
+    type: Symbol
+    default: "`:medium`"
+    description: One of `:small` (`16`), `:medium` (`32`), or `:large` (`64`).
+- component: Subhead
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/subhead_component.rb
+  parameters:
+  - name: spacious
+    type: Boolean
+    default: "`false`"
+    description: Whether to add spacing to the Subhead.
+  - name: hide_border
+    type: Boolean
+    default: "`false`"
+    description: Whether to hide the border under the heading.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: TabContainer
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/tab_container_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: TabNav
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/tab_nav_component.rb
+  parameters:
+  - name: aria_label
+    type: String
+    default: "`nil`"
+    description: Used to set the `aria-label` on the top level `<nav>` element.
+  - name: with_panel
+    type: Boolean
+    default: "`false`"
+    description: Whether the TabNav should navigate through pages or panels.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Text
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/text_component.rb
+  parameters:
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: TimeAgo
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/time_ago_component.rb
+  parameters:
+  - name: time
+    type: Time
+    default: N/A
+    description: The time to be formatted
+  - name: micro
+    type: Boolean
+    default: "`false`"
+    description: If true then the text will be formatted in "micro" mode, using as
+      few characters as possible
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: TimelineItem
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/timeline_item_component.rb
+  parameters:
+  - name: condensed
+    type: Boolean
+    default: "`false`"
+    description: Reduce the vertical padding and remove the background from the badge
+      item. Most commonly used in commits.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Tooltip
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/tooltip_component.rb
+  parameters:
+  - name: label
+    type: String
+    default: N/A
+    description: the text to appear in the tooltip
+  - name: direction
+    type: String
+    default: "`:n`"
+    description: Direction of the tooltip. One of `:n`, `:nw`, `:ne`, `:w`, `:e`,
+      `:sw`, `:s`, or `:se`.
+  - name: align
+    type: String
+    default: "`:default`"
+    description: Align tooltips to the left or right of an element, combined with
+      a `direction` to specify north or south. One of `:default`, `:left_1`, `:right_1`,
+      `:left_2`, or `:right_2`.
+  - name: multiline
+    type: Boolean
+    default: "`false`"
+    description: Use this when you have long content
+  - name: no_delay
+    type: Boolean
+    default: "`false`"
+    description: By default the tooltips have a slight delay before appearing. Set
+      true to override this
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: Truncate
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/truncate_component.rb
+  parameters:
+  - name: inline
+    type: Boolean
+    default: "`false`"
+    description: Whether the element is inline (or inline-block).
+  - name: expandable
+    type: Boolean
+    default: "`false`"
+    description: Whether the entire string should be revealed on hover. Can only be
+      used in conjunction with `inline`.
+  - name: max_width
+    type: Integer
+    default: "`nil`"
+    description: Sets the max-width of the text.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
+- component: UnderlineNav
+  source: https://github.com/primer/view_components/tree/main/app/components/primer/underline_nav_component.rb
+  parameters:
+  - name: with_panel
+    type: Boolean
+    default: "`false`"
+    description: Whether the TabNav should navigate through pages or panels.
+  - name: align
+    type: Symbol
+    default: "`:left`"
+    description: One of `:left` and `:right`. - Defaults to left
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"


### PR DESCRIPTION
Update the docs:build process to output a yaml blob of the arguments and types for each component. We can then programmatically (via http raw requests to dotcom probably) use this data to align our other component projects.

The file lives along the other static statuses.json file.

Since we run the build step on PR's, this file should stay up to date "for free" as we add / change components.