### PR TITLE
Read `TESTS` environmental variable for tests to run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,7 @@ bundle exec thor component_generator my_component_name --js=some-npm-package-nam
 0. [Fork](https://github.com/primer/view_components/fork) and clone the repository
 0. Configure and install the dependencies: `./script/setup`
 0. Make sure the tests pass on your machine: `bundle exec rake`
-  - You can restrict the test runner to only run your changes by supplying a filename or glob to the test command: `TESTS="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`
-
+   - You can restrict the test runner to only run your changes by supplying a filename or glob to the test command: `TESTS="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
 0. Add an entry to the top of `CHANGELOG.md` for your changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ bundle exec thor component_generator my_component_name --js=some-npm-package-nam
 0. [Fork](https://github.com/primer/view_components/fork) and clone the repository
 0. Configure and install the dependencies: `./script/setup`
 0. Make sure the tests pass on your machine: `bundle exec rake`
+  - You can restrict the test runner to only run your changes by supplying a filename or glob to the test command: `TESTS="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`
+
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
 0. Add an entry to the top of `CHANGELOG.md` for your changes

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ require "pathname"
 Rake::TestTask.new(:test) do |t|
   t.libs << "test"
   t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.test_files = FileList.new(ENV["TESTS"] || "test/**/*_test.rb")
 end
 
 Rake::TestTask.new(:bench) do |t|


### PR DESCRIPTION
This PR adds the capability for developers to pass in a `TESTS` environmental variable when running the `test` rake task. The rake task will populate the tests to run after the glob that is passed into `TESTS` and subsequentially only run the tests that match that glob. If no `TESTS` environmental variable is set, the rake task will default to `test/**/*_test.rb` as a glob.

This change will make it easier for developers to run only specific tests and not bother running tests unrelated to their debugging or development.