### PR TITLE
Set custom controller for previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## main
 
+### Misc
+
+* Configure previews controller to allow view helper usage in preview template.
+
+    *Kate Higa*
+
 ### Breaking changes
 
 * Restrict allowed tags for `Truncate`, `Markdown`, and `HiddenTextExpander`.
+
+    *Kate Higa*
 
 ## 0.0.41
 

--- a/demo/app/controllers/preview_controller.rb
+++ b/demo/app/controllers/preview_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails/application_controller"
+
+class PreviewController < ViewComponentsController # :nodoc:
+  helper Primer::ViewHelper
+end

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -20,6 +20,7 @@ module Demo
     # Initialize configuration defaults for originally generated Rails version.
     config.view_component_storybook.show_stories = true
     config.view_component.show_previews = true
+    config.view_component.preview_controller = "PreviewController"
 
     config.action_dispatch.default_headers.clear
 


### PR DESCRIPTION
**What**
In order for our preview templates to have access to methods in `Primer::ViewHelper`, we must configure a custom preview controller which includes the helper.

[Configure preview controller docs](https://viewcomponent.org/guide/previews.html#configuring-preview-controller) 

**Why**
An upcoming PR will introduce preview templates that use view helpers. Without this change, an error will be thrown when trying to view the preview.

**Notes**
thanks @manuelpuyol, @joelhawksley for helping me with this!