### PR TITLE
Update octicons_helper runtime dependency version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     primer_view_components (0.0.34)
-      octicons_helper (>= 9.0.0, < 13.0.0)
+      octicons_helper (>= 9.0.0, < 14.0.0)
       rails (>= 5.0.0, < 7.0)
       view_component (>= 2.0.0, < 3.0)
 

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/statuses.json"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency     "octicons_helper", [">= 9.0.0", "< 13.0.0"]
+  spec.add_runtime_dependency     "octicons_helper", [">= 9.0.0", "< 14.0.0"]
   spec.add_runtime_dependency     "rails", [">= 5.0.0", "< 7.0"]
   spec.add_runtime_dependency     "view_component", [">= 2.0.0", "< 3.0"]
 


### PR DESCRIPTION
This PR updates the `octicons_helper` runtime dependency version range to include the latest Octicons release ([`v13.0.0`](https://github.com/primer/octicons/releases/tag/v13.0.0)). This is necessary in order to allow dotcom to use the latest version of Octicons.