### PR TITLE
Use glob to match all JS files in subdirectories for NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "url": "https://github.com/primer/view_components/issues"
   },
   "files": [
-    "app/components/primer/*.js",
-    "app/components/primer/*.d.ts"
+    "app/components/primer/**/*.js",
+    "app/components/primer/**/*.d.ts"
   ],
   "scripts": {
     "prepare": "tsc && rollup -c",


### PR DESCRIPTION
The NPM package was only matching files in the `app/components/primer` directory, without checking subdirectories. This is causing issues when importing the NPM package in version 0.0.35