### PR TITLE
Add validations to docs generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
 
 * Sort documentation arguments.
 
-  *Jon Rohan*
+    *Jon Rohan*
+
+* Add validations for docs generation.
+
+    *Manuel Puyol, Kate Higa*
 
 ## 0.0.43
 

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -107,6 +107,7 @@ module Primer
     # @param narrow [Boolean] Adds a maximum width.
     # @param large [Boolean] Increases the font size.
     # @param spacious [Boolean] Adds extra padding.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(
       title: "",
       title_tag: :h3,

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -83,6 +83,7 @@ module Primer
     # @param group_item [Boolean] Whether button is part of a ButtonGroup.
     # @param block [Boolean] Whether button is full-width with `display: block`.
     # @param caret [Boolean] Whether or not to render a caret.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(
       scheme: DEFAULT_SCHEME,
       variant: DEFAULT_VARIANT,

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -33,6 +33,17 @@ module Primer
       Primer::BaseComponent.new(**system_arguments)
     }
 
+    # @example Default
+    #
+    #   <%= render Primer::DetailsComponent.new do |c| %>
+    #     component.summary do
+    #       "Summary"
+    #     end
+    #     component.body do
+    #       "Body"
+    #     end
+    #   <% end %>
+    #
     # @param overlay [Symbol] Dictates the type of overlay to render with. <%= one_of(Primer::DetailsComponent::OVERLAY_MAPPINGS.keys) %>
     # @param reset [Boolean] Defatuls to false. If set to true, it will remove the default caret and remove style from the summary element
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -27,7 +27,8 @@ module Primer
     # @example Helper
     #   <%= primer_octicon(:check) %>
     #
-    # @param icon [Symbol] Name of <%= link_to_octicons %> to use.
+    # @param icon_name [Symbol, String] Name of <%= link_to_octicons %> to use.
+    # @param icon [Symbol, String] Name of <%= link_to_octicons %> to use.
     # @param size [Symbol] <%= one_of(Primer::OcticonComponent::SIZE_MAPPINGS, sort: false) %>
     # @param use_symbol [Boolean] EXPERIMENTAL (May change or be removed) - Set to true when using with <%= link_to_component(Primer::OcticonSymbolsComponent) %>.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/spinner_component.rb
+++ b/app/components/primer/spinner_component.rb
@@ -27,6 +27,8 @@ module Primer
     #   <%= render(Primer::SpinnerComponent.new(size: :large)) %>
     #
     # @param size [Symbol] <%= one_of(Primer::SpinnerComponent::SIZE_MAPPINGS) %>
+    # @param style [String] Custom element styles.
+    # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(size: DEFAULT_SIZE, style: DEFAULT_STYLE, **system_arguments)
       @system_arguments = system_arguments
       @system_arguments[:tag] = :svg

--- a/docs/content/components/blankslate.md
+++ b/docs/content/components/blankslate.md
@@ -141,6 +141,7 @@ There are a few variations of how the Blankslate appears: `narrow` adds a maximu
 | `narrow` | `Boolean` | `false` | Adds a maximum width. |
 | `large` | `Boolean` | `false` | Increases the font size. |
 | `spacious` | `Boolean` | `false` | Adds extra padding. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots
 

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -100,6 +100,7 @@ Use `Button` for actions (e.g. in forms). Use links for destinations, or moving 
 | `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
 | `block` | `Boolean` | `false` | Whether button is full-width with `display: block`. |
 | `caret` | `Boolean` | `false` | Whether or not to render a caret. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots
 

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -28,3 +28,30 @@ Use `DetailsComponent` to reveal content after clicking a button.
   end
 <% end %>
 ```
+
+## Arguments
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `overlay` | `Symbol` | `:none` | Dictates the type of overlay to render with. One of `:dark`, `:default`, or `:none`. |
+| `reset` | `Boolean` | `false` | Defatuls to false. If set to true, it will remove the default caret and remove style from the summary element |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+
+## Slots
+
+### `Summary`
+
+Use the Summary slot as a trigger to reveal the content.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `button` | `Boolean` | N/A | Whether to render the Summary as a button or not. |
+| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
+
+### `Body`
+
+Use the Body slot as the main content to be shown when triggered by the Summary.
+
+| Name | Type | Default | Description |
+| :- | :- | :- | :- |
+| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -11,29 +11,20 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `DetailsComponent` to reveal content after clicking a button.
 
-## Arguments
+## Examples
 
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `overlay` | `Symbol` | `:none` | Dictates the type of overlay to render with. One of `:dark`, `:default`, or `:none`. |
-| `reset` | `Boolean` | `false` | Defatuls to false. If set to true, it will remove the default caret and remove style from the summary element |
-| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
+### Default
 
-## Slots
+<Example src="" />
 
-### `Summary`
+```erb
 
-Use the Summary slot as a trigger to reveal the content.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `button` | `Boolean` | N/A | Whether to render the Summary as a button or not. |
-| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
-
-### `Body`
-
-Use the Body slot as the main content to be shown when triggered by the Summary.
-
-| Name | Type | Default | Description |
-| :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
+<%= render Primer::DetailsComponent.new do |c| %>
+  component.summary do
+    "Summary"
+  end
+  component.body do
+    "Body"
+  end
+<% end %>
+```

--- a/docs/content/components/octicon.md
+++ b/docs/content/components/octicon.md
@@ -43,7 +43,8 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `icon` | `Symbol` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
+| `icon_name` | `Symbol, String` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
+| `icon` | `Symbol, String` | `nil` | Name of [Octicon](https://primer.style/octicons/) to use. |
 | `size` | `Symbol` | `:small` | One of `:small` (`16`) and `:medium` (`24`). |
 | `use_symbol` | `Boolean` | `false` | EXPERIMENTAL (May change or be removed) - Set to true when using with [OcticonSymbols](/components/octiconsymbols). |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/spinner.md
+++ b/docs/content/components/spinner.md
@@ -42,3 +42,5 @@ Use `Spinner` to let users know that content is being loaded.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `size` | `Symbol` | `:medium` | One of `[:large, 64]`, `[:medium, 32]`, or `[:small, 16]`. |
+| `style` | `String` | `box-sizing: content-box; color: var(--color-icon-primary);` | Custom element styles. |
+| `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -288,6 +288,10 @@
     type: Boolean
     default: "`false`"
     description: Adds extra padding.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
 - component: BorderBox
   source: https://github.com/primer/view_components/tree/main/app/components/primer/border_box_component.rb
   parameters:
@@ -345,6 +349,10 @@
     type: Boolean
     default: "`false`"
     description: Whether or not to render a caret.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
 - component: ButtonGroup
   source: https://github.com/primer/view_components/tree/main/app/components/primer/button_group.rb
   parameters:
@@ -711,8 +719,12 @@
 - component: Octicon
   source: https://github.com/primer/view_components/tree/main/app/components/primer/octicon_component.rb
   parameters:
+  - name: icon_name
+    type: Symbol, String
+    default: "`nil`"
+    description: Name of [Octicon](https://primer.style/octicons/) to use.
   - name: icon
-    type: Symbol
+    type: Symbol, String
     default: "`nil`"
     description: Name of [Octicon](https://primer.style/octicons/) to use.
   - name: size
@@ -777,6 +789,14 @@
     type: Symbol
     default: "`:medium`"
     description: One of `[:large, 64]`, `[:medium, 32]`, or `[:small, 16]`.
+  - name: style
+    type: String
+    default: "`box-sizing: content-box; color: var(--color-icon-primary);`"
+    description: Custom element styles.
+  - name: system_arguments
+    type: Hash
+    default: N/A
+    description: "[System arguments](/system-arguments)"
 - component: Subhead
   source: https://github.com/primer/view_components/tree/main/app/components/primer/subhead_component.rb
   parameters:


### PR DESCRIPTION
When running `docs:build`, the rake task will check if the component has:
1. examples
2. docs for all the `initialize` arguments.

If there is any offenses, it will show you what is missing.

![image](https://user-images.githubusercontent.com/11280312/121415363-47306f80-c92d-11eb-8f6d-da9a97bf5ffc.png)
