### PR TITLE
Allow `@param` tag to accept default value

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -294,6 +294,15 @@ namespace :docs do
           f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
         end
 
+        # Default system_arguments settings
+        initialize_method.tags(:option).each do |option|
+          pair = option.pair
+          binding.pry
+          default = pair.defaults && pair.defaults[0]
+          binding.pry
+          f.puts("| `#{pair.name}` | `#{pair.types.join(', ')}` | #{view_context.render(inline: default)} | #{view_context.render(inline: pair.text)} |")
+        end
+
         component_args = {
           "component" => short_name,
           "source" => "https://github.com/primer/view_components/tree/main/app/components/primer/#{component.to_s.demodulize.underscore}.rb",
@@ -319,7 +328,9 @@ namespace :docs do
             end
 
             param_tags = slot_documentation.tags(:param)
-            if param_tags.any?
+            option_tags = slot_documentation.tags(:option)
+
+            if param_tags.any? || option_tags.any?
               f.puts
               f.puts("| Name | Type | Default | Description |")
               f.puts("| :- | :- | :- | :- |")
@@ -336,6 +347,13 @@ namespace :docs do
                 end
 
               f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
+            end
+
+            # Default system_arguments settings
+            option_tags.each do |option| 
+              pair = option.pair
+              default_value = pair.defaults && pair.defaults[0]
+              f.puts("| `#{pair.name.to_s}` | `#{pair.types.join(', ')}` | `#{view_context.render(inline: default_value)}` | #{view_context.render(inline: pair.text)} |")
             end
           end
         end

--- a/app/components/primer/auto_complete.rb
+++ b/app/components/primer/auto_complete.rb
@@ -5,22 +5,19 @@ module Primer
   class AutoComplete < Primer::Component
     status :beta
 
-    DEFAULT_TAG = :ul 
-    TAG_OPTIONS = [DEFAULT_TAG].freeze
+    DEFAULT_TAG = :"auto-complete"
 
     DEFAULT_INPUT_TYPE = :text
     INPUT_TYPE_OPTIONS = [DEFAULT_INPUT_TYPE, :search].freeze
     DEFAULT_INPUT_TAG = :input
-    INPUT_TAG_OPTIONS = [DEFAULT_INPUT_TAG].freeze
 
     DEFAULT_RESULTS_TAG = :ul
-    RESULTS_TAG_OPTIONS = [DEFAULT_RESULTS_TAG].freeze
 
     # Required input used to search for results
     #
-    # @param type [Symbol] <%= one_of(Primer::AutoComplete::INPUT_TYPE_OPTIONS) %>
+    # @param type [Symbol] (<%= pretty_value(Primer::AutoComplete::DEFAULT_INPUT_TYPE) %>) <%= one_of(Primer::AutoComplete::INPUT_TYPE_OPTIONS) %>
+    # @param tag [Symbol] (<%= pretty_value(Primer::AutoComplete::DEFAULT_INPUT_TAG) %>) <%= locked_tag_text %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_INPUT_TAG %>) <%= one_of(Primer::AutoComplete::INPUT_TAG_OPTIONS) %>
     renders_one :input, lambda { |type: DEFAULT_INPUT_TYPE, classes: "form-control", **system_arguments|
       system_arguments[:tag] = DEFAULT_INPUT_TAG
       system_arguments[:type] = fetch_or_fallback(INPUT_TYPE_OPTIONS, type, DEFAULT_INPUT_TYPE)
@@ -33,8 +30,8 @@ module Primer
 
     # Customizable results list.
     #
+    # @param tag [Symbol] (<%= pretty_value(Primer::AutoComplete::DEFAULT_RESULTS_TAG) %>) <%= locked_tag_text %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_RESULTS_TAG %>) <%= one_of(Primer::AutoComplete::RESULTS_TAG_OPTIONS) %>
     renders_one :results, lambda { |**system_arguments|
       system_arguments[:tag] = :ul
       system_arguments[:id] = @id
@@ -88,13 +85,13 @@ module Primer
     #
     # @param src [String] The route to query.
     # @param id [String] Id of the list element.
+    # @param tag [Symbol] (<%= pretty_value(Primer::AutoComplete::DEFAULT_TAG) %>) <%= locked_tag_text %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_TAG %>) <%= one_of(Primer::AutoComplete::TAG_OPTIONS) %>
     def initialize(src:, id:, **system_arguments)
       @id = id
 
       @system_arguments = system_arguments
-      @system_arguments[:tag] = "auto-complete"
+      @system_arguments[:tag] = DEFAULT_TAG
       @system_arguments[:src] = src
       @system_arguments[:for] = id
     end

--- a/app/components/primer/auto_complete.rb
+++ b/app/components/primer/auto_complete.rb
@@ -5,15 +5,24 @@ module Primer
   class AutoComplete < Primer::Component
     status :beta
 
+    DEFAULT_TAG = :ul 
+    TAG_OPTIONS = [DEFAULT_TAG].freeze
+
     DEFAULT_INPUT_TYPE = :text
     INPUT_TYPE_OPTIONS = [DEFAULT_INPUT_TYPE, :search].freeze
+    DEFAULT_INPUT_TAG = :input
+    INPUT_TAG_OPTIONS = [DEFAULT_INPUT_TAG].freeze
+
+    DEFAULT_RESULTS_TAG = :ul
+    RESULTS_TAG_OPTIONS = [DEFAULT_RESULTS_TAG].freeze
 
     # Required input used to search for results
     #
     # @param type [Symbol] <%= one_of(Primer::AutoComplete::INPUT_TYPE_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_INPUT_TAG %>) <%= one_of(Primer::AutoComplete::INPUT_TAG_OPTIONS) %>
     renders_one :input, lambda { |type: DEFAULT_INPUT_TYPE, classes: "form-control", **system_arguments|
-      system_arguments[:tag] = :input
+      system_arguments[:tag] = DEFAULT_INPUT_TAG
       system_arguments[:type] = fetch_or_fallback(INPUT_TYPE_OPTIONS, type, DEFAULT_INPUT_TYPE)
       system_arguments[:classes] = classes
       Primer::BaseComponent.new(**system_arguments)
@@ -25,6 +34,7 @@ module Primer
     # Customizable results list.
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_RESULTS_TAG %>) <%= one_of(Primer::AutoComplete::RESULTS_TAG_OPTIONS) %>
     renders_one :results, lambda { |**system_arguments|
       system_arguments[:tag] = :ul
       system_arguments[:id] = @id
@@ -79,6 +89,7 @@ module Primer
     # @param src [String] The route to query.
     # @param id [String] Id of the list element.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+    # @option system_arguments [Symbol] tag (<%= Primer::AutoComplete::DEFAULT_TAG %>) <%= one_of(Primer::AutoComplete::TAG_OPTIONS) %>
     def initialize(src:, id:, **system_arguments)
       @id = id
 

--- a/app/components/primer/auto_complete/item.rb
+++ b/app/components/primer/auto_complete/item.rb
@@ -6,6 +6,8 @@ module Primer
     class Item < Primer::Component
       status :beta
 
+      DEFAULT_TAG = :li
+
       # @example Default
       #   <%= render(Primer::AutoComplete::Item.new(selected: true, value: "value")) do |c| %>
       #     Selected
@@ -17,10 +19,11 @@ module Primer
       # @param value [String] Value of the item.
       # @param selected [Boolean] Whether the item is selected.
       # @param disabled [Boolean] Whether the item is disabled.
+      # @param tag [Symbol] (<%= pretty_value(Primer::AutoComplete::Item::DEFAULT_TAG) %>) <%= locked_tag_text %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(value:, selected: false, disabled: false, **system_arguments)
         @system_arguments = system_arguments
-        @system_arguments[:tag] = :li
+        @system_arguments[:tag] = DEFAULT_TAG
         @system_arguments[:role] = :option
         @system_arguments[:"data-autocomplete-value"] = value
 

--- a/app/components/primer/avatar_component.rb
+++ b/app/components/primer/avatar_component.rb
@@ -19,6 +19,7 @@ module Primer
     status :beta
 
     SMALL_THRESHOLD = 24
+    DEFAULT_TAG = :img
 
     # @example Default
     #   <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser")) %>
@@ -42,11 +43,12 @@ module Primer
     # @param size [Integer] Adds the avatar-small class if less than 24.
     # @param square [Boolean] Used to create a square avatar.
     # @param href [String] The URL to link to. If used, component will be wrapped by an `<a>` tag.
+    # @param tag [Symbol] (<%= pretty_value(Primer::AvatarComponent::DEFAULT_TAG) %>) If `href` is set, component will be wrapped by an `<a>` tag
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(src:, alt:, size: 20, square: false, href: nil, **system_arguments)
       @href = href
       @system_arguments = system_arguments
-      @system_arguments[:tag] = :img
+      @system_arguments[:tag] = DEFAULT_TAG
       @system_arguments[:src] = src
       @system_arguments[:alt] = alt
       @system_arguments[:size] = size

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -78,8 +78,8 @@ module Primer
     #
     # @param scheme [Symbol] <%= one_of(Primer::ButtonComponent::SCHEME_OPTIONS) %>
     # @param variant [Symbol] <%= one_of(Primer::ButtonComponent::VARIANT_OPTIONS) %>
-    # @param tag [Symbol] <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
-    # @param type [Symbol] <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
+    # @param tag [Symbol] (<%= pretty_value(Primer::BaseButton::DEFAULT_TAG) %>) <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
+    # @param type [Symbol] (<%= pretty_value(Primer::BaseButton::DEFAULT_TYPE) %>) <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
     # @param group_item [Boolean] Whether button is part of a ButtonGroup.
     # @param block [Boolean] Whether button is full-width with `display: block`.
     # @param caret [Boolean] Whether or not to render a caret.

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -78,6 +78,7 @@ Use `AutoComplete` to populate input values from server search results.
 | `src` | `String` | N/A | The route to query. |
 | `id` | `String` | N/A | Id of the list element. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+| `tag` | `Symbol` | ul | One of `:ul`. |
 
 ## Slots
 
@@ -89,6 +90,7 @@ Required input used to search for results
 | :- | :- | :- | :- |
 | `type` | `Symbol` | N/A | One of `:text` and `:search`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+| `tag` | `Symbol` | `input` | One of `:input`. |
 
 ### `Icon`
 
@@ -101,3 +103,4 @@ Customizable results list.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+| `tag` | `Symbol` | `ul` | One of `:ul`. |

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -77,8 +77,8 @@ Use `AutoComplete` to populate input values from server search results.
 | :- | :- | :- | :- |
 | `src` | `String` | N/A | The route to query. |
 | `id` | `String` | N/A | Id of the list element. |
+| `tag` | `Symbol` | `:auto-complete` | Cannot be modified |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-| `tag` | `Symbol` | ul | One of `:ul`. |
 
 ## Slots
 
@@ -88,9 +88,9 @@ Required input used to search for results
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `type` | `Symbol` | N/A | One of `:text` and `:search`. |
+| `type` | `Symbol` | `:text` | One of `:text` and `:search`. |
+| `tag` | `Symbol` | `:input` | Cannot be modified |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-| `tag` | `Symbol` | `input` | One of `:input`. |
 
 ### `Icon`
 
@@ -102,5 +102,5 @@ Customizable results list.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:ul` | Cannot be modified |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-| `tag` | `Symbol` | `ul` | One of `:ul`. |

--- a/docs/content/components/autocompleteitem.md
+++ b/docs/content/components/autocompleteitem.md
@@ -33,4 +33,5 @@ Use AutoCompleteItem to list results of an auto-completed search.
 | `value` | `String` | N/A | Value of the item. |
 | `selected` | `Boolean` | `false` | Whether the item is selected. |
 | `disabled` | `Boolean` | `false` | Whether the item is disabled. |
+| `tag` | `Symbol` | `:li` | Cannot be modified |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -73,4 +73,5 @@ rather than `@kittenuser`.
 | `size` | `Integer` | `20` | Adds the avatar-small class if less than 24. |
 | `square` | `Boolean` | `false` | Used to create a square avatar. |
 | `href` | `String` | `nil` | The URL to link to. If used, component will be wrapped by an `<a>` tag. |
+| `tag` | `Symbol` | `:img` | If `href` is set, component will be wrapped by an `<a>` tag |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -95,8 +95,8 @@ Use `Button` for actions (e.g. in forms). Use links for destinations, or moving 
 | :- | :- | :- | :- |
 | `scheme` | `Symbol` | `:default` | One of `:default`, `:primary`, `:danger`, `:outline`, `:invisible`, or `:link`. |
 | `variant` | `Symbol` | `:medium` | One of `:small`, `:medium`, or `:large`. |
-| `tag` | `Symbol` | N/A | One of `:button`, `:a`, or `:summary`. |
-| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
+| `tag` | `Symbol` | `:button` | One of `:button`, `:a`, or `:summary`. |
+| `type` | `Symbol` | `:button` | One of `:button`, `:reset`, or `:submit`. |
 | `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
 | `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
 | `caret` | `Boolean` | `false` | Whether or not to render a caret. |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -33,6 +33,10 @@
     type: String
     default: N/A
     description: Id of the list element.
+  - name: tag
+    type: Symbol
+    default: "`:auto-complete`"
+    description: Cannot be modified
   - name: system_arguments
     type: Hash
     default: N/A
@@ -52,6 +56,10 @@
     type: Boolean
     default: "`false`"
     description: Whether the item is disabled.
+  - name: tag
+    type: Symbol
+    default: "`:li`"
+    description: Cannot be modified
   - name: system_arguments
     type: Hash
     default: N/A
@@ -80,6 +88,10 @@
     default: "`nil`"
     description: The URL to link to. If used, component will be wrapped by an `<a>`
       tag.
+  - name: tag
+    type: Symbol
+    default: "`:img`"
+    description: If `href` is set, component will be wrapped by an `<a>` tag
   - name: system_arguments
     type: Hash
     default: N/A
@@ -225,11 +237,11 @@
     description: One of `:small`, `:medium`, or `:large`.
   - name: tag
     type: Symbol
-    default: N/A
+    default: "`:button`"
     description: One of `:button`, `:a`, or `:summary`.
   - name: type
     type: Symbol
-    default: N/A
+    default: "`:button`"
     description: One of `:button`, `:reset`, or `:submit`.
   - name: group_item
     type: Boolean


### PR DESCRIPTION
Part of #491 

**What**
- Updates the yard tag`@param` by redefining the tag with `:with_types_name_and_default`. Currently,`@param` can only hold: 
```
@param name [Types] description
```
This change allows `@param` to also optionally hold a default value within parentheses so we can use this info when populating docs: 
```
@param name (Optional default value) [Types] description
```
- Update logic in `Rake` for populating the `Arguments` table to use default information on tag if its available. The current logic infers what the default is set by looking at the method argument. This may not work for cases like `Button` which inherits a default from `BaseButton`. This also makes it hard to surface defaults that are set within initialize that may not be part of method arguments.
- Updates a few component to see how documentation turns out 

**Why**
The documentation is missing some pieces of info that are useful for consumer to know. We have defaults that aren't exposed in the method arguments that we may want to surface manually. A good example is `AutoComplete`. 

**Notes**
- Instead of overriding `@param`, I considered introducing [@option](https://rubydoc.info/gems/yard/file/docs/Tags.md#option) which can already hold a default value. It isn't clear to me what should be `@param` and what should be `@option`.  Since we already use `@param` to refer to any argument, it feels more intuitive to stick to it.

 [Defining a custom tag docs](https://www.rubydoc.info/gems/yard/YARD/Tags/Library)
[Methods available for tag parsing docs](https://www.rubydoc.info/gems/yard/YARD/Tags/DefaultFactory#parse_tag_with_types_name_and_default-instance_method)
