### PR TITLE
Add aria-label to `CloseButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
     *Kate Higa*
 
+* Add default `aria-label` of "Close" to `CloseButton` component.
+
+    *Kate Higa*
+
 ## 0.0.37
 
 * Update NPM package to include subdirectory JS files.

--- a/app/components/primer/close_button.rb
+++ b/app/components/primer/close_button.rb
@@ -2,6 +2,12 @@
 
 module Primer
   # Use CloseButton to render an `×` without default button styles.
+  #
+  # ## Accessibility
+  #
+  # - This component has a default `aria-label` of "Close" which provides assistive technologies with an accessible label. You may override this label with [system_arguments][0].
+  #
+  # [0]: https://primer.style/view-components/system-arguments#html-attributes
   class CloseButton < Primer::Component
     DEFAULT_TYPE = :button
     TYPE_OPTIONS = [DEFAULT_TYPE, :submit].freeze
@@ -19,6 +25,7 @@ module Primer
         "close-button",
         system_arguments[:classes]
       )
+      @system_arguments[:"aria-label"] ||= "Close"
     end
 
     def call

--- a/demo/.storybook/main.js
+++ b/demo/.storybook/main.js
@@ -1,8 +1,8 @@
 module.exports = {
   stories: ['../../**/*.stories.json'],
   addons: [
-    '@storybook/addon-controls',
-    '@storybook/addon-a11y'
+    '@storybook/addon-a11y',
+    '@storybook/addon-controls'
   ],
   webpackFinal: async (config, { configType }) => {
     if(configType == 'PRODUCTION')

--- a/docs/content/components/closebutton.md
+++ b/docs/content/components/closebutton.md
@@ -11,11 +11,17 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use CloseButton to render an `×` without default button styles.
 
+## Accessibility
+
+- This component has a default `aria-label` of "Close" which provides assistive technologies with an accessible label. You may override this label with [system_arguments][0].
+
+[0]: https://primer.style/view-components/system-arguments#html-attributes
+
 ## Examples
 
 ### Default
 
-<Example src="<button type='button' class='close-button '><svg class='octicon octicon-x' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z'></path></svg></button>" />
+<Example src="<button type='button' aria-label='Close' class='close-button '><svg class='octicon octicon-x' height='16' viewBox='0 0 16 16' version='1.1' width='16' aria-hidden='true'><path fill-rule='evenodd' d='M3.72 3.72a.75.75 0 011.06 0L8 6.94l3.22-3.22a.75.75 0 111.06 1.06L9.06 8l3.22 3.22a.75.75 0 11-1.06 1.06L8 9.06l-3.22 3.22a.75.75 0 01-1.06-1.06L6.94 8 3.72 4.78a.75.75 0 010-1.06z'></path></svg></button>" />
 
 ```erb
 <%= render(Primer::CloseButton.new) %>


### PR DESCRIPTION
Closes #460 

**What**
This PR adds a missing `aria-label` to the `CloseButton` component along with relevant documentation

**Notes**
- It seems beneficial to have a section in the documentation specifically around `Accessibility` (and maybe eventually even sections like `When to use`, `When not to use`) to guide developers to correct component usage. I think it's worth adding a custom `@accessibility` tag. I explored modifying `Rake` but couldn't quite figure out how to add a custom tag to output associated comments. If reviewer is yard savvy and has ideas on how this is done, please let me know! :-) 
