### PR TITLE
Fix the conditional inclusion of ViewComponent::SlotableV2

### DIFF
--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -6,7 +6,7 @@ require "view_component/version"
 module Primer
   # @private
   class Component < ViewComponent::Base
-    include ViewComponent::SlotableV2 unless ViewComponent::VERSION::STRING.to_f >= 2.28
+    include ViewComponent::SlotableV2 unless ViewComponent::VERSION::MINOR >= 28
     include ClassNameHelper
     include FetchOrFallbackHelper
     include OcticonsHelper


### PR DESCRIPTION
For some `ViewComponent::VERSION::STRING` values, the comparison is unexpectedly `true`:

```ruby
"2.31.0".to_f >= 2.28 # true
"2.29.0".to_f >= 2.28 # true
"2.28.0".to_f >= 2.28 # true
"2.27.0".to_f >= 2.28 # false
"2.19.0".to_f >= 2.28 # false
```

But what's this? 🙈 

```ruby
"2.3.0".to_f >= 2.28 # true
```

Because we're currently locked to ViewComponent major version 2 by the `primer_view_components.gemspec`, we can use `ViewComponent::VERSION::MINOR` for the comparison (which exists for all ViewComponent 2.X versions).