### PR TITLE
Only run linters and tests on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   markdown:


### PR DESCRIPTION
`main` is a protected branch that developers cannot push to directly. Therefore we don't need to run the test and linters on pushes. This change means that a pull request will run the tests and linters just once for each test or lint job.