### PR TITLE
Update Classify spacing constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Add `p: :responsive` system argument.
+
+    *Manuel Puyol*
+
 ## 0.0.33
 
 * Remove `TabbedComponent` validation requiring a tab to be selected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## main
 
-* Add `p: :responsive` system argument.
+* Add `p: :responsive` and `m: :auto` system arguments.
+
+    *Manuel Puyol*
+
+* Remove `my: :auto` and negative `m:` system arguments.
 
     *Manuel Puyol*
 

--- a/Rakefile
+++ b/Rakefile
@@ -64,7 +64,7 @@ namespace :docs do
     sleep
   end
 
-  def one_of(enumerable)
+  def one_of(enumerable, lower: false)
     values =
       case enumerable
       when Hash
@@ -77,7 +77,10 @@ namespace :docs do
         end
       end
 
-    "One of #{values.to_sentence(last_word_connector: ', or ')}."
+    prefix = "One of"
+    prefix = prefix.downcase if lower
+
+    "#{prefix} #{values.to_sentence(last_word_connector: ', or ')}."
   end
 
   def link_to_system_arguments_docs

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -52,7 +52,6 @@ module Primer
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
-    # | `border_color` | Symbol | <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> <br /> |
     # | `border_left` | Integer | Set to `0` to remove the left border. |
     # | `border_radius` | Integer | <%= one_of([0, 1, 2, 3]) %> |
     # | `border_right` | Integer | Set to `0` to remove the right border. |
@@ -64,8 +63,9 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-    # | `color` | Symbol | Text color. <br /> <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> <br />  |
+    # | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS, lower: true) %> |
+    # | `border_color` | Symbol | Border color. <%= one_of(Primer::Classify::FunctionalBorderColors::OPTIONS) %> |
+    # | `color` | Symbol | Text color. <%= one_of(Primer::Classify::FunctionalTextColors::OPTIONS) %> |
     #
     # ## Flex
     #
@@ -110,20 +110,20 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `m` | Integer | Margin. <%= one_of((-6..6).to_a) %> |
-    # | `mb` | Integer | Margin bottom. <%= one_of((-6..6).to_a) %> |
-    # | `ml` | Integer | Margin left. <%= one_of((-6..6).to_a) %> |
-    # | `mr` | Integer | Margin right. <%= one_of((-6..6).to_a) %> |
-    # | `mt` | Integer | Margin top. <%= one_of((-6..6).to_a) %> |
-    # | `mx` | Integer | Horizontal margins. <%= one_of((-6..6).to_a + [:auto]) %> |
-    # | `my` | Integer | Vertical margins. <%= one_of((-6..6).to_a) %> |
-    # | `p` | Integer | Padding. <%= one_of((0..6).to_a) %> |
-    # | `pb` | Integer | Padding bottom. <%= one_of((0..6).to_a) %> |
-    # | `pl` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-    # | `pr` | Integer | Padding right. <%= one_of((0..6).to_a) %> |
-    # | `pt` | Integer | Padding left. <%= one_of((0..6).to_a) %> |
-    # | `px` | Integer | Horizontal padding. <%= one_of((0..6).to_a) %> |
-    # | `py` | Integer | Vertical padding. <%= one_of((0..6).to_a) %> |
+    # | `m` | Integer | Margin. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:m]) %> |
+    # | `mb` | Integer | Margin bottom. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:mb]) %> |
+    # | `ml` | Integer | Margin left. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:ml]) %> |
+    # | `mr` | Integer | Margin right. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:mr]) %> |
+    # | `mt` | Integer | Margin top. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:mt]) %> |
+    # | `mx` | Integer | Horizontal margins. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:mx]) %> |
+    # | `my` | Integer | Vertical margins. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:my]) %> |
+    # | `p` | Integer | Padding. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:p]) %> |
+    # | `pb` | Integer | Padding bottom. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:pb]) %> |
+    # | `pl` | Integer | Padding left. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:pl]) %> |
+    # | `pr` | Integer | Padding right. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:pr]) %> |
+    # | `pt` | Integer | Padding left. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:pt]) %> |
+    # | `px` | Integer | Horizontal padding. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:px]) %> |
+    # | `py` | Integer | Vertical padding. <%= one_of(Primer::Classify::Spacing::MAPPINGS[:py]) %> |
     #
     # ## Typography
     #

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -3,12 +3,11 @@
 module Primer
   # :nodoc:
   class Classify
-    MARGIN_DIRECTION_KEYS = %i[mt ml mb mr].freeze
-    SPACING_KEYS = (%i[m my mx p py px pt pl pb pr] + MARGIN_DIRECTION_KEYS).freeze
     DIRECTION_KEY = :direction
     JUSTIFY_CONTENT_KEY = :justify_content
     ALIGN_ITEMS_KEY = :align_items
     DISPLAY_KEY = :display
+    SPACING_KEYS = Primer::Classify::Spacing::KEYS
     RESPONSIVE_KEYS = ([DISPLAY_KEY, DIRECTION_KEY, JUSTIFY_CONTENT_KEY, ALIGN_ITEMS_KEY, :col, :float] + SPACING_KEYS).freeze
     BREAKPOINTS = ["", "-sm", "-md", "-lg", "-xl"].freeze
 
@@ -184,14 +183,8 @@ module Primer
         return if val.nil? || val == ""
 
         if SPACING_KEYS.include?(key)
-          if MARGIN_DIRECTION_KEYS.include?(key)
-            raise ArgumentError, "value of #{key} must be between -6 and 6" if val < -6 || val > 6
-          elsif !((key == :mx || key == :my) && val == :auto)
-            raise ArgumentError, "value of #{key} must be between 0 and 6" if val.negative? || val > 6
-          end
-        end
-
-        if BOOLEAN_MAPPINGS.key?(key)
+          memo[:classes] << Primer::Classify::Spacing.spacing(key, val, breakpoint)
+        elsif BOOLEAN_MAPPINGS.key?(key)
           BOOLEAN_MAPPINGS[key][:mappings].each do |m|
             memo[:classes] << m[:css_class] if m[:value] == val && m[:css_class].present?
           end
@@ -248,8 +241,6 @@ module Primer
           memo[:classes] << "text-#{val.to_s.dasherize}"
         elsif TYPOGRAPHY_KEYS.include?(key)
           memo[:classes] << "f#{val.to_s.dasherize}"
-        elsif MARGIN_DIRECTION_KEYS.include?(key) && val.negative?
-          memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}"
         elsif key == BOX_SHADOW_KEY
           memo[:classes] << if val == true
                               "color-shadow-small"

--- a/app/lib/primer/classify/cache.rb
+++ b/app/lib/primer/classify/cache.rb
@@ -20,13 +20,23 @@ module Primer
 
         def preload!
           preload(
-            keys: Primer::Classify::MARGIN_DIRECTION_KEYS,
-            values: [-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6]
+            keys: Primer::Classify::Spacing::MARGIN_DIRECTION_MAPPINGS.keys,
+            values: Primer::Classify::Spacing::MARGIN_DIRECTION_OPTIONS
           )
 
           preload(
-            keys: (Primer::Classify::SPACING_KEYS - Primer::Classify::MARGIN_DIRECTION_KEYS),
-            values: [0, 1, 2, 3, 4, 5, 6]
+            keys: Primer::Classify::Spacing::BASE_MAPPINGS.keys,
+            values: Primer::Classify::Spacing::BASE_OPTIONS
+          )
+
+          preload(
+            keys: Primer::Classify::Spacing::AUTO_MAPPINGS.keys,
+            values: Primer::Classify::Spacing::AUTO_OPTIONS
+          )
+
+          preload(
+            keys: Primer::Classify::Spacing::RESPONSIVE_MAPPINGS.keys,
+            values: Primer::Classify::Spacing::RESPONSIVE_OPTIONS
           )
 
           preload(

--- a/app/lib/primer/classify/spacing.rb
+++ b/app/lib/primer/classify/spacing.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Primer
+  class Classify
+    class Spacing
+      BASE_OPTIONS = (0..6).to_a.freeze
+      BASE_MAPPINGS = {
+        m: BASE_OPTIONS,
+        pb: BASE_OPTIONS,
+        pl: BASE_OPTIONS,
+        pr: BASE_OPTIONS,
+        pt: BASE_OPTIONS,
+        px: BASE_OPTIONS,
+        py: BASE_OPTIONS
+      }.freeze
+
+      MARGIN_DIRECTION_OPTIONS = [*(-6..-1), *BASE_OPTIONS].freeze
+      MARGIN_DIRECTION_MAPPINGS = {
+        mb: MARGIN_DIRECTION_OPTIONS,
+        ml: MARGIN_DIRECTION_OPTIONS,
+        mr: MARGIN_DIRECTION_OPTIONS,
+        mt: MARGIN_DIRECTION_OPTIONS
+      }.freeze
+
+      AUTO_OPTIONS = [*BASE_OPTIONS, :auto].freeze
+      AUTO_MAPPINGS = {
+        mx: AUTO_OPTIONS,
+        my: AUTO_OPTIONS
+      }.freeze
+
+      RESPONSIVE_OPTIONS = [*BASE_OPTIONS, :responsive].freeze
+      RESPONSIVE_MAPPINGS = {
+        p: RESPONSIVE_OPTIONS
+      }.freeze
+
+      MAPPINGS = {
+        **BASE_MAPPINGS,
+        **MARGIN_DIRECTION_MAPPINGS,
+        **AUTO_MAPPINGS,
+        **RESPONSIVE_MAPPINGS
+      }.freeze
+      KEYS = MAPPINGS.keys.freeze
+
+      class << self
+        def spacing(key, val, breakpoint)
+          validate(key, val) unless Rails.env.production?
+
+          return "#{key.to_s.dasherize}#{breakpoint}-n#{val.abs}" if val.is_a?(Numeric) && val.negative?
+
+          "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
+        end
+
+        private
+
+        def validate(key, val)
+          raise ArgumentError, "#{key} is not a spacing key" unless KEYS.include?(key)
+          raise ArgumentError, "#{val} is not a valid value for :#{key}. Use one of  #{MAPPINGS[key]}" unless MAPPINGS[key].include?(val)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/primer/classify/spacing.rb
+++ b/app/lib/primer/classify/spacing.rb
@@ -2,6 +2,7 @@
 
 module Primer
   class Classify
+    # Spacing PrimerCSS classes handler.
     class Spacing
       BASE_OPTIONS = (0..6).to_a.freeze
       BASE_MAPPINGS = {

--- a/app/lib/primer/classify/spacing.rb
+++ b/app/lib/primer/classify/spacing.rb
@@ -5,7 +5,7 @@ module Primer
     class Spacing
       BASE_OPTIONS = (0..6).to_a.freeze
       BASE_MAPPINGS = {
-        m: BASE_OPTIONS,
+        my: BASE_OPTIONS,
         pb: BASE_OPTIONS,
         pl: BASE_OPTIONS,
         pr: BASE_OPTIONS,
@@ -24,8 +24,8 @@ module Primer
 
       AUTO_OPTIONS = [*BASE_OPTIONS, :auto].freeze
       AUTO_MAPPINGS = {
-        mx: AUTO_OPTIONS,
-        my: AUTO_OPTIONS
+        m: AUTO_OPTIONS,
+        mx: AUTO_OPTIONS
       }.freeze
 
       RESPONSIVE_OPTIONS = [*BASE_OPTIONS, :responsive].freeze

--- a/app/lib/primer/classify/spacing.rb
+++ b/app/lib/primer/classify/spacing.rb
@@ -2,7 +2,7 @@
 
 module Primer
   class Classify
-    # Spacing PrimerCSS classes handler.
+    # Handler for PrimerCSS spacing classes.
     class Spacing
       BASE_OPTIONS = (0..6).to_a.freeze
       BASE_MAPPINGS = {

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -51,7 +51,6 @@ System arguments include most HTML attributes. For example:
 | Name | Type | Description |
 | :- | :- | :- |
 | `border_bottom` | Integer | Set to `0` to remove the bottom border. |
-| `border_color` | Symbol | One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. <br /> |
 | `border_left` | Integer | Set to `0` to remove the left border. |
 | `border_radius` | Integer | One of `0`, `1`, `2`, or `3`. |
 | `border_right` | Integer | Set to `0` to remove the right border. |
@@ -63,8 +62,9 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `bg` | String, Symbol | Background color. Accepts either a hex value as a String or a color name as a Symbol. |
-| `color` | Symbol | Text color. <br /> One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. <br />  |
+| `bg` | String, Symbol | Background color. Accepts either a hex value as a String or one of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. |
+| `border_color` | Symbol | Border color. One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. |
+| `color` | Symbol | Text color. One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. |
 
 ## Flex
 
@@ -109,14 +109,14 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `m` | Integer | Margin. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `m` | Integer | Margin. One of `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
 | `mb` | Integer | Margin bottom. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `ml` | Integer | Margin left. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mr` | Integer | Margin right. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `mt` | Integer | Margin top. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `mx` | Integer | Horizontal margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
-| `my` | Integer | Vertical margins. One of `-6`, `-5`, `-4`, `-3`, `-2`, `-1`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `p` | Integer | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `mx` | Integer | Horizontal margins. One of `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:auto`. |
+| `my` | Integer | Vertical margins. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
+| `p` | Integer | Padding. One of `0`, `1`, `2`, `3`, `4`, `5`, `6`, or `:responsive`. |
 | `pb` | Integer | Padding bottom. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `pl` | Integer | Padding left. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
 | `pr` | Integer | Padding right. One of `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -44,6 +44,14 @@ class PrimerClassifyTest < Minitest::Test
     assert_raises ArgumentError do
       Primer::Classify.call(mr: -7)
     end
+
+    assert_raises ArgumentError do
+      Primer::Classify.call(m: :auto)
+    end
+
+    assert_raises ArgumentError do
+      Primer::Classify.call(mr: :auto)
+    end
   end
 
   def test_p
@@ -54,6 +62,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("pl-4", { pl: 4 })
     assert_generated_class("pb-4", { pb: 4 })
     assert_generated_class("pr-4", { pr: 4 })
+    assert_generated_class("p-responsive", { p: :responsive })
 
     assert_raises ArgumentError do
       Primer::Classify.call(p: -1)
@@ -61,6 +70,14 @@ class PrimerClassifyTest < Minitest::Test
 
     assert_raises ArgumentError do
       Primer::Classify.call(p: 7)
+    end
+
+    assert_raises ArgumentError do
+      Primer::Classify.call(pr: :responsive)
+    end
+
+    assert_raises ArgumentError do
+      Primer::Classify.call(px: :responsive)
     end
   end
 

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -32,7 +32,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("mb-n4",   { mb: -4 })
     assert_generated_class("mr-n4",   { mr: -4 })
     assert_generated_class("mx-auto", { mx: :auto })
-    assert_generated_class("mr-1 mr-sm-2 mr-md-3 mr-lg-4 mr-xl-5",  { mr: [1, 2, 3, 4, 5] })
+    assert_generated_class("mr-1 mr-sm-2 mr-md-3 mr-lg-4 mr-xl-5", { mr: [1, 2, 3, 4, 5] })
 
     assert_raises ArgumentError do
       Primer::Classify.call(m: -1)
@@ -64,7 +64,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("pb-4", { pb: 4 })
     assert_generated_class("pr-4", { pr: 4 })
     assert_generated_class("p-responsive", { p: :responsive })
-    assert_generated_class("pr-1 pr-sm-2 pr-md-3 pr-lg-4 pr-xl-5",  { pr: [1, 2, 3, 4, 5] })
+    assert_generated_class("pr-1 pr-sm-2 pr-md-3 pr-lg-4 pr-xl-5", { pr: [1, 2, 3, 4, 5] })
 
     assert_raises ArgumentError do
       Primer::Classify.call(p: -1)

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -32,6 +32,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("mb-n4",   { mb: -4 })
     assert_generated_class("mr-n4",   { mr: -4 })
     assert_generated_class("mx-auto", { mx: :auto })
+    assert_generated_class("mr-1 mr-sm-2 mr-md-3 mr-lg-4 mr-xl-5",  { mr: [1, 2, 3, 4, 5] })
 
     assert_raises ArgumentError do
       Primer::Classify.call(m: -1)
@@ -63,6 +64,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("pb-4", { pb: 4 })
     assert_generated_class("pr-4", { pr: 4 })
     assert_generated_class("p-responsive", { p: :responsive })
+    assert_generated_class("pr-1 pr-sm-2 pr-md-3 pr-lg-4 pr-xl-5",  { pr: [1, 2, 3, 4, 5] })
 
     assert_raises ArgumentError do
       Primer::Classify.call(p: -1)

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -46,7 +46,7 @@ class PrimerClassifyTest < Minitest::Test
     end
 
     assert_raises ArgumentError do
-      Primer::Classify.call(m: :auto)
+      Primer::Classify.call(my: :auto)
     end
 
     assert_raises ArgumentError do


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/422

This PR:
- adds a list of possible values for each spacing key. This will make it easier to document, validate and enforce their usage.
- adds support for `p: :responsive` and `m: :auto`.
- drops `my: :auto` and `m: negative_number` since they don't exist in PrimerCSS