### PR TITLE
Restrict tag to`:div` for `Blankslate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+* **Breaking change:** Restrict `Blankslate` tag to `div`.
+
+    *Kate Higa*
+
 * **Breaking change:** Explicitly limit tag for `AvatarStack` to `:div` and `:span`
 
     *Kate Higa*

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -111,7 +111,7 @@ module Primer
       **system_arguments
     )
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :div
+      @system_arguments[:tag] = :div
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
         "blankslate",


### PR DESCRIPTION
Part of #491 

**What**
Don't allow `Blankslate` tag to be changed. Currently we have no restrictions but we only ever instantiate this component as a `div`. We already don't mention the `tag` attribute in the docs here so no need to change anything here. 

**Notes**
 I verified that there's no instance of `Blankslate` with `tag` argument by grepping the following regex in dotcom:
```
Primer::BlankslateComponent.new(((?!%>).)|\n)*(tag:)+(((?!%>).)|\n)*%>
```
