### PR TITLE
Move docs around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
   *Jon Rohan*
 
+* Change docs header order.
+
+    *Manuel Puyol, Kate Higa*
+
 ## 0.0.43
 
 * Upgrade primer/css to 17.2.1

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -78,8 +78,8 @@ module Primer
     #
     # @param scheme [Symbol] <%= one_of(Primer::ButtonComponent::SCHEME_OPTIONS) %>
     # @param variant [Symbol] <%= one_of(Primer::ButtonComponent::VARIANT_OPTIONS) %>
-    # @param tag [Symbol] <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
-    # @param type [Symbol] <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
+    # @param tag [Symbol] (Primer::BaseButton::DEFAULT_TAG) <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
+    # @param type [Symbol] (Primer::BaseButton::DEFAULT_TYPE) <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
     # @param group_item [Boolean] Whether button is part of a ButtonGroup.
     # @param block [Boolean] Whether button is full-width with `display: block`.
     # @param caret [Boolean] Whether or not to render a caret.

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -14,7 +14,7 @@ module Primer
 
     # Use the Summary slot as a trigger to reveal the content.
     #
-    # @param button [Boolean] Whether to render the Summary as a button or not.
+    # @param button [Boolean] (true) Whether to render the Summary as a button or not.
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
     renders_one :summary, lambda { |button: true, **system_arguments|
       system_arguments[:tag] = :summary

--- a/docs/content/components/alphabuttonmarketing.md
+++ b/docs/content/components/alphabuttonmarketing.md
@@ -11,6 +11,16 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `ButtonMarketing` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `scheme` | `Symbol` | `:default` | One of `:default`, `:outline`, `:primary`, or `:transparent`. |
+| `variant` | `Symbol` | `:default` | One of `:default` and `:large`. |
+| `tag` | `Symbol` | `:button` | One of `:a` and `:button`. |
+| `type` | `Symbol` | `:button` | One of `:button` and `:submit`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Schemes
@@ -34,13 +44,3 @@ Use `ButtonMarketing` for actions (e.g. in forms). Use links for destinations, o
 <%= render(Primer::Alpha::ButtonMarketing.new(mr: 2)) { "Default" } %>
 <%= render(Primer::Alpha::ButtonMarketing.new(variant: :large)) { "Large" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `scheme` | `Symbol` | `:default` | One of `:default`, `:outline`, `:primary`, or `:transparent`. |
-| `variant` | `Symbol` | `:default` | One of `:default` and `:large`. |
-| `tag` | `Symbol` | `:button` | One of `:a` and `:button`. |
-| `type` | `Symbol` | `:button` | One of `:button` and `:submit`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -25,6 +25,46 @@ as a label by setting `aria-labelledby`.
 will apply it to the correct elements. However, please note that a visible label should almost
 always be used unless there is compelling reason not to. A placeholder is not a label.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `src` | `String` | N/A | The route to query. |
+| `input_id` | `String` | N/A | Id of the input element. |
+| `list_id` | `String` | N/A | Id of the list element. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Label`
+
+Optionally render a visible label. See [Accessibility](#system-arguments)
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Input`
+
+Required input used to search for results
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `type` | `Symbol` | N/A | One of `:search` and `:text`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Icon`
+
+Optional icon to be rendered before the input. Has the same arguments as [Octicon](/components/octicon).
+
+### `Results`
+
+Customizable results list.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -89,43 +129,3 @@ always be used unless there is compelling reason not to. A placeholder is not a 
   <% c.icon(icon: :search) %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `src` | `String` | N/A | The route to query. |
-| `input_id` | `String` | N/A | Id of the input element. |
-| `list_id` | `String` | N/A | Id of the list element. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Label`
-
-Optionally render a visible label. See [Accessibility](#system-arguments)
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Input`
-
-Required input used to search for results
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `type` | `Symbol` | N/A | One of `:search` and `:text`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Icon`
-
-Optional icon to be rendered before the input. Has the same arguments as [Octicon](/components/octicon).
-
-### `Results`
-
-Customizable results list.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/autocompleteitem.md
+++ b/docs/content/components/autocompleteitem.md
@@ -11,6 +11,15 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `AutoCompleteItem` to list results of an auto-completed search.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `value` | `String` | N/A | Value of the item. |
+| `selected` | `Boolean` | `false` | Whether the item is selected. |
+| `disabled` | `Boolean` | `false` | Whether the item is disabled. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -25,12 +34,3 @@ Use `AutoCompleteItem` to list results of an auto-completed search.
   Not selected
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `value` | `String` | N/A | Value of the item. |
-| `selected` | `Boolean` | `false` | Whether the item is selected. |
-| `disabled` | `Boolean` | `false` | Whether the item is disabled. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/avatar.md
+++ b/docs/content/components/avatar.md
@@ -25,6 +25,17 @@ if `Avatar` is a link to a user profile, the alt attribute should be `@kittenuse
 rather than `@kittenuser`.
 [Learn more about best image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/)
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `src` | `String` | N/A | The source url of the avatar image. |
+| `alt` | `String` | N/A | Passed through to alt on img tag. |
+| `size` | `Integer` | `20` | Adds the avatar-small class if less than 24. |
+| `square` | `Boolean` | `false` | Used to create a square avatar. |
+| `href` | `String` | `nil` | The URL to link to. If used, component will be wrapped by an `<a>` tag. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -63,14 +74,3 @@ rather than `@kittenuser`.
 <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 32)) %>
 <%= render(Primer::AvatarComponent.new(src: "http://placekitten.com/200/200", alt: "@kittenuser", size: 36)) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `src` | `String` | N/A | The source url of the avatar image. |
-| `alt` | `String` | N/A | Passed through to alt on img tag. |
-| `size` | `Integer` | `20` | Adds the avatar-small class if less than 24. |
-| `square` | `Boolean` | `false` | Used to create a square avatar. |
-| `href` | `String` | `nil` | The URL to link to. If used, component will be wrapped by an `<a>` tag. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -11,6 +11,26 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `AvatarStack` to stack multiple avatars together.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:div` | One of `:div` and `:span`. |
+| `align` | `Symbol` | `:left` | One of `:left` and `:right`. |
+| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not. |
+| `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Avatars`
+
+Required list of stacked avatars.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/avatar). |
+
 ## Examples
 
 ### Default
@@ -48,23 +68,3 @@ Use `AvatarStack` to stack multiple avatars together.
   <%= c.avatar(src: "http://placekitten.com/200/200", alt: "@kittenuser") %>
 <% end  %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:div` | One of `:div` and `:span`. |
-| `align` | `Symbol` | `:left` | One of `:left` and `:right`. |
-| `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not. |
-| `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Avatars`
-
-Required list of stacked avatars.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/avatar). |

--- a/docs/content/components/basebutton.md
+++ b/docs/content/components/basebutton.md
@@ -11,6 +11,15 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `BaseButton` to render an unstyled `<button>` tag that can be customized.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:button` | One of `:a`, `:button`, or `:summary`. |
+| `type` | `Symbol` | `:button` | One of `:button`, `:reset`, or `:submit`. |
+| `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Block
@@ -21,12 +30,3 @@ Use `BaseButton` to render an unstyled `<button>` tag that can be customized.
 <%= render(Primer::BaseButton.new(block: :true)) { "Block" } %>
 <%= render(Primer::BaseButton.new(block: :true, scheme: :primary)) { "Primary block" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:button` | One of `:a`, `:button`, or `:summary`. |
-| `type` | `Symbol` | `:button` | One of `:button`, `:reset`, or `:submit`. |
-| `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/betatext.md
+++ b/docs/content/components/betatext.md
@@ -11,6 +11,13 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 `Text` is a wrapper component that will apply typography styles to the text inside.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:span` |  |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -21,10 +28,3 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 <%= render(Primer::Beta::Text.new(tag: :p, font_weight: :bold)) { "Bold Text" } %>
 <%= render(Primer::Beta::Text.new(tag: :p, color: :text_danger)) { "Danger Text" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:span` |  |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -16,6 +16,36 @@ Use `Blankslate` when there is a lack of content within a page or section. Use a
 `Blankslate` renders an `<h3>` element for the title by default. Update the heading level based on what is appropriate for your page hierarchy by setting `title_tag`.
 [Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `title` | `String` | `""` | Text that appears in a larger bold font. |
+| `title_tag` | `Symbol` | `:h3` | HTML tag to use for title. |
+| `icon` | `Symbol` | `""` | Octicon icon to use at top of component. |
+| `icon_size` | `Symbol` | `:medium` | One of `:small` (`16`) and `:medium` (`24`). |
+| `image_src` | `String` | `""` | Image to display. |
+| `image_alt` | `String` | `" "` | Alt text for image. |
+| `description` | `String` | `""` | Text that appears below the title. Typically a whole sentence. |
+| `button_text` | `String` | `""` | The text of the button. |
+| `button_url` | `String` | `""` | The URL where the user will be taken after clicking the button. |
+| `button_classes` | `String` | `"btn-primary my-3"` | Classes to apply to action button |
+| `link_text` | `String` | `""` | The text of the link. |
+| `link_url` | `String` | `""` | The URL where the user will be taken after clicking the link. |
+| `narrow` | `Boolean` | `false` | Adds a maximum width. |
+| `large` | `Boolean` | `false` | Increases the font size. |
+| `spacious` | `Boolean` | `false` | Adds extra padding. |
+
+## Slots
+
+### `Spinner`
+
+Optional Spinner.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [Spinner](/components/spinner). |
+
 ## Examples
 
 ### Basic
@@ -121,33 +151,3 @@ There are a few variations of how the Blankslate appears: `narrow` adds a maximu
   spacious: true,
 ) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `title` | `String` | `""` | Text that appears in a larger bold font. |
-| `title_tag` | `Symbol` | `:h3` | HTML tag to use for title. |
-| `icon` | `Symbol` | `""` | Octicon icon to use at top of component. |
-| `icon_size` | `Symbol` | `:medium` | One of `:small` (`16`) and `:medium` (`24`). |
-| `image_src` | `String` | `""` | Image to display. |
-| `image_alt` | `String` | `" "` | Alt text for image. |
-| `description` | `String` | `""` | Text that appears below the title. Typically a whole sentence. |
-| `button_text` | `String` | `""` | The text of the button. |
-| `button_url` | `String` | `""` | The URL where the user will be taken after clicking the button. |
-| `button_classes` | `String` | `"btn-primary my-3"` | Classes to apply to action button |
-| `link_text` | `String` | `""` | The text of the link. |
-| `link_url` | `String` | `""` | The URL where the user will be taken after clicking the link. |
-| `narrow` | `Boolean` | `false` | Adds a maximum width. |
-| `large` | `Boolean` | `false` | Increases the font size. |
-| `spacious` | `Boolean` | `false` | Adds extra padding. |
-
-## Slots
-
-### `Spinner`
-
-Optional Spinner.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Spinner](/components/spinner). |

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -11,6 +11,47 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 `BorderBox` is a Box component with a border.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `padding` | `Symbol` | `:default` | One of `:condensed`, `:default`, or `:spacious`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Header`
+
+Optional Header.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Body`
+
+Optional Body.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Footer`
+
+Optional Footer.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Rows`
+
+Use Rows to add rows with borders and maintain the same padding.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Header, body, rows, and footer
@@ -59,44 +100,3 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `padding` | `Symbol` | `:default` | One of `:condensed`, `:default`, or `:spacious`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Header`
-
-Optional Header.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Body`
-
-Optional Body.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Footer`
-
-Optional Footer.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Rows`
-
-Use Rows to add rows with borders and maintain the same padding.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/box.md
+++ b/docs/content/components/box.md
@@ -11,6 +11,12 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 `Box` is a basic wrapper component for most layout related needs.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -28,9 +34,3 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 ```erb
 <%= render(Primer::BoxComponent.new(bg: :tertiary, p: 3)) { "Hello world" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/breadcrumb.md
+++ b/docs/content/components/breadcrumb.md
@@ -11,20 +11,6 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Breadcrumb` to display page hierarchy within a section of the site. All of the items in the breadcrumb "trail" are links except for the final item, which is a plain string indicating the current page.
 
-## Examples
-
-### Basic
-
-<Example src="<nav aria-label='Breadcrumb' data-view-component='true'>  <ol>      <li data-view-component='true' class='breadcrumb-item'><a href='/' data-view-component='true'>Home</a></li>      <li data-view-component='true' class='breadcrumb-item'><a href='/about' data-view-component='true'>About</a></li>      <li aria-current='page' data-view-component='true' class='breadcrumb-item'>Team</li>  </ol></nav>" />
-
-```erb
-<%= render(Primer::BreadcrumbComponent.new) do |component| %>
-  <% component.item(href: "/") do %>Home<% end %>
-  <% component.item(href: "/about") do %>About<% end %>
-  <% component.item(selected: true) do %>Team<% end %>
-<% end %>
-```
-
 ## Arguments
 
 | Name | Type | Default | Description |
@@ -42,3 +28,17 @@ _Note: if both `href` and `selected: true` are passed in, `href` will be ignored
 | `href` | `String` | N/A | The URL to link to. |
 | `selected` | `Boolean` | N/A | Whether or not the item is selected and not rendered as a link. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Examples
+
+### Basic
+
+<Example src="<nav aria-label='Breadcrumb' data-view-component='true'>  <ol>      <li data-view-component='true' class='breadcrumb-item'><a href='/' data-view-component='true'>Home</a></li>      <li data-view-component='true' class='breadcrumb-item'><a href='/about' data-view-component='true'>About</a></li>      <li aria-current='page' data-view-component='true' class='breadcrumb-item'>Team</li>  </ol></nav>" />
+
+```erb
+<%= render(Primer::BreadcrumbComponent.new) do |component| %>
+  <% component.item(href: "/") do %>Home<% end %>
+  <% component.item(href: "/about") do %>About<% end %>
+  <% component.item(selected: true) do %>Team<% end %>
+<% end %>
+```

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -11,6 +11,36 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Button` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:invisible`, `:link`, `:outline`, or `:primary`. |
+| `variant` | `Symbol` | `:medium` | One of `:large`, `:medium`, or `:small`. |
+| `tag` | `Symbol` | N/A | One of `:a`, `:button`, or `:summary`. |
+| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
+| `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
+| `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
+| `caret` | `Boolean` | `false` | Whether or not to render a caret. |
+
+## Slots
+
+### `Icon`
+
+Icon to be rendered in the button.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | Same arguments as [Octicon](/components/octicon). |
+
+### `Counter`
+
+Counter to be rendered in the button.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | Same arguments as [Counter](/components/counter). |
+
 ## Examples
 
 ### Schemes
@@ -88,33 +118,3 @@ Use `Button` for actions (e.g. in forms). Use links for destinations, or moving 
   Button
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:invisible`, `:link`, `:outline`, or `:primary`. |
-| `variant` | `Symbol` | `:medium` | One of `:large`, `:medium`, or `:small`. |
-| `tag` | `Symbol` | N/A | One of `:a`, `:button`, or `:summary`. |
-| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
-| `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
-| `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
-| `caret` | `Boolean` | `false` | Whether or not to render a caret. |
-
-## Slots
-
-### `Icon`
-
-Icon to be rendered in the button.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | Same arguments as [Octicon](/components/octicon). |
-
-### `Counter`
-
-Counter to be rendered in the button.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | Same arguments as [Counter](/components/counter). |

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -17,8 +17,8 @@ Use `Button` for actions (e.g. in forms). Use links for destinations, or moving 
 | :- | :- | :- | :- |
 | `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:invisible`, `:link`, `:outline`, or `:primary`. |
 | `variant` | `Symbol` | `:medium` | One of `:large`, `:medium`, or `:small`. |
-| `tag` | `Symbol` | N/A | One of `:a`, `:button`, or `:summary`. |
-| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
+| `tag` | `Symbol` | `:button` | One of `:a`, `:button`, or `:summary`. |
+| `type` | `Symbol` | `:button` | One of `:button`, `:reset`, or `:submit`. |
 | `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
 | `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
 | `caret` | `Boolean` | `false` | Whether or not to render a caret. |

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -11,6 +11,23 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `ButtonGroup` to render a series of buttons.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `variant` | `Symbol` | `Primer::ButtonComponent::DEFAULT_VARIANT` | One of `:large`, `:medium`, or `:small`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Buttons`
+
+Required list of buttons to be rendered.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [Button](/components/button) except for `variant` and `group_item`. |
+
 ## Examples
 
 ### Default
@@ -48,20 +65,3 @@ Use `ButtonGroup` to render a series of buttons.
   <% component.button(scheme: :outline) { "Outline" } %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `variant` | `Symbol` | `Primer::ButtonComponent::DEFAULT_VARIANT` | One of `:large`, `:medium`, or `:small`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Buttons`
-
-Required list of buttons to be rendered.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Button](/components/button) except for `variant` and `group_item`. |

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -15,7 +15,7 @@ Use `ButtonGroup` to render a series of buttons.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `variant` | `Symbol` | `Primer::ButtonComponent::DEFAULT_VARIANT` | One of `:large`, `:medium`, or `:small`. |
+| `variant` | `Symbol` | `:medium` | One of `:large`, `:medium`, or `:small`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -14,6 +14,14 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 Use `ClipboardCopy` to copy element text content or input values to the clipboard.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `label` | `String` | N/A | String that will be read to screenreaders when the component is focused |
+| `value` | `String` | N/A | Text to copy into the users clipboard when they click the component |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -33,11 +41,3 @@ Use `ClipboardCopy` to copy element text content or input values to the clipboar
   Click to copy!
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `label` | `String` | N/A | String that will be read to screenreaders when the component is focused |
-| `value` | `String` | N/A | Text to copy into the users clipboard when they click the component |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/closebutton.md
+++ b/docs/content/components/closebutton.md
@@ -18,6 +18,13 @@ Use `CloseButton` to render an `×` without default button styles.
 `CloseButton` has a default `aria-label` of "Close" to provides assistive technologies with an accessible label.
 You may choose to override this label with something more descriptive via [system_arguments][0].
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `type` | `Symbol` | `:button` | One of `:button` and `:submit`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -27,10 +34,3 @@ You may choose to override this label with something more descriptive via [syste
 ```erb
 <%= render(Primer::CloseButton.new) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `type` | `Symbol` | `:button` | One of `:button` and `:submit`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/counter.md
+++ b/docs/content/components/counter.md
@@ -16,6 +16,18 @@ Use `Counter` to add a count to navigational elements and buttons.
 Always use `Counter` with adjacent text that provides supplementary information regarding what the count is for. For instance, `Counter`
 should be accompanied with text such as `issues` or `pull requests`.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `count` | `Integer, Float::INFINITY, nil` | `0` | The number to be displayed (e.x. # of issues, pull requests) |
+| `scheme` | `Symbol` | `:default` | Color scheme. One of `:default`, `:primary`, or `:secondary`. |
+| `limit` | `Integer, nil` | `5_000` | Maximum value to display. Pass `nil` for no limit. (e.x. if `count` == 6,000 and `limit` == 5000, counter will display "5,000+") |
+| `hide_if_zero` | `Boolean` | `false` | If true, a `hidden` attribute is added to the counter if `count` is zero. |
+| `text` | `String` | `""` | Text to display instead of count. |
+| `round` | `Boolean` | `false` | Whether to apply our standard rounding logic to value. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -34,15 +46,3 @@ should be accompanied with text such as `issues` or `pull requests`.
 <%= render(Primer::CounterComponent.new(count: 25, scheme: :primary)) %>
 <%= render(Primer::CounterComponent.new(count: 25, scheme: :secondary)) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `count` | `Integer, Float::INFINITY, nil` | `0` | The number to be displayed (e.x. # of issues, pull requests) |
-| `scheme` | `Symbol` | `:default` | Color scheme. One of `:default`, `:primary`, or `:secondary`. |
-| `limit` | `Integer, nil` | `5_000` | Maximum value to display. Pass `nil` for no limit. (e.x. if `count` == 6,000 and `limit` == 5000, counter will display "5,000+") |
-| `hide_if_zero` | `Boolean` | `false` | If true, a `hidden` attribute is added to the counter if `count` is zero. |
-| `text` | `String` | `""` | Text to display instead of count. |
-| `round` | `Boolean` | `false` | Whether to apply our standard rounding logic to value. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -27,7 +27,7 @@ Use the Summary slot as a trigger to reveal the content.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `button` | `Boolean` | N/A | Whether to render the Summary as a button or not. |
+| `button` | `Boolean` | `true` | Whether to render the Summary as a button or not. |
 | `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
 
 ### `Body`

--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -12,6 +12,33 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 `Dropdown` is a lightweight context menu for housing navigation and actions.
 They're great for instances where you don't need the full power (and code) of the select menu.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `overlay` | `Symbol` | `:default` | One of `:dark`, `:default`, or `:none`. |
+| `reset` | `Boolean` | `true` | Whether to hide the default caret on the button |
+| `summary_classes` | `String` | `""` | Custom classes to add to the button |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Button`
+
+Required trigger for the dropdown. Only accepts a content.
+Its classes can be customized by the `summary_classes` param in the parent component
+
+### `Menu`
+
+Required context menu for the dropdown
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `direction` | `Symbol` | N/A | One of `:e`, `:ne`, `:s`, `:se`, `:sw`, or `:w`. |
+| `scheme` | `Symbol` | N/A | Pass `:dark` for dark mode theming |
+| `header` | `String` | N/A | Optional string to display as the header |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -57,30 +84,3 @@ They're great for instances where you don't need the full power (and code) of th
   <% end %>
 </div>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `overlay` | `Symbol` | `:default` | One of `:dark`, `:default`, or `:none`. |
-| `reset` | `Boolean` | `true` | Whether to hide the default caret on the button |
-| `summary_classes` | `String` | `""` | Custom classes to add to the button |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Button`
-
-Required trigger for the dropdown. Only accepts a content.
-Its classes can be customized by the `summary_classes` param in the parent component
-
-### `Menu`
-
-Required context menu for the dropdown
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `direction` | `Symbol` | N/A | One of `:e`, `:ne`, `:s`, `:se`, `:sw`, or `:w`. |
-| `scheme` | `Symbol` | N/A | Pass `:dark` for dark mode theming |
-| `header` | `String` | N/A | Optional string to display as the header |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/dropdownmenu.md
+++ b/docs/content/components/dropdownmenu.md
@@ -13,6 +13,15 @@ DropdownMenus are lightweight context menus for housing navigation and actions.
 They're great for instances where you don't need the full power (and code)
 of the select menu.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `direction` | `Symbol` | `:se` | One of `:e`, `:ne`, `:s`, `:se`, `:sw`, or `:w`. |
+| `scheme` | `Symbol` | `:default` | Pass `:dark` for dark mode theming |
+| `header` | `String` | `nil` | Optional string to display as the header |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### With a header
@@ -38,12 +47,3 @@ of the select menu.
   <% end %>
 </div>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `direction` | `Symbol` | `:se` | One of `:e`, `:ne`, `:s`, `:se`, `:sw`, or `:w`. |
-| `scheme` | `Symbol` | `:default` | Pass `:dark` for dark mode theming |
-| `header` | `String` | `nil` | Optional string to display as the header |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -11,6 +11,27 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Flash` to inform users of successful or pending actions.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `full` | `Boolean` | `false` | Whether the component should take up the full width of the screen. |
+| `spacious` | `Boolean` | `false` | Whether to add margin to the bottom of the component. |
+| `dismissible` | `Boolean` | `false` | Whether the component can be dismissed with an X button. |
+| `icon` | `Symbol` | `nil` | Name of Octicon icon to use. |
+| `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:success`, or `:warning`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Action`
+
+Optional action content showed on the right side of the component.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Schemes
@@ -60,24 +81,3 @@ Use `Flash` to inform users of successful or pending actions.
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `full` | `Boolean` | `false` | Whether the component should take up the full width of the screen. |
-| `spacious` | `Boolean` | `false` | Whether to add margin to the bottom of the component. |
-| `dismissible` | `Boolean` | `false` | Whether the component can be dismissed with an X button. |
-| `icon` | `Symbol` | `nil` | Name of Octicon icon to use. |
-| `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:success`, or `:warning`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Action`
-
-Optional action content showed on the right side of the component.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/flex.md
+++ b/docs/content/components/flex.md
@@ -38,6 +38,17 @@ Use [Box](/components/box) instead.
 <%= render Primer::BoxComponent.new(display: :flex, direction: :column) %>
 ```
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `justify_content` | `Symbol` | `JUSTIFY_CONTENT_DEFAULT` | Use this param to distribute space between and around flex items along the main axis of the container. One of `nil`, `:center`, `:flex_end`, `:flex_start`, `:space_around`, or `:space_between`. |
+| `inline` | `Boolean` | `false` | Defaults to false. |
+| `flex_wrap` | `Boolean` | `FLEX_WRAP_DEFAULT` | Defaults to nil. |
+| `align_items` | `Symbol` | `ALIGN_ITEMS_DEFAULT` | Use this param to align items on the cross axis. One of `nil`, `:baseline`, `:center`, `:end`, `:start`, or `:stretch`. |
+| `direction` | `Symbol` | `nil` | Use this param to define the orientation of the main axis (row or column). By default, flex items will display in a row. One of `nil`, `:column`, `:column_reverse`, `:row`, or `:row_reverse`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -87,14 +98,3 @@ Use [Box](/components/box) instead.
   <%= render(Primer::BoxComponent.new(p: 5, bg: :secondary, classes: "border")) { "Item 3" } %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `justify_content` | `Symbol` | `JUSTIFY_CONTENT_DEFAULT` | Use this param to distribute space between and around flex items along the main axis of the container. One of `nil`, `:center`, `:flex_end`, `:flex_start`, `:space_around`, or `:space_between`. |
-| `inline` | `Boolean` | `false` | Defaults to false. |
-| `flex_wrap` | `Boolean` | `FLEX_WRAP_DEFAULT` | Defaults to nil. |
-| `align_items` | `Symbol` | `ALIGN_ITEMS_DEFAULT` | Use this param to align items on the cross axis. One of `nil`, `:baseline`, `:center`, `:end`, `:start`, or `:stretch`. |
-| `direction` | `Symbol` | `nil` | Use this param to define the orientation of the main axis (row or column). By default, flex items will display in a row. One of `nil`, `:column`, `:column_reverse`, `:row`, or `:row_reverse`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/flexitem.md
+++ b/docs/content/components/flexitem.md
@@ -28,6 +28,13 @@ Use [Box](/components/box) instead.
 <%= render Primer::BoxComponent.new(flex: :auto) %>
 ```
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `flex_auto` | `Boolean` | `false` | Fills available space and auto-sizes based on the content. Defaults to false |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -45,10 +52,3 @@ Use [Box](/components/box) instead.
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `flex_auto` | `Boolean` | `false` | Fills available space and auto-sizes based on the content. Defaults to false |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/heading.md
+++ b/docs/content/components/heading.md
@@ -26,6 +26,13 @@ consistent. [See WCAG success criteria: 1.3.1: Info and Relationships](https://w
 Headings allow assistive technology users to quickly navigate around a page. Navigation to text that is not meant to be a heading can be a confusing experience.
 [Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `String` | N/A | One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -40,10 +47,3 @@ Headings allow assistive technology users to quickly navigate around a page. Nav
 <%= render(Primer::HeadingComponent.new(tag: :h5)) { "H5 Text" } %>
 <%= render(Primer::HeadingComponent.new(tag: :h6)) { "H6 Text" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `String` | N/A | One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/hiddentextexpander.md
+++ b/docs/content/components/hiddentextexpander.md
@@ -11,6 +11,14 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `HiddenTextExpander` to indicate and toggle hidden text.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `inline` | `Boolean` | `false` | Whether or not the expander is inline. |
+| `button_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the button element. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -36,11 +44,3 @@ Use `HiddenTextExpander` to indicate and toggle hidden text.
 ```erb
 <%= render(Primer::HiddenTextExpander.new(button_arguments: { p: 1, classes: "custom-class" })) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `inline` | `Boolean` | `false` | Whether or not the expander is inline. |
-| `button_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the button element. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/iconbutton.md
+++ b/docs/content/components/iconbutton.md
@@ -19,6 +19,17 @@ if your `IconButton` renders a magnifying glass icon and invokves a search actio
 `"Search"` instead of `"Magnifying glass"`.
 [Learn more about best functional image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/functional)
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `scheme` | `Symbol` | `:default` | One of `:danger` and `:default`. |
+| `icon` | `String` | N/A | Name of [Octicon](https://primer.style/octicons/) to use. |
+| `tag` | `Symbol` | N/A | One of `:a`, `:button`, or `:summary`. |
+| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
+| `box` | `Boolean` | `false` | Whether the button is in a [BorderBox](/components/borderbox). If `true`, the button will have the `Box-btn-octicon` class. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -53,14 +64,3 @@ if your `IconButton` renders a magnifying glass icon and invokves a search actio
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `scheme` | `Symbol` | `:default` | One of `:danger` and `:default`. |
-| `icon` | `String` | N/A | Name of [Octicon](https://primer.style/octicons/) to use. |
-| `tag` | `Symbol` | N/A | One of `:a`, `:button`, or `:summary`. |
-| `type` | `Symbol` | N/A | One of `:button`, `:reset`, or `:submit`. |
-| `box` | `Boolean` | `false` | Whether the button is in a [BorderBox](/components/borderbox). If `true`, the button will have the `Box-btn-octicon` class. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/image.md
+++ b/docs/content/components/image.md
@@ -15,6 +15,15 @@ Use `Image` to render images.
 
 Always provide a meaningful `alt`.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `src` | `String` | N/A | The source url of the image. |
+| `alt` | `String` | N/A | Specifies an alternate text for the image. |
+| `lazy` | `Boolean` | `false` | Whether or not to lazily load the image. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -52,12 +61,3 @@ Always provide a meaningful `alt`.
 
 <%= render(Primer::Image.new(src: "https://github.com/github.png", alt: "GitHub", height: 100, width: 100)) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `src` | `String` | N/A | The source url of the image. |
-| `alt` | `String` | N/A | Specifies an alternate text for the image. |
-| `lazy` | `Boolean` | `false` | Whether or not to lazily load the image. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/imagecrop.md
+++ b/docs/content/components/imagecrop.md
@@ -14,6 +14,24 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 A client-side mechanism to crop images.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `src` | `String` | N/A | The path of the image to crop. |
+| `rounded` | `Boolean` | `true` | If the crop mask should be a circle. Defaults to true. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Loading`
+
+A loading indicator that is shown while the image is loading.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Simple cropper
@@ -41,21 +59,3 @@ A client-side mechanism to crop images.
   <% cropper.loading(style: "width: 120px").with_content("Loading...") %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `src` | `String` | N/A | The path of the image to crop. |
-| `rounded` | `Boolean` | `true` | If the crop mask should be a circle. Defaults to true. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Loading`
-
-A loading indicator that is shown while the image is loading.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -11,6 +11,16 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Label` to add contextual metadata to a design.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:span` | One of `:a`, `:div`, `:span`, or `:summary`. |
+| `title` | `String` | N/A | `title` attribute for the component element. |
+| `scheme` | `Symbol` | `nil` | One of `:danger`, `:info`, `:orange`, `:primary`, `:purple`, `:secondary`, `:success`, or `:warning`. |
+| `variant` | `Symbol` | `nil` | One of `nil`, `:inline`, or `:large`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Schemes
@@ -35,13 +45,3 @@ Use `Label` to add contextual metadata to a design.
 <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
 <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:span` | One of `:a`, `:div`, `:span`, or `:summary`. |
-| `title` | `String` | N/A | `title` attribute for the component element. |
-| `scheme` | `Symbol` | `nil` | One of `:danger`, `:info`, `:orange`, `:primary`, `:purple`, `:secondary`, `:success`, or `:warning`. |
-| `variant` | `Symbol` | `nil` | One of `nil`, `:inline`, or `:large`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/layout.md
+++ b/docs/content/components/layout.md
@@ -11,30 +11,6 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Layout` to build a main/sidebar layout.
 
-## Examples
-
-### Default
-
-<Example src="<div data-view-component='true' class='gutter-condensed gutter-lg d-flex'>  <div data-view-component='true' class='flex-shrink-0 col-9'>Main</div>    <div data-view-component='true' class='flex-shrink-0 col-3'>Sidebar</div></div>" />
-
-```erb
-<%= render(Primer::LayoutComponent.new) do |component| %>
-  <% component.sidebar { "Sidebar" } %>
-  <% component.main { "Main" } %>
-<% end %>
-```
-
-### Left sidebar
-
-<Example src="<div data-view-component='true' class='gutter-condensed gutter-lg d-flex'>    <div data-view-component='true' class='flex-shrink-0 col-3'>Sidebar</div>  <div data-view-component='true' class='flex-shrink-0 col-9'>Main</div></div>" />
-
-```erb
-<%= render(Primer::LayoutComponent.new(side: :left)) do |component| %>
-  <% component.sidebar { "Sidebar" } %>
-  <% component.main { "Main" } %>
-<% end %>
-```
-
 ## Arguments
 
 | Name | Type | Default | Description |
@@ -61,3 +37,27 @@ The sidebar content
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Examples
+
+### Default
+
+<Example src="<div data-view-component='true' class='gutter-condensed gutter-lg d-flex'>  <div data-view-component='true' class='flex-shrink-0 col-9'>Main</div>    <div data-view-component='true' class='flex-shrink-0 col-3'>Sidebar</div></div>" />
+
+```erb
+<%= render(Primer::LayoutComponent.new) do |component| %>
+  <% component.sidebar { "Sidebar" } %>
+  <% component.main { "Main" } %>
+<% end %>
+```
+
+### Left sidebar
+
+<Example src="<div data-view-component='true' class='gutter-condensed gutter-lg d-flex'>    <div data-view-component='true' class='flex-shrink-0 col-3'>Sidebar</div>  <div data-view-component='true' class='flex-shrink-0 col-9'>Main</div></div>" />
+
+```erb
+<%= render(Primer::LayoutComponent.new(side: :left)) do |component| %>
+  <% component.sidebar { "Sidebar" } %>
+  <% component.main { "Main" } %>
+<% end %>
+```

--- a/docs/content/components/link.md
+++ b/docs/content/components/link.md
@@ -11,6 +11,17 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Link` for navigating from one page to another. `Link` styles anchor tags with default blue styling and hover text-decoration.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `String` | `:a` | One of `:a` and `:span`. |
+| `href` | `String` | `nil` | URL to be used for the Link. Required if tag is `:a`. If the requirements are not met an error will be raised in non production environments. In production, an empty link element will be rendered. |
+| `scheme` | `Symbol` | `:default` | One of `:default`, `:primary`, or `:secondary`. |
+| `muted` | `Boolean` | `false` | Uses light gray for Link color, and blue on hover. |
+| `underline` | `Boolean` | `true` | Whether or not to underline the link. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -53,14 +64,3 @@ Use `Link` for navigating from one page to another. `Link` styles anchor tags wi
 ```erb
 <%= render(Primer::LinkComponent.new(tag: :span)) { "Span as a link" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `String` | `:a` | One of `:a` and `:span`. |
-| `href` | `String` | `nil` | URL to be used for the Link. Required if tag is `:a`. If the requirements are not met an error will be raised in non production environments. In production, an empty link element will be rendered. |
-| `scheme` | `Symbol` | `:default` | One of `:default`, `:primary`, or `:secondary`. |
-| `muted` | `Boolean` | `false` | Uses light gray for Link color, and blue on hover. |
-| `underline` | `Boolean` | `true` | Whether or not to underline the link. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/localtime.md
+++ b/docs/content/components/localtime.md
@@ -14,6 +14,22 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 Use `LocalTime` to format a date and time in the user's preferred locale format. This component requires JavaScript.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `datetime` | `DateTime` | N/A | The date to parse |
+| `initial_text` | `String` | `nil` | Text to render before component is initialized |
+| `weekday` | `Symbol` | `:short` | One of `:long` and `:short`. |
+| `year` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
+| `month` | `Symbol` | `:short` | One of `:long` and `:short`. |
+| `day` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
+| `hour` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
+| `minute` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
+| `second` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
+| `time_zone_name` | `Symbol` | `:short` | One of `:long` and `:short`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -42,19 +58,3 @@ Use `LocalTime` to format a date and time in the user's preferred locale format.
   2014/06/01 13:05
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `datetime` | `DateTime` | N/A | The date to parse |
-| `initial_text` | `String` | `nil` | Text to render before component is initialized |
-| `weekday` | `Symbol` | `:short` | One of `:long` and `:short`. |
-| `year` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
-| `month` | `Symbol` | `:short` | One of `:long` and `:short`. |
-| `day` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
-| `hour` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
-| `minute` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
-| `second` | `Symbol` | `:numeric` | One of `:2-digit` and `:numeric`. |
-| `time_zone_name` | `Symbol` | `:short` | One of `:long` and `:short`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/markdown.md
+++ b/docs/content/components/markdown.md
@@ -11,6 +11,13 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Markdown` to wrap markdown content
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:div` | One of `:article`, `:div`, or `:td`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -289,10 +296,3 @@ Use `Markdown` to wrap markdown content
   <pre><code>This is the final element on the page and there should be no margin below this.</code></pre>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:div` | One of `:article`, `:div`, or `:td`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/menu.md
+++ b/docs/content/components/menu.md
@@ -11,32 +11,6 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Menu` to create vertical lists of navigational links.
 
-## Examples
-
-### Default
-
-<Example src="<nav data-view-component='true' class='menu'>  <span data-view-component='true' class='menu-heading'>    Heading</span>    <a href='#url' aria-current='page' data-view-component='true' class='menu-item'>    Item 1</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon and Counter    <span title='25' data-view-component='true' class='Counter'>25</span></a></nav>" />
-
-```erb
-<%= render(Primer::MenuComponent.new) do |c| %>
-  <% c.heading do %>
-    Heading
-  <% end %>
-  <% c.item(selected: true, href: "#url") do %>
-    Item 1
-  <% end %>
-  <% c.item(href: "#url") do %>
-    <%= render(Primer::OcticonComponent.new("check")) %>
-    With Icon
-  <% end %>
-  <% c.item(href: "#url") do %>
-    <%= render(Primer::OcticonComponent.new("check")) %>
-    With Icon and Counter
-    <%= render(Primer::CounterComponent.new(count: 25)) %>
-  <% end %>
-<% end %>
-```
-
 ## Arguments
 
 | Name | Type | Default | Description |
@@ -62,3 +36,29 @@ Required list of navigational links
 | `href` | `String` | N/A | URL to be used for the Link |
 | `selected` | `Boolean` | N/A | Whether the item is the current selection |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Examples
+
+### Default
+
+<Example src="<nav data-view-component='true' class='menu'>  <span data-view-component='true' class='menu-heading'>    Heading</span>    <a href='#url' aria-current='page' data-view-component='true' class='menu-item'>    Item 1</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon and Counter    <span title='25' data-view-component='true' class='Counter'>25</span></a></nav>" />
+
+```erb
+<%= render(Primer::MenuComponent.new) do |c| %>
+  <% c.heading do %>
+    Heading
+  <% end %>
+  <% c.item(selected: true, href: "#url") do %>
+    Item 1
+  <% end %>
+  <% c.item(href: "#url") do %>
+    <%= render(Primer::OcticonComponent.new("check")) %>
+    With Icon
+  <% end %>
+  <% c.item(href: "#url") do %>
+    <%= render(Primer::OcticonComponent.new("check")) %>
+    With Icon and Counter
+    <%= render(Primer::CounterComponent.new(count: 25)) %>
+  <% end %>
+<% end %>
+```

--- a/docs/content/components/navigationtab.md
+++ b/docs/content/components/navigationtab.md
@@ -17,6 +17,54 @@ and `Primer::UnderlineNavComponent` and should not be used by itself.
 `TabComponent` renders the selected anchor tab with `aria-current="page"` by default.
  When the selected tab does not correspond to the current page, such as in a nested inner tab, make sure to use aria-current="true"
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `list` | `Boolean` | `false` | Whether the Tab is an item in a `<ul>` list. |
+| `selected` | `Boolean` | `false` | Whether the Tab is selected or not. |
+| `with_panel` | `Boolean` | `false` | Whether the Tab has an associated panel. |
+| `icon_classes` | `Boolean` | `""` | Classes that must always be applied to icons. |
+| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) to be used in the `<li>` wrapper when the tab is an item in a list. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Panel`
+
+Panel controlled by the Tab. This will not render anything in the tab itself.
+It will provide a accessor for the Tab's parent to call and render the panel
+content in the appropriate place.
+Refer to `UnderlineNavComponent` and `TabNavComponent` implementations for examples.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Icon`
+
+Icon to be rendered in the Tab left.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [Octicon](/components/octicon). |
+
+### `Text`
+
+The Tab's text.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [BetaText](/components/betatext). |
+
+### `Counter`
+
+Counter to be rendered in the Tab right.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [Counter](/components/counter). |
+
 ## Examples
 
 ### Default
@@ -73,51 +121,3 @@ and `Primer::UnderlineNavComponent` and should not be used by itself.
   </div>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `list` | `Boolean` | `false` | Whether the Tab is an item in a `<ul>` list. |
-| `selected` | `Boolean` | `false` | Whether the Tab is selected or not. |
-| `with_panel` | `Boolean` | `false` | Whether the Tab has an associated panel. |
-| `icon_classes` | `Boolean` | `""` | Classes that must always be applied to icons. |
-| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) to be used in the `<li>` wrapper when the tab is an item in a list. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Panel`
-
-Panel controlled by the Tab. This will not render anything in the tab itself.
-It will provide a accessor for the Tab's parent to call and render the panel
-content in the appropriate place.
-Refer to `UnderlineNavComponent` and `TabNavComponent` implementations for examples.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Icon`
-
-Icon to be rendered in the Tab left.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Octicon](/components/octicon). |
-
-### `Text`
-
-The Tab's text.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [BetaText](/components/betatext). |
-
-### `Counter`
-
-Counter to be rendered in the Tab right.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Counter](/components/counter). |

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -12,6 +12,15 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 `Octicon` renders an [Octicon](https://primer.style/octicons/) with [System arguments](/system-arguments).
 `Octicon` can also be rendered with the `primer_octicon` helper, which accepts the same arguments.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `icon` | `Symbol` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
+| `size` | `Symbol` | `:small` | One of `:small` (`16`) and `:medium` (`24`). |
+| `use_symbol` | `Boolean` | `false` | EXPERIMENTAL (May change or be removed) - Set to true when using with [OcticonSymbols](/components/octiconsymbols). |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -38,12 +47,3 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 ```erb
 <%= primer_octicon(:check) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `icon` | `Symbol` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
-| `size` | `Symbol` | `:small` | One of `:small` (`16`) and `:medium` (`24`). |
-| `use_symbol` | `Boolean` | `false` | EXPERIMENTAL (May change or be removed) - Set to true when using with [OcticonSymbols](/components/octiconsymbols). |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/octiconsymbols.md
+++ b/docs/content/components/octiconsymbols.md
@@ -11,6 +11,12 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 OcticonSymbols renders a symbol dictionary using a list of [Octicon](https://primer.style/octicons/).
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `icons` | `Array<Hash>` | `[]` | List of icons to render, in the format { symbol: :icon_name, size: :small } |
+
 ## Examples
 
 ### Symbol dictionary
@@ -23,9 +29,3 @@ OcticonSymbols renders a symbol dictionary using a list of [Octicon](https://pri
 <%= render(Primer::OcticonComponent.new(icon: :check, use_symbol: true, size: :medium)) %>
 <%= render(Primer::OcticonSymbolsComponent.new(icons: [{ symbol: :check }, { symbol: :check, size: :medium }])) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `icons` | `Array<Hash>` | `[]` | List of icons to render, in the format { symbol: :icon_name, size: :small } |

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -13,6 +13,32 @@ Use `Popover` to bring attention to specific user interface elements, typically 
 
 By default, the popover renders with absolute positioning, meaning it should usually be wrapped in an element with a relative position in order to be positioned properly. To render the popover with relative positioning, use the relative property.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Heading`
+
+The heading
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Body`
+
+The body
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `caret` | `Symbol` | N/A | One of `:bottom`, `:bottom_left`, `:bottom_right`, `:left`, `:left_bottom`, `:left_top`, `:right`, `:right_bottom`, `:right_top`, `:top`, `:top_left`, or `:top_right`. |
+| `large` | `Boolean` | N/A | Whether to use the large version of the component. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -81,29 +107,3 @@ By default, the popover renders with absolute positioning, meaning it should usu
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Heading`
-
-The heading
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Body`
-
-The body
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `caret` | `Symbol` | N/A | One of `:bottom`, `:bottom_left`, `:bottom_right`, `:left`, `:left_bottom`, `:left_top`, `:right`, `:right_bottom`, `:right_top`, `:top`, `:top_left`, or `:top_right`. |
-| `large` | `Boolean` | N/A | Whether to use the large version of the component. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/progressbar.md
+++ b/docs/content/components/progressbar.md
@@ -11,6 +11,25 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `ProgressBar` to visualize task completion.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `size` | `Symbol` | `:default` | One of `:default`, `:large`, or `:small`. Increases height. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Items`
+
+Use the Item slot to add an item to the progress bas
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `percentage` | `Integer` | N/A | The percent complete |
+| `bg` | `Symbol` | N/A | The background color |
+| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
+
 ## Examples
 
 ### Default
@@ -54,22 +73,3 @@ Use `ProgressBar` to visualize task completion.
   <% component.item(bg: :danger_inverse, percentage: 30) %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `size` | `Symbol` | `:default` | One of `:default`, `:large`, or `:small`. Increases height. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Items`
-
-Use the Item slot to add an item to the progress bas
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `percentage` | `Integer` | N/A | The percent complete |
-| `bg` | `Symbol` | N/A | The background color |
-| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -11,6 +11,12 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Spinner` to let users know that content is being loaded.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `size` | `Symbol` | `:medium` | One of `[:large, 64]`, `[:medium, 32]`, or `[:small, 16]`. |
+
 ## Examples
 
 ### Default
@@ -36,9 +42,3 @@ Use `Spinner` to let users know that content is being loaded.
 ```erb
 <%= render(Primer::SpinnerComponent.new(size: :large)) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `size` | `Symbol` | `:medium` | One of `[:large, 64]`, `[:medium, 32]`, or `[:small, 16]`. |

--- a/docs/content/components/state.md
+++ b/docs/content/components/state.md
@@ -11,6 +11,16 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `State` for rendering the status of an item.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `title` | `String` | N/A | `title` HTML attribute. |
+| `scheme` | `Symbol` | `:default` | Background color. One of `:closed`, `:default`, `:green`, `:merged`, `:open`, `:purple`, or `:red`. |
+| `tag` | `Symbol` | `:span` | HTML tag for element. One of `:div` and `:span`. |
+| `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -40,13 +50,3 @@ Use `State` for rendering the status of an item.
 <%= render(Primer::StateComponent.new(title: "title")) { "Default" } %>
 <%= render(Primer::StateComponent.new(title: "title", size: :small)) { "Small" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `title` | `String` | N/A | `title` HTML attribute. |
-| `scheme` | `Symbol` | `:default` | Background color. One of `:closed`, `:default`, `:green`, `:merged`, `:open`, `:purple`, or `:red`. |
-| `tag` | `Symbol` | `:span` | HTML tag for element. One of `:div` and `:span`. |
-| `size` | `Symbol` | `:default` | One of `:default` and `:small`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/subhead.md
+++ b/docs/content/components/subhead.md
@@ -20,6 +20,42 @@ Use `Subhead` as the start of a section. The `:heading` slot will render an `<h2
 The `:heading` slot defaults to rendering a `<div>`. Update the tag to a heading element with the appropriate level to improve page navigation for assistive technologies.
 [Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `spacious` | `Boolean` | `false` | Whether to add spacing to the Subhead. |
+| `hide_border` | `Boolean` | `false` | Whether to hide the border under the heading. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Heading`
+
+The heading
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | N/A | One of `:div`, `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
+| `danger` | `Boolean` | N/A | Whether to style the heading as dangerous. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Actions`
+
+Actions
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Description`
+
+The description
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -101,39 +137,3 @@ The `:heading` slot defaults to rendering a `<div>`. Update the tag to a heading
   <% end %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `spacious` | `Boolean` | `false` | Whether to add spacing to the Subhead. |
-| `hide_border` | `Boolean` | `false` | Whether to hide the border under the heading. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Heading`
-
-The heading
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | N/A | One of `:div`, `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
-| `danger` | `Boolean` | N/A | Whether to style the heading as dangerous. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Actions`
-
-Actions
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Description`
-
-The description
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/tabcontainer.md
+++ b/docs/content/components/tabcontainer.md
@@ -17,6 +17,12 @@ It only provides the tab functionality. If you want styled Tabs you can look at 
 
 This component requires javascript.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -41,9 +47,3 @@ This component requires javascript.
   </div>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -14,6 +14,35 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 Use `TabNav` to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `label` | `String` | N/A | Used to set the `aria-label` on the top level `<nav>` element. |
+| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
+| `body_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the body wrapper. |
+| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Tabs`
+
+Tabs to be rendered. For more information, refer to [NavigationTab](/components/navigationtab).
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `selected` | `Boolean` | N/A | Whether the tab is selected. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Extra`
+
+Renders extra content to the `TabNav`. This will be rendered after the tabs.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `align` | `Symbol` | N/A | One of `:left` and `:right`. |
+
 ## Examples
 
 ### Default
@@ -132,32 +161,3 @@ Use `TabNav` to style navigation with a tab-based selected state, typically used
   <% c.tab(href: "#") { "Tab 3" } %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `label` | `String` | N/A | Used to set the `aria-label` on the top level `<nav>` element. |
-| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
-| `body_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the body wrapper. |
-| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Tabs`
-
-Tabs to be rendered. For more information, refer to [NavigationTab](/components/navigationtab).
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `selected` | `Boolean` | N/A | Whether the tab is selected. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Extra`
-
-Renders extra content to the `TabNav`. This will be rendered after the tabs.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `align` | `Symbol` | N/A | One of `:left` and `:right`. |

--- a/docs/content/components/timeago.md
+++ b/docs/content/components/timeago.md
@@ -14,6 +14,14 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 Use `TimeAgo` to display a time relative to how long ago it was. This component requires JavaScript.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `time` | `Time` | N/A | The time to be formatted |
+| `micro` | `Boolean` | `false` | If true then the text will be formatted in "micro" mode, using as few characters as possible |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -23,11 +31,3 @@ Use `TimeAgo` to display a time relative to how long ago it was. This component 
 ```erb
 <%= render(Primer::TimeAgoComponent.new(time: Time.at(628232400))) %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `time` | `Time` | N/A | The time to be formatted |
-| `micro` | `Boolean` | `false` | If true then the text will be formatted in "micro" mode, using as few characters as possible |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -11,22 +11,6 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `TimelineItem` to display items on a vertical timeline, connected by badge elements.
 
-## Examples
-
-### Default
-
-<Example src="<div style='padding-left: 60px'>  <div data-view-component='true' class='TimelineItem'>  <img src='https://github.com/github.png' alt='github' size='40' data-view-component='true' height='40' width='40' class='TimelineItem-avatar avatar'></img>  <div data-view-component='true' class='TimelineItem-badge color-bg-success-inverse color-text-white'><svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></div>  <div data-view-component='true' class='TimelineItem-body'>Success!</div></div></div>" />
-
-```erb
-<div style="padding-left: 60px">
-  <%= render(Primer::TimelineItemComponent.new) do |component| %>
-    <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    <% component.badge(bg: :success_inverse, color: :text_white, icon: :check) %>
-    <% component.body { "Success!" } %>
-  <% end %>
-</div>
-```
-
 ## Arguments
 
 | Name | Type | Default | Description |
@@ -60,3 +44,19 @@ Body to be rendered to the left of the Badge.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Examples
+
+### Default
+
+<Example src="<div style='padding-left: 60px'>  <div data-view-component='true' class='TimelineItem'>  <img src='https://github.com/github.png' alt='github' size='40' data-view-component='true' height='40' width='40' class='TimelineItem-avatar avatar'></img>  <div data-view-component='true' class='TimelineItem-badge color-bg-success-inverse color-text-white'><svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></div>  <div data-view-component='true' class='TimelineItem-body'>Success!</div></div></div>" />
+
+```erb
+<div style="padding-left: 60px">
+  <%= render(Primer::TimelineItemComponent.new) do |component| %>
+    <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
+    <% component.badge(bg: :success_inverse, color: :text_white, icon: :check) %>
+    <% component.body { "Success!" } %>
+  <% end %>
+</div>
+```

--- a/docs/content/components/tooltip.md
+++ b/docs/content/components/tooltip.md
@@ -11,6 +11,17 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 `Tooltip` is a wrapper component that will apply a tooltip to the provided content.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `label` | `String` | N/A | the text to appear in the tooltip |
+| `direction` | `String` | `:n` | Direction of the tooltip. One of `:e`, `:n`, `:ne`, `:nw`, `:s`, `:se`, `:sw`, or `:w`. |
+| `align` | `String` | `:default` | Align tooltips to the left or right of an element, combined with a `direction` to specify north or south. One of `:default`, `:left_1`, `:left_2`, `:right_1`, or `:right_2`. |
+| `multiline` | `Boolean` | `false` | Use this when you have long content |
+| `no_delay` | `Boolean` | `false` | By default the tooltips have a slight delay before appearing. Set true to override this |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -64,14 +75,3 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
   <%= render(Primer::Tooltip.new(label: "Even bolder", direction: :s, no_delay: true)) { "Bold Text without a delay" } %>
 </div>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `label` | `String` | N/A | the text to appear in the tooltip |
-| `direction` | `String` | `:n` | Direction of the tooltip. One of `:e`, `:n`, `:ne`, `:nw`, `:s`, `:se`, `:sw`, or `:w`. |
-| `align` | `String` | `:default` | Align tooltips to the left or right of an element, combined with a `direction` to specify north or south. One of `:default`, `:left_1`, `:left_2`, `:right_1`, or `:right_2`. |
-| `multiline` | `Boolean` | `false` | Use this when you have long content |
-| `no_delay` | `Boolean` | `false` | By default the tooltips have a slight delay before appearing. Set true to override this |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -11,6 +11,16 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Truncate` to shorten overflowing text with an ellipsis.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `tag` | `Symbol` | `:div` | One of `:div`, `:p`, or `:span`. |
+| `inline` | `Boolean` | `false` | Whether the element is inline (or inline-block). |
+| `expandable` | `Boolean` | `false` | Whether the entire string should be revealed on hover. Can only be used in conjunction with `inline`. |
+| `max_width` | `Integer` | `nil` | Sets the max-width of the text. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -46,13 +56,3 @@ Use `Truncate` to shorten overflowing text with an ellipsis.
 ```erb
 <%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) { "branch-name-that-is-really-long" } %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `tag` | `Symbol` | `:div` | One of `:div`, `:p`, or `:span`. |
-| `inline` | `Boolean` | `false` | Whether the element is inline (or inline-block). |
-| `expandable` | `Boolean` | `false` | Whether the entire string should be revealed on hover. Can only be used in conjunction with `inline`. |
-| `max_width` | `Integer` | `nil` | Sets the max-width of the text. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -16,6 +16,36 @@ Use `UnderlineNav` to style navigation with a minimal
 underlined selected state, typically used for navigation placed at the top
 of the page.
 
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `label` | `String` | N/A | The `aria-label` on top level `<nav>` element. |
+| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
+| `align` | `Symbol` | `:left` | One of `:left` and `:right`. - Defaults to left |
+| `body_arguments` | `Hash` | `{ tag: BODY_TAG_DEFAULT }` | [System arguments](/system-arguments) for the body wrapper. |
+| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Tabs`
+
+Use the tabs to list navigation items. For more information, refer to [NavigationTab](/components/navigationtab).
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `selected` | `Boolean` | N/A | Whether the tab is selected. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+### `Actions`
+
+Use actions for a call to action.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
 ## Examples
 
 ### Default
@@ -140,33 +170,3 @@ of the page.
   <% c.tab(href: "#") { "Tab 3" } %>
 <% end %>
 ```
-
-## Arguments
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `label` | `String` | N/A | The `aria-label` on top level `<nav>` element. |
-| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
-| `align` | `Symbol` | `:left` | One of `:left` and `:right`. - Defaults to left |
-| `body_arguments` | `Hash` | `{ tag: BODY_TAG_DEFAULT }` | [System arguments](/system-arguments) for the body wrapper. |
-| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-## Slots
-
-### `Tabs`
-
-Use the tabs to list navigation items. For more information, refer to [NavigationTab](/components/navigationtab).
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `selected` | `Boolean` | N/A | Whether the tab is selected. |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
-
-### `Actions`
-
-Use actions for a call to action.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -124,15 +124,6 @@ namespace :docs do
         f.puts
         f.puts(view_context.render(inline: documentation.base_docstring))
 
-        if documentation.tags(:accessibility).any?
-          f.puts
-          f.puts("## Accessibility")
-          documentation.tags(:accessibility).each do |tag|
-            f.puts
-            f.puts view_context.render(inline: tag.text)
-          end
-        end
-
         if documentation.tags(:deprecated).any?
           f.puts
           f.puts("## Deprecation")
@@ -142,44 +133,13 @@ namespace :docs do
           end
         end
 
-        initialize_method = documentation.meths.find(&:constructor?)
-
-        if initialize_method.tags(:example).any?
+        if documentation.tags(:accessibility).any?
           f.puts
-          f.puts("## Examples")
-        else
-          components_without_examples << component
-        end
-
-        initialize_method.tags(:example).each do |tag|
-          name = tag.name
-          description = nil
-          code = nil
-
-          if tag.text.include?("@description")
-            splitted = tag.text.split(/@description|@code/)
-            description = splitted.second.gsub(/^[ \t]{2}/, "").strip
-            code = splitted.last.gsub(/^[ \t]{2}/, "").strip
-          else
-            code = tag.text
-          end
-
-          f.puts
-          f.puts("### #{name}")
-          if description
+          f.puts("## Accessibility")
+          documentation.tags(:accessibility).each do |tag|
             f.puts
-            f.puts(description)
+            f.puts view_context.render(inline: tag.text)
           end
-          f.puts
-          html = view_context.render(inline: code)
-          html.scan(/class="([^"]*)"/) do |classnames|
-            classes_found_in_examples.concat(classnames[0].split(" ").reject { |c| c.starts_with?("octicon", "js", "my-") }.map { ".#{_1}"})
-          end
-          f.puts("<Example src=\"#{html.tr('"', "\'").delete("\n")}\" />")
-          f.puts
-          f.puts("```erb")
-          f.puts(code.to_s)
-          f.puts("```")
         end
 
         params = initialize_method.tags(:param)
@@ -262,6 +222,45 @@ namespace :docs do
               f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
             end
           end
+        end
+
+        initialize_method = documentation.meths.find(&:constructor?)
+        if initialize_method.tags(:example).any?
+          f.puts
+          f.puts("## Examples")
+        else
+          components_without_examples << component
+        end
+
+        initialize_method.tags(:example).each do |tag|
+          name = tag.name
+          description = nil
+          code = nil
+
+          if tag.text.include?("@description")
+            splitted = tag.text.split(/@description|@code/)
+            description = splitted.second.gsub(/^[ \t]{2}/, "").strip
+            code = splitted.last.gsub(/^[ \t]{2}/, "").strip
+          else
+            code = tag.text
+          end
+
+          f.puts
+          f.puts("### #{name}")
+          if description
+            f.puts
+            f.puts(description)
+          end
+          f.puts
+          html = view_context.render(inline: code)
+          html.scan(/class="([^"]*)"/) do |classnames|
+            classes_found_in_examples.concat(classnames[0].split(" ").reject { |c| c.starts_with?("octicon", "js", "my-") }.map { ".#{_1}"})
+          end
+          f.puts("<Example src=\"#{html.tr('"', "\'").delete("\n")}\" />")
+          f.puts
+          f.puts("```erb")
+          f.puts(code.to_s)
+          f.puts("```")
         end
       end
     end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -217,14 +217,16 @@ namespace :docs do
             param_tags.each do |tag|
               params = tag.object.parameters.find { |param| [tag.name.to_s, tag.name.to_s + ":"].include?(param[0]) }
 
-              default =
-                if params && params[1]
-                  "`#{params[1]}`"
+              default = tag.defaults&.first || params&.second
+
+              default_value =
+                if default
+                  "`#{default}`"
                 else
                   "N/A"
                 end
 
-              f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default} | #{view_context.render(inline: tag.text)} |")
+              f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default_value} | #{view_context.render(inline: tag.text)} |")
             end
           end
         end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -154,23 +154,7 @@ namespace :docs do
 
           args = []
           params.each do |tag|
-            params = tag.object.parameters.find { |param| [tag.name.to_s, tag.name.to_s + ":"].include?(param[0]) }
-
-            default = tag.defaults&.first || params&.second
-
-            default_value =
-              if default
-                constant_name = "#{component.name}::#{default}"
-                constant_value = default.safe_constantize || constant_name.safe_constantize
-
-                if constant_value.nil?
-                  pretty_value(default)
-                else
-                  pretty_value(constant_value)
-                end
-              else
-                "N/A"
-              end
+            default_value = pretty_default_value(tag, component)
 
             args << {
               "name" => tag.name,
@@ -215,18 +199,7 @@ namespace :docs do
             end
 
             param_tags.each do |tag|
-              params = tag.object.parameters.find { |param| [tag.name.to_s, tag.name.to_s + ":"].include?(param[0]) }
-
-              default = tag.defaults&.first || params&.second
-
-              default_value =
-                if default
-                  "`#{default}`"
-                else
-                  "N/A"
-                end
-
-              f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default_value} | #{view_context.render(inline: tag.text)} |")
+              f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{pretty_default_value(tag, component)} | #{view_context.render(inline: tag.text)} |")
             end
           end
         end
@@ -376,5 +349,19 @@ namespace :docs do
     registry = YARD::RegistryStore.new
     registry.load!(".yardoc")
     registry
+  end
+
+  def pretty_default_value(tag, component)
+    params = tag.object.parameters.find { |param| [tag.name.to_s, tag.name.to_s + ":"].include?(param[0]) }
+    default = tag.defaults&.first || params&.second
+
+    return "N/A" unless default
+
+    constant_name = "#{component.name}::#{default}"
+    constant_value = default.safe_constantize || constant_name.safe_constantize
+
+    return pretty_value(default) if constant_value.nil?
+
+    pretty_value(constant_value)
   end
 end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -113,6 +113,8 @@ namespace :docs do
         f.puts
         f.puts("import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'")
 
+        initialize_method = documentation.meths.find(&:constructor?)
+
         if js_components.include?(component)
           f.puts("import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/requires-js-flash'")
           f.puts
@@ -224,7 +226,6 @@ namespace :docs do
           end
         end
 
-        initialize_method = documentation.meths.find(&:constructor?)
         if initialize_method.tags(:example).any?
           f.puts
           f.puts("## Examples")

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -327,11 +327,11 @@
     description: One of `:large`, `:medium`, or `:small`.
   - name: tag
     type: Symbol
-    default: N/A
+    default: "`:button`"
     description: One of `:a`, `:button`, or `:summary`.
   - name: type
     type: Symbol
-    default: N/A
+    default: "`:button`"
     description: One of `:button`, `:reset`, or `:submit`.
   - name: group_item
     type: Boolean
@@ -350,7 +350,7 @@
   parameters:
   - name: variant
     type: Symbol
-    default: "`Primer::ButtonComponent::DEFAULT_VARIANT`"
+    default: "`:medium`"
     description: One of `:large`, `:medium`, or `:small`.
   - name: system_arguments
     type: Hash


### PR DESCRIPTION
Changes the information architecture of the Docs to follow the order:

1. Component description
2. Deprecation warning
3. Accessibility notes
4. Arguments
5. Slots
6. Examples

I feel like most users don't ever reach the `Arguments` session now and ask things that are in the docs, like "how do I use a different tag for the component?". So it is nice to have it in the top.

Extra:

Added a way to manually set defaults to params, which will help slots documentations and cases (like button) where a parameter is hidden in the code.