### PR TITLE
Add more system arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## main
 
+### New
+
+* Add `font_family`, `font_style` and `text_transform` system arguments.
+
+    *Manuel Puyol*
+
+* Add more options for `font_size` and `font_weight`.
+
+    *Manuel Puyol*
+
 ### Misc
 
 * Auto-generate component previews from doc examples and run integration test checks.

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -129,9 +129,12 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `font_size` | String, Integer | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6]) %> |
-    # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold]) %> |
+    # | `font_family` | Symbol | Font weight. <%= one_of([:mono]) %> |
+    # | `font_size` | String, Integer, Symbol | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6, :small, :normal]) %> |
+    # | `font_style` | Symbol | Font weight. <%= one_of([:italic]) %> |
+    # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold, :emphasized]) %> |
     # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
+    # | `text_transform` | Symbol | Text alignment. <%= one_of([:uppercase]) %> |
     # | `underline` | Boolean | Whether text should be underlined. |
     # | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
     #

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -16,7 +16,7 @@ module Primer
     BG_KEY = :bg
     VERTICAL_ALIGN_KEY = :vertical_align
     WORD_BREAK_KEY = :word_break
-    TEXT_KEYS = %i[text_align font_weight].freeze
+    TEXT_KEYS = %i[font_family font_style font_weight text_align text_transform].freeze
     WIDTH_KEY = :width
     HEIGHT_KEY = :height
     BOX_SHADOW_KEY = :box_shadow
@@ -215,7 +215,11 @@ module Primer
         elsif TEXT_KEYS.include?(key)
           memo[:classes] << "text-#{val.to_s.dasherize}"
         elsif TYPOGRAPHY_KEYS.include?(key)
-          memo[:classes] << "f#{val.to_s.dasherize}"
+          memo[:classes] << if value == :small || val == :normal
+                              "text-#{val.to_s.dasherize}"
+                            else
+                              "f#{val.to_s.dasherize}"
+                            end
         elsif key == BOX_SHADOW_KEY
           memo[:classes] << if val == true
                               "color-shadow-small"

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -215,7 +215,7 @@ module Primer
         elsif TEXT_KEYS.include?(key)
           memo[:classes] << "text-#{val.to_s.dasherize}"
         elsif TYPOGRAPHY_KEYS.include?(key)
-          memo[:classes] << if value == :small || val == :normal
+          memo[:classes] << if val == :small || val == :normal
                               "text-#{val.to_s.dasherize}"
                             else
                               "f#{val.to_s.dasherize}"

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -130,9 +130,12 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `font_size` | String, Integer | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, or `6`. |
-| `font_weight` | Symbol | Font weight. One of `:light`, `:normal`, or `:bold`. |
+| `font_family` | Symbol | Font weight. One of `:mono`. |
+| `font_size` | String, Integer, Symbol | One of `00`, `0`, `1`, `2`, `3`, `4`, `5`, `6`, `:small`, or `:normal`. |
+| `font_style` | Symbol | Font weight. One of `:italic`. |
+| `font_weight` | Symbol | Font weight. One of `:light`, `:normal`, `:bold`, or `:emphasized`. |
 | `text_align` | Symbol | Text alignment. One of `:left`, `:right`, or `:center`. |
+| `text_transform` | Symbol | Text alignment. One of `:uppercase`. |
 | `underline` | Boolean | Whether text should be underlined. |
 | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
 

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -16,7 +16,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("f4",  { font_size: 4 })
     assert_generated_class("f5",  { font_size: 5 })
     assert_generated_class("f6",  { font_size: 6 })
-    assert_generated_class("text-small",  { font_size: :small })
+    assert_generated_class("text-small", { font_size: :small })
     assert_generated_class("text-normal",  { font_size: :normal })
   end
 

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -16,6 +16,8 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("f4",  { font_size: 4 })
     assert_generated_class("f5",  { font_size: 5 })
     assert_generated_class("f6",  { font_size: 6 })
+    assert_generated_class("text-small",  { font_size: :small })
+    assert_generated_class("text-normal",  { font_size: :normal })
   end
 
   def test_m
@@ -359,10 +361,23 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("text-left",       { text_align: :left })
   end
 
+  def test_font_family
+    assert_generated_class("text-mono", { font_family: :mono })
+  end
+
+  def test_font_style
+    assert_generated_class("text-italic", { font_style: :italic })
+  end
+
+  def test_text_transform
+    assert_generated_class("text-uppercase", { text_transform: :uppercase })
+  end
+
   def test_font_weight
-    assert_generated_class("text-light",    { font_weight: :light })
-    assert_generated_class("text-normal",   { font_weight: :normal })
-    assert_generated_class("text-bold",     { font_weight: :bold })
+    assert_generated_class("text-light",      { font_weight: :light })
+    assert_generated_class("text-normal",     { font_weight: :normal })
+    assert_generated_class("text-bold",       { font_weight: :bold })
+    assert_generated_class("text-emphasized", { font_weight: :emphasized })
   end
 
   def test_box_shadow


### PR DESCRIPTION
Add `font_family`, `font_style` and `text_transform` system arguments so we can support more PrimerCSS typography utilities.
Also adds more options for `font_size` and `font_weight` since we were missing some classes.