### PR TITLE
Don't try to toggle icons unless they exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* Create `ClipboardCopy` component.
+
+    *Kristjan Oddsson*
+
 * Add `icon` and `counter` slots to `ButtonComponent`.
 
     *Manuel Puyol*
@@ -27,6 +31,10 @@
 * Set button variants in the `ButtonGroup` parent.
 
     *Manuel Puyol*
+
+* Create `ClipboardCopy` component.
+
+    *Kristjan Oddsson*
 
 * **Breaking change**: Rename `ButtonGroupComponent` to `ButtonGroup` and promote it to beta.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## main
 
-* Create `ClipboardCopy` component.
+* Update `ClipboardCopy` to not toggle icons unless they both exist.
 
     *Kristjan Oddsson*
 

--- a/app/components/primer/clipboard_copy_component.ts
+++ b/app/components/primer/clipboard_copy_component.ts
@@ -12,12 +12,10 @@ function toggleSVG(svg: SVGElement) {
 function toggleCopyButton(button: HTMLElement) {
   const [clippyIcon, checkIcon] = button.querySelectorAll<SVGElement>('.octicon')
 
-  if (clippyIcon) {
-    toggleSVG(clippyIcon)
-  }
-  if (checkIcon) {
-    toggleSVG(checkIcon)
-  }
+  if (!clippyIcon || !checkIcon) return
+
+  toggleSVG(clippyIcon)
+  toggleSVG(checkIcon)
 }
 
 document.addEventListener('clipboard-copy', function ({target}) {


### PR DESCRIPTION
If a "clippy" icon exists but no "check" icon, we don't want to do anything.

Ref: https://github.com/primer/view_components/pull/457