### PR TITLE
Add ClipboardCopy to list of JS components

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -177,9 +177,10 @@ namespace :docs do
 
     js_components = [
       Primer::AutoComplete,
-      Primer::TimeAgoComponent,
+      Primer::ClipboardCopy,
       Primer::TabContainerComponent,
       Primer::TabNavComponent,
+      Primer::TimeAgoComponent,
       Primer::UnderlineNavComponent
     ]
 

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -6,6 +6,9 @@ storybook: https://primer.style/view-components/stories/?path=/story/primer-clip
 ---
 
 import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
+import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/requires-js-flash'
+
+<RequiresJSFlash />
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 


### PR DESCRIPTION
Missed this in #457. This is needed for the "This component requires JavaScript to function. Please ...". flash banner.