### PR TITLE
Enable cuprite inspector for better debugging

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,7 +3,8 @@
 require "test_helper"
 require "capybara/rails"
 require "capybara/minitest"
-require "capybara/cuprite"
+
+require "test_helpers/cuprite_setup"
 
 Ferrum::Browser.new(process_timeout: 60, timeout: 60)
 

--- a/test/test_helpers/cuprite_setup.rb
+++ b/test/test_helpers/cuprite_setup.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# First, load Cuprite Capybara integration
+require "capybara/cuprite"
+
+# Then, we need to register our driver to be able to use it later
+# with #driven_by method.
+Capybara.register_driver(:cuprite) do |app|
+  Capybara::Cuprite::Driver.new(
+    app,
+    **{
+      # Enable debugging capabilities
+      inspector: true,
+      # Allow running Chrome in a headful mode by setting HEADLESS env
+      # var to a falsey value
+      headless: !ENV["HEADLESS"].in?(%w[n 0 no false])
+    }
+  )
+end
+
+# Configure Capybara to use :cuprite driver by default
+Capybara.default_driver = Capybara.javascript_driver = :cuprite


### PR DESCRIPTION
Enabling the `inspector` flag allows developers to set breakpoints in their integration tests. Remote debugging is extremely helpful in determining the behavior of the component in the browser.

## References

https://github.com/rubycdp/cuprite#debugging
https://paraside.in/design+code/system-test-withs-cuprite/