### PR TITLE
Only update rails related dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle update actionview activemodel activesupport railties
         bundle exec rake bench
       env:
         RAILS_VERSION: main
@@ -112,10 +112,10 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle update actionview activemodel activesupport railties
         cd demo
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle update actionview activemodel activesupport railties
         bin/rails view_component_storybook:write_stories_json
   test:
     needs: lint
@@ -155,7 +155,7 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundle update actionview activemodel activesupport railties
         bundle exec rake
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle update
+        bundle install --jobs 4 --retry 3
         bundle exec rake bench
       env:
         RAILS_VERSION: main
@@ -112,10 +112,10 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle update
+        bundle install --jobs 4 --retry 3
         cd demo
         bundle config path vendor/bundle
-        bundle update
+        bundle install --jobs 4 --retry 3
         bin/rails view_component_storybook:write_stories_json
   test:
     needs: lint
@@ -155,7 +155,7 @@ jobs:
       run: |
         gem install bundler:2.2.9
         bundle config path vendor/bundle
-        bundle update
+        bundle install --jobs 4 --retry 3
         bundle exec rake
       env:
         RAILS_VERSION: ${{ matrix.rails_version }}


### PR DESCRIPTION
Running `bundle update` would update the version of locked gems, which could cause CI to fail see https://github.com/primer/view_components/pull/577/checks?check_run_id=2587131939
