### PR TITLE
Deprecate tag from system_arguments docs

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -138,7 +138,6 @@ module Primer
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | classes | String | CSS class name value to be concatenated with generated Primer CSS classes. |
-    # | tag | Symbol | HTML tag name to be passed to `content_tag`. |
     # | test_selector | String | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
     def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -139,5 +139,4 @@ System arguments include most HTML attributes. For example:
 | Name | Type | Description |
 | :- | :- | :- |
 | classes | String | CSS class name value to be concatenated with generated Primer CSS classes. |
-| tag | Symbol | HTML tag name to be passed to `content_tag`. |
 | test_selector | String | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |


### PR DESCRIPTION
**What**
Remove `tag` from our System arguments docs

**Why**
The top of our[ System argument docs](https://primer.style/view-components/system-arguments) page states: `All Primer ViewComponents accept a standard set of options called system arguments`. Came up in discussion with @joelhawksley that this is not true for `tag:` for most of our components.  Many of our components have fixed tags that can't be updated even if a user were to pass in a `tag:` argument. 

Let's remove it from the docs as it is misleading.

**Note**
Part of #491 