### PR TITLE
Update docs for `Avatar` component

### DIFF
--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -1,18 +1,20 @@
 # frozen_string_literal: true
 
 module Primer
-  # Avatars are images used to represent users and organizations on GitHub.
+  # `Avatar` can be used to represent users and organizations on GitHub.
+  #
   # - Use the default round avatar for users, and the `square` argument
   # for organizations or any other non-human avatars.
-  # - By default, Avatar will render a static `<img>`. To have the Avatar function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
-  # 
-  # @accessibility 
+  # - By default, `Avatar` will render a static `<img>`. To have `Avatar` function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
+  # - Set `size` to update the height and width of the `Avatar` in pixels.
+  # - To stack multiple avatars together, use <%= link_to_component(Primer::AvatarStackComponent) %>.
   #
-  # Images should have text alternatives that describe the information or function represented.
-  # If the avatar functions as a link, provide an alt text that helps convey the function. For instance,
-  # if Avatar is a link to a user profile, the alt image should be "@kittenuser profile"
-  # rather than "@kittenuser".
-  # [Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
+  # @accessibility
+  #   Images should have text alternatives that describe the information or function represented.
+  #   If the avatar functions as a link, provide alt text that helps convey the function. For instance,
+  #   if `Avatar` is a link to a user profile, the alt attribute should be `@kittenuser profile`
+  #   rather than `@kittenuser`.
+  #   [Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
   class AvatarComponent < Primer::Component
     status :beta
 
@@ -26,6 +28,14 @@ module Primer
     #
     # @example Link
     #   <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser profile")) %>
+    #
+    # @example With size
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 16)) %>
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 20)) %>
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 24)) %>
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 28)) %>
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 32)) %>
+    #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 36)) %>
     #
     # @param src [String] The source url of the avatar image.
     # @param alt [String] Passed through to alt on img tag.

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -2,8 +2,17 @@
 
 module Primer
   # Avatars are images used to represent users and organizations on GitHub.
-  # Use the default round avatar for users, and the `square` argument
+  # - Use the default round avatar for users, and the `square` argument
   # for organizations or any other non-human avatars.
+  # - By default, Avatar will render a static `<img>`. To have the Avatar function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
+  # 
+  # @accessibility 
+  #
+  # Images should have text alternatives that describe the information or function represented.
+  # If the avatar functions as a link, provide an alt text that helps convey the function. For instance,
+  # if Avatar is a link to a user profile, the alt image should be "@kittenuser profile"
+  # rather than "@kittenuser".
+  # [Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
   class AvatarComponent < Primer::Component
     status :beta
 
@@ -16,7 +25,7 @@ module Primer
     #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", square: true)) %>
     #
     # @example Link
-    #   <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>
+    #   <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser profile")) %>
     #
     # @param src [String] The source url of the avatar image.
     # @param alt [String] Passed through to alt on img tag.

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -9,20 +9,21 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Avatars are images used to represent users and organizations on GitHub.
+`Avatar` can be used to represent users and organizations on GitHub.
+
 - Use the default round avatar for users, and the `square` argument
 for organizations or any other non-human avatars.
-- By default, Avatar will render a static `<img>`. To have the Avatar function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
-
-Images should have text alternatives that describe the information or function represented.
-If the avatar functions as a link, provide an alt text that helps convey the function. For instance,
-if Avatar is a link to a user profile, the alt image should be "@kittenuser profile"
-rather than "@kittenuser".
-[Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
+- By default, `Avatar` will render a static `<img>`. To have `Avatar` function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
+- Set `size` to update the height and width of the `Avatar` in pixels.
+- To stack multiple avatars together, use [AvatarStack](/components/avatarstack).
 
 ## Accessibility
 
-
+Images should have text alternatives that describe the information or function represented.
+If the avatar functions as a link, provide alt text that helps convey the function. For instance,
+if `Avatar` is a link to a user profile, the alt attribute should be `@kittenuser profile`
+rather than `@kittenuser`.
+[Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
 
 ## Examples
 
@@ -48,6 +49,19 @@ rather than "@kittenuser".
 
 ```erb
 <%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser profile")) %>
+```
+
+### With size
+
+<Example src="<img src='http://placekitten.com/200/200' alt='@kittenuser' size='16' height='16' width='16' class='avatar avatar-small circle '></img><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20' class='avatar avatar-small circle '></img><img src='http://placekitten.com/200/200' alt='@kittenuser' size='24' height='24' width='24' class='avatar circle '></img><img src='http://placekitten.com/200/200' alt='@kittenuser' size='28' height='28' width='28' class='avatar circle '></img><img src='http://placekitten.com/200/200' alt='@kittenuser' size='32' height='32' width='32' class='avatar circle '></img><img src='http://placekitten.com/200/200' alt='@kittenuser' size='36' height='36' width='36' class='avatar circle '></img>" />
+
+```erb
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 16)) %>
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 20)) %>
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 24)) %>
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 28)) %>
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 32)) %>
+<%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 36)) %>
 ```
 
 ## Arguments

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -10,8 +10,19 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
 Avatars are images used to represent users and organizations on GitHub.
-Use the default round avatar for users, and the `square` argument
+- Use the default round avatar for users, and the `square` argument
 for organizations or any other non-human avatars.
+- By default, Avatar will render a static `<img>`. To have the Avatar function as a link, set the `href` which will wrap the `<img>` in a `<a>`.
+
+Images should have text alternatives that describe the information or function represented.
+If the avatar functions as a link, provide an alt text that helps convey the function. For instance,
+if Avatar is a link to a user profile, the alt image should be "@kittenuser profile"
+rather than "@kittenuser".
+[Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
+
+## Accessibility
+
+
 
 ## Examples
 
@@ -33,10 +44,10 @@ for organizations or any other non-human avatars.
 
 ### Link
 
-<Example src="<a href='#' class='avatar avatar-small circle lh-0 '><img src='http://placekitten.com/200/200' alt='@kittenuser' size='20' height='20' width='20'></img></a>" />
+<Example src="<a href='#' class='avatar avatar-small circle lh-0 '><img src='http://placekitten.com/200/200' alt='@kittenuser profile' size='20' height='20' width='20'></img></a>" />
 
 ```erb
-<%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>
+<%= render(Primer::AvatarComponent.new(href: "#", src: "http://placekitten.com/200/200", alt: "@kittenuser profile")) %>
 ```
 
 ## Arguments


### PR DESCRIPTION
**What**
This PR updates the `Avatar` component documentation with accessibility considerations around alt text as well as more examples with different sizes.

**Why**
We should guide user to cprrect usage of `Avatar` component by highlighting some important usage considerations.

**Notes**
- primer css documents [avatar-specific sizing classes ](https://primer.style/css/components/avatars#avatar-sizes)but it is not totally clear whether this is preferable to the other alternative of setting width/height which our current `Avatar` implementation supports. 