### PR TITLE
Set tag for Text and ButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ### Breaking Changes
 
+* Restrict `ButtonGroup` tag to `:div` and update docs for `Text` tag.
+
+    *Kate Higa*
+
 * Remove non-functional `width` and `height` `:fill` option.
 
     *Jon Rohan*, *Joel Hawksley*

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -46,7 +46,7 @@ module Primer
     def initialize(variant: Primer::ButtonComponent::DEFAULT_VARIANT, **system_arguments)
       @variant = variant
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :div
+      @system_arguments[:tag] = :div
 
       @system_arguments[:classes] = class_names(
         "BtnGroup",

--- a/app/components/primer/text_component.rb
+++ b/app/components/primer/text_component.rb
@@ -5,14 +5,17 @@ module Primer
   class TextComponent < Primer::Component
     status :beta
 
+    DEFAULT_TAG = :span
+
     # @example Default
     #   <%= render(Primer::TextComponent.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
     #   <%= render(Primer::TextComponent.new(tag: :p, color: :text_danger)) { "Danger Text" } %>
     #
+    # @param tag [Symbol]
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**system_arguments)
+    def initialize(tag: DEFAULT_TAG, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :span
+      @system_arguments[:tag] = tag
     end
 
     def call

--- a/docs/content/components/text.md
+++ b/docs/content/components/text.md
@@ -26,4 +26,5 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:span` |  |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -706,6 +706,10 @@
 - component: Text
   source: https://github.com/primer/view_components/tree/main/app/components/primer/text_component.rb
   parameters:
+  - name: tag
+    type: Symbol
+    default: "`:span`"
+    description: ''
   - name: system_arguments
     type: Hash
     default: N/A


### PR DESCRIPTION
**What**
- Add `tag` to `Text` component docs for explicitness. 
- Restrict `ButtonGroup` tag to `:div`

**Notes** 
Part of #491 