### PR TITLE
Moving Primer::OcticonComponent::Cache to lib directory

### DIFF
--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -42,7 +42,7 @@ module Primer
         @system_arguments[:aria][:hidden] = true
       end
 
-      if (cache_icon = Primer::OcticonComponent::Cache.read(cache_key))
+      if (cache_icon = Primer::Octicon::Cache.read(cache_key))
         @icon = cache_icon
       else
         # Filter out classify options to prevent them from becoming invalid html attributes.
@@ -52,7 +52,7 @@ module Primer
         }.merge(@system_arguments.slice(:height, :width))
 
         @icon = Octicons::Octicon.new(icon_key, octicon_options)
-        Primer::OcticonComponent::Cache.set(cache_key, @icon)
+        Primer::Octicon::Cache.set(cache_key, @icon)
       end
 
       @system_arguments[:classes] = class_names(
@@ -66,39 +66,6 @@ module Primer
       render(Primer::BaseComponent.new(**@system_arguments)) { @icon.path.html_safe } # rubocop:disable Rails/OutputSafety
     end
 
-    # :nodoc:
-    class Cache
-      LOOKUP = {} # rubocop:disable Style/MutableConstant
-      # Preload the top 20 used icons.
-      PRELOADED_ICONS = [:alert, :check, :"chevron-down", :clippy, :clock, :"dot-fill", :info, :"kebab-horizontal", :link, :lock, :mail, :pencil, :plus, :question, :repo, :search, :"shield-lock", :star, :trash, :x].freeze
-
-      class << self
-        def read(key)
-          LOOKUP[key]
-        end
-
-        # Cache size limit.
-        def limit
-          500
-        end
-
-        def set(key, value)
-          LOOKUP[key] = value
-
-          # Remove first item when the cache is too large.
-          LOOKUP.shift if LOOKUP.size > limit
-        end
-
-        def clear!
-          LOOKUP.clear
-        end
-
-        def preload!
-          PRELOADED_ICONS.each { |icon| Primer::OcticonComponent.new(icon: icon) }
-        end
-      end
-    end
-
-    Cache.preload!
+    Primer::Octicon::Cache.preload!
   end
 end

--- a/app/lib/primer/octicon/cache.rb
+++ b/app/lib/primer/octicon/cache.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Primer
+  module Octicon
+    # :nodoc:
+    class Cache
+      LOOKUP = {} # rubocop:disable Style/MutableConstant
+      # Preload the top 20 used icons.
+      PRELOADED_ICONS = [:alert, :check, :"chevron-down", :clippy, :clock, :"dot-fill", :info, :"kebab-horizontal", :link, :lock, :mail, :pencil, :plus, :question, :repo, :search, :"shield-lock", :star, :trash, :x].freeze
+
+      class << self
+        def read(key)
+          LOOKUP[key]
+        end
+
+        # Cache size limit.
+        def limit
+          500
+        end
+
+        def set(key, value)
+          LOOKUP[key] = value
+
+          # Remove first item when the cache is too large.
+          LOOKUP.shift if LOOKUP.size > limit
+        end
+
+        def clear!
+          LOOKUP.clear
+        end
+
+        def preload!
+          PRELOADED_ICONS.each { |icon| Primer::OcticonComponent.new(icon: icon) }
+        end
+      end
+    end
+  end
+end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -12,16 +12,16 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
-    Primer::OcticonComponent::Cache.clear!
+    Primer::Octicon::Cache.clear!
     assert_allocations 43 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
-    Primer::OcticonComponent::Cache.preload!
+    Primer::Octicon::Cache.preload!
   end
 
   def bench_allocations_with_cache
-    Primer::OcticonComponent::Cache.preload!
+    Primer::Octicon::Cache.preload!
     assert_allocations 20 do
       Primer::OcticonComponent.new(**@options)
     end

--- a/test/components/octicon_component_test.rb
+++ b/test/components/octicon_component_test.rb
@@ -104,18 +104,18 @@ class PrimerOcticonComponentTest < Minitest::Test
   end
 
   def test_cache_evacuates_after_limit_reached
-    Primer::OcticonComponent::Cache.clear!
-    Primer::OcticonComponent::Cache.stub :limit, 3 do
+    Primer::Octicon::Cache.clear!
+    Primer::Octicon::Cache.stub :limit, 3 do
       # Assert the limit is stubbed properly
-      assert_equal Primer::OcticonComponent::Cache.limit, 3
+      assert_equal Primer::Octicon::Cache.limit, 3
       # Assert the cache is empty
-      assert_equal 0, Primer::OcticonComponent::Cache::LOOKUP.size
+      assert_equal 0, Primer::Octicon::Cache::LOOKUP.size
 
       # Preload the cache should be 20 items
-      Primer::OcticonComponent::Cache.preload!
+      Primer::Octicon::Cache.preload!
 
       # Assert the cache size is 3 because the limit is 3
-      assert_equal 3, Primer::OcticonComponent::Cache::LOOKUP.size
+      assert_equal 3, Primer::Octicon::Cache::LOOKUP.size
     end
   end
 end


### PR DESCRIPTION
This is a follow up to #496 that moves the cache to the lib directory. as suggested by @manuelpuyol here https://github.com/primer/view_components/pull/496#discussion_r623111986

I moved it to `lib/primer/octicon/cache.rb` and will be accessed by `Primer::Octicon::Cache` This is a necessary change as I'll be using the same cache when constructing a `OcticonSymbolComponent` in another pr.