### PR TITLE
Retry ferrum tests up to 3 times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+### Misc
+
+* Rerun flaky system tests.
+
+    *Manuel Puyol*
+
 ## 0.0.44
 
 ### Updates
@@ -49,10 +55,6 @@
 * Add preliminary criteria for new `alpha` components.
 
     *Joel Hawksley*
-
-* Rerun flaky system tests.
-
-    *Manuel Puyol*
 
 ## 0.0.43
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@
 
     *Joel Hawksley*
 
+* Rerun flaky system tests.
+
+    *Manuel Puyol*
+
 ## 0.0.43
 
 ### New

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -8,6 +8,7 @@ require "axe/matchers/be_axe_clean"
 require "axe/expectation"
 
 require "test_helpers/cuprite_setup"
+require "test_helpers/retry"
 
 Ferrum::Browser.new(process_timeout: 60, timeout: 60)
 

--- a/test/test_helpers/retry.rb
+++ b/test/test_helpers/retry.rb
@@ -15,7 +15,7 @@ module Minitest
         return result if !should_retry?(result.failures) || result.skipped?
 
         Minitest::Retry::RETRY_MAX.times do |count|
-          puts "Retrying '#{method_name}' #{count + 1} of #{Minitest::Retry::RETRY_MAX}. Error: #{result.failures.map(&:message).join(",")}"
+          puts "Retrying '#{method_name}' #{count + 1} of #{Minitest::Retry::RETRY_MAX}. Error: #{result.failures.map(&:message).join(',')}"
 
           result = super(klass, method_name)
           break if result.failures.empty?

--- a/test/test_helpers/retry.rb
+++ b/test/test_helpers/retry.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# based on https://github.com/y-yagi/minitest-retry/blob/master/lib/minitest/retry.rb
+module Minitest
+  module Retry
+    RETRY_MAX = 3
+    ERRORS = [
+      Ferrum::TimeoutError
+    ].freeze
+
+    module ClassMethods
+      def run_one_method(klass, method_name)
+        result = super(klass, method_name)
+
+        return result if !should_retry?(result.failures) || result.skipped?
+
+        Minitest::Retry::RETRY_MAX.times do |count|
+          puts "Retrying '#{method_name}' #{count + 1} of #{Minitest::Retry::RETRY_MAX}. Error: #{result.failures.map(&:message).join(",")}"
+
+          result = super(klass, method_name)
+          break if result.failures.empty?
+        end
+
+        result
+      end
+
+      def should_retry?(failures)
+        return false if failures.empty?
+
+        errors = failures.map(&:error).map(&:class)
+        (errors & Minitest::Retry::ERRORS).any?
+      end
+    end
+
+    def self.prepended(base)
+      class << base
+        prepend ClassMethods
+      end
+    end
+  end
+end
+
+Minitest.prepend(Minitest::Retry)


### PR DESCRIPTION
Based on https://github.com/y-yagi/minitest-retry

This module allows us to rerun failed tests according to their error. In this case, every time a test fails with `Ferrum::TimeoutError`, it will retry up to 3 times. If it fails all 3 times, the test suite will fail.