### PR TITLE
Provide linters for component migrations.

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,7 @@
+---
+EnableDefaultLinters: true
+linters:
+  ButtonComponentMigrationCounter:
+    enabled: true
+  FlashComponentMigrationCounter:
+    enabled: true

--- a/.erb-linters/linters.rb
+++ b/.erb-linters/linters.rb
@@ -1,0 +1,1 @@
+require "primer/view_components/linters"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rubocop
+        bundle exec erblint app/components
   lint_js:
     runs-on: ubuntu-latest
     steps:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -110,6 +110,20 @@
       "problemMatcher": []
     },
     {
+      "label": "erblint: autofix erblint errors",
+      "type": "shell",
+      "group": "build",
+      "command": "bundle exec erblint -a app/components",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "runOptions": {
+        "reevaluateOnRerun": false
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "yarn: build assets",
       "type": "shell",
       "group": "build",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Promote `TabNav` component to beta.
 
     *Manuel Puyol*
-    
+
 ### Misc
 
 * Provide linters for component migrations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+### Misc
+
+* Provide linters for component migrations.
+
+    *Manuel Puyol*
+
 ## 0.0.42
 
 ### New

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,14 @@ GEM
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
     benchmark-ips (2.8.4)
+    better_html (1.0.16)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -73,6 +81,14 @@ GEM
     docile (1.3.4)
     dumb_delegator (1.0.0)
     equalizer (0.0.11)
+    erb_lint (0.0.37)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.10.0)
     ferrum (0.11)
       addressable (~> 2.5)
@@ -80,6 +96,7 @@ GEM
       concurrent-ruby (~> 1.1)
       websocket-driver (>= 0.6, < 0.8)
     ffi (1.14.2)
+    html_tokenizer (0.0.7)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -171,6 +188,7 @@ GEM
       simplecov
       terminal-table
     simplecov-html (0.12.3)
+    smart_properties (1.15.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -224,6 +242,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   capybara (~> 3)
   cuprite (= 0.13)
+  erb_lint
   listen (~> 3.0)
   minitest (~> 5.0)
   mocha

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -1,3 +1,4 @@
+<%# erblint:counter ButtonComponentMigrationCounter 1 %>
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <% if spinner.present? %>
     <%= spinner %>

--- a/lib/primer/view_components/linters.rb
+++ b/lib/primer/view_components/linters.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Dir[File.join(__dir__, "linters", "*.rb")].sort.each { |file| require file }

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -10,7 +10,7 @@ module ERBLint
 
       TAGS = %w[button summary a].freeze
       CLASS = "btn"
-      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML. Reach out to `@github/view-component-reviewers` or #view-component with any questions!"
+      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
     end
   end
 end

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "helpers"
+
+module ERBLint
+  module Linters
+    # Counts the number of times a HTML button is used instead of the component.
+    class ButtonComponentMigrationCounter < Linter
+      include Helpers
+
+      TAGS = %w[button summary a].freeze
+      CLASS = "btn"
+      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML. Reach out to `@github/view-component-reviewers` or #view-component with any questions!"
+    end
+  end
+end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -10,7 +10,7 @@ module ERBLint
 
       TAGS = %w[div].freeze
       CLASS = "flash"
-      MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML. Reach out to `@github/view-component-reviewers` or #view-component with any questions!"
+      MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
     end
   end
 end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "helpers"
+
+module ERBLint
+  module Linters
+    # Counts the number of times a HTML flash is used instead of the component.
+    class FlashComponentMigrationCounter < Linter
+      include Helpers
+
+      TAGS = %w[div].freeze
+      CLASS = "flash"
+      MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML. Reach out to `@github/view-component-reviewers` or #view-component with any questions!"
+    end
+  end
+end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "json"
+require "openssl"
+
+module ERBLint
+  module Linters
+    # Helper methods for linting ERB.
+    module Helpers
+      def self.included(base)
+        base.include(LinterRegistry)
+
+        define_method "run" do |processed_source|
+          tags(processed_source).each do |tag|
+            next if tag.closing?
+            next unless self.class::TAGS&.include?(tag.name)
+
+            classes = tag.attributes["class"]&.value&.split(" ")
+
+            next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
+
+            generate_offense(self.class, processed_source, tag, self.class::MESSAGE)
+          end
+
+          counter_correct?(processed_source)
+        end
+
+        define_method "autocorrect" do |processed_source, offense|
+          return unless offense.context
+
+          lambda do |corrector|
+            if processed_source.file_content.include?("erblint:counter #{self.class.name.demodulize}")
+              # update the counter if exists
+              corrector.replace(offense.source_range, offense.context)
+            else
+              # add comment with counter if none
+              corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
+            end
+          end
+        end
+      end
+
+      private
+
+      def tags(processed_source)
+        processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
+      end
+
+      def counter_correct?(processed_source)
+        comment_node = nil
+        expected_count = 0
+        rule_name = self.class.name.match(/:?:?(\w+)\Z/)[1]
+        offenses_count = @offenses.length
+
+        processed_source.parser.ast.descendants(:erb).each do |node|
+          indicator_node, _, code_node, = *node
+          indicator = indicator_node&.loc&.source
+          comment = code_node&.loc&.source&.strip
+
+          if indicator == "#" && comment.start_with?("erblint:count") && comment.match(rule_name)
+            comment_node = code_node
+            expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
+          end
+        end
+
+        if offenses_count.zero?
+          add_offense(processed_source.to_source_range(comment_node.loc), "Unused erblint:count comment for #{rule_name}") if comment_node
+          return
+        end
+
+        first_offense = @offenses[0]
+
+        if comment_node.nil?
+          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
+        else
+          clear_offenses
+          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", " erblint:counter #{rule_name} #{offenses_count} ") if expected_count != offenses_count
+        end
+      end
+
+      def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
+        message ||= klass::MESSAGE
+        klass_name = klass.name.split("::")[-1]
+        offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
+        add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
+      end
+    end
+  end
+end

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "benchmark-ips", "~> 2.8.4"
   spec.add_development_dependency "capybara", "~> 3"
   spec.add_development_dependency "cuprite", "= 0.13"
+  spec.add_development_dependency "erb_lint"
   spec.add_development_dependency "listen", "~> 3.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "mocha"


### PR DESCRIPTION
This PR adds [erblint](https://github.com/Shopify/erb-lint) to the project and provides custom linters to guide users towards component migrations.