### PR TITLE
Linter suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
     *Manuel Puyol*
 
+### Misc
+
+* Add linter suggestions for `Button` component.
+
+    *Manuel Puyol*
+
 ## 0.0.43
 
 * Upgrade primer/css to 17.2.1

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -20,6 +20,8 @@ module ERBLint
           "btn-large" => ":large"
         }.freeze
 
+        TYPE_OPTIONS = %w[button reset submit].freeze
+
         def initialize(tag)
           @tag = tag
         end
@@ -36,6 +38,13 @@ module ERBLint
               args = args.merge(classes_to_args(attribute))
             elsif attr_name == "disabled"
               args[:disabled] = true
+            elsif attr_name == "type"
+              # button is the default type, so we don't need to do anything.
+              next if attribute.value == "button"
+
+              raise ConversionError, "Button component does not support type \"#{attribute.value}\"" unless TYPE_OPTIONS.include?(attribute.value)
+
+              args[:type] = ":#{attribute.value}"
             elsif attr_name.start_with?("aria-", "data-")
               # if attribute has no value_node, it means it is a boolean attribute.
               args["\"#{attr_name}\""] = attribute.value_node ? "\"#{attribute.value}\"" : true

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -60,7 +60,7 @@ module ERBLint
         end
 
         def classes_to_args(classes)
-          hash = classes.value.split(" ").each_with_object({}) do |class_name, acc|
+          classes.value.split(" ").each_with_object({}) do |class_name, acc|
             next if class_name == "btn"
 
             if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
@@ -75,8 +75,6 @@ module ERBLint
               raise ConversionError, "Cannot convert class \"#{class_name}\""
             end
           end
-
-          hash
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -27,6 +27,10 @@ module ERBLint
           @tag = tag
         end
 
+        def to_s
+          to_args.map { |k, v| "#{k}: #{v}" }.join(", ")
+        end
+
         def to_args
           args = {}
 
@@ -52,7 +56,7 @@ module ERBLint
             end
           end
 
-          args.map { |k, v| "#{k}: #{v}" }.join(", ")
+          args
         end
 
         def classes_to_args(classes)

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "conversion_error"
+require_relative "system_arguments"
 
 module ERBLint
   module Linters
@@ -45,11 +46,9 @@ module ERBLint
               raise ConversionError, "Button component does not support type \"#{attribute.value}\"" unless TYPE_OPTIONS.include?(attribute.value)
 
               args[:type] = ":#{attribute.value}"
-            elsif attr_name.start_with?("aria-", "data-")
-              # if attribute has no value_node, it means it is a boolean attribute.
-              args["\"#{attr_name}\""] = attribute.value_node ? "\"#{attribute.value}\"" : true
             else
-              raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
+              # Assume the attribute is a system argument.
+              args.merge!(SystemArguments.new(attribute).to_args)
             end
           end
 

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -38,9 +38,10 @@ module Primer
               elsif attr_name == "disabled"
                 args[:disabled] = true
               elsif attr_name.start_with?("aria-", "data-")
-                args["\"#{attr_name}\""] = "\"#{attribute.value}\""
+                # if attribute has no value_node, it means it is a boolean attribute.
+                args["\"#{attr_name}\""] = attribute.value_node ? "\"#{attribute.value}\"" : true
               else
-                raise ConversionError, "Cannot convert attribute #{attr_name}"
+                raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
               end
             end
 
@@ -60,7 +61,7 @@ module Primer
               elsif class_name == "BtnGroup-item"
                 acc[:group_item] = true
               else
-                raise ConversionError, "Cannot convert class #{class_name}"
+                raise ConversionError, "Cannot convert class \"#{class_name}\""
               end
             end
 

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "conversion_error"
+
+module Primer
+  module ViewComponents
+    module Linters
+      module ArgumentMappers
+        # Maps classes in a button element to arguments for the Button component.
+        class Button
+          SCHEME_MAPPINGS = {
+            "btn-primary" => ":primary",
+            "btn-danger" => ":danger",
+            "btn-outline" => ":outline",
+            "btn-invisible" => ":invisible",
+            "btn-link" => ":link"
+          }.freeze
+
+          VARIANT_MAPPINGS = {
+            "btn-sm" => ":small",
+            "btn-large" => ":large"
+          }.freeze
+
+          def initialize(tag)
+            @tag = tag
+          end
+
+          def to_args
+            args = {}
+
+            args[:tag] = ":#{@tag.name}" unless @tag.name == "button"
+
+            @tag.attributes.each do |attribute|
+              attr_name = attribute.name
+
+              if attr_name == "class"
+                args = args.merge(classes_to_args(attribute))
+              elsif attr_name == "disabled"
+                args[:disabled] = true
+              elsif attr_name.start_with?("aria-", "data-")
+                args["\"#{attr_name}\""] = "\"#{attribute.value}\""
+              else
+                raise ConversionError, "Cannot convert attribute #{attr_name}"
+              end
+            end
+
+            args.map { |k, v| "#{k}: #{v}" }.join(", ")
+          end
+
+          def classes_to_args(classes)
+            hash = classes.value.split(" ").each_with_object({}) do |class_name, acc|
+              next if class_name == "btn"
+
+              if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
+                acc[:scheme] = SCHEME_MAPPINGS[class_name]
+              elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
+                acc[:variant] = VARIANT_MAPPINGS[class_name]
+              elsif class_name == "btn-block"
+                acc[:block] = true
+              elsif class_name == "BtnGroup-item"
+                acc[:group_item] = true
+              else
+                raise ConversionError, "Cannot convert class #{class_name}"
+              end
+            end
+
+            hash
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -2,71 +2,69 @@
 
 require_relative "conversion_error"
 
-module Primer
-  module ViewComponents
-    module Linters
-      module ArgumentMappers
-        # Maps classes in a button element to arguments for the Button component.
-        class Button
-          SCHEME_MAPPINGS = {
-            "btn-primary" => ":primary",
-            "btn-danger" => ":danger",
-            "btn-outline" => ":outline",
-            "btn-invisible" => ":invisible",
-            "btn-link" => ":link"
-          }.freeze
+module ERBLint
+  module Linters
+    module ArgumentMappers
+      # Maps classes in a button element to arguments for the Button component.
+      class Button
+        SCHEME_MAPPINGS = {
+          "btn-primary" => ":primary",
+          "btn-danger" => ":danger",
+          "btn-outline" => ":outline",
+          "btn-invisible" => ":invisible",
+          "btn-link" => ":link"
+        }.freeze
 
-          VARIANT_MAPPINGS = {
-            "btn-sm" => ":small",
-            "btn-large" => ":large"
-          }.freeze
+        VARIANT_MAPPINGS = {
+          "btn-sm" => ":small",
+          "btn-large" => ":large"
+        }.freeze
 
-          def initialize(tag)
-            @tag = tag
-          end
+        def initialize(tag)
+          @tag = tag
+        end
 
-          def to_args
-            args = {}
+        def to_args
+          args = {}
 
-            args[:tag] = ":#{@tag.name}" unless @tag.name == "button"
+          args[:tag] = ":#{@tag.name}" unless @tag.name == "button"
 
-            @tag.attributes.each do |attribute|
-              attr_name = attribute.name
+          @tag.attributes.each do |attribute|
+            attr_name = attribute.name
 
-              if attr_name == "class"
-                args = args.merge(classes_to_args(attribute))
-              elsif attr_name == "disabled"
-                args[:disabled] = true
-              elsif attr_name.start_with?("aria-", "data-")
-                # if attribute has no value_node, it means it is a boolean attribute.
-                args["\"#{attr_name}\""] = attribute.value_node ? "\"#{attribute.value}\"" : true
-              else
-                raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
-              end
+            if attr_name == "class"
+              args = args.merge(classes_to_args(attribute))
+            elsif attr_name == "disabled"
+              args[:disabled] = true
+            elsif attr_name.start_with?("aria-", "data-")
+              # if attribute has no value_node, it means it is a boolean attribute.
+              args["\"#{attr_name}\""] = attribute.value_node ? "\"#{attribute.value}\"" : true
+            else
+              raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
             end
-
-            args.map { |k, v| "#{k}: #{v}" }.join(", ")
           end
 
-          def classes_to_args(classes)
-            hash = classes.value.split(" ").each_with_object({}) do |class_name, acc|
-              next if class_name == "btn"
+          args.map { |k, v| "#{k}: #{v}" }.join(", ")
+        end
 
-              if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
-                acc[:scheme] = SCHEME_MAPPINGS[class_name]
-              elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
-                acc[:variant] = VARIANT_MAPPINGS[class_name]
-              elsif class_name == "btn-block"
-                acc[:block] = true
-              elsif class_name == "BtnGroup-item"
-                acc[:group_item] = true
-              else
-                raise ConversionError, "Cannot convert class \"#{class_name}\""
-              end
+        def classes_to_args(classes)
+          hash = classes.value.split(" ").each_with_object({}) do |class_name, acc|
+            next if class_name == "btn"
+
+            if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
+              acc[:scheme] = SCHEME_MAPPINGS[class_name]
+            elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
+              acc[:variant] = VARIANT_MAPPINGS[class_name]
+            elsif class_name == "btn-block"
+              acc[:block] = true
+            elsif class_name == "BtnGroup-item"
+              acc[:group_item] = true
+            else
+              raise ConversionError, "Cannot convert class \"#{class_name}\""
             end
-
-            hash
           end
+
+          hash
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
+++ b/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-module Primer
-  module ViewComponents
-    module Linters
-      module ArgumentMappers
-        # Error when converting atguments.
-        class ConversionError < StandardError; end
-      end
+module ERBLint
+  module Linters
+    module ArgumentMappers
+      # Error when converting atguments.
+      class ConversionError < StandardError; end
     end
   end
 end

--- a/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
+++ b/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
@@ -3,7 +3,7 @@
 module ERBLint
   module Linters
     module ArgumentMappers
-      # Error when converting atguments.
+      # Error when converting arguments.
       class ConversionError < StandardError; end
     end
   end

--- a/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
+++ b/lib/primer/view_components/linters/argument_mappers/conversion_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Primer
+  module ViewComponents
+    module Linters
+      module ArgumentMappers
+        # Error when converting atguments.
+        class ConversionError < StandardError; end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -17,7 +17,7 @@ module ERBLint
 
         def to_args
           if attribute.erb?
-            _, _, code_node, = *attribute.node
+            _, _, code_node = *attribute.node
 
             raise ConversionError, "Cannot convert erb block" if code_node.nil?
 

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -5,7 +5,7 @@ require_relative "conversion_error"
 module ERBLint
   module Linters
     module ArgumentMappers
-      # Maps classes in a button element to arguments for the Button component.
+      # Maps element attributes to system arguments.
       class SystemArguments
         STRING_PARAETERS = %w[aria- data-].freeze
         TEST_SELECTOR_REGEX = /test_selector\((?<selector>.+)\)$/.freeze

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -26,7 +26,7 @@ module ERBLint
 
             raise ConversionError, "Cannot convert erb block" if m.blank?
 
-            { test_selector: m[:selector].gsub("'", '"') }
+            { test_selector: m[:selector].tr("'", '"') }
           elsif attr_name == "data-test-selector"
             { test_selector: attribute.value.to_json }
           elsif attr_name.start_with?(*STRING_PARAETERS)

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "conversion_error"
+
+module ERBLint
+  module Linters
+    module ArgumentMappers
+      # Maps classes in a button element to arguments for the Button component.
+      class SystemArguments
+        STRING_PARAETERS = %w[aria- data-].freeze
+
+        attr_reader :attribute
+        def initialize(attribute)
+          @attribute = attribute
+        end
+
+        def to_args
+          if attr_name == "data-test-selector"
+            { test_selector: "\"#{attribute.value}\""}
+          elsif attr_name.start_with?(*STRING_PARAETERS)
+            # if attribute has no value_node, it means it is a boolean attribute.
+            { "\"#{attr_name}\"" => attribute.value_node ? "\"#{attribute.value}\"" : true }
+          else
+            raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
+          end
+        end
+
+        def attr_name
+          attribute.name
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -14,21 +14,6 @@ module Primer
         CLASSES = %w[btn btn-link].freeze
         MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
 
-        # def run(processed_source)
-        #   tags(processed_source).each do |tag|
-        #     next if tag.closing?
-        #     next unless TAGS&.include?(tag.name)
-
-        #     classes = tag.attributes["class"]&.value&.split(" ")
-
-        #     next if classes&.intersection(CLASSES).blank?
-
-        #     generate_offense(self.class, processed_source, tag, message(tag))
-        #   end
-
-        #   counter_correct?(processed_source)
-        # end
-
         private
 
         def map_arguments(tag)

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -66,6 +66,8 @@ module Primer
           def to_args
             args = {}
 
+            args[:tag] = ":#{@tag.name}" unless @tag.name == "button"
+
             @tag.attributes.each do |attribute|
               attr_name = attribute.name
 

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -3,33 +3,32 @@
 require_relative "helpers"
 require_relative "argument_mappers/button"
 
-module Primer
-  module ViewComponents
-    module Linters
-      # Counts the number of times a HTML button is used instead of the component.
-      class ButtonComponentMigrationCounter < ERBLint::Linter
-        include Helpers
+module ERBLint
+  module Linters
+    # Counts the number of times a HTML button is used instead of the component.
+    class ButtonComponentMigrationCounter < Linter
+      include Helpers
 
-        TAGS = %w[button summary a].freeze
-        CLASSES = %w[btn btn-link].freeze
-        MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
+      TAGS = %w[button summary a].freeze
+      CLASSES = %w[btn btn-link].freeze
+      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
 
-        private
+      private
 
-        def map_arguments(tag)
-          ArgumentMappers::Button.new(tag).to_args
-        rescue ArgumentMappers::ConversionError
-          nil
-        end
+      def map_arguments(tag)
+        ArgumentMappers::Button.new(tag).to_args
+      rescue ArgumentMappers::ConversionError
+        nil
+      end
 
-        def message(tag)
-          args = map_arguments(tag)
+      def message(tag)
+        args = map_arguments(tag)
 
-          return MESSAGE if args.nil?
-          return MESSAGE + "\n<%= render Primer::ButtonComponent.new %>" if args.empty?
+        return MESSAGE if args.nil?
 
-          MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
-        end
+        msg = "#{MESSAGE}\n\nTry using:\n\n<%= render Primer::ButtonComponent.new"
+        msg += "(#{args})" if args.present?
+        "#{msg} %>\n\nInstead of:\n"
       end
     end
   end

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -22,7 +22,7 @@ module Primer
 
             next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
 
-            args = ArgumentMapper.new(classes).to_args
+            args = ArgumentMapper.new(tag).to_args
 
             message = if args.nil?
                         self.class::MESSAGE
@@ -53,11 +53,15 @@ module Primer
             "btn-large" => ":large"
           }.freeze
 
-          def initialize(classes)
-            @classes = classes
+          def initialize(tag)
+            @tag = tag
+            @classes = tag.attributes["class"]
           end
 
           def to_args
+            # We currently only know how to convert simple buttons.
+            return nil if @tag.attributes_node.to_a > 1
+
             hash = @classes.each_with_object({}) do |class_name, acc|
               next if class_name == "btn"
 
@@ -65,6 +69,8 @@ module Primer
                 acc[:scheme] = SCHEME_MAPPINGS[class_name]
               elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
                 acc[:variant] = VARIANT_MAPPINGS[class_name]
+              elsif class_name == "btn-block"
+                acc[:block] = true
               else
                 acc[:conversion_error] = true
                 break

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -2,15 +2,81 @@
 
 require_relative "helpers"
 
-module ERBLint
-  module Linters
-    # Counts the number of times a HTML button is used instead of the component.
-    class ButtonComponentMigrationCounter < Linter
-      include Helpers
+module Primer
+  module ViewComponents
+    module Linters
+      # Counts the number of times a HTML button is used instead of the component.
+      class ButtonComponentMigrationCounter < ERBLint::Linter
+        include Helpers
 
-      TAGS = %w[button summary a].freeze
-      CLASS = "btn"
-      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
+        TAGS = %w[button summary a].freeze
+        CLASS = "btn"
+        MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
+
+        def run(processed_source)
+          tags(processed_source).each do |tag|
+            next if tag.closing?
+            next unless self.class::TAGS&.include?(tag.name)
+
+            classes = tag.attributes["class"]&.value&.split(" ")
+
+            next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
+
+            args = ArgumentMapper.new(classes).to_args
+
+            message = if args.nil?
+                        self.class::MESSAGE
+                      elsif args.empty?
+                        self.class::MESSAGE + "\n<%= render Primer::ButtonComponent.new %>"
+                      else
+                        self.class::MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
+                      end
+
+            generate_offense(self.class, processed_source, tag, message)
+          end
+
+          counter_correct?(processed_source)
+        end
+
+        # Maps from classes to arguments.
+        class ArgumentMapper
+          SCHEME_MAPPINGS = {
+            "btn-primary" => ":primary",
+            "btn-danger" => ":danger",
+            "btn-outline" => ":outline",
+            "btn-invisible" => ":invisible",
+            "btn-link" => ":link"
+          }.freeze
+
+          VARIANT_MAPPINGS = {
+            "btn-sm" => ":small",
+            "btn-large" => ":large"
+          }.freeze
+
+          def initialize(classes)
+            @classes = classes
+          end
+
+          def to_args
+            hash = @classes.each_with_object({}) do |class_name, acc|
+              next if class_name == "btn"
+
+              if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
+                acc[:scheme] = SCHEME_MAPPINGS[class_name]
+              elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
+                acc[:variant] = VARIANT_MAPPINGS[class_name]
+              else
+                acc[:conversion_error] = true
+                break
+              end
+            end
+
+            return nil if hash[:conversion_error]
+
+            hash.map { |k, v| "#{k}: #{v}" }.join(", ")
+          end
+        end
+      end
     end
   end
 end

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -16,7 +16,7 @@ module ERBLint
       private
 
       def map_arguments(tag)
-        ArgumentMappers::Button.new(tag).to_args
+        ArgumentMappers::Button.new(tag).to_s
       rescue ArgumentMappers::ConversionError
         nil
       end

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -20,7 +20,7 @@ module Primer
 
             classes = tag.attributes["class"]&.value&.split(" ")
 
-            next unless classes&.intersection(CLASSES)&.any?
+            next if classes&.intersection(CLASSES).blank?
 
             args = begin
                      ArgumentMapper.new(tag).to_args

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -10,17 +10,17 @@ module Primer
         include Helpers
 
         TAGS = %w[button summary a].freeze
-        CLASS = "btn"
+        CLASSES = %w[btn btn-link].freeze
         MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
 
         def run(processed_source)
           tags(processed_source).each do |tag|
             next if tag.closing?
-            next unless self.class::TAGS&.include?(tag.name)
+            next unless TAGS&.include?(tag.name)
 
             classes = tag.attributes["class"]&.value&.split(" ")
 
-            next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
+            next unless classes&.intersection(CLASSES)&.any?
 
             args = begin
                      ArgumentMapper.new(tag).to_args
@@ -29,11 +29,11 @@ module Primer
                    end
 
             message = if args.nil?
-                        self.class::MESSAGE
+                        MESSAGE
                       elsif args.empty?
-                        self.class::MESSAGE + "\n<%= render Primer::ButtonComponent.new %>"
+                        MESSAGE + "\n<%= render Primer::ButtonComponent.new %>"
                       else
-                        self.class::MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
+                        MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
                       end
 
             generate_offense(self.class, processed_source, tag, message)

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "helpers"
+require_relative "argument_mappers/button"
 
 module Primer
   module ViewComponents
@@ -13,97 +14,36 @@ module Primer
         CLASSES = %w[btn btn-link].freeze
         MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
 
-        def run(processed_source)
-          tags(processed_source).each do |tag|
-            next if tag.closing?
-            next unless TAGS&.include?(tag.name)
+        # def run(processed_source)
+        #   tags(processed_source).each do |tag|
+        #     next if tag.closing?
+        #     next unless TAGS&.include?(tag.name)
 
-            classes = tag.attributes["class"]&.value&.split(" ")
+        #     classes = tag.attributes["class"]&.value&.split(" ")
 
-            next if classes&.intersection(CLASSES).blank?
+        #     next if classes&.intersection(CLASSES).blank?
 
-            args = begin
-                     ArgumentMapper.new(tag).to_args
-                   rescue ArgumentMapper::ConversionError
-                     nil
-                   end
+        #     generate_offense(self.class, processed_source, tag, message(tag))
+        #   end
 
-            message = if args.nil?
-                        MESSAGE
-                      elsif args.empty?
-                        MESSAGE + "\n<%= render Primer::ButtonComponent.new %>"
-                      else
-                        MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
-                      end
+        #   counter_correct?(processed_source)
+        # end
 
-            generate_offense(self.class, processed_source, tag, message)
-          end
+        private
 
-          counter_correct?(processed_source)
+        def map_arguments(tag)
+          ArgumentMappers::Button.new(tag).to_args
+        rescue ArgumentMappers::ConversionError
+          nil
         end
 
-        # Maps from classes to arguments.
-        class ArgumentMapper
-          class ConversionError < StandardError; end
+        def message(tag)
+          args = map_arguments(tag)
 
-          SCHEME_MAPPINGS = {
-            "btn-primary" => ":primary",
-            "btn-danger" => ":danger",
-            "btn-outline" => ":outline",
-            "btn-invisible" => ":invisible",
-            "btn-link" => ":link"
-          }.freeze
+          return MESSAGE if args.nil?
+          return MESSAGE + "\n<%= render Primer::ButtonComponent.new %>" if args.empty?
 
-          VARIANT_MAPPINGS = {
-            "btn-sm" => ":small",
-            "btn-large" => ":large"
-          }.freeze
-
-          def initialize(tag)
-            @tag = tag
-          end
-
-          def to_args
-            args = {}
-
-            args[:tag] = ":#{@tag.name}" unless @tag.name == "button"
-
-            @tag.attributes.each do |attribute|
-              attr_name = attribute.name
-
-              if attr_name == "class"
-                args = args.merge(classes_to_args(attribute))
-              elsif attr_name == "disabled"
-                args[:disabled] = true
-              elsif attr_name.start_with?("aria-", "data-")
-                args["\"#{attr_name}\""] = "\"#{attribute.value}\""
-              else
-                raise ConversionError, "Cannot convert attribute #{attr_name}"
-              end
-            end
-
-            args.map { |k, v| "#{k}: #{v}" }.join(", ")
-          end
-
-          def classes_to_args(classes)
-            hash = classes.value.split(" ").each_with_object({}) do |class_name, acc|
-              next if class_name == "btn"
-
-              if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
-                acc[:scheme] = SCHEME_MAPPINGS[class_name]
-              elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
-                acc[:variant] = VARIANT_MAPPINGS[class_name]
-              elsif class_name == "btn-block"
-                acc[:block] = true
-              elsif class_name == "BtnGroup-item"
-                acc[:group_item] = true
-              else
-                raise ConversionError, "Cannot convert class #{class_name}"
-              end
-            end
-
-            hash
-          end
+          MESSAGE + "\n<%= render Primer::ButtonComponent.new(#{args}) %>"
         end
       end
     end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -2,15 +2,17 @@
 
 require_relative "helpers"
 
-module ERBLint
-  module Linters
-    # Counts the number of times a HTML flash is used instead of the component.
-    class FlashComponentMigrationCounter < Linter
-      include Helpers
+module Primer
+  module ViewComponents
+    module Linters
+      # Counts the number of times a HTML flash is used instead of the component.
+      class FlashComponentMigrationCounter < ERBLint::Linter
+        include Helpers
 
-      TAGS = %w[div].freeze
-      CLASS = "flash"
-      MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
+        TAGS = %w[div].freeze
+        CLASS = "flash"
+        MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
+      end
     end
   end
 end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -10,7 +10,7 @@ module Primer
         include Helpers
 
         TAGS = %w[div].freeze
-        CLASS = "flash"
+        CLASSES = %w[flash].freeze
         MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
       end
     end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -2,17 +2,15 @@
 
 require_relative "helpers"
 
-module Primer
-  module ViewComponents
-    module Linters
-      # Counts the number of times a HTML flash is used instead of the component.
-      class FlashComponentMigrationCounter < ERBLint::Linter
-        include Helpers
+module ERBLint
+  module Linters
+    # Counts the number of times a HTML flash is used instead of the component.
+    class FlashComponentMigrationCounter < Linter
+      include Helpers
 
-        TAGS = %w[div].freeze
-        CLASSES = %w[flash].freeze
-        MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
-      end
+      TAGS = %w[div].freeze
+      CLASSES = %w[flash].freeze
+      MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
     end
   end
 end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -18,7 +18,7 @@ module Primer
 
               classes = tag.attributes["class"]&.value&.split(" ")
 
-              next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
+              next if self.class::CLASSES.any? && classes&.intersection(self.class::CLASSES).blank?
 
               generate_offense(self.class, processed_source, tag, self.class::MESSAGE)
             end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -3,86 +3,88 @@
 require "json"
 require "openssl"
 
-module ERBLint
-  module Linters
-    # Helper methods for linting ERB.
-    module Helpers
-      def self.included(base)
-        base.include(LinterRegistry)
+module Primer
+  module ViewComponents
+    module Linters
+      # Helper methods for linting ERB.
+      module Helpers
+        def self.included(base)
+          base.include(ERBLint::LinterRegistry)
 
-        define_method "run" do |processed_source|
-          tags(processed_source).each do |tag|
-            next if tag.closing?
-            next unless self.class::TAGS&.include?(tag.name)
+          define_method "run" do |processed_source|
+            tags(processed_source).each do |tag|
+              next if tag.closing?
+              next unless self.class::TAGS&.include?(tag.name)
 
-            classes = tag.attributes["class"]&.value&.split(" ")
+              classes = tag.attributes["class"]&.value&.split(" ")
 
-            next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
+              next unless !self.class::CLASS || classes&.include?(self.class::CLASS)
 
-            generate_offense(self.class, processed_source, tag, self.class::MESSAGE)
+              generate_offense(self.class, processed_source, tag, self.class::MESSAGE)
+            end
+
+            counter_correct?(processed_source)
           end
 
-          counter_correct?(processed_source)
-        end
+          define_method "autocorrect" do |processed_source, offense|
+            return unless offense.context
 
-        define_method "autocorrect" do |processed_source, offense|
-          return unless offense.context
-
-          lambda do |corrector|
-            if processed_source.file_content.include?("erblint:counter #{self.class.name.demodulize}")
-              # update the counter if exists
-              corrector.replace(offense.source_range, offense.context)
-            else
-              # add comment with counter if none
-              corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
+            lambda do |corrector|
+              if processed_source.file_content.include?("erblint:counter #{self.class.name.demodulize}")
+                # update the counter if exists
+                corrector.replace(offense.source_range, offense.context)
+              else
+                # add comment with counter if none
+                corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
+              end
             end
           end
         end
-      end
 
-      private
+        private
 
-      def tags(processed_source)
-        processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
-      end
+        def tags(processed_source)
+          processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
+        end
 
-      def counter_correct?(processed_source)
-        comment_node = nil
-        expected_count = 0
-        rule_name = self.class.name.match(/:?:?(\w+)\Z/)[1]
-        offenses_count = @offenses.length
+        def counter_correct?(processed_source)
+          comment_node = nil
+          expected_count = 0
+          rule_name = self.class.name.match(/:?:?(\w+)\Z/)[1]
+          offenses_count = @offenses.length
 
-        processed_source.parser.ast.descendants(:erb).each do |node|
-          indicator_node, _, code_node, = *node
-          indicator = indicator_node&.loc&.source
-          comment = code_node&.loc&.source&.strip
+          processed_source.parser.ast.descendants(:erb).each do |node|
+            indicator_node, _, code_node, = *node
+            indicator = indicator_node&.loc&.source
+            comment = code_node&.loc&.source&.strip
 
-          if indicator == "#" && comment.start_with?("erblint:count") && comment.match(rule_name)
-            comment_node = code_node
-            expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
+            if indicator == "#" && comment.start_with?("erblint:count") && comment.match(rule_name)
+              comment_node = code_node
+              expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
+            end
+          end
+
+          if offenses_count.zero?
+            add_offense(processed_source.to_source_range(comment_node.loc), "Unused erblint:count comment for #{rule_name}") if comment_node
+            return
+          end
+
+          first_offense = @offenses[0]
+
+          if comment_node.nil?
+            add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
+          else
+            clear_offenses
+            add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", " erblint:counter #{rule_name} #{offenses_count} ") if expected_count != offenses_count
           end
         end
 
-        if offenses_count.zero?
-          add_offense(processed_source.to_source_range(comment_node.loc), "Unused erblint:count comment for #{rule_name}") if comment_node
-          return
+        def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
+          message ||= klass::MESSAGE
+          klass_name = klass.name.split("::")[-1]
+          offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
+          add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
         end
-
-        first_offense = @offenses[0]
-
-        if comment_node.nil?
-          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
-        else
-          clear_offenses
-          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", " erblint:counter #{rule_name} #{offenses_count} ") if expected_count != offenses_count
-        end
-      end
-
-      def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
-        message ||= klass::MESSAGE
-        klass_name = klass.name.split("::")[-1]
-        offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
-        add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
       end
     end
   end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -20,7 +20,7 @@ module Primer
 
               next if self.class::CLASSES.any? && classes&.intersection(self.class::CLASSES).blank?
 
-              generate_offense(self.class, processed_source, tag, self.class::MESSAGE)
+              generate_offense(self.class, processed_source, tag, message(tag))
             end
 
             counter_correct?(processed_source)
@@ -42,6 +42,10 @@ module Primer
         end
 
         private
+
+        def message(tag)
+          self.class::MESSAGE
+        end
 
         def tags(processed_source)
           processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -43,7 +43,7 @@ module Primer
 
         private
 
-        def message(tag)
+        def message(_tag)
           self.class::MESSAGE
         end
 

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -17,7 +17,7 @@ module ERBLint
 
             classes = tag.attributes["class"]&.value&.split(" ")
 
-            next if self.class::CLASSES.any? && classes&.intersection(self.class::CLASSES).blank?
+            next if self.class::CLASSES.any? && (classes & self.class::CLASSES).blank?
 
             generate_offense(self.class, processed_source, tag, message(tag))
           end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -3,92 +3,90 @@
 require "json"
 require "openssl"
 
-module Primer
-  module ViewComponents
-    module Linters
-      # Helper methods for linting ERB.
-      module Helpers
-        def self.included(base)
-          base.include(ERBLint::LinterRegistry)
+module ERBLint
+  module Linters
+    # Helper methods for linting ERB.
+    module Helpers
+      def self.included(base)
+        base.include(ERBLint::LinterRegistry)
 
-          define_method "run" do |processed_source|
-            tags(processed_source).each do |tag|
-              next if tag.closing?
-              next unless self.class::TAGS&.include?(tag.name)
+        define_method "run" do |processed_source|
+          tags(processed_source).each do |tag|
+            next if tag.closing?
+            next unless self.class::TAGS&.include?(tag.name)
 
-              classes = tag.attributes["class"]&.value&.split(" ")
+            classes = tag.attributes["class"]&.value&.split(" ")
 
-              next if self.class::CLASSES.any? && classes&.intersection(self.class::CLASSES).blank?
+            next if self.class::CLASSES.any? && classes&.intersection(self.class::CLASSES).blank?
 
-              generate_offense(self.class, processed_source, tag, message(tag))
-            end
-
-            counter_correct?(processed_source)
+            generate_offense(self.class, processed_source, tag, message(tag))
           end
 
-          define_method "autocorrect" do |processed_source, offense|
-            return unless offense.context
+          counter_correct?(processed_source)
+        end
 
-            lambda do |corrector|
-              if processed_source.file_content.include?("erblint:counter #{self.class.name.demodulize}")
-                # update the counter if exists
-                corrector.replace(offense.source_range, offense.context)
-              else
-                # add comment with counter if none
-                corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
-              end
+        define_method "autocorrect" do |processed_source, offense|
+          return unless offense.context
+
+          lambda do |corrector|
+            if processed_source.file_content.include?("erblint:counter #{self.class.name.demodulize}")
+              # update the counter if exists
+              corrector.replace(offense.source_range, offense.context)
+            else
+              # add comment with counter if none
+              corrector.insert_before(processed_source.source_buffer.source_range, "#{offense.context}\n")
             end
           end
         end
+      end
 
-        private
+      private
 
-        def message(_tag)
-          self.class::MESSAGE
-        end
+      def message(_tag)
+        self.class::MESSAGE
+      end
 
-        def tags(processed_source)
-          processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
-        end
+      def tags(processed_source)
+        processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
+      end
 
-        def counter_correct?(processed_source)
-          comment_node = nil
-          expected_count = 0
-          rule_name = self.class.name.match(/:?:?(\w+)\Z/)[1]
-          offenses_count = @offenses.length
+      def counter_correct?(processed_source)
+        comment_node = nil
+        expected_count = 0
+        rule_name = self.class.name.match(/:?:?(\w+)\Z/)[1]
+        offenses_count = @offenses.length
 
-          processed_source.parser.ast.descendants(:erb).each do |node|
-            indicator_node, _, code_node, = *node
-            indicator = indicator_node&.loc&.source
-            comment = code_node&.loc&.source&.strip
+        processed_source.parser.ast.descendants(:erb).each do |node|
+          indicator_node, _, code_node, = *node
+          indicator = indicator_node&.loc&.source
+          comment = code_node&.loc&.source&.strip
 
-            if indicator == "#" && comment.start_with?("erblint:count") && comment.match(rule_name)
-              comment_node = code_node
-              expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
-            end
-          end
-
-          if offenses_count.zero?
-            add_offense(processed_source.to_source_range(comment_node.loc), "Unused erblint:count comment for #{rule_name}") if comment_node
-            return
-          end
-
-          first_offense = @offenses[0]
-
-          if comment_node.nil?
-            add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
-          else
-            clear_offenses
-            add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", " erblint:counter #{rule_name} #{offenses_count} ") if expected_count != offenses_count
+          if indicator == "#" && comment.start_with?("erblint:count") && comment.match(rule_name)
+            comment_node = code_node
+            expected_count = comment.match(/\s(\d+)\s?$/)[1].to_i
           end
         end
 
-        def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
-          message ||= klass::MESSAGE
-          klass_name = klass.name.split("::")[-1]
-          offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
-          add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
+        if offenses_count.zero?
+          add_offense(processed_source.to_source_range(comment_node.loc), "Unused erblint:count comment for #{rule_name}") if comment_node
+          return
         end
+
+        first_offense = @offenses[0]
+
+        if comment_node.nil?
+          add_offense(processed_source.to_source_range(first_offense.source_range), "#{rule_name}: If you must, add <%# erblint:counter #{rule_name} #{offenses_count} %> to bypass this check.", "<%# erblint:counter #{rule_name} #{offenses_count} %>")
+        else
+          clear_offenses
+          add_offense(processed_source.to_source_range(comment_node.loc), "Incorrect erblint:counter number for #{rule_name}. Expected: #{expected_count}, actual: #{offenses_count}.", " erblint:counter #{rule_name} #{offenses_count} ") if expected_count != offenses_count
+        end
+      end
+
+      def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
+        message ||= klass::MESSAGE
+        klass_name = klass.name.split("::")[-1]
+        offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
+        add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
       end
     end
   end

--- a/test/linter_test_case.rb
+++ b/test/linter_test_case.rb
@@ -6,8 +6,10 @@ require "primer/view_components/linters"
 
 class LinterTestCase < Minitest::Test
   def setup
-    @linter = linter_class.new(file_loader, linter_class.config_schema.new)
+    @linter = linter_class&.new(file_loader, linter_class.config_schema.new)
   end
+
+  def linter_class; end
 
   def file_loader
     ERBLint::FileLoader.new(".")
@@ -15,6 +17,10 @@ class LinterTestCase < Minitest::Test
 
   def processed_source
     ERBLint::ProcessedSource.new("file.rb", @file)
+  end
+
+  def tags
+    processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
   end
 
   def corrector

--- a/test/linter_test_case.rb
+++ b/test/linter_test_case.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "erb_lint"
+require "primer/view_components/linters"
+
+class LinterTestCase < Minitest::Test
+  def setup
+    @linter = linter_class.new(file_loader, linter_class.config_schema.new)
+  end
+
+  def file_loader
+    ERBLint::FileLoader.new(".")
+  end
+
+  def processed_source
+    ERBLint::ProcessedSource.new("file.rb", @file)
+  end
+
+  def corrector
+    ERBLint::Corrector.new(processed_source, @linter.offenses)
+  end
+
+  delegate :corrected_content, to: :corrector
+end

--- a/test/linter_test_case.rb
+++ b/test/linter_test_case.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "erb_lint"
-require "primer/view_components/linters"
 
 class LinterTestCase < Minitest::Test
   def setup
@@ -10,6 +8,10 @@ class LinterTestCase < Minitest::Test
   end
 
   def linter_class; end
+
+  def offenses
+    @linter.offenses
+  end
 
   def file_loader
     ERBLint::FileLoader.new(".")

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -79,6 +79,27 @@ class ArgumentMappersButtonTest < LinterTestCase
     end
   end
 
+  def test_returns_type_argument
+    Primer::BaseButton::TYPE_OPTIONS.each do |type|
+      # button is the default, so it does not require a `type` argument
+      next if type == :button
+
+      @file = "<button class=\"btn\" type=\"#{type}\">Button</button>"
+      args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+      assert_equal "type: :#{type}", args
+    end
+  end
+
+  def test_raises_if_type_is_not_supported
+    @file = "<button class=\"btn\" type=\"some-type\">Button</button>"
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    end
+
+    assert_equal "Button component does not support type \"some-type\"", err.message
+  end
+
   def test_raises_if_cannot_map_class
     @file = "<button class=\"some-class\">Button</button>"
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -5,42 +5,42 @@ require "linter_test_case"
 class ArgumentMappersButtonTest < LinterTestCase
   def test_returns_no_arguments_if_only_btn
     @file = "<button class=\"btn\">Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "", args
   end
 
   def test_returns_aria_arguments_as_string_symbols
     @file = "<button aria-label=\"label\" aria-disabled=\"true\" aria-boolean>Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "\"aria-label\": \"label\", \"aria-disabled\": \"true\", \"aria-boolean\": true", args
   end
 
   def test_returns_data_arguments_as_string_symbols
     @file = "<button data-action=\"click\" data-pjax>Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "\"data-action\": \"click\", \"data-pjax\": true", args
   end
 
   def test_returns_disabled_argument_as_boolean
     @file = "<button disabled>Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "disabled: true", args
   end
 
   def test_returns_block_argument
     @file = "<button class=\"btn-block\">Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "block: true", args
   end
 
   def test_returns_group_item_argument
     @file = "<button class=\"BtnGroup-item\">Button</button>"
-    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal "group_item: true", args
   end
@@ -50,7 +50,7 @@ class ArgumentMappersButtonTest < LinterTestCase
       next if class_name.blank?
 
       @file = "<button class=\"#{class_name}\">Button</button>"
-      args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+      args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
       assert_equal "scheme: :#{value}", args
     end
@@ -61,7 +61,7 @@ class ArgumentMappersButtonTest < LinterTestCase
       next if class_name.blank?
 
       @file = "<button class=\"#{class_name}\">Button</button>"
-      args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+      args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
       assert_equal "variant: :#{value}", args
     end
@@ -69,8 +69,8 @@ class ArgumentMappersButtonTest < LinterTestCase
 
   def test_raises_if_cannot_map_class
     @file = "<button class=\"some-class\">Button</button>"
-    err = assert_raises Primer::ViewComponents::Linters::ArgumentMappers::ConversionError do
-      Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
 
     assert_equal "Cannot convert class \"some-class\"", err.message
@@ -78,8 +78,8 @@ class ArgumentMappersButtonTest < LinterTestCase
 
   def test_raises_if_cannot_map_attribute
     @file = "<button some-attribute=\"some-value\">Button</button>"
-    err = assert_raises Primer::ViewComponents::Linters::ArgumentMappers::ConversionError do
-      Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
 
     assert_equal "Cannot convert attribute \"some-attribute\"", err.message

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -117,4 +117,11 @@ class ArgumentMappersButtonTest < LinterTestCase
 
     assert_equal "Cannot convert attribute \"some-attribute\"", err.message
   end
+
+  def test_converts_data_test_selector
+    @file = "<button data-test-selector=\"some-selector\">Button</button>"
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "test_selector: \"some-selector\"", args
+  end
 end

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -67,6 +67,18 @@ class ArgumentMappersButtonTest < LinterTestCase
     end
   end
 
+  def test_returns_tag_argument
+    Primer::BaseButton::TAG_OPTIONS.each do |tag|
+      # button is the default, so it does not require a `tag` argument
+      next if tag == :button
+
+      @file = "<#{tag} class=\"btn\">Button</#{tag}>"
+      args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+      assert_equal "tag: :#{tag}", args
+    end
+  end
+
   def test_raises_if_cannot_map_class
     @file = "<button class=\"some-class\">Button</button>"
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -4,45 +4,52 @@ require "linter_test_case"
 
 class ArgumentMappersButtonTest < LinterTestCase
   def test_returns_no_arguments_if_only_btn
-    @file = "<button class=\"btn\">Button</button>"
+    @file = '<button class="btn">Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "", args
+    assert_empty args
   end
 
   def test_returns_aria_arguments_as_string_symbols
-    @file = "<button aria-label=\"label\" aria-disabled=\"true\" aria-boolean>Button</button>"
+    @file = '<button aria-label="label" aria-disabled="true" aria-boolean>Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "\"aria-label\": \"label\", \"aria-disabled\": \"true\", \"aria-boolean\": true", args
+    assert_equal({
+      '"aria-label"' => '"label"',
+      '"aria-disabled"' => '"true"',
+      '"aria-boolean"' => true
+    }, args)
   end
 
   def test_returns_data_arguments_as_string_symbols
-    @file = "<button data-action=\"click\" data-pjax>Button</button>"
+    @file = '<button data-action="click" data-pjax>Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "\"data-action\": \"click\", \"data-pjax\": true", args
+    assert_equal({
+      '"data-action"' => '"click"',
+      '"data-pjax"' => true
+    }, args)
   end
 
   def test_returns_disabled_argument_as_boolean
     @file = "<button disabled>Button</button>"
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "disabled: true", args
+    assert_equal({ disabled: true }, args)
   end
 
   def test_returns_block_argument
-    @file = "<button class=\"btn-block\">Button</button>"
+    @file = '<button class="btn-block">Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "block: true", args
+    assert_equal({ block: true }, args)
   end
 
   def test_returns_group_item_argument
-    @file = "<button class=\"BtnGroup-item\">Button</button>"
+    @file = '<button class="BtnGroup-item">Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "group_item: true", args
+    assert_equal({ group_item: true }, args)
   end
 
   def test_returns_scheme_argument
@@ -52,7 +59,7 @@ class ArgumentMappersButtonTest < LinterTestCase
       @file = "<button class=\"#{class_name}\">Button</button>"
       args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-      assert_equal "scheme: :#{value}", args
+      assert_equal({ scheme: ":#{value}" }, args)
     end
   end
 
@@ -63,7 +70,7 @@ class ArgumentMappersButtonTest < LinterTestCase
       @file = "<button class=\"#{class_name}\">Button</button>"
       args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-      assert_equal "variant: :#{value}", args
+      assert_equal({ variant: ":#{value}" }, args)
     end
   end
 
@@ -75,7 +82,7 @@ class ArgumentMappersButtonTest < LinterTestCase
       @file = "<#{tag} class=\"btn\">Button</#{tag}>"
       args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-      assert_equal "tag: :#{tag}", args
+      assert_equal({ tag: ":#{tag}" }, args)
     end
   end
 
@@ -87,12 +94,12 @@ class ArgumentMappersButtonTest < LinterTestCase
       @file = "<button class=\"btn\" type=\"#{type}\">Button</button>"
       args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-      assert_equal "type: :#{type}", args
+      assert_equal({ type: ":#{type}" }, args)
     end
   end
 
   def test_raises_if_type_is_not_supported
-    @file = "<button class=\"btn\" type=\"some-type\">Button</button>"
+    @file = '<button class="btn" type="some-type">Button</button>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
@@ -101,7 +108,7 @@ class ArgumentMappersButtonTest < LinterTestCase
   end
 
   def test_raises_if_cannot_map_class
-    @file = "<button class=\"some-class\">Button</button>"
+    @file = '<button class="some-class">Button</button>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
@@ -110,7 +117,7 @@ class ArgumentMappersButtonTest < LinterTestCase
   end
 
   def test_raises_if_cannot_map_attribute
-    @file = "<button some-attribute=\"some-value\">Button</button>"
+    @file = '<button some-attribute="some-value">Button</button>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
@@ -119,21 +126,21 @@ class ArgumentMappersButtonTest < LinterTestCase
   end
 
   def test_converts_data_test_selector
-    @file = "<button data-test-selector=\"some-selector\">Button</button>"
+    @file = '<button data-test-selector="some-selector">Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "test_selector: \"some-selector\"", args
+    assert_equal({ test_selector: '"some-selector"' }, args)
   end
 
   def test_converts_erb_test_selector_call
-    @file = "<button class=\"btn\" <%= test_selector('some-selector') %>>Button</button>"
+    @file = '<button class="btn" <%= test_selector("some-selector") %>>Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal "test_selector: \"some-selector\"", args
+    assert_equal({ test_selector: '"some-selector"' }, args)
   end
 
   def test_raises_if_unsupported_erb_block
-    @file = "<button class=\"btn\" <%= some_method('some-selector') %>>Button</button>"
+    @file = '<button class="btn" <%= some_method("some-selector") %>>Button</button>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
@@ -155,6 +162,24 @@ class ArgumentMappersButtonTest < LinterTestCase
 
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-    assert_equal 'scheme: :primary, variant: :small, block: true, group_item: true, "aria-label": "some label", "data-pjax": true, "data-click": "click", test_selector: "some_selector", disabled: true, type: :submit', args
+    assert_equal({
+      :scheme => ":primary",
+      :variant => ":small",
+      :block => true,
+      :group_item => true,
+      '"aria-label"' => '"some label"',
+      '"data-pjax"' => true,
+      '"data-click"' => '"click"',
+      :test_selector => '"some_selector"',
+      :disabled => true,
+      :type => ":submit"
+    }, args)
+  end
+
+  def test_returns_arguments_as_string
+    @file = '<a class="btn btn-primary" aria-label="some label">Link</a>'
+    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_s
+
+    assert_equal 'tag: :a, scheme: :primary, "aria-label": "some label"', args
   end
 end

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -15,10 +15,10 @@ class ArgumentMappersButtonTest < LinterTestCase
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal({
-      '"aria-label"' => '"label"',
-      '"aria-disabled"' => '"true"',
-      '"aria-boolean"' => true
-    }, args)
+                   '"aria-label"' => '"label"',
+                   '"aria-disabled"' => '"true"',
+                   '"aria-boolean"' => true
+                 }, args)
   end
 
   def test_returns_data_arguments_as_string_symbols
@@ -26,9 +26,9 @@ class ArgumentMappersButtonTest < LinterTestCase
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal({
-      '"data-action"' => '"click"',
-      '"data-pjax"' => true
-    }, args)
+                   '"data-action"' => '"click"',
+                   '"data-pjax"' => true
+                 }, args)
   end
 
   def test_returns_disabled_argument_as_boolean
@@ -163,17 +163,17 @@ class ArgumentMappersButtonTest < LinterTestCase
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal({
-      :scheme => ":primary",
-      :variant => ":small",
-      :block => true,
-      :group_item => true,
-      '"aria-label"' => '"some label"',
-      '"data-pjax"' => true,
-      '"data-click"' => '"click"',
-      :test_selector => '"some_selector"',
-      :disabled => true,
-      :type => ":submit"
-    }, args)
+                   :scheme => ":primary",
+                   :variant => ":small",
+                   :block => true,
+                   :group_item => true,
+                   '"aria-label"' => '"some label"',
+                   '"data-pjax"' => true,
+                   '"data-click"' => '"click"',
+                   :test_selector => '"some_selector"',
+                   :disabled => true,
+                   :type => ":submit"
+                 }, args)
   end
 
   def test_returns_arguments_as_string

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class ArgumentMappersButtonTest < LinterTestCase
+  def test_returns_no_arguments_if_only_btn
+    @file = "<button class=\"btn\">Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "", args
+  end
+
+  def test_returns_aria_arguments_as_string_symbols
+    @file = "<button aria-label=\"label\" aria-disabled=\"true\" aria-boolean>Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "\"aria-label\": \"label\", \"aria-disabled\": \"true\", \"aria-boolean\": true", args
+  end
+
+  def test_returns_data_arguments_as_string_symbols
+    @file = "<button data-action=\"click\" data-pjax>Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "\"data-action\": \"click\", \"data-pjax\": true", args
+  end
+
+  def test_returns_disabled_argument_as_boolean
+    @file = "<button disabled>Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "disabled: true", args
+  end
+
+  def test_returns_block_argument
+    @file = "<button class=\"btn-block\">Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "block: true", args
+  end
+
+  def test_returns_group_item_argument
+    @file = "<button class=\"BtnGroup-item\">Button</button>"
+    args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+    assert_equal "group_item: true", args
+  end
+
+  def test_returns_scheme_argument
+    Primer::ButtonComponent::SCHEME_MAPPINGS.each do |value, class_name|
+      next if class_name.blank?
+
+      @file = "<button class=\"#{class_name}\">Button</button>"
+      args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+      assert_equal "scheme: :#{value}", args
+    end
+  end
+
+  def test_returns_variant_argument
+    Primer::ButtonComponent::VARIANT_MAPPINGS.each do |value, class_name|
+      next if class_name.blank?
+
+      @file = "<button class=\"#{class_name}\">Button</button>"
+      args = Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+
+      assert_equal "variant: :#{value}", args
+    end
+  end
+
+  def test_raises_if_cannot_map_class
+    @file = "<button class=\"some-class\">Button</button>"
+    err = assert_raises Primer::ViewComponents::Linters::ArgumentMappers::ConversionError do
+      Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert class \"some-class\"", err.message
+  end
+
+  def test_raises_if_cannot_map_attribute
+    @file = "<button some-attribute=\"some-value\">Button</button>"
+    err = assert_raises Primer::ViewComponents::Linters::ArgumentMappers::ConversionError do
+      Primer::ViewComponents::Linters::ArgumentMappers::Button.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert attribute \"some-attribute\"", err.message
+  end
+end

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -14,6 +14,13 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     refute_empty @linter.offenses
   end
 
+  def test_warns_if_there_is_a_html_link_button
+    @file = "<button class=\"btn-link\">Button</button>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
   def test_suggests_ignoring_with_correct_number_of_buttons
     @file = "<button class=\"btn\">Button</button><button class=\"btn\">Button</button><button class=\"not-a-btn\">Button</button>"
     @linter.run(processed_source)
@@ -33,6 +40,13 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     @linter.run(processed_source)
 
     assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
+  end
+
+  def test_suggests_how_to_use_the_component_as_link
+    @file = "<button class=\"btn-link\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(scheme: :link)")
   end
 
   def test_suggests_how_to_use_the_component_with_aria_arguments

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -4,7 +4,7 @@ require "linter_test_case"
 
 class ButtonComponentMigrationCounterTest < LinterTestCase
   def linter_class
-    Primer::ViewComponents::Linters::ButtonComponentMigrationCounter
+    ERBLint::Linters::ButtonComponentMigrationCounter
   end
 
   def test_warns_if_there_is_a_html_button

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -28,6 +28,13 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     assert_equal "<%# erblint:counter ButtonComponentMigrationCounter 2 %>\n#{@file}", corrected_content
   end
 
+  def test_suggests_updating_the_number_of_ignored_buttons
+    @file = "<%# erblint:counter ButtonComponentMigrationCounter 1 %>\n<button class=\"btn\">Button</button><button class=\"btn\">Button</button><button class=\"not-a-btn\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_equal " erblint:counter ButtonComponentMigrationCounter 2 ", offenses.first.context
+  end
+
   def test_does_not_warn_if_wrong_tag
     @file = "<span class=\"btn\">Button</span>"
     @linter.run(processed_source)
@@ -39,55 +46,55 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     @file = "<button class=\"btn btn-sm btn-primary\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
   end
 
   def test_suggests_how_to_use_the_component_as_link
     @file = "<button class=\"btn-link\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(scheme: :link)")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(scheme: :link)")
   end
 
   def test_suggests_how_to_use_the_component_with_aria_arguments
     @file = "<button class=\"btn\" aria-label=\"Some label\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(\"aria-label\": \"Some label\")")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(\"aria-label\": \"Some label\")")
   end
 
   def test_suggests_how_to_use_the_component_with_data_arguments
     @file = "<button class=\"btn\" data-confirm=\"Some confirmation\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(\"data-confirm\": \"Some confirmation\")")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(\"data-confirm\": \"Some confirmation\")")
   end
 
   def test_suggest_when_button_is_disabled
     @file = "<button class=\"btn\" disabled>Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(disabled: true)")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(disabled: true)")
   end
 
   def test_suggest_using_the_tag_system_argument
     @file = "<a class=\"btn\">Button</a>"
     @linter.run(processed_source)
 
-    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(tag: :a)")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(tag: :a)")
   end
 
   def test_does_not_suggest_if_using_unsupported_arguments
     @file = "<button class=\"btn\" onclick>Button</button>"
     @linter.run(processed_source)
 
-    refute_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new")
+    refute_includes(offenses.first.message, "render Primer::ButtonComponent.new")
   end
 
   def test_does_not_suggest_if_using_unsupported_classes
     @file = "<button class=\"btn some-custom-class\">Button</button>"
     @linter.run(processed_source)
 
-    refute_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new")
+    refute_includes(offenses.first.message, "render Primer::ButtonComponent.new")
   end
 end

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -4,7 +4,7 @@ require "linter_test_case"
 
 class ButtonComponentMigrationCounterTest < LinterTestCase
   def linter_class
-    ERBLint::Linters::ButtonComponentMigrationCounter
+    Primer::ViewComponents::Linters::ButtonComponentMigrationCounter
   end
 
   def test_warns_if_there_is_a_html_button
@@ -26,5 +26,12 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
+  end
+
+  def test_suggests_how_to_use_the_component_with_arguments
+    @file = "<button class=\"btn btn-sm btn-primary\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
   end
 end

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -34,4 +34,39 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
 
     assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
   end
+
+  def test_suggests_how_to_use_the_component_with_aria_arguments
+    @file = "<button class=\"btn\" aria-label=\"Some label\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(\"aria-label\": \"Some label\")")
+  end
+
+  def test_suggests_how_to_use_the_component_with_data_arguments
+    @file = "<button class=\"btn\" data-confirm=\"Some confirmation\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(\"data-confirm\": \"Some confirmation\")")
+  end
+
+  def test_suggest_when_button_is_disabled
+    @file = "<button class=\"btn\" disabled>Button</button>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(disabled: true)")
+  end
+
+  def test_does_not_suggest_if_using_unsupported_arguments
+    @file = "<button class=\"btn\" onclick>Button</button>"
+    @linter.run(processed_source)
+
+    refute_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new")
+  end
+
+  def test_does_not_suggest_if_using_unsupported_classes
+    @file = "<button class=\"btn some-custom-class\">Button</button>"
+    @linter.run(processed_source)
+
+    refute_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new")
+  end
 end

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -70,6 +70,13 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(disabled: true)")
   end
 
+  def test_suggest_using_the_tag_system_argument
+    @file = "<a class=\"btn\">Button</a>"
+    @linter.run(processed_source)
+
+    assert_includes(@linter.offenses.first.message, "render Primer::ButtonComponent.new(tag: :a)")
+  end
+
   def test_does_not_suggest_if_using_unsupported_arguments
     @file = "<button class=\"btn\" onclick>Button</button>"
     @linter.run(processed_source)

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class ButtonComponentMigrationCounterTest < LinterTestCase
+  def linter_class
+    ERBLint::Linters::ButtonComponentMigrationCounter
+  end
+
+  def test_warns_if_there_is_a_html_button
+    @file = "<button class=\"btn\">Button</button>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_suggests_ignoring_with_correct_number_of_buttons
+    @file = "<button class=\"btn\">Button</button><button class=\"btn\">Button</button><button class=\"not-a-btn\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_equal "<%# erblint:counter ButtonComponentMigrationCounter 2 %>\n#{@file}", corrected_content
+  end
+
+  def test_does_not_warn_if_wrong_tag
+    @file = "<span class=\"btn\">Button</span>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+end

--- a/test/linters/flash_component_migration_counter_test.rb
+++ b/test/linters/flash_component_migration_counter_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class FlashComponentMigrationCounterTest < LinterTestCase
+  def linter_class
+    ERBLint::Linters::FlashComponentMigrationCounter
+  end
+
+  def test_warns_if_there_is_a_html_flash
+    @file = "<div class=\"flash\">flash</div>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_suggests_ignoring_with_correct_number_of_flashes
+    @file = "<div class=\"flash\">flash</div><div class=\"flash\">flash</div><div class=\"not-a-flash\">flash</div>"
+    @linter.run(processed_source)
+
+    assert_equal "<%# erblint:counter FlashComponentMigrationCounter 2 %>\n#{@file}", corrected_content
+  end
+
+  def test_does_not_warn_if_wrong_tag
+    @file = "<span class=\"flash\">flash</span>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+end

--- a/test/linters/flash_component_migration_counter_test.rb
+++ b/test/linters/flash_component_migration_counter_test.rb
@@ -4,7 +4,7 @@ require "linter_test_case"
 
 class FlashComponentMigrationCounterTest < LinterTestCase
   def linter_class
-    ERBLint::Linters::FlashComponentMigrationCounter
+    Primer::ViewComponents::Linters::FlashComponentMigrationCounter
   end
 
   def test_warns_if_there_is_a_html_flash

--- a/test/linters/flash_component_migration_counter_test.rb
+++ b/test/linters/flash_component_migration_counter_test.rb
@@ -4,7 +4,7 @@ require "linter_test_case"
 
 class FlashComponentMigrationCounterTest < LinterTestCase
   def linter_class
-    Primer::ViewComponents::Linters::FlashComponentMigrationCounter
+    ERBLint::Linters::FlashComponentMigrationCounter
   end
 
   def test_warns_if_there_is_a_html_flash

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] = "test"
 
+require "erb_lint"
 require "minitest/autorun"
 require "mocha/minitest"
 require "rails"
@@ -14,6 +15,7 @@ require "yaml"
 require File.expand_path("../demo/config/environment.rb", __dir__)
 
 require "primer/view_components"
+require "primer/view_components/linters"
 
 if ENV["COVERAGE"] == "1"
   require "simplecov"


### PR DESCRIPTION
Related to https://github.com/primer/view_components/issues/623

### Summary

This PR starts to work on linter suggestions, providing a better feedback for users on how to use our components.

| Before | After |
|--------|--------|
| ![image](https://user-images.githubusercontent.com/11280312/121209617-98af0080-c840-11eb-8b98-ae603a31c856.png) | ![image](https://user-images.githubusercontent.com/11280312/121210988-c183c580-c841-11eb-9825-f1501b936d2d.png)  |

### When does it work?

For now, the linter suggestion supports:

1. classes that the component generate (not System Arguments / custom classes)
2. `aria-` attributes
3. `data-` attributes
4. `test_selector` ERB block
5. `tag` attribute
6. `disabled` and `type` (for Button only)

### TODOs

1. I'm not looking at the content, so the "suggestion" is not auto-correctable since I still don't know how to look at the whole element block (any AST experts here? 😄 ).
2. Integrating with https://github.com/primer/view_components/pull/612
3. Dealing with slots