### PR TITLE
Fixing bug in octicon component compare

### DIFF
--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -35,7 +35,7 @@ module Primer
       icon_key = icon_name || icon
 
       # Don't allow sizes under 16px
-      if system_arguments[:height].present? && system_arguments[:height] < 16 || system_arguments[:width].present? && system_arguments[:width] < 16
+      if system_arguments[:height].present? && system_arguments[:height].to_i < 16 || system_arguments[:width].present? && system_arguments[:width].to_i < 16
         system_arguments.delete(:height)
         system_arguments.delete(:width)
       end


### PR DESCRIPTION
I noticed this comparision was assuming the data was an int, but in some cases people incorrectly passed in strings. Causing this build failure. https://janky.githubapp.com/test_failures/637737bcec1efdd8f12735e11bacb37606ec4f9aba73b3fb9a34f2b606a0e95f

So I'm casting the input to `to_i` here.