### PR TITLE
add a11y section to `Blankslate` docs

### DIFF
--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -2,6 +2,9 @@
 
 module Primer
   # Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
+  # @accessibility
+  #   `BlankSlate` renders an `<h3>` element for the title by default. Update the heading level based on what is appropriate for your page hierarchy by setting `title_tag`.
+  #   [Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
   class BlankslateComponent < Primer::Component
     status :beta
 

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -11,6 +11,11 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
 
+## Accessibility
+
+`BlankSlate` renders an `<h3>` element for the title by default. Update the heading level based on what is appropriate for your page hierarchy by setting `title_tag`.
+[Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
+
 ## Examples
 
 ### Basic


### PR DESCRIPTION
Closes #504 

**What**
Updates `Blankslate` docs with an a11y section.

**Why**
`Blankslate` component has a default title tag of `:h3` which should be updated by consumer based on page context. 

**Notes**
dotcom uses `Blankslate` component extensively and `title_tag` doesn't seem to be updated in most cases so it'd be good to audit usage for correctness.

