### PR TITLE
don't set default tag for Heading component and improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* **Breaking change**: Do not provide default for `Heading` and improve documentation.
+
+    *Kate Higa*
+
 * Extract `BaseButton` component.
 
     *Manuel Puyol*
@@ -11,8 +15,6 @@
     *Kate Higa*
 
 * **Breaking change**: Don't allow `StateComponent` to be a link.
-
-    *Kate Higa*
 
 ## 0.0.37
 

--- a/Rakefile
+++ b/Rakefile
@@ -91,6 +91,10 @@ namespace :docs do
     "[System arguments](/system-arguments)"
   end
 
+  def link_to_typography_docs
+    "[Typography](/system-arguments#typography)"
+  end
+
   def link_to_component(component)
     short_name = component.name.gsub(/Primer|::|Component/, "")
     "[#{short_name}](/components/#{short_name.downcase})"

--- a/app/components/primer/heading_component.rb
+++ b/app/components/primer/heading_component.rb
@@ -1,19 +1,47 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use the Heading component to wrap a component that will create a heading element
+  # Heading can be used to communicate page organization and hierarchy.
+  #
+  # - Set tag to one of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6` based on what is
+  #   appropriate for the page context.
+  # - Use Heading as the title of a section or sub section.
+  # - Do not use Heading for styling alone. To style text without conveying heading semantics,
+  #   consider using <%= link_to_component(Primer::TextComponent) %> with relevant <%= link_to_typography_docs %>.
+  # - Do not jump heading levels. For instance, do not follow a `<h1>` with an `<h3>`. Heading levels should
+  #   increase by one in ascending order.
+  #
+  # @accessibility
+  #   Headings convey semantic meaning. Assistive technology users rely on headings to quickly navigate and scan information on a page.
+  #   Inappropriate use of headings can lead to a confusing experience.
+  #   [Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
   class HeadingComponent < Primer::Component
     status :beta
 
+    TAG_FALLBACK = :h2
+    TAG_OPTIONS = [:h1, TAG_FALLBACK, :h3, :h4, :h5, :h6].freeze
+
     # @example Default
-    #   <%= render(Primer::HeadingComponent.new) { "H1 Text" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h1)) { "H1 Text" } %>
     #   <%= render(Primer::HeadingComponent.new(tag: :h2)) { "H2 Text" } %>
     #   <%= render(Primer::HeadingComponent.new(tag: :h3)) { "H3 Text" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h4)) { "H4 Text" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h5)) { "H5 Text" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h6)) { "H6 Text" } %>
     #
+    # @example With `font_size`
+    #   <%= render(Primer::HeadingComponent.new(tag: :h1, font_size: 6)) { "h1 tag, font_size 6" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h2, font_size: 3)) { "h2 tag, font_size 3" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h3, font_size: 2)) { "h3 tag, font_size 2" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h4, font_size: 0)) { "h4 tag, font_size 0" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h5, font_size: 1)) { "h5 tag, font_size 1" } %>
+    #   <%= render(Primer::HeadingComponent.new(tag: :h6, font_size: 4)) { "h6 tag, font_size 4" } %>
+    #
+    # @param tag [String]  <%= one_of(Primer::HeadingComponent::TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**system_arguments)
+    def initialize(tag:, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :h1
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, TAG_FALLBACK)
     end
 
     def call

--- a/docs/content/components/heading.md
+++ b/docs/content/components/heading.md
@@ -9,22 +9,53 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use the Heading component to wrap a component that will create a heading element
+Heading can be used to communicate page organization and hierarchy.
+
+- Set tag to one of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6` based on what is
+  appropriate for the page context.
+- Use Heading as the title of a section or sub section.
+- Do not use Heading for styling alone. To style text without conveying heading semantics,
+  consider using [Text](/components/text) with relevant [Typography](/system-arguments#typography).
+- Do not jump heading levels. For instance, do not follow a `<h1>` with an `<h3>`. Heading levels should
+  increase by one in ascending order.
+
+## Accessibility
+
+Headings convey semantic meaning. Assistive technology users rely on headings to quickly navigate and scan information on a page.
+Inappropriate use of headings can lead to a confusing experience.
+[Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 
 ## Examples
 
 ### Default
 
-<Example src="<h1>H1 Text</h1><h2>H2 Text</h2><h3>H3 Text</h3>" />
+<Example src="<h1>H1 Text</h1><h2>H2 Text</h2><h3>H3 Text</h3><h4>H4 Text</h4><h5>H5 Text</h5><h6>H6 Text</h6>" />
 
 ```erb
-<%= render(Primer::HeadingComponent.new) { "H1 Text" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h1)) { "H1 Text" } %>
 <%= render(Primer::HeadingComponent.new(tag: :h2)) { "H2 Text" } %>
 <%= render(Primer::HeadingComponent.new(tag: :h3)) { "H3 Text" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h4)) { "H4 Text" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h5)) { "H5 Text" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h6)) { "H6 Text" } %>
+```
+
+### With `font_size`
+
+<Example src="<h1 class='f6'>h1 tag, font_size 6</h1><h2 class='f3'>h2 tag, font_size 3</h2><h3 class='f2'>h3 tag, font_size 2</h3><h4 class='f0'>h4 tag, font_size 0</h4><h5 class='f1'>h5 tag, font_size 1</h5><h6 class='f4'>h6 tag, font_size 4</h6>" />
+
+```erb
+<%= render(Primer::HeadingComponent.new(tag: :h1, font_size: 6)) { "h1 tag, font_size 6" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h2, font_size: 3)) { "h2 tag, font_size 3" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h3, font_size: 2)) { "h3 tag, font_size 2" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h4, font_size: 0)) { "h4 tag, font_size 0" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h5, font_size: 1)) { "h5 tag, font_size 1" } %>
+<%= render(Primer::HeadingComponent.new(tag: :h6, font_size: 4)) { "h6 tag, font_size 4" } %>
 ```
 
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `String` | N/A | One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -434,6 +434,10 @@
 - component: Heading
   source: https://github.com/primer/view_components/tree/main/app/components/primer/heading_component.rb
   parameters:
+  - name: tag
+    type: String
+    default: N/A
+    description: One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`.
   - name: system_arguments
     type: Hash
     default: N/A

--- a/stories/primer/heading_component_stories.rb
+++ b/stories/primer/heading_component_stories.rb
@@ -3,7 +3,7 @@
 class Primer::HeadingComponentStories < ViewComponent::Storybook::Stories
   layout "storybook_preview"
 
-  story(:heading) do
+  story(:heading, tag: :h1) do
     content do
       "This is a heading!"
     end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -40,7 +40,7 @@ class PrimerComponentTest < Minitest::Test
     [Primer::FlexComponent, {}],
     [Primer::FlashComponent, {}],
     [Primer::FlexItemComponent, { flex_auto: true }],
-    [Primer::HeadingComponent, {}],
+    [Primer::HeadingComponent, { tag: :h1 }],
     [Primer::HiddenTextExpander, {}],
     [Primer::LabelComponent, { title: "Hello!" }],
     [Primer::LayoutComponent, {}],

--- a/test/components/heading_component_test.rb
+++ b/test/components/heading_component_test.rb
@@ -6,13 +6,21 @@ class PrimerHeadingComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_content
-    render_inline(Primer::HeadingComponent.new) { "content" }
+    render_inline(Primer::HeadingComponent.new(tag: :h1)) { "content" }
 
     assert_text("content")
   end
 
+  def test_falls_back_when_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::HeadingComponent.new(tag: :div)) { "content" }
+
+      assert_selector("h2")
+    end
+  end
+
   def test_renders_h1
-    render_inline(Primer::HeadingComponent.new) { "content" }
+    render_inline(Primer::HeadingComponent.new(tag: :h1)) { "content" }
 
     assert_selector("h1")
   end


### PR DESCRIPTION
Closes #466 

**What**

1.  Don't have any default tag and require the consumer to always pass it in. (We will still provide a fallback tag of `:h2` for prod)
2.  Restrict the possible tags to `<h1>` ~ `<h6>` tags for this component
3. Add examples that dissociate heading levels from aesthetics.

**Why**

1. Heading tag level is largely dependent on context so it may not make sense to have a default. 
2. There is currently no limitation on tag that can be set. We should limit ability of consumer to make incorrect decisions.
3. People often use heading levels for stylistic purposes (e.g. they want a large text and so they use `<h1>`), but this should be discouraged. We should have examples in the documentation that disassociate heading levels from aesthetics (maybe examples using `font_size:`). 
