### PR TITLE
Fix Primer::ButtonComponent rendering with a summary tag

### DIFF
--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -55,10 +55,10 @@ module Primer
       @system_arguments = system_arguments
       @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
 
-      if @system_arguments[:tag] == :a
-        @system_arguments[:role] = :button
-      else
+      if @system_arguments[:tag] == :button
         @system_arguments[:type] = type
+      else
+        @system_arguments[:role] = :button
       end
 
       @system_arguments[:classes] = class_names(

--- a/test/components/button_component_test.rb
+++ b/test/components/button_component_test.rb
@@ -21,6 +21,14 @@ class PrimerButtonComponentTest < Minitest::Test
     render_inline(Primer::ButtonComponent.new(tag: :a)) { "content" }
 
     assert_selector("a.btn[role='button']")
+    refute_selector("a[type]")
+  end
+
+  def test_renders_summary_as_a_button
+    render_inline(Primer::ButtonComponent.new(tag: :summary)) { "content" }
+
+    assert_selector("summary.btn[role='button']")
+    refute_selector("summary[type]")
   end
 
   def test_renders_href


### PR DESCRIPTION
Previously, the "type" attribute was being applied to "summary" buttons, which is invalid and broke visual styling in Safari.

| Before | After |
|:---:|:---:|
| <img width="261" alt="Screen Shot 2021-04-13 at 9 58 09 AM" src="https://user-images.githubusercontent.com/34264/114565023-e3e0d480-9c3e-11eb-88d6-5c4da8770019.png"> | <img width="261" alt="Screen Shot 2021-04-13 at 9 58 34 AM" src="https://user-images.githubusercontent.com/34264/114565067-ee9b6980-9c3e-11eb-9aba-2ae7e980171c.png"> |