### PR TITLE
Explicitly limit tag for `Label` component 

### DIFF
--- a/.github/lint/markdown.json
+++ b/.github/lint/markdown.json
@@ -4,5 +4,6 @@
   "ol-prefix": false,
   "no-trailing-punctuation": false,
   "no-inline-html": false,
-  "first-line-heading": false
+  "first-line-heading": false,
+  "no-duplicate-heading": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
     *Jon Rohan*
 
+### Breaking Changes
+
+* Restrict `Label` tag to `span`, `div`, `a`, `summary`.
+
+    *Kate Higa*
+
 ## 0.0.40
 
 ### New

--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -5,6 +5,9 @@ module Primer
   class LabelComponent < Primer::Component
     status :beta
 
+    DEFAULT_TAG = :span
+    TAG_OPTIONS = [DEFAULT_TAG, :summary, :a, :div].freeze
+
     SCHEME_MAPPINGS = {
       primary: "Label--primary",
       secondary: "Label--secondary",
@@ -38,13 +41,14 @@ module Primer
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
     #   <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
     #
+    # @param tag [Symbol] <%= one_of(Primer::LabelComponent::TAG_OPTIONS) %>
     # @param title [String] `title` attribute for the component element.
     # @param scheme [Symbol] <%= one_of(Primer::LabelComponent::SCHEME_MAPPINGS.keys) %>
     # @param variant [Symbol] <%= one_of(Primer::LabelComponent::VARIANT_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(title:, scheme: nil, variant: nil, **system_arguments)
+    def initialize(tag: DEFAULT_TAG, title:, scheme: nil, variant: nil, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :span
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
       @system_arguments[:title] = title
       @system_arguments[:classes] = class_names(
         "Label",

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -40,6 +40,7 @@ Use `Label` to add contextual metadata to a design.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:span` | One of `:span`, `:summary`, `:a`, or `:div`. |
 | `title` | `String` | N/A | `title` attribute for the component element. |
 | `scheme` | `Symbol` | `nil` | One of `:primary`, `:secondary`, `:info`, `:success`, `:warning`, `:danger`, `:orange`, or `:purple`. |
 | `variant` | `Symbol` | `nil` | One of `:large`, `:inline`, or `nil`. |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -523,6 +523,10 @@
 - component: Label
   source: https://github.com/primer/view_components/tree/main/app/components/primer/label_component.rb
   parameters:
+  - name: tag
+    type: Symbol
+    default: "`:span`"
+    description: One of `:span`, `:summary`, `:a`, or `:div`.
   - name: title
     type: String
     default: N/A

--- a/test/components/label_component_test.rb
+++ b/test/components/label_component_test.rb
@@ -11,6 +11,13 @@ class PrimerLabelComponentTest < Minitest::Test
     assert_text("private")
   end
 
+  def test_falls_back_when_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::LabelComponent.new(title: "foo", tag: :h1))
+      assert_selector("span.Label")
+    end
+  end
+
   def test_supports_functional_schemes
     render_inline(Primer::LabelComponent.new(title: "foo", scheme: :danger)) { "private" }
 


### PR DESCRIPTION
**What**
Explicitly limited tags for `Label` component and updated docs.

**Why**
Part of #491 

**Notes**
I chose these tags based on current usage in dotcom and am open to other recommendations.