### PR TITLE
Restrict tags for `HiddenTextExpander` and `Truncate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 * Do not raise error if Primer CSS class name is passed to component if `PRIMER_WARNINGS_DISABLED` is set.
 
     *Joel Hawksley*
+### Breaking changes
+
+* Restrict allowed tags for `Truncate` and `HiddenTextExpander` components.
 
 ### Accessibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+### Breaking changes
+
+* Restrict allowed tags for `Truncate`, `Markdown`, and `HiddenTextExpander`.
+
 ## 0.0.41
 
 ### New
@@ -21,9 +25,6 @@
 * Do not raise error if Primer CSS class name is passed to component if `PRIMER_WARNINGS_DISABLED` is set.
 
     *Joel Hawksley*
-### Breaking changes
-
-* Restrict allowed tags for `Truncate` and `HiddenTextExpander` components.
 
 ### Accessibility
 

--- a/app/components/primer/hidden_text_expander.rb
+++ b/app/components/primer/hidden_text_expander.rb
@@ -17,7 +17,7 @@ module Primer
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(inline: false, button_arguments: {}, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :span
+      @system_arguments[:tag] = :span
       @system_arguments[:classes] = class_names(
         "hidden-text-expander",
         @system_arguments[:classes],

--- a/app/components/primer/markdown.rb
+++ b/app/components/primer/markdown.rb
@@ -6,6 +6,7 @@ module Primer
     status :beta
 
     DEFAULT_TAG = :div
+    TAG_OPTIONS = [DEFAULT_TAG, :article, :td].freeze
     # @example Default
     #   <%= render(Primer::Markdown.new) do %>
     #     <p>Text can be <b>bold</b>, <i>italic</i>, or <s>strikethrough</s>. <a href="https://github.com">Links </a> should be blue with no underlines (unless hovered over).</p>
@@ -278,11 +279,11 @@ module Primer
     #     <pre><code>This is the final element on the page and there should be no margin below this.</code></pre>
     #   <% end %>
     #
-    # @param tag [Symbol]
+    # @param tag [Symbol] <%= one_of(Primer::Markdown::TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(tag: DEFAULT_TAG, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= tag
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
 
       @system_arguments[:classes] = class_names(
         "markdown-body",

--- a/app/components/primer/markdown.rb
+++ b/app/components/primer/markdown.rb
@@ -4,6 +4,8 @@ module Primer
   # Use `Markdown` to wrap markdown content
   class Markdown < Primer::Component
     status :beta
+
+    DEFAULT_TAG = :div
     # @example Default
     #   <%= render(Primer::Markdown.new) do %>
     #     <p>Text can be <b>bold</b>, <i>italic</i>, or <s>strikethrough</s>. <a href="https://github.com">Links </a> should be blue with no underlines (unless hovered over).</p>
@@ -276,10 +278,11 @@ module Primer
     #     <pre><code>This is the final element on the page and there should be no margin below this.</code></pre>
     #   <% end %>
     #
+    # @param tag [Symbol]
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(**system_arguments)
+    def initialize(tag: DEFAULT_TAG, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :div
+      @system_arguments[:tag] ||= tag
 
       @system_arguments[:classes] = class_names(
         "markdown-body",

--- a/app/components/primer/truncate.rb
+++ b/app/components/primer/truncate.rb
@@ -5,6 +5,9 @@ module Primer
   class Truncate < Primer::Component
     status :beta
 
+    DEFAULT_TAG = :div
+    TAG_OPTIONS = [DEFAULT_TAG, :span, :p].freeze
+
     # @example Default
     #   <div class="col-2">
     #     <%= render(Primer::Truncate.new(tag: :p)) { "branch-name-that-is-really-long" } %>
@@ -19,13 +22,14 @@ module Primer
     # @example Custom size
     #   <%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) { "branch-name-that-is-really-long" } %>
     #
+    # @param tag [Symbol] <%= one_of(Primer::Truncate::TAG_OPTIONS) %>
     # @param inline [Boolean] Whether the element is inline (or inline-block).
     # @param expandable [Boolean] Whether the entire string should be revealed on hover. Can only be used in conjunction with `inline`.
     # @param max_width [Integer] Sets the max-width of the text.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(inline: false, expandable: false, max_width: nil, **system_arguments)
+    def initialize(tag: DEFAULT_TAG, inline: false, expandable: false, max_width: nil, **system_arguments)
       @system_arguments = system_arguments
-      @system_arguments[:tag] ||= :div
+      @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
       @system_arguments[:classes] = class_names(
         @system_arguments[:classes],
         "css-truncate",

--- a/docs/content/components/markdown.md
+++ b/docs/content/components/markdown.md
@@ -294,4 +294,5 @@ Use `Markdown` to wrap markdown content
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:div` | One of `:div`, `:article`, or `:td`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -51,6 +51,7 @@ Use `Truncate` to shorten overflowing text with an ellipsis.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:div` | One of `:div`, `:span`, or `:p`. |
 | `inline` | `Boolean` | `false` | Whether the element is inline (or inline-block). |
 | `expandable` | `Boolean` | `false` | Whether the entire string should be revealed on hover. Can only be used in conjunction with `inline`. |
 | `max_width` | `Integer` | `nil` | Sets the max-width of the text. |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -661,6 +661,10 @@
 - component: Markdown
   source: https://github.com/primer/view_components/tree/main/app/components/primer/markdown.rb
   parameters:
+  - name: tag
+    type: Symbol
+    default: "`:div`"
+    description: One of `:div`, `:article`, or `:td`.
   - name: system_arguments
     type: Hash
     default: N/A
@@ -883,6 +887,10 @@
 - component: Truncate
   source: https://github.com/primer/view_components/tree/main/app/components/primer/truncate.rb
   parameters:
+  - name: tag
+    type: Symbol
+    default: "`:div`"
+    description: One of `:div`, `:span`, or `:p`.
   - name: inline
     type: Boolean
     default: "`false`"

--- a/test/components/markdown_test.rb
+++ b/test/components/markdown_test.rb
@@ -11,9 +11,22 @@ class PrimerMarkdownTest < Minitest::Test
     assert_selector(".markdown-body", text: "Content")
   end
 
-  def test_renders_different_tags
+  def test_renders_with_article
+    render_inline(Primer::Markdown.new(tag: :article)) { "Content" }
+
+    assert_selector("article.markdown-body", text: "Content")
+  end
+
+  def test_renders_with_td
     render_inline(Primer::Markdown.new(tag: :td)) { "Content" }
 
     assert_selector("td.markdown-body", text: "Content")
+  end
+
+  def test_falls_back_when_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::Markdown.new(tag: :h3)) { "Content" }
+      assert_selector("div.markdown-body")
+    end
   end
 end

--- a/test/components/truncate_test.rb
+++ b/test/components/truncate_test.rb
@@ -17,6 +17,13 @@ class PrimerTruncateTest < Minitest::Test
     assert_selector("span.css-truncate.css-truncate-overflow", text: "content")
   end
 
+  def test_falls_back_when_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::Truncate.new(tag: :ul)) { "content" }
+      assert_selector("div.css-truncate")
+    end
+  end
+
   def test_renders_truncated_inline
     render_inline(Primer::Truncate.new(inline: true)) { "content" }
 


### PR DESCRIPTION
**What**
This PR restricts tags for `HiddenTextExpander` to `:span`, and also restricts tags for `Truncate` to `[:div, :span, :p]`. I chose these tags based on current usage in dotcom and what seemed reasonable. 

This PR also makes explicit the tag argument for `Markdown` so consumers know they can set the `tag` argument. I was unsure what the allowed tags for this component should be based on current usage of `article, `td` in dotcom. `test_renders_different_tags` also seemed to imply that this component can be relatively flexible so I did not add restrictions. Open to thoughts if you have any.
 
**Why**
Part of #491 