### PR TITLE
Add `force_system_arguments` options instead of relying on RAILS_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
     *Kate Higa*
 
+* Add `force_system_arguments` option to raise an error if a class is used instead of using System Arguments.
+
+    *Manuel Puyol*
+
 ### Breaking changes
 
 * Restrict allowed tags for `Truncate`, `Markdown`, and `HiddenTextExpander`.

--- a/app/components/primer/auto_complete.rb
+++ b/app/components/primer/auto_complete.rb
@@ -54,7 +54,7 @@ module Primer
     # @example With custom classes for the results
     #   <%= render(Primer::AutoComplete.new(src: "/users/search", id: "user-popup", position: :relative)) do |c| %>
     #     <% c.input(type: :text, name: "input") %>
-    #     <% c.results(classes: "my-custom-class") do %>
+    #     <% c.results(classes: "custom-class") do %>
     #       <%= render(Primer::AutoComplete::Item.new(selected: true, value: "value")) do |c| %>
     #         Selected
     #       <% end %>

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -22,7 +22,7 @@ module Primer
     #     <% component.button(scheme: :primary) { "Primary" } %>
     #     <% component.button(scheme: :danger) { "Danger" } %>
     #     <% component.button(scheme: :outline) { "Outline" } %>
-    #     <% component.button(classes: "my-class") { "Custom class" } %>
+    #     <% component.button(classes: "custom-class") { "Custom class" } %>
     #   <% end %>
     #
     # @example Variants

--- a/app/components/primer/hidden_text_expander.rb
+++ b/app/components/primer/hidden_text_expander.rb
@@ -10,7 +10,7 @@ module Primer
     #   <%= render(Primer::HiddenTextExpander.new(inline: true)) %>
     #
     # @example Styling the button
-    #   <%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "my-custom-class" })) %>
+    #   <%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "custom-class" })) %>
     #
     # @param inline [Boolean] Whether or not the expander is inline.
     # @param button_arguments [Hash] <%= link_to_system_arguments_docs %> for the button element.

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -123,7 +123,7 @@ module Primer
       def validated_class_names(classes)
         return if classes.blank?
 
-        if ENV["RAILS_ENV"] == "development" && !ENV["PRIMER_WARNINGS_DISABLED"]
+        if force_system_arguments? && !ENV["PRIMER_WARNINGS_DISABLED"]
           invalid_class_names =
             classes.split(" ").each_with_object([]) do |class_name, memo|
               memo << class_name if INVALID_CLASS_NAME_PREFIXES.any? { |prefix| class_name.start_with?(prefix) }
@@ -235,6 +235,10 @@ module Primer
         else
           memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
         end
+      end
+
+      def force_system_arguments?
+        Rails.application.config.primer_view_components.force_system_arguments
       end
     end
 

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -43,4 +43,5 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.primer_view_components.silence_deprecations = true
+  config.primer_view_components.force_system_arguments = false
 end

--- a/demo/test/components/previews/primer/docs/auto_complete_preview/with_custom_classes_for_the_results.html.erb
+++ b/demo/test/components/previews/primer/docs/auto_complete_preview/with_custom_classes_for_the_results.html.erb
@@ -1,6 +1,6 @@
 <%= render(Primer::AutoComplete.new(src: "/users/search", id: "user-popup", position: :relative)) do |c| %>
   <% c.input(type: :text, name: "input") %>
-  <% c.results(classes: "my-custom-class") do %>
+  <% c.results(classes: "custom-class") do %>
     <%= render(Primer::AutoComplete::Item.new(selected: true, value: "value")) do |c| %>
       Selected
     <% end %>

--- a/demo/test/components/previews/primer/docs/button_group_preview/default.html.erb
+++ b/demo/test/components/previews/primer/docs/button_group_preview/default.html.erb
@@ -4,5 +4,5 @@
   <% component.button(scheme: :primary) { "Primary" } %>
   <% component.button(scheme: :danger) { "Danger" } %>
   <% component.button(scheme: :outline) { "Outline" } %>
-  <% component.button(classes: "my-class") { "Custom class" } %>
+  <% component.button(classes: "custom-class") { "Custom class" } %>
 <% end %>

--- a/demo/test/components/previews/primer/docs/hidden_text_expander_preview/styling_the_button.html.erb
+++ b/demo/test/components/previews/primer/docs/hidden_text_expander_preview/styling_the_button.html.erb
@@ -1,1 +1,1 @@
-<%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "my-custom-class" })) %>
+<%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "custom-class" })) %>

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -40,12 +40,12 @@ Always provide a label for the `Autocomplete` component.
 
 ### With custom classes for the results
 
-<Example src="<auto-complete src='/users/search' for='user-popup' data-view-component='true' class='position-relative'>  <input name='input' type='text' data-view-component='true' class='form-control'></input>    <ul id='user-popup' data-view-component='true' class='autocomplete-results my-custom-class'>    <li role='option' data-autocomplete-value='value' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Selected</li>    <li role='option' data-autocomplete-value='value' data-view-component='true' class='autocomplete-item'>      Not selected</li></ul></auto-complete>" />
+<Example src="<auto-complete src='/users/search' for='user-popup' data-view-component='true' class='position-relative'>  <input name='input' type='text' data-view-component='true' class='form-control'></input>    <ul id='user-popup' data-view-component='true' class='autocomplete-results custom-class'>    <li role='option' data-autocomplete-value='value' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Selected</li>    <li role='option' data-autocomplete-value='value' data-view-component='true' class='autocomplete-item'>      Not selected</li></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::AutoComplete.new(src: "/users/search", id: "user-popup", position: :relative)) do |c| %>
   <% c.input(type: :text, name: "input") %>
-  <% c.results(classes: "my-custom-class") do %>
+  <% c.results(classes: "custom-class") do %>
     <%= render(Primer::AutoComplete::Item.new(selected: true, value: "value")) do |c| %>
       Selected
     <% end %>

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -15,7 +15,7 @@ Use `ButtonGroup` to render a series of buttons.
 
 ### Default
 
-<Example src="<div data-view-component='true' class='BtnGroup'>    <button type='button' data-view-component='true' class='btn BtnGroup-item'>    Default  </button>    <button type='button' data-view-component='true' class='btn-primary btn BtnGroup-item'>    Primary  </button>    <button type='button' data-view-component='true' class='btn-danger btn BtnGroup-item'>    Danger  </button>    <button type='button' data-view-component='true' class='btn-outline btn BtnGroup-item'>    Outline  </button>    <button type='button' data-view-component='true' class='my-class btn BtnGroup-item'>    Custom class  </button></div>" />
+<Example src="<div data-view-component='true' class='BtnGroup'>    <button type='button' data-view-component='true' class='btn BtnGroup-item'>    Default  </button>    <button type='button' data-view-component='true' class='btn-primary btn BtnGroup-item'>    Primary  </button>    <button type='button' data-view-component='true' class='btn-danger btn BtnGroup-item'>    Danger  </button>    <button type='button' data-view-component='true' class='btn-outline btn BtnGroup-item'>    Outline  </button>    <button type='button' data-view-component='true' class='custom-class btn BtnGroup-item'>    Custom class  </button></div>" />
 
 ```erb
 
@@ -24,7 +24,7 @@ Use `ButtonGroup` to render a series of buttons.
   <% component.button(scheme: :primary) { "Primary" } %>
   <% component.button(scheme: :danger) { "Danger" } %>
   <% component.button(scheme: :outline) { "Outline" } %>
-  <% component.button(classes: "my-class") { "Custom class" } %>
+  <% component.button(classes: "custom-class") { "Custom class" } %>
 <% end %>
 ```
 

--- a/docs/content/components/hiddentextexpander.md
+++ b/docs/content/components/hiddentextexpander.md
@@ -31,10 +31,10 @@ Use `HiddenTextExpander` to indicate and toggle hidden text.
 
 ### Styling the button
 
-<Example src="<span data-view-component='true' class='hidden-text-expander'><button aria-expanded='false' type='button' data-view-component='true' class='ellipsis-expander my-custom-class p-1'>&hellip;</button></span>" />
+<Example src="<span data-view-component='true' class='hidden-text-expander'><button aria-expanded='false' type='button' data-view-component='true' class='ellipsis-expander custom-class p-1'>&hellip;</button></span>" />
 
 ```erb
-<%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "my-custom-class" })) %>
+<%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "custom-class" })) %>
 ```
 
 ## Arguments

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -13,7 +13,9 @@ module Primer
       ]
 
       config.primer_view_components = ActiveSupport::OrderedOptions.new
+
       config.primer_view_components.force_functional_colors = true
+      config.primer_view_components.force_system_arguments = true
       config.primer_view_components.silence_deprecations = false
 
       initializer "primer_view_components.assets" do |app|

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -15,7 +15,7 @@ module Primer
       config.primer_view_components = ActiveSupport::OrderedOptions.new
 
       config.primer_view_components.force_functional_colors = true
-      config.primer_view_components.force_system_arguments = true
+      config.primer_view_components.force_system_arguments = false
       config.primer_view_components.silence_deprecations = false
 
       initializer "primer_view_components.assets" do |app|

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -103,6 +103,7 @@
 - ".css-truncate"
 - ".css-truncate-overflow"
 - ".css-truncate-target"
+- ".custom-class"
 - ".d-flex"
 - ".details-overlay"
 - ".details-reset"

--- a/test/components/auto_complete_test.rb
+++ b/test/components/auto_complete_test.rb
@@ -40,12 +40,12 @@ class PrimerAutoCompleteTest < Minitest::Test
   def test_renders_results_with_custom_classes
     render_inline Primer::AutoComplete.new(src: "/url", id: "my-id") do |component|
       component.input(classes: "custom-class")
-      component.results(classes: "my-class")
+      component.results(classes: "custom-class")
     end
 
     assert_selector("auto-complete[for=\"my-id\"][src=\"/url\"]") do
       assert_selector("input.custom-class")
-      assert_selector("ul[id=\"my-id\"].autocomplete-results.my-class")
+      assert_selector("ul[id=\"my-id\"].autocomplete-results.custom-class")
     end
   end
 end

--- a/test/components/button_group_test.rb
+++ b/test/components/button_group_test.rb
@@ -25,7 +25,7 @@ class PrimerButtonGroupTest < Minitest::Test
       c.button(scheme: :primary) { "Primary" }
       c.button(scheme: :danger) { "Danger" }
       c.button(scheme: :outline) { "Outline" }
-      c.button(classes: "my-class") { "Custom class" }
+      c.button(classes: "custom-class") { "Custom class" }
     end
 
     assert_selector("div.BtnGroup") do
@@ -33,7 +33,7 @@ class PrimerButtonGroupTest < Minitest::Test
       assert_selector("button.btn.BtnGroup-item.btn-primary", text: "Primary")
       assert_selector("button.btn.BtnGroup-item.btn-danger", text: "Danger")
       assert_selector("button.btn.BtnGroup-item.btn-outline", text: "Outline")
-      assert_selector("button.btn.BtnGroup-item.my-class", text: "Custom class")
+      assert_selector("button.btn.BtnGroup-item.custom-class", text: "Custom class")
     end
   end
 

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -615,25 +615,13 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("hover-grow", { animation: :grow })
   end
 
-  def test_raises_error_when_passing_in_a_primer_css_class_name_in_development
-    ENV["RAILS_ENV"] = "development"
-    exception = assert_raises ArgumentError do
-      Primer::Classify.call(classes: "bg-blue text-center float-left ml-1")
-    end
-
-    assert_includes exception.message, "Primer CSS class names"
-  ensure
-    ENV["RAILS_ENV"] = "test"
-  end
-
   def test_raises_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set
-    ENV["RAILS_ENV"] = "development"
     ENV["PRIMER_WARNINGS_DISABLED"] = "1"
-
-    assert_generated_class("bg-blue text-center float-left ml-1", { classes: "bg-blue text-center float-left ml-1" })
+    with_force_system_arguments(true) do
+      assert_generated_class("bg-blue text-center float-left ml-1", { classes: "bg-blue text-center float-left ml-1" })
+    end
   ensure
     ENV["PRIMER_WARNINGS_DISABLED"] = nil
-    ENV["RAILS_ENV"] = "test"
   end
 
   def test_does_not_raise_error_when_passing_in_a_primer_css_class_otherwise
@@ -644,6 +632,22 @@ class PrimerClassifyTest < Minitest::Test
     generated_class = Primer::Classify.call(classes: "foo-class")[:class]
     refute(generated_class.start_with?(" "))
     refute(generated_class.end_with?(" "))
+  end
+
+  def test_raises_if_not_using_system_arguments_when_force_system_arguments_is_true
+    with_force_system_arguments(true) do
+      exception = assert_raises ArgumentError do
+        Primer::Classify.call(classes: "d-block")
+      end
+
+      assert_includes exception.message, "Use System Arguments (https://primer.style/view-components/system-arguments) instead of Primer CSS class"
+    end
+  end
+
+  def test_does_not_raise_if_not_using_system_arguments_when_force_system_arguments_is_false
+    with_force_system_arguments(false) do
+      assert_generated_class("d-block", { classes: "d-block" })
+    end
   end
 
   private

--- a/test/lib/css_coverage_test.rb
+++ b/test/lib/css_coverage_test.rb
@@ -33,7 +33,9 @@ class CssCoverageTest < Minitest::Test
       ".p-lg-responsive",
       ".m-xl-auto",
       ".p-xl-responsive",
-      ".hx_Subhead--responsive"
+      ".hx_Subhead--responsive",
+      # used to showcase custom classes in component docs
+      ".custom-class"
     ]
 
     @css_data =

--- a/test/test_helpers/component_test_helpers.rb
+++ b/test/test_helpers/component_test_helpers.rb
@@ -16,6 +16,14 @@ module Primer
       FetchOrFallbackHelper.fallback_raises = true
     end
 
+    def with_force_system_arguments(new_value)
+      old_value = Rails.application.config.primer_view_components.force_system_arguments
+      Rails.application.config.primer_view_components.force_system_arguments = new_value
+      yield
+    ensure
+      Rails.application.config.primer_view_components.force_system_arguments = old_value
+    end
+
     def with_force_functional_colors(new_value)
       old_value = Rails.application.config.primer_view_components.force_functional_colors
       Rails.application.config.primer_view_components.force_functional_colors = new_value


### PR DESCRIPTION
Adds a configuration that allows users to choose if not using System Arguments should raise an error or not. It will allow users to select which environments will raise an error.