### PR TITLE
Preload cache using _after_compile

### DIFF
--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -69,7 +69,7 @@ module Primer
     def call
       render(Primer::BaseComponent.new(**@system_arguments)) { @icon.path.html_safe } # rubocop:disable Rails/OutputSafety
     end
-    
+
     def self._after_compile
       Primer::Octicon::Cache.preload!
     end

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -69,7 +69,9 @@ module Primer
     def call
       render(Primer::BaseComponent.new(**@system_arguments)) { @icon.path.html_safe } # rubocop:disable Rails/OutputSafety
     end
-
-    Primer::Octicon::Cache.preload!
+    
+    def self._after_compile
+      Primer::Octicon::Cache.preload!
+    end
   end
 end


### PR DESCRIPTION
I _believe_ this use of `_after_compile` should be equivalent to what we had before, and perhaps could serve as a nice example to point to when folks ask what the lifecycle hook is useful for!