### PR TITLE
Add ClipboardCopy to site sidebar

### DIFF
--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -10,7 +10,7 @@ module Primer
     #
     # @example With text instead of icons
     #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) do %>
-    #     "Click to copy!"
+    #     Click to copy!
     #   <% end %>
     #
     # @param label [String] String that will be read to screenreaders when the component is focused

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -23,11 +23,11 @@ Use ClipboardCopy to copy element text content or input values to the clipboard.
 
 ### With text instead of icons
 
-<Example src="<clipboard-copy value='Text to copy' aria-label='Copy text to the system clipboard'>      'Click to copy!'</clipboard-copy>" />
+<Example src="<clipboard-copy value='Text to copy' aria-label='Copy text to the system clipboard'>      Click to copy!</clipboard-copy>" />
 
 ```erb
 <%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) do %>
-  "Click to copy!"
+  Click to copy!
 <% end %>
 ```
 

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -34,6 +34,8 @@
       url: /components/buttongroup
     - title: ButtonMarketing
       url: /components/buttonmarketing
+    - title: ClipboardCopy
+      url: /components/clipboardcopy
     - title: CloseButton
       url: /components/closebutton
     - title: Counter


### PR DESCRIPTION
We can merge this after we tag a new version. Since `ClipboardCopy` requires JS, we need to reference the newly built JS package that includes `<clipboard-copy>`.