### PR TITLE
Remove border_color: :overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
     *Jon Rohan*
 
+* **Breaking change:** Remove `:overlay` option from `border_color`.
+
+    *Simon Luthi*
+
 ## 0.0.38
 
 * Extract `BaseButton` component.
@@ -28,15 +32,15 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `ButtonGroupComponent` to `ButtonGroup` and promote it to beta.
+* **Breaking change:** Rename `ButtonGroupComponent` to `ButtonGroup` and promote it to beta.
 
     *Manuel Puyol*
 
-* **Breaking change**: Do not provide default for `Heading` and improve documentation.
+* **Breaking change:** Do not provide default for `Heading` and improve documentation.
 
     *Kate Higa*
 
-* **Breaking change**: Don't allow `StateComponent` to be a link.
+* **Breaking change:** Don't allow `StateComponent` to be a link.
 
     *Kate Higa*
 
@@ -60,11 +64,11 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `AutoCompleteComponent` to `AutoComplete` and `AutoCompleteItemComponent` to `AutoComplete::Item`.
+* **Breaking change:** Rename `AutoCompleteComponent` to `AutoComplete` and `AutoCompleteItemComponent` to `AutoComplete::Item`.
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `TruncateComponent` to `Truncate` and promote it to beta.
+* **Breaking change:** Rename `TruncateComponent` to `Truncate` and promote it to beta.
 
     *Manuel Puyol*
 
@@ -82,7 +86,7 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Make `label` required for `UnderlineNav` and `TabNav`.
+* **Breaking change:** Make `label` required for `UnderlineNav` and `TabNav`.
 
     *Manuel Puyol*
 
@@ -96,23 +100,23 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `FlashComponent` `variant` argument to `scheme`.
+* **Breaking change:** Rename `FlashComponent` `variant` argument to `scheme`.
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `LinkComponent` `variant` argument to `scheme`.
+* **Breaking change:** Rename `LinkComponent` `variant` argument to `scheme`.
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `ButtonComponent` `button_type` argument to `scheme`.
+* **Breaking change:** Rename `ButtonComponent` `button_type` argument to `scheme`.
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `ButtonMarketingComponent` `button_type` argument to `scheme`.
+* **Breaking change:** Rename `ButtonMarketingComponent` `button_type` argument to `scheme`.
 
     *Manuel Puyol*
 
-* **Breaking change**: Rename `StateComponent` `color` argument to `scheme`.
+* **Breaking change:** Rename `StateComponent` `color` argument to `scheme`.
 
     *Manuel Puyol*
 
@@ -132,11 +136,11 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Update `TabNav#tab` API to accept the tab content as a block and panel content as a slot.
+* **Breaking change:** Update `TabNav#tab` API to accept the tab content as a block and panel content as a slot.
 
     *Manuel Puyol*
 
-* **Breaking change**: Update `UnderlineNavComponent` API be more strict and support `TabContainer`.
+* **Breaking change:** Update `UnderlineNavComponent` API be more strict and support `TabContainer`.
 
     *Manuel Puyol*
 
@@ -200,7 +204,7 @@
 
     *Steve Richert*
 
-* **Breaking change**: Updates `PopoverComponent` to use Slots V2.
+* **Breaking change:** Updates `PopoverComponent` to use Slots V2.
 
     *Manuel Puyol*
 
@@ -218,11 +222,11 @@
 
     *Keith Cirkel*
 
-* **Breaking change**: Updates `UnderlineNavComponent` to use Slots V2.
+* **Breaking change:** Updates `UnderlineNavComponent` to use Slots V2.
 
     *Simon Taranto*
 
-* **Breaking change**: Upgrade `LayoutComponent` to use Slots V2.
+* **Breaking change:** Upgrade `LayoutComponent` to use Slots V2.
 
     *Simon Taranto*
 
@@ -252,11 +256,11 @@
 
     *Manuel Puyol*
 
-* **Breaking change**: Upgrade `ProgressBarComponent` to use Slots V2.
+* **Breaking change:** Upgrade `ProgressBarComponent` to use Slots V2.
 
     *Simon Taranto*
 
-* **Breaking change**: Upgrade `BreadcrumbComponent` to use Slots V2.
+* **Breaking change:** Upgrade `BreadcrumbComponent` to use Slots V2.
 
     *Manuel Puyol*
 
@@ -266,11 +270,11 @@
 
   *Manuel Puyol*
 
-* **Breaking change**: Upgrade `SubheadComponent` to use Slots V2.
+* **Breaking change:** Upgrade `SubheadComponent` to use Slots V2.
 
     *Simon Taranto*
 
-* **Breaking change**: Update `LabelComponent` to use only functional color
+* **Breaking change:** Update `LabelComponent` to use only functional color
   supportive scheme keys. The component no longer accepts colors (`:gray`, for
   example) but only functional schemes (`primary`, for example).
   `LabelComponent` is promoted to beta status.
@@ -291,29 +295,29 @@
 
     *Simon Taranto*
 
-* **Breaking change**: Upgrade `BorderBoxComponent` to use Slots V2.
+* **Breaking change:** Upgrade `BorderBoxComponent` to use Slots V2.
 
     *Manuel Puyol*
 
-* **Breaking change**: Upgrade `StateComponent` to support functional colors. This change requires using [@primer/css-next](https://www.npmjs.com/package/@primer/css-next). The required changes will be upstreamed to @primer/css at a later date.
+* **Breaking change:** Upgrade `StateComponent` to support functional colors. This change requires using [@primer/css-next](https://www.npmjs.com/package/@primer/css-next). The required changes will be upstreamed to @primer/css at a later date.
 
     *Simon Taranto*
 
-* **Breaking change**: Upgrade `DetailsComponent` to use Slots V2.
+* **Breaking change:** Upgrade `DetailsComponent` to use Slots V2.
 
     *Simon Taranto*
 
 ## 0.0.21
 
-* **Breaking change**: Upgrade `FlashComponent` to use Slots V2.
+* **Breaking change:** Upgrade `FlashComponent` to use Slots V2.
 
     *Joel Hawksley, Simon Taranto*
 
-* **Breaking change**: Upgrade `BlankslateComponent` to use Slots V2.
+* **Breaking change:** Upgrade `BlankslateComponent` to use Slots V2.
 
     *Manuel Puyol*
 
-* **Breaking change**: Upgrade `TimelineItemComponent` to use Slots V2.
+* **Breaking change:** Upgrade `TimelineItemComponent` to use Slots V2.
 
     *Manuel Puyol*
 
@@ -357,7 +361,7 @@
 
     *Simon Taranto*
 
-* **Breaking change**: Drop support for Ruby 2.4.
+* **Breaking change:** Drop support for Ruby 2.4.
 
     *Simon Taranto*
 

--- a/app/lib/primer/classify/functional_border_colors.rb
+++ b/app/lib/primer/classify/functional_border_colors.rb
@@ -13,8 +13,7 @@ module Primer
         success: :success,
         warning: :warning,
         danger: :danger,
-        inverse: :inverse,
-        overlay: :overlay
+        inverse: :inverse
       }.freeze
 
       MAPPINGS = {

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -62,7 +62,7 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `bg` | String, Symbol | Background color. Accepts either a hex value as a String or one of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. |
+| `bg` | String, Symbol | Background color. Accepts either a hex value as a String or one of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, or `:inverse`. |
 | `border_color` | Symbol | Border color. One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, or `:inverse`. |
 | `color` | Symbol | Text color. One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. |
 

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -63,7 +63,7 @@ System arguments include most HTML attributes. For example:
 | Name | Type | Description |
 | :- | :- | :- |
 | `bg` | String, Symbol | Background color. Accepts either a hex value as a String or one of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. |
-| `border_color` | Symbol | Border color. One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, `:inverse`, or `:overlay`. |
+| `border_color` | Symbol | Border color. One of `:primary`, `:secondary`, `:tertiary`, `:info`, `:success`, `:warning`, `:danger`, or `:inverse`. |
 | `color` | Symbol | Text color. One of `:icon_primary`, `:icon_secondary`, `:icon_tertiary`, `:icon_info`, `:icon_success`, `:icon_warning`, `:icon_danger`, `:text_primary`, `:text_secondary`, `:text_tertiary`, `:text_link`, `:text_success`, `:text_warning`, `:text_danger`, `:text_white`, or `:text_inverse`. |
 
 ## Flex


### PR DESCRIPTION
The `border.overlay` will be removed from https://github.com/primer/primitives/pull/82. In preparation for that change, this PR removes `border_color: :overlay`. It can be replaced with `border_color: :primary` and should not cause a visual difference since both use the same color.

**Note**: I think `border_color: :overlay` is not yet used on dotcom, but we probably still wanna release this change before releasing https://github.com/primer/css/pull/1370.

This is part of https://github.com/github/design-systems/issues/1393.