### PR TITLE
Organize system arguments into sections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -301,19 +301,12 @@ namespace :docs do
       f.puts
       f.puts("<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->")
       f.puts
-      f.puts(view_context.render(inline: documentation.base_docstring))
+      f.puts(documentation.base_docstring)
       f.puts
 
       initialize_method = documentation.meths.find(&:constructor?)
 
-      f.puts("## Arguments")
-      f.puts
-      f.puts("| Name | Type | Description |")
-      f.puts("| :- | :- | :- |")
-
-      initialize_method.tags(:param).each do |tag|
-        f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{view_context.render(inline: tag.text)} |")
-      end
+      f.puts(view_context.render(inline: initialize_method.base_docstring))
     end
 
     puts "Markdown compiled."

--- a/Rakefile
+++ b/Rakefile
@@ -301,7 +301,7 @@ namespace :docs do
       f.puts
       f.puts("<!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->")
       f.puts
-      f.puts(documentation.base_docstring)
+      f.puts(view_context.render(inline: documentation.base_docstring))
       f.puts
 
       initialize_method = documentation.meths.find(&:constructor?)

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -29,87 +29,115 @@ module Primer
   #
   # | Name | Type | Description |
   # | :- | :- | :- |
-  # | `width` | `Integer` | Width. |
-  # | `height` | `Integer` | Height. |
-  # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
   # | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
-  # | `title` | `String` | The `title` attribute. |
-  # | `style` | `String` | Inline styles. |
+  # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
+  # | `height` | `Integer` | Height. |
   # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
+  # | `style` | `String` | Inline styles. |
+  # | `title` | `String` | The `title` attribute. |
+  # | `width` | `Integer` | Width. |
+  #
+  # ## Animation
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
+  #
+  # ## Border
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
+  # | `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
+  # | `border_left` | Integer | Set to `0` to remove the left border. |
+  # | `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
+  # | `border_right` | Integer | Set to `0` to remove the right border. |
+  # | `border_top` | Integer | Set to `0` to remove the top border. |
+  # | `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
+  # | `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
+  #
+  # ## Color
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
+  # | `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
+  #
+  # ## Flex
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `align_items` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %> |
+  # | `align_self` | Symbol | <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %> |
+  # | `flex_grow` | Integer | To enable, set to `0`. |
+  # | `flex_shrink` | Integer | To enable, set to `0`. |
+  # | `flex` | Integer, Symbol | <%= one_of([1, :auto]) %> |
+  # | `justify_content` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %> |
+  # | `width` | Symbol | <%= one_of([:fit, :fill]) %> |
+  #
+  # ## Grid
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `col` | Integer | Number of columns. |
+  #
+  # ## Layout
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %> |
+  # | `height` | Symbol | <%= one_of([:fit, :fill]) %> |
+  # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %> |
+  # | `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
+  # | `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
+  #
+  # ## Position
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
+  # | `float` | Symbol | <%= one_of([:left, :right]) %> |
+  # | `left` | Boolean | If `false`, sets `left: 0`. |
+  # | `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
+  # | `right` | Boolean | If `false`, sets `right: 0`. |
+  # | `top` | Boolean | If `false`, sets `top: 0`. |
+  #
+  # ## Spacing
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
+  # | `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
+  # | `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
+  # | `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
+  # | `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
+  # | `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
+  # | `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
+  # | `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
+  # | `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
+  # | `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+  # | `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
+  # | `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+  # | `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
+  # | `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
+  #
+  # ## Typography
+  #
+  # | Name | Type | Description |
+  # | :- | :- | :- |
+  # | `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
+  # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
+  # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
+  # | `underline` | Boolean | Whether text should be underlined. |
+  # | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
   class BaseComponent < Primer::Component
     status :beta
 
     include TestSelectorHelper
 
-    # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
-    #
-    # @param m [Integer] Margin. <%= one_of((-6..6).to_a) %>
-    # @param mt [Integer] Margin top. <%= one_of((-6..6).to_a) %>
-    # @param mr [Integer] Margin right. <%= one_of((-6..6).to_a) %>
-    # @param mb [Integer] Margin bottom. <%= one_of((-6..6).to_a) %>
-    # @param ml [Integer] Margin left. <%= one_of((-6..6).to_a) %>
-    # @param mx [Integer] Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %>
-    # @param my [Integer] Vertical margins. <%= one_of((-6..6).to_a) %>
-    # @param p [Integer] Padding. <%= one_of((0..6).to_a) %>
-    # @param pt [Integer] Padding left. <%= one_of((0..6).to_a) %>
-    # @param pr [Integer] Padding right. <%= one_of((0..6).to_a) %>
-    # @param pb [Integer] Padding bottom. <%= one_of((0..6).to_a) %>
-    # @param pl [Integer] Padding left. <%= one_of((0..6).to_a) %>
-    # @param px [Integer] Horizontal padding. <%= one_of((0..6).to_a) %>
-    # @param py [Integer] Vertical padding. <%= one_of((0..6).to_a) %>
-    #
-    # @param position [Symbol] <%= one_of([:relative, :absolute, :fixed]) %>
-    #
-    # @param top [Boolean] If `false`, sets `top: 0`.
-    # @param right [Boolean] If `false`, sets `right: 0`.
-    # @param bottom [Boolean] If `false`, sets `bottom: 0`.
-    # @param left [Boolean] If `false`, sets `left: 0`.
-    #
-    # @param display [Symbol] <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %>
-    #
-    # @param v [Symbol] Visibility. <%= one_of([:hidden, :visible]) %>
-    #
-    # @param hide [Symbol] Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %>
-    #
-    # @param vertical_align [Symbol] <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %>
-    #
-    # @param float [Symbol] <%= one_of([:left, :right]) %>
-    #
-    # @param col [Integer] Number of columns.
-    #
-    # @param underline [Boolean] Whether text should be underlined.
-    #
-    # @param color [Symbol] Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br /> Deprecated options: <%= one_of(Primer::Classify::FunctionalTextColors::DEPRECATED_OPTIONS) %>
-    # @param bg [String, Symbol] Background color. Accepts either a hex value as a String or a color name as a Symbol.
-    #
-    # @param box_shadow [Boolean, Symbol] Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %>
-    # @param border [Symbol] <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %>
-    # @param border_color [Symbol] <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> Deprecated options: <%= one_of(Primer::Classify::FunctionalBorderColors::DEPRECATED_OPTIONS) %>
-    # @param border_top [Integer] Set to `0` to remove the top border.
-    # @param border_bottom [Integer] Set to `0` to remove the bottom border.
-    # @param border_left [Integer] Set to `0` to remove the left border.
-    # @param border_right [Integer] Set to `0` to remove the right border.
-    # @param border_radius [Integer] <%= one_of([0, 1, 2, 3]) %>
-    #
-    # @param font_size [String, Integer] <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %>
-    # @param text_align [Symbol] Text alignment. <%= one_of([:left, :right, :center]) %>
-    # @param font_weight [Symbol] Font weight. <%= one_of([:light, :normal, :bold]) %>
-    #
-    # @param flex [Integer, Symbol] <%= one_of([1, :auto]) %>
-    # @param flex_grow [Integer] To enable, set to `0`.
-    # @param flex_shrink [Integer] To enable, set to `0`.
-    # @param align_self [Symbol] <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %>
-    # @param justify_content [Symbol] <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %>
-    # @param align_items [Symbol] <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %>
-    # @param width [Symbol] <%= one_of([:fit, :fill]) %>
-    # @param height [Symbol] <%= one_of([:fit, :fill]) %>
-    #
-    # @param word_break [Symbol] Whether to break words on line breaks. Can only be `:break_all`.
-    #
-    # @param animation [Symbol] <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %>
-    #
-    # @param tag [Symbol] HTML tag name to be passed to `tag.send`.
     # @param classes [String] CSS class name value to be concatenated with generated Primer CSS classes.
+    # @param tag [Symbol] HTML tag name to be passed to `content_tag`.
+    # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
     def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag
       @result = Primer::Classify.call(**system_arguments.merge(classes: classes))

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -22,122 +22,126 @@ module Primer
   # ```html
   # <h1 class="mt-0 mt-lg-4 mt-xl-2">Hello world</h1>
   # ```
-  #
-  # ## HTML attributes
-  #
-  # System arguments include most HTML attributes. For example:
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
-  # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
-  # | `height` | `Integer` | Height. |
-  # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
-  # | `style` | `String` | Inline styles. |
-  # | `title` | `String` | The `title` attribute. |
-  # | `width` | `Integer` | Width. |
-  #
-  # ## Animation
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
-  #
-  # ## Border
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
-  # | `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
-  # | `border_left` | Integer | Set to `0` to remove the left border. |
-  # | `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
-  # | `border_right` | Integer | Set to `0` to remove the right border. |
-  # | `border_top` | Integer | Set to `0` to remove the top border. |
-  # | `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
-  # | `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
-  #
-  # ## Color
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-  # | `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
-  #
-  # ## Flex
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `align_items` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %> |
-  # | `align_self` | Symbol | <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %> |
-  # | `flex_grow` | Integer | To enable, set to `0`. |
-  # | `flex_shrink` | Integer | To enable, set to `0`. |
-  # | `flex` | Integer, Symbol | <%= one_of([1, :auto]) %> |
-  # | `justify_content` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %> |
-  # | `width` | Symbol | <%= one_of([:fit, :fill]) %> |
-  #
-  # ## Grid
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `col` | Integer | Number of columns. |
-  #
-  # ## Layout
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %> |
-  # | `height` | Symbol | <%= one_of([:fit, :fill]) %> |
-  # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %> |
-  # | `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
-  # | `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
-  #
-  # ## Position
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
-  # | `float` | Symbol | <%= one_of([:left, :right]) %> |
-  # | `left` | Boolean | If `false`, sets `left: 0`. |
-  # | `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
-  # | `right` | Boolean | If `false`, sets `right: 0`. |
-  # | `top` | Boolean | If `false`, sets `top: 0`. |
-  #
-  # ## Spacing
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
-  # | `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
-  # | `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
-  # | `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
-  # | `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
-  # | `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
-  # | `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
-  # | `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
-  # | `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
-  # | `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-  # | `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
-  # | `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-  # | `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
-  # | `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
-  #
-  # ## Typography
-  #
-  # | Name | Type | Description |
-  # | :- | :- | :- |
-  # | `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
-  # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
-  # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
-  # | `underline` | Boolean | Whether text should be underlined. |
-  # | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
   class BaseComponent < Primer::Component
     status :beta
 
     include TestSelectorHelper
 
-    # @param classes [String] CSS class name value to be concatenated with generated Primer CSS classes.
-    # @param tag [Symbol] HTML tag name to be passed to `content_tag`.
-    # @param test_selector [String] Adds `data-test-selector='given value'` in non-Production environments for testing purposes.
+    # ## HTML attributes
+    #
+    # System arguments include most HTML attributes. For example:
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
+    # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
+    # | `height` | `Integer` | Height. |
+    # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
+    # | `style` | `String` | Inline styles. |
+    # | `title` | `String` | The `title` attribute. |
+    # | `width` | `Integer` | Width. |
+    #
+    # ## Animation
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
+    #
+    # ## Border
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
+    # | `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
+    # | `border_left` | Integer | Set to `0` to remove the left border. |
+    # | `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
+    # | `border_right` | Integer | Set to `0` to remove the right border. |
+    # | `border_top` | Integer | Set to `0` to remove the top border. |
+    # | `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
+    # | `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
+    #
+    # ## Color
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
+    # | `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
+    #
+    # ## Flex
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `align_items` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %> |
+    # | `align_self` | Symbol | <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %> |
+    # | `flex_grow` | Integer | To enable, set to `0`. |
+    # | `flex_shrink` | Integer | To enable, set to `0`. |
+    # | `flex` | Integer, Symbol | <%= one_of([1, :auto]) %> |
+    # | `justify_content` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %> |
+    # | `width` | Symbol | <%= one_of([:fit, :fill]) %> |
+    #
+    # ## Grid
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `col` | Integer | Number of columns. |
+    #
+    # ## Layout
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %> |
+    # | `height` | Symbol | <%= one_of([:fit, :fill]) %> |
+    # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %> |
+    # | `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
+    # | `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
+    #
+    # ## Position
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
+    # | `float` | Symbol | <%= one_of([:left, :right]) %> |
+    # | `left` | Boolean | If `false`, sets `left: 0`. |
+    # | `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
+    # | `right` | Boolean | If `false`, sets `right: 0`. |
+    # | `top` | Boolean | If `false`, sets `top: 0`. |
+    #
+    # ## Spacing
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
+    # | `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
+    # | `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
+    # | `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
+    # | `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
+    # | `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
+    # | `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
+    # | `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
+    # | `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
+    # | `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+    # | `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
+    # | `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+    # | `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
+    # | `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
+    #
+    # ## Typography
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
+    # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
+    # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
+    # | `underline` | Boolean | Whether text should be underlined. |
+    # | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
+    #
+    # ## Other
+    #
+    # | Name | Type | Description |
+    # | :- | :- | :- |
+    # | classes | String | CSS class name value to be concatenated with generated Primer CSS classes. |
+    # | tag | Symbol | HTML tag name to be passed to `content_tag`. |
+    # | test_selector | String | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
     def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag
       @result = Primer::Classify.call(**system_arguments.merge(classes: classes))

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -15,9 +15,10 @@ To apply different values across responsive breakpoints, pass an array with up t
 For example:
 
 ```erb
-<h1 class="mt-0 mt-lg-4 mt-xl-2">
+<%= render Primer::HeadingComponent.new(mt: [0, nil, nil, 4, 2]) do %>
   Hello world
-</h1>```
+<% end %>
+```
 
 Renders:
 
@@ -133,10 +134,10 @@ System arguments include most HTML attributes. For example:
 | `underline` | Boolean | Whether text should be underlined. |
 | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
 
-## Arguments
+## Other
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `classes` | `String` | CSS class name value to be concatenated with generated Primer CSS classes. |
-| `tag` | `Symbol` | HTML tag name to be passed to `content_tag`. |
-| `test_selector` | `String` | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
+| classes | String | CSS class name value to be concatenated with generated Primer CSS classes. |
+| tag | Symbol | HTML tag name to be passed to `content_tag`. |
+| test_selector | String | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -32,67 +32,112 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `width` | `Integer` | Width. |
-| `height` | `Integer` | Height. |
-| `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
 | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
-| `title` | `String` | The `title` attribute. |
-| `style` | `String` | Inline styles. |
+| `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
+| `height` | `Integer` | Height. |
 | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
+| `style` | `String` | Inline styles. |
+| `title` | `String` | The `title` attribute. |
+| `width` | `Integer` | Width. |
+
+## Animation
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
+
+## Border
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `border_bottom` | Integer | Set to `0` to remove the bottom border. |
+| `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
+| `border_left` | Integer | Set to `0` to remove the left border. |
+| `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
+| `border_right` | Integer | Set to `0` to remove the right border. |
+| `border_top` | Integer | Set to `0` to remove the top border. |
+| `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
+| `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
+
+## Color
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
+| `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
+
+## Flex
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `align_items` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %> |
+| `align_self` | Symbol | <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %> |
+| `flex_grow` | Integer | To enable, set to `0`. |
+| `flex_shrink` | Integer | To enable, set to `0`. |
+| `flex` | Integer, Symbol | <%= one_of([1, :auto]) %> |
+| `justify_content` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %> |
+| `width` | Symbol | <%= one_of([:fit, :fill]) %> |
+
+## Grid
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `col` | Integer | Number of columns. |
+
+## Layout
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %> |
+| `height` | Symbol | <%= one_of([:fit, :fill]) %> |
+| `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %> |
+| `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
+| `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
+
+## Position
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `bottom` | Boolean | If `false`, sets `bottom: 0`. |
+| `float` | Symbol | <%= one_of([:left, :right]) %> |
+| `left` | Boolean | If `false`, sets `left: 0`. |
+| `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
+| `right` | Boolean | If `false`, sets `right: 0`. |
+| `top` | Boolean | If `false`, sets `top: 0`. |
+
+## Spacing
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
+| `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
+| `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
+| `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
+| `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
+| `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
+| `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
+| `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
+| `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
+| `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+| `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
+| `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
+| `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
+| `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
+
+## Typography
+
+| Name | Type | Description |
+| :- | :- | :- |
+| `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
+| `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
+| `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
+| `underline` | Boolean | Whether text should be underlined. |
+| `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
 
 ## Arguments
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `test_selector` | `String` | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
-| `m` | `Integer` | Margin. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mt` | `Integer` | Margin top. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mr` | `Integer` | Margin right. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mb` | `Integer` | Margin bottom. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `ml` | `Integer` | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mx` | `Integer` | Horizontal margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
-| `my` | `Integer` | Vertical margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `p` | `Integer` | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `pt` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `pr` | `Integer` | Padding right. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `pb` | `Integer` | Padding bottom. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `pl` | `Integer` | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `px` | `Integer` | Horizontal padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `py` | `Integer` | Vertical padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `position` | `Symbol` | One of `:relative`, `:absolute`, or `:fixed`. |
-| `top` | `Boolean` | If `false`, sets `top: 0`. |
-| `right` | `Boolean` | If `false`, sets `right: 0`. |
-| `bottom` | `Boolean` | If `false`, sets `bottom: 0`. |
-| `left` | `Boolean` | If `false`, sets `left: 0`. |
-| `display` | `Symbol` | One of `:none`, `:block`, `:flex`, `:inline`, `:inline_block`, `:table`, or `:table_cell`. |
-| `v` | `Symbol` | Visibility. One of `:hidden` and `:visible`. |
-| `hide` | `Symbol` | Hide the element at a specific breakpoint. One of `:sm`, `:md`, `:lg`, or `:xl`. |
-| `vertical_align` | `Symbol` | One of `:baseline`, `:top`, `:middle`, `:bottom`, `:text_top`, or `:text_bottom`. |
-| `float` | `Symbol` | One of `:left` and `:right`. |
-| `col` | `Integer` | Number of columns. |
-| `underline` | `Boolean` | Whether text should be underlined. |
-| `color` | `Symbol` | Text color. <br /> One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. <br /> Deprecated options: One of `:gray_dark`, `:gray`, `:gray_light`, `:blue`, `:green`, `:yellow`, `:red`, `:white`, `:black`, `:orange`, `:orange_light`, `:purple`, `:pink`, or `:inherit`. |
-| `bg` | `String, Symbol` | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-| `box_shadow` | `Boolean, Symbol` | Box shadow. One of `true`, `:medium`, `:large`, `:extra_large`, or `:none`. |
-| `border` | `Symbol` | One of `:left`, `:top`, `:bottom`, `:right`, `:y`, `:x`, or `true`. |
-| `border_color` | `Symbol` | One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. <br /> Deprecated options: One of `:gray`, `:gray_light`, `:gray_dark`, `:blue`, `:green`, `:yellow`, `:red`, `:white`, `:gray_darker`, `:blue_light`, `:red_light`, `:purple`, `:black_fade`, or `:white_fade`. |
-| `border_top` | `Integer` | Set to `0` to remove the top border. |
-| `border_bottom` | `Integer` | Set to `0` to remove the bottom border. |
-| `border_left` | `Integer` | Set to `0` to remove the left border. |
-| `border_right` | `Integer` | Set to `0` to remove the right border. |
-| `border_radius` | `Integer` | One of `0`, `1`, `2`, or `3`. |
-| `font_size` | `String, Integer` | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `text_align` | `Symbol` | Text alignment. One of `:left`, `:right`, or `:center`. |
-| `font_weight` | `Symbol` | Font weight. One of `:light`, `:normal`, or `:bold`. |
-| `flex` | `Integer, Symbol` | One of `1` and `:auto`. |
-| `flex_grow` | `Integer` | To enable, set to `0`. |
-| `flex_shrink` | `Integer` | To enable, set to `0`. |
-| `align_self` | `Symbol` | One of `:auto`, `:start`, `:end`, `:center`, `:baseline`, or `:stretch`. |
-| `justify_content` | `Symbol` | One of `:flex_start`, `:flex_end`, `:center`, `:space_between`, or `:space_around`. |
-| `align_items` | `Symbol` | One of `:flex_start`, `:flex_end`, `:center`, `:baseline`, or `:stretch`. |
-| `width` | `Symbol` | One of `:fit` and `:fill`. |
-| `height` | `Symbol` | One of `:fit` and `:fill`. |
-| `word_break` | `Symbol` | Whether to break words on line breaks. Can only be `:break_all`. |
-| `animation` | `Symbol` | One of `:fade_in`, `:fade_out`, `:fade_up`, `:fade_down`, `:scale_in`, `:pulse`, `:grow_x`, or `:grow`. |
-| `tag` | `Symbol` | HTML tag name to be passed to `tag.send`. |
 | `classes` | `String` | CSS class name value to be concatenated with generated Primer CSS classes. |
+| `tag` | `Symbol` | HTML tag name to be passed to `content_tag`. |
+| `test_selector` | `String` | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -15,10 +15,9 @@ To apply different values across responsive breakpoints, pass an array with up t
 For example:
 
 ```erb
-<%= render Primer::HeadingComponent.new(mt: [0, nil, nil, 4, 2]) do %>
+<h1 class="mt-0 mt-lg-4 mt-xl-2">
   Hello world
-<% end %>
-```
+</h1>```
 
 Renders:
 
@@ -44,39 +43,39 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
+| `animation` | Symbol | One of `:fade_in`, `:fade_out`, `:fade_up`, `:fade_down`, `:scale_in`, `:pulse`, `:grow_x`, or `:grow`. |
 
 ## Border
 
 | Name | Type | Description |
 | :- | :- | :- |
 | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
-| `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
+| `border_color` | Symbol | One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. <br /> |
 | `border_left` | Integer | Set to `0` to remove the left border. |
-| `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
+| `border_radius` | Integer | One of `0`, `1`, `2`, or `3`. |
 | `border_right` | Integer | Set to `0` to remove the right border. |
 | `border_top` | Integer | Set to `0` to remove the top border. |
-| `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
-| `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
+| `border` | Symbol | One of `:left`, `:top`, `:bottom`, `:right`, `:y`, `:x`, or `true`. |
+| `box_shadow` | Boolean, Symbol | Box shadow. One of `true`, `:medium`, `:large`, `:extra_large`, or `:none`. |
 
 ## Color
 
 | Name | Type | Description |
 | :- | :- | :- |
 | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-| `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
+| `color` | Symbol | Text color. <br /> One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. <br />  |
 
 ## Flex
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `align_items` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :baseline, :stretch]) %> |
-| `align_self` | Symbol | <%= one_of([:auto, :start, :end, :center, :baseline, :stretch]) %> |
+| `align_items` | Symbol | One of `:flex_start`, `:flex_end`, `:center`, `:baseline`, or `:stretch`. |
+| `align_self` | Symbol | One of `:auto`, `:start`, `:end`, `:center`, `:baseline`, or `:stretch`. |
 | `flex_grow` | Integer | To enable, set to `0`. |
 | `flex_shrink` | Integer | To enable, set to `0`. |
-| `flex` | Integer, Symbol | <%= one_of([1, :auto]) %> |
-| `justify_content` | Symbol | <%= one_of([:flex_start, :flex_end, :center, :space_between, :space_around]) %> |
-| `width` | Symbol | <%= one_of([:fit, :fill]) %> |
+| `flex` | Integer, Symbol | One of `1` and `:auto`. |
+| `justify_content` | Symbol | One of `:flex_start`, `:flex_end`, `:center`, `:space_between`, or `:space_around`. |
+| `width` | Symbol | One of `:fit` and `:fill`. |
 
 ## Grid
 
@@ -88,20 +87,20 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :table, :table_cell]) %> |
-| `height` | Symbol | <%= one_of([:fit, :fill]) %> |
-| `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of([:sm, :md, :lg, :xl]) %> |
-| `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
-| `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
+| `display` | Symbol | One of `:none`, `:block`, `:flex`, `:inline`, `:inline_block`, `:table`, or `:table_cell`. |
+| `height` | Symbol | One of `:fit` and `:fill`. |
+| `hide` | Symbol | Hide the element at a specific breakpoint. One of `:sm`, `:md`, `:lg`, or `:xl`. |
+| `v` | Symbol | Visibility. One of `:hidden` and `:visible`. |
+| `vertical_align` | Symbol | One of `:baseline`, `:top`, `:middle`, `:bottom`, `:text_top`, or `:text_bottom`. |
 
 ## Position
 
 | Name | Type | Description |
 | :- | :- | :- |
 | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
-| `float` | Symbol | <%= one_of([:left, :right]) %> |
+| `float` | Symbol | One of `:left` and `:right`. |
 | `left` | Boolean | If `false`, sets `left: 0`. |
-| `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
+| `position` | Symbol | One of `:relative`, `:absolute`, or `:fixed`. |
 | `right` | Boolean | If `false`, sets `right: 0`. |
 | `top` | Boolean | If `false`, sets `top: 0`. |
 
@@ -109,28 +108,28 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
-| `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
-| `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
-| `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
-| `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
-| `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
-| `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
-| `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
-| `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
-| `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-| `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
-| `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-| `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
-| `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
+| `m` | Integer | Margin. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mb` | Integer | Margin bottom. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `ml` | Integer | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mr` | Integer | Margin right. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mt` | Integer | Margin top. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mx` | Integer | Horizontal margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
+| `my` | Integer | Vertical margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `p` | Integer | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pb` | Integer | Padding bottom. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pl` | Integer | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pr` | Integer | Padding right. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `pt` | Integer | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `px` | Integer | Horizontal padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `py` | Integer | Vertical padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 
 ## Typography
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
-| `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
-| `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
+| `font_size` | String, Integer | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `font_weight` | Symbol | Font weight. One of `:light`, `:normal`, or `:bold`. |
+| `text_align` | Symbol | Text alignment. One of `:left`, `:right`, or `:center`. |
 | `underline` | Boolean | Whether text should be underlined. |
 | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
 


### PR DESCRIPTION
Having everything in a single table makes it hard to find the argument you want. Here I'm separating the System Arguments into sections to make it easier to navigate:
![image](https://user-images.githubusercontent.com/11280312/112886704-e3b9d400-9097-11eb-91cc-e1aea893b854.png)
