### PR TITLE
Ensure State component is not a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* **Breaking change**: Don't allow `StateComponent` to be a link.
+
+    *Kate Higa*
+
 ## 0.0.37
 
 * Update NPM package to include subdirectory JS files.

--- a/app/components/primer/state_component.rb
+++ b/app/components/primer/state_component.rb
@@ -29,7 +29,7 @@ module Primer
     SIZE_OPTIONS = SIZE_MAPPINGS.keys
 
     TAG_DEFAULT = :span
-    TAG_OPTIONS = [TAG_DEFAULT, :div, :a].freeze
+    TAG_OPTIONS = [TAG_DEFAULT, :div].freeze
 
     # @example Default
     #   <%= render(Primer::StateComponent.new(title: "title")) { "State" } %>

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -47,6 +47,6 @@ Component for rendering the status of an item.
 | :- | :- | :- | :- |
 | `title` | `String` | N/A | `title` HTML attribute. |
 | `scheme` | `Symbol` | `:default` | Background color. One of `:open`, `:closed`, `:merged`, `:default`, `:green`, `:red`, or `:purple`. |
-| `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span`, `:div`, or `:a`. |
+| `tag` | `Symbol` | `:span` | HTML tag for element. One of `:span` and `:div`. |
 | `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -577,7 +577,7 @@
   - name: tag
     type: Symbol
     default: "`:span`"
-    description: HTML tag for element. One of `:span`, `:div`, or `:a`.
+    description: HTML tag for element. One of `:span` and `:div`.
   - name: size
     type: Symbol
     default: "`:default`"


### PR DESCRIPTION
Closes #418 

**What**
This makes it so a State component cannot be rendered as a link.

**Why**
The purpose of `State` is to render the status of an item. It seems like `State` is being in some places in dotcom for the rounded aesthetic, but there are other components that are probably a better fit for rendering a link.

On our end, we can enforce correct future usage of the `StateComponent` by not allowing it to be a link. 

**Notes**
[Related PR][1]

[1]: https://github.com/github/github/pull/176322