### PR TITLE
Only run Docs Build workflow on PR and skip if actor is dependabot

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,13 +1,10 @@
 name: Docs Build
 
-on:
-  push:
-    branches-ignore:
-      - main
-
+on: [pull_request]
 
 jobs:
   build-docs:
+    if: github.actor!= 'dependabot[bot]'
     name: Build Docs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Running the docs workflow on push was causing some trouble in local development since it may add unwanted commits when you push without opening a PR.
I'm also skipping dependabot PRs from this workflow since they shouldn't change any docs.