### PR TITLE
Fix argument warning in tests

### DIFF
--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -631,7 +631,7 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_does_include_leading_trailing_whitespace_in_class
-    generated_class = Primer::Classify.call({ classes: "foo-class" })[:class]
+    generated_class = Primer::Classify.call(classes: "foo-class")[:class]
     refute(generated_class.start_with?(" "))
     refute(generated_class.end_with?(" "))
   end


### PR DESCRIPTION
This fixes an argument warning I was seeing in the tests

```
@primer/view_components/test/lib/classify_test.rb:634: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
@primer/view_components/app/lib/primer/classify.rb:105: warning: The called method `call' is defined here
```