### PR TITLE
Update component reference for consistency

### DIFF
--- a/app/components/primer/auto_complete.rb
+++ b/app/components/primer/auto_complete.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use AutoComplete to populate input values from server search results.
+  # Use `AutoComplete` to populate input values from server search results.
   class AutoComplete < Primer::Component
     status :beta
 

--- a/app/components/primer/avatar_stack_component.rb
+++ b/app/components/primer/avatar_stack_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use AvatarStack to stack multiple avatars together.
+  # Use `AvatarStack` to stack multiple avatars together.
   class AvatarStackComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/base_button.rb
+++ b/app/components/primer/base_button.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use BaseButton to render an unstyled `<button>` tag that can be customized.
+  # Use `BaseButton` to render an unstyled `<button>` tag that can be customized.
   class BaseButton < Primer::Component
     status :beta
 

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Primer::BlankslateComponent when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
+  # Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
   class BlankslateComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # BorderBox is a Box component with a border.
+  # `BorderBox` is a Box component with a border.
   class BorderBoxComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # A basic wrapper component for most layout related needs.
+  # `Box` is a basic wrapper component for most layout related needs.
   class BoxComponent < Primer::Component
     status :stable
 

--- a/app/components/primer/breadcrumb_component.rb
+++ b/app/components/primer/breadcrumb_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use breadcrumbs to display page hierarchy within a section of the site. All of the items in the breadcrumb "trail" are links except for the final item, which is a plain string indicating the current page.
+  # Use `Breadcrumb` to display page hierarchy within a section of the site. All of the items in the breadcrumb "trail" are links except for the final item, which is a plain string indicating the current page.
   class BreadcrumbComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use buttons for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
+  # Use `Button` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
   class ButtonComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use ButtonGroup to render a series of buttons.
+  # Use `ButtonGroup` to render a series of buttons.
   class ButtonGroup < Primer::Component
     status :beta
 

--- a/app/components/primer/button_marketing_component.rb
+++ b/app/components/primer/button_marketing_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use buttons for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
+  # Use `ButtonMarketing` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
   class ButtonMarketingComponent < Primer::Component
     DEFAULT_SCHEME = :default
     SCHEME_MAPPINGS = {

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use ClipboardCopy to copy element text content or input values to the clipboard.
+  # Use `ClipboardCopy` to copy element text content or input values to the clipboard.
   class ClipboardCopy < Primer::Component
     status :alpha
 

--- a/app/components/primer/close_button.rb
+++ b/app/components/primer/close_button.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use CloseButton to render an `×` without default button styles.
+  # Use `CloseButton` to render an `×` without default button styles.
   #
   # @accessibility
-  #   CloseButton has a default `aria-label` of "Close" to provides assistive technologies with an accessible label.
+  #   `CloseButton` has a default `aria-label` of "Close" to provides assistive technologies with an accessible label.
   #   You may choose to override this label with something more descriptive via [system_arguments][0].
   # [0]: https://primer.style/view-components/system-arguments#html-attributes
   class CloseButton < Primer::Component

--- a/app/components/primer/counter_component.rb
+++ b/app/components/primer/counter_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Primer::CounterComponent to add a count to navigational elements and buttons.
+  # Use `CounterComponent` to add a count to navigational elements and buttons.
   class CounterComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use DetailsComponent to reveal content after clicking a button.
+  # Use `DetailsComponent` to reveal content after clicking a button.
   class DetailsComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/dropdown_component.rb
+++ b/app/components/primer/dropdown_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Dropdowns are lightweight context menus for housing navigation and actions.
+  # `Dropdown` is a lightweight context menu for housing navigation and actions.
   # They're great for instances where you don't need the full power (and code) of the select menu.
   class DropdownComponent < Primer::Component
     # Required trigger for the dropdown. Only accepts a content.

--- a/app/components/primer/flash_component.rb
+++ b/app/components/primer/flash_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use the Flash component to inform users of successful or pending actions.
+  # Use `Flash` to inform users of successful or pending actions.
   class FlashComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/flex_component.rb
+++ b/app/components/primer/flex_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use FlexComponent to make an element lay out its content using the flexbox model.
+  # Use `Flex` to make an element lay out its content using the flexbox model.
   # Before using these utilities, you should be familiar with CSS3 Flexible Box
   # spec. If you are not, check out MDN's guide  [Using CSS Flexible
   # Boxes](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox).

--- a/app/components/primer/flex_item_component.rb
+++ b/app/components/primer/flex_item_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use FlexItemComponent to specify the ability of a flex item to alter its
+  # Use `FlexItem` to specify the ability of a flex item to alter its
   # dimensions to fill available space
   class FlexItemComponent < Primer::Component
     FLEX_AUTO_DEFAULT = false

--- a/app/components/primer/heading_component.rb
+++ b/app/components/primer/heading_component.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module Primer
-  # Heading can be used to communicate page organization and hierarchy.
+  # `Heading` can be used to communicate page organization and hierarchy.
   #
   # - Set tag to one of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6` based on what is
   #   appropriate for the page context.
-  # - Use Heading as the title of a section or sub section.
-  # - Do not use Heading for styling alone. To style text without conveying heading semantics,
+  # - Use `Heading` as the title of a section or sub section.
+  # - Do not use `Heading` for styling alone. To style text without conveying heading semantics,
   #   consider using <%= link_to_component(Primer::TextComponent) %> with relevant <%= link_to_typography_docs %>.
   # - Do not jump heading levels. For instance, do not follow a `<h1>` with an `<h3>`. Heading levels should
   #   increase by one in ascending order.

--- a/app/components/primer/hidden_text_expander.rb
+++ b/app/components/primer/hidden_text_expander.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use HiddenTextExpander to indicate and toggle hidden text.
+  # Use `HiddenTextExpander` to indicate and toggle hidden text.
   class HiddenTextExpander < Primer::Component
     # @example Default
     #   <%= render(Primer::HiddenTextExpander.new) %>

--- a/app/components/primer/icon_button.rb
+++ b/app/components/primer/icon_button.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use IconButton to render Icon-only buttons without the default button styles.
+  # Use `IconButton` to render Icon-only buttons without the default button styles.
   #
   # @accessibility
-  #   IconButton requires an `aria-label`, which will provide assistive technologies with an accessible label.
+  #   `IconButton` requires an `aria-label`, which will provide assistive technologies with an accessible label.
   class IconButton < Primer::Component
     DEFAULT_SCHEME = :default
     SCHEME_MAPPINGS = {

--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use labels to add contextual metadata to a design.
+  # Use `Label` to add contextual metadata to a design.
   class LabelComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/layout_component.rb
+++ b/app/components/primer/layout_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Layout to build a main/sidebar layout.
+  # Use `Layout` to build a main/sidebar layout.
   class LayoutComponent < Primer::Component
     # The main content
     #

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use links for moving from one page to another. The Link component styles anchor tags with default blue styling and hover text-decoration.
+  # Use `Link` for navigating from one page to another. `Link` styles anchor tags with default blue styling and hover text-decoration.
   class LinkComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/markdown_component.rb
+++ b/app/components/primer/markdown_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use MarkdownComponent to wrap markdown content
+  # Use `Markdown` to wrap markdown content
   class MarkdownComponent < Primer::Component
     # @example Default
     #   <%= render(Primer::MarkdownComponent.new) do %>

--- a/app/components/primer/menu_component.rb
+++ b/app/components/primer/menu_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use menus to create vertical lists of navigational links.
+  # Use `Menu` to create vertical lists of navigational links.
   class MenuComponent < Primer::Component
     # Optional menu heading
     #

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Renders an <%= link_to_octicons %> with <%= link_to_system_arguments_docs %>.
+  # `Octicon` renders an <%= link_to_octicons %> with <%= link_to_system_arguments_docs %>.
   class OcticonComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use popovers to bring attention to specific user interface elements, typically to suggest an action or to guide users through a new experience.
+  # Use `Popover` to bring attention to specific user interface elements, typically to suggest an action or to guide users through a new experience.
   #
   # By default, the popover renders with absolute positioning, meaning it should usually be wrapped in an element with a relative position in order to be positioned properly. To render the popover with relative positioning, use the relative property.
   class PopoverComponent < Primer::Component

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use ProgressBar to visualize task completion.
+  # Use `ProgressBar` to visualize task completion.
   class ProgressBarComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Primer::SpinnerComponent to let users know that content is being loaded.
+  # Use `Spinner` to let users know that content is being loaded.
   class SpinnerComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/state_component.rb
+++ b/app/components/primer/state_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Component for rendering the status of an item.
+  # Use `State` for rendering the status of an item.
   class StateComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/subhead_component.rb
+++ b/app/components/primer/subhead_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use the Subhead component for page headings.
+  # Use `Subhead` for page headings.
   class SubheadComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/tab_container_component.rb
+++ b/app/components/primer/tab_container_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use TabContainer to create tabbed content with keyboard support. This component does not add any styles.
+  # Use `TabContainer` to create tabbed content with keyboard support. This component does not add any styles.
   # It only provides the tab functionality. If you want styled Tabs you can look at <%= link_to_component(Primer::TabNavComponent) %>.
   #
   # This component requires javascript.

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use TabNav to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
+  # Use `TabNav` to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
   class TabNavComponent < Primer::Component
     include Primer::TabbedComponentHelper
 

--- a/app/components/primer/text_component.rb
+++ b/app/components/primer/text_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # The Text component is a wrapper component that will apply typography styles to the text inside.
+  # `Text` is a wrapper component that will apply typography styles to the text inside.
   class TextComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/time_ago_component.rb
+++ b/app/components/primer/time_ago_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Primer::TimeAgoComponent to display a time relative to how long ago it was. This component requires JavaScript.
+  # Use `TimeAgo` to display a time relative to how long ago it was. This component requires JavaScript.
   class TimeAgoComponent < Primer::Component
     status :beta
 

--- a/app/components/primer/tooltip_component.rb
+++ b/app/components/primer/tooltip_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # The Tooltip component is a wrapper component that will apply a tooltip to the provided content.
+  # `Tooltip` is a wrapper component that will apply a tooltip to the provided content.
   class TooltipComponent < Primer::Component
     DIRECTION_DEFAULT = :n
     ALIGN_DEFAULT = :default

--- a/app/components/primer/truncate.rb
+++ b/app/components/primer/truncate.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use Truncate to shorten overflowing text with an ellipsis.
+  # Use `Truncate` to shorten overflowing text with an ellipsis.
   class Truncate < Primer::Component
     status :beta
 

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use the UnderlineNav component to style navigation with a minimal
+  # Use `UnderlineNav` to style navigation with a minimal
   # underlined selected state, typically used for navigation placed at the top
   # of the page.
   class UnderlineNavComponent < Primer::Component

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use AutoComplete to populate input values from server search results.
+Use `AutoComplete` to populate input values from server search results.
 
 ## Examples
 

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use AvatarStack to stack multiple avatars together.
+Use `AvatarStack` to stack multiple avatars together.
 
 ## Examples
 

--- a/docs/content/components/basebutton.md
+++ b/docs/content/components/basebutton.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use BaseButton to render an unstyled `<button>` tag that can be customized.
+Use `BaseButton` to render an unstyled `<button>` tag that can be customized.
 
 ## Examples
 

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Primer::BlankslateComponent when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
+Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
 
 ## Examples
 

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-BorderBox is a Box component with a border.
+`BorderBox` is a Box component with a border.
 
 ## Examples
 

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-A basic wrapper component for most layout related needs.
+`Box` is a basic wrapper component for most layout related needs.
 
 ## Examples
 

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use breadcrumbs to display page hierarchy within a section of the site. All of the items in the breadcrumb "trail" are links except for the final item, which is a plain string indicating the current page.
+Use `Breadcrumb` to display page hierarchy within a section of the site. All of the items in the breadcrumb "trail" are links except for the final item, which is a plain string indicating the current page.
 
 ## Examples
 

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use buttons for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
+Use `Button` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
 
 ## Examples
 

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use ButtonGroup to render a series of buttons.
+Use `ButtonGroup` to render a series of buttons.
 
 ## Examples
 

--- a/docs/content/components/buttonmarketing.md
+++ b/docs/content/components/buttonmarketing.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use buttons for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
+Use `ButtonMarketing` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
 
 ## Examples
 

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use ClipboardCopy to copy element text content or input values to the clipboard.
+Use `ClipboardCopy` to copy element text content or input values to the clipboard.
 
 ## Examples
 

--- a/docs/content/components/closebutton.md
+++ b/docs/content/components/closebutton.md
@@ -9,13 +9,13 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use CloseButton to render an `×` without default button styles.
+Use `CloseButton` to render an `×` without default button styles.
 
 [0]: https://primer.style/view-components/system-arguments#html-attributes
 
 ## Accessibility
 
-CloseButton has a default `aria-label` of "Close" to provides assistive technologies with an accessible label.
+`CloseButton` has a default `aria-label` of "Close" to provides assistive technologies with an accessible label.
 You may choose to override this label with something more descriptive via [system_arguments][0].
 
 ## Examples

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Primer::CounterComponent to add a count to navigational elements and buttons.
+Use `CounterComponent` to add a count to navigational elements and buttons.
 
 ## Examples
 

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use DetailsComponent to reveal content after clicking a button.
+Use `DetailsComponent` to reveal content after clicking a button.
 
 ## Arguments
 

--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Dropdowns are lightweight context menus for housing navigation and actions.
+`Dropdown` is a lightweight context menu for housing navigation and actions.
 They're great for instances where you don't need the full power (and code) of the select menu.
 
 ## Examples

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use the Flash component to inform users of successful or pending actions.
+Use `Flash` to inform users of successful or pending actions.
 
 ## Examples
 

--- a/docs/content/components/flex.md
+++ b/docs/content/components/flex.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use FlexComponent to make an element lay out its content using the flexbox model.
+Use `Flex` to make an element lay out its content using the flexbox model.
 Before using these utilities, you should be familiar with CSS3 Flexible Box
 spec. If you are not, check out MDN's guide  [Using CSS Flexible
 Boxes](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox).

--- a/docs/content/components/flexitem.md
+++ b/docs/content/components/flexitem.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use FlexItemComponent to specify the ability of a flex item to alter its
+Use `FlexItem` to specify the ability of a flex item to alter its
 dimensions to fill available space
 
 ## Examples

--- a/docs/content/components/heading.md
+++ b/docs/content/components/heading.md
@@ -9,12 +9,12 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Heading can be used to communicate page organization and hierarchy.
+`Heading` can be used to communicate page organization and hierarchy.
 
 - Set tag to one of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6` based on what is
   appropriate for the page context.
-- Use Heading as the title of a section or sub section.
-- Do not use Heading for styling alone. To style text without conveying heading semantics,
+- Use `Heading` as the title of a section or sub section.
+- Do not use `Heading` for styling alone. To style text without conveying heading semantics,
   consider using [Text](/components/text) with relevant [Typography](/system-arguments#typography).
 - Do not jump heading levels. For instance, do not follow a `<h1>` with an `<h3>`. Heading levels should
   increase by one in ascending order.

--- a/docs/content/components/hiddentextexpander.md
+++ b/docs/content/components/hiddentextexpander.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use HiddenTextExpander to indicate and toggle hidden text.
+Use `HiddenTextExpander` to indicate and toggle hidden text.
 
 ## Examples
 

--- a/docs/content/components/iconbutton.md
+++ b/docs/content/components/iconbutton.md
@@ -9,11 +9,11 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use IconButton to render Icon-only buttons without the default button styles.
+Use `IconButton` to render Icon-only buttons without the default button styles.
 
 ## Accessibility
 
-IconButton requires an `aria-label`, which will provide assistive technologies with an accessible label.
+`IconButton` requires an `aria-label`, which will provide assistive technologies with an accessible label.
 
 ## Examples
 

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use labels to add contextual metadata to a design.
+Use `Label` to add contextual metadata to a design.
 
 ## Examples
 

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Layout to build a main/sidebar layout.
+Use `Layout` to build a main/sidebar layout.
 
 ## Examples
 

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use links for moving from one page to another. The Link component styles anchor tags with default blue styling and hover text-decoration.
+Use `Link` for navigating from one page to another. `Link` styles anchor tags with default blue styling and hover text-decoration.
 
 ## Examples
 

--- a/docs/content/components/markdown.md
+++ b/docs/content/components/markdown.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use MarkdownComponent to wrap markdown content
+Use `Markdown` to wrap markdown content
 
 ## Examples
 

--- a/docs/content/components/menu.md
+++ b/docs/content/components/menu.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use menus to create vertical lists of navigational links.
+Use `Menu` to create vertical lists of navigational links.
 
 ## Examples
 

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Renders an [Octicon](https://primer.style/octicons/) with [System arguments](/system-arguments).
+`Octicon` renders an [Octicon](https://primer.style/octicons/) with [System arguments](/system-arguments).
 
 ## Examples
 

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use popovers to bring attention to specific user interface elements, typically to suggest an action or to guide users through a new experience.
+Use `Popover` to bring attention to specific user interface elements, typically to suggest an action or to guide users through a new experience.
 
 By default, the popover renders with absolute positioning, meaning it should usually be wrapped in an element with a relative position in order to be positioned properly. To render the popover with relative positioning, use the relative property.
 

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use ProgressBar to visualize task completion.
+Use `ProgressBar` to visualize task completion.
 
 ## Examples
 

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Primer::SpinnerComponent to let users know that content is being loaded.
+Use `Spinner` to let users know that content is being loaded.
 
 ## Examples
 

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Component for rendering the status of an item.
+Use `State` for rendering the status of an item.
 
 ## Examples
 

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use the Subhead component for page headings.
+Use `Subhead` for page headings.
 
 ## Examples
 

--- a/docs/content/components/tabcontainer.md
+++ b/docs/content/components/tabcontainer.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use TabContainer to create tabbed content with keyboard support. This component does not add any styles.
+Use `TabContainer` to create tabbed content with keyboard support. This component does not add any styles.
 It only provides the tab functionality. If you want styled Tabs you can look at [TabNav](/components/tabnav).
 
 This component requires javascript.

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use TabNav to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
+Use `TabNav` to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
 
 ## Examples
 

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-The Text component is a wrapper component that will apply typography styles to the text inside.
+`Text` is a wrapper component that will apply typography styles to the text inside.
 
 ## Examples
 

--- a/docs/content/components/timeago.md
+++ b/docs/content/components/timeago.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Primer::TimeAgoComponent to display a time relative to how long ago it was. This component requires JavaScript.
+Use `TimeAgo` to display a time relative to how long ago it was. This component requires JavaScript.
 
 ## Examples
 

--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-The Tooltip component is a wrapper component that will apply a tooltip to the provided content.
+`Tooltip` is a wrapper component that will apply a tooltip to the provided content.
 
 ## Examples
 

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -9,7 +9,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use Truncate to shorten overflowing text with an ellipsis.
+Use `Truncate` to shorten overflowing text with an ellipsis.
 
 ## Examples
 

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -12,7 +12,7 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use the UnderlineNav component to style navigation with a minimal
+Use `UnderlineNav` to style navigation with a minimal
 underlined selected state, typically used for navigation placed at the top
 of the page.
 


### PR DESCRIPTION
Closes #487 

**What**
This PR standardizes how we refer to components in the docs to use the 
`Button` syntax over ButtonComponent or Primer::ButtonComponent.

**Why**
For consistency in our docs and less cognitive overhead when writing docs. 

cc: @koddsson 