### PR TITLE
Adding more primer utilities to the utilities rake process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
     *Manuel Puyol*
 
+* Adding animation & position arguments to the utilities class.
+
+    *Jon Rohan*
+
 ### Misc
 
 * Add autocorrect for button linters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
     *Manuel Puyol*
 
-* Adding animation & position arguments to the utilities class.
+* Adding animation, vertical_align, word_break, display, visibility, & position arguments to the utilities class.
 
     *Jon Rohan*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+### Breaking changes
+
+* Adding animation, vertical_align, word_break, display, visibility, & position arguments to the utilities class.
+
+    *Jon Rohan*
+
 ## 0.0.45
 
 ### Updates
@@ -15,10 +21,6 @@
 * Remove `label` argument in favor of `aria-label` in `ClipboardCopy`.
 
     *Manuel Puyol*
-
-* Adding animation, vertical_align, word_break, display, visibility, & position arguments to the utilities class.
-
-    *Jon Rohan*
 
 ### Misc
 

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -91,7 +91,7 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :inline_flex, :table, :table_cell]) %> |
+    # | `display` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:display)) %> |
     # | `height` | Symbol | <%= one_of([:fit]) %> |
     # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of(Primer::Classify::Utilities.mappings(:hide)) %> |
     # | `visibility` | Symbol | Visibility. <%= one_of(Primer::Classify::Utilities.mappings(:visibility)) %> |

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -43,7 +43,7 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `animation` | Symbol | <%= one_of([:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow]) %> |
+    # | `animation` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:animation)) %> |
     #
     # ## Border
     #

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -94,8 +94,8 @@ module Primer
     # | `display` | Symbol | <%= one_of([:none, :block, :flex, :inline, :inline_block, :inline_flex, :table, :table_cell]) %> |
     # | `height` | Symbol | <%= one_of([:fit]) %> |
     # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of(Primer::Classify::Utilities.mappings(:hide)) %> |
-    # | `v` | Symbol | Visibility. <%= one_of([:hidden, :visible]) %> |
-    # | `vertical_align` | Symbol | <%= one_of([:baseline, :top, :middle, :bottom, :text_top, :text_bottom]) %> |
+    # | `visibility` | Symbol | Visibility. <%= one_of(Primer::Classify::Utilities.mappings(:visibility)) %> |
+    # | `vertical_align` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:vertical_align)) %> |
     #
     # ## Position
     #
@@ -138,7 +138,7 @@ module Primer
     # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
     # | `text_transform` | Symbol | Text alignment. <%= one_of([:uppercase]) %> |
     # | `underline` | Boolean | Whether text should be underlined. |
-    # | `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
+    # | `word_break` | Symbol | Whether to break words on line breaks. <%= one_of(Primer::Classify::Utilities.mappings(:word_break)) %> |
     #
     # ## Other
     #

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -104,7 +104,7 @@ module Primer
     # | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
     # | `float` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:float)) %> |
     # | `left` | Boolean | If `false`, sets `left: 0`. |
-    # | `position` | Symbol | <%= one_of([:relative, :absolute, :fixed]) %> |
+    # | `position` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:position)) %> |
     # | `right` | Boolean | If `false`, sets `right: 0`. |
     # | `top` | Boolean | If `false`, sets `top: 0`. |
     #

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -30,7 +30,6 @@ module Primer
     HEIGHT_KEY = :height
     BOX_SHADOW_KEY = :box_shadow
     VISIBILITY_KEY = :visibility
-    ANIMATION_KEY = :animation
     CONTAINER_KEY = :container
 
     BREAKPOINTS = ["", "-sm", "-md", "-lg", "-xl"].freeze
@@ -108,7 +107,6 @@ module Primer
         HEIGHT_KEY,
         BOX_SHADOW_KEY,
         VISIBILITY_KEY,
-        ANIMATION_KEY,
         CONTAINER_KEY
       ]
     ).freeze
@@ -244,12 +242,6 @@ module Primer
                             end
         elsif key == VISIBILITY_KEY
           memo[:classes] << "v-#{val.to_s.dasherize}"
-        elsif key == ANIMATION_KEY
-          memo[:classes] << if val == :grow
-                              "hover-grow"
-                            else
-                              "anim-#{val.to_s.dasherize}"
-                            end
         else
           memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
         end

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -16,7 +16,7 @@ module Primer
     DISPLAY_KEY = :display
 
     # Keys where we can simply translate { key: value } into ".key-value"
-    CONCAT_KEYS = UTILITIES.keys + %i[position v text box_shadow].freeze
+    CONCAT_KEYS = UTILITIES.keys + %i[v text box_shadow].freeze
 
     INVALID_CLASS_NAME_PREFIXES =
       (["bg-", "color-", "text-", "d-", "v-align-", "wb-", "box-shadow-"] + CONCAT_KEYS.map { |k| "#{k}-" }).freeze

--- a/app/lib/primer/classify.rb
+++ b/app/lib/primer/classify.rb
@@ -13,27 +13,22 @@ module Primer
     ).freeze
     # rubocop:enable Security/YAMLLoad
 
-    DISPLAY_KEY = :display
-
     # Keys where we can simply translate { key: value } into ".key-value"
-    CONCAT_KEYS = %i[v text box_shadow].freeze
+    CONCAT_KEYS = %i[text box_shadow].freeze
 
     INVALID_CLASS_NAME_PREFIXES =
-      (["bg-", "color-", "text-", "d-", "v-align-", "wb-", "box-shadow-"] + CONCAT_KEYS.map { |k| "#{k}-" }).freeze
+      (["bg-", "color-", "text-", "box-shadow-"] + CONCAT_KEYS.map { |k| "#{k}-" }).freeze
 
     COLOR_KEY = :color
     BG_KEY = :bg
-    VERTICAL_ALIGN_KEY = :vertical_align
-    WORD_BREAK_KEY = :word_break
     TEXT_KEYS = %i[font_family font_style font_weight text_align text_transform].freeze
     WIDTH_KEY = :width
     HEIGHT_KEY = :height
     BOX_SHADOW_KEY = :box_shadow
-    VISIBILITY_KEY = :visibility
     CONTAINER_KEY = :container
 
     BREAKPOINTS = ["", "-sm", "-md", "-lg", "-xl"].freeze
-    RESPONSIVE_KEYS = ([DISPLAY_KEY, Primer::Classify::Grid::COL_KEY] + Primer::Classify::Flex::RESPONSIVE_KEYS).freeze
+    RESPONSIVE_KEYS = ([Primer::Classify::Grid::COL_KEY] + Primer::Classify::Flex::RESPONSIVE_KEYS).freeze
 
     BOOLEAN_MAPPINGS = {
       underline: {
@@ -101,13 +96,9 @@ module Primer
         BORDER_RADIUS_KEY,
         COLOR_KEY,
         BG_KEY,
-        DISPLAY_KEY,
-        VERTICAL_ALIGN_KEY,
-        WORD_BREAK_KEY,
         WIDTH_KEY,
         HEIGHT_KEY,
         BOX_SHADOW_KEY,
-        VISIBILITY_KEY,
         CONTAINER_KEY
       ]
     ).freeze
@@ -195,12 +186,6 @@ module Primer
           end
         elsif key == COLOR_KEY
           memo[:classes] << Primer::Classify::FunctionalTextColors.color(val)
-        elsif key == DISPLAY_KEY
-          memo[:classes] << "d#{breakpoint}-#{val.to_s.dasherize}"
-        elsif key == VERTICAL_ALIGN_KEY
-          memo[:classes] << "v-align-#{val.to_s.dasherize}"
-        elsif key == WORD_BREAK_KEY
-          memo[:classes] << "wb-#{val.to_s.dasherize}"
         elsif key == BORDER_KEY
           border_value = if val == true
                            "border"
@@ -241,8 +226,6 @@ module Primer
                             else
                               "color-shadow-#{val.to_s.dasherize}"
                             end
-        elsif key == VISIBILITY_KEY
-          memo[:classes] << "v-#{val.to_s.dasherize}"
         else
           memo[:classes] << "#{key.to_s.dasherize}#{breakpoint}-#{val.to_s.dasherize}"
         end

--- a/app/lib/primer/classify/cache.rb
+++ b/app/lib/primer/classify/cache.rb
@@ -50,11 +50,6 @@ module Primer
           )
 
           preload(
-            keys: Primer::Classify::DISPLAY_KEY,
-            values: [:flex, :block, :inline_block, :inline_flex, :none, :table, :table_cell]
-          )
-
-          preload(
             keys: [Primer::Classify::COLOR_KEY],
             values: Primer::Classify::FunctionalTextColors::OPTIONS
           )
@@ -62,16 +57,6 @@ module Primer
           preload(
             keys: [Primer::Classify::BG_KEY],
             values: Primer::Classify::FunctionalBackgroundColors::OPTIONS
-          )
-
-          preload(
-            keys: Primer::Classify::VERTICAL_ALIGN_KEY,
-            values: [:baseline, :top, :middle, :bottom, :text_top, :text_bottom]
-          )
-
-          preload(
-            keys: Primer::Classify::WORD_BREAK_KEY,
-            values: [:break_all]
           )
 
           preload(
@@ -112,11 +97,6 @@ module Primer
           preload(
             keys: Primer::Classify::BOX_SHADOW_KEY,
             values: [true, :small, :medium, :large, :extra_large, :none]
-          )
-
-          preload(
-            keys: Primer::Classify::VISIBILITY_KEY,
-            values: [:hidden, :visible]
           )
         end
 

--- a/app/lib/primer/classify/utilities.yml
+++ b/app/lib/primer/classify/utilities.yml
@@ -22,6 +22,37 @@
   - anim-hover-grow
   :rotate:
   - anim-rotate
+:position:
+  :static:
+  - position-static
+  - position-sm-static
+  - position-md-static
+  - position-lg-static
+  - position-xl-static
+  :relative:
+  - position-relative
+  - position-sm-relative
+  - position-md-relative
+  - position-lg-relative
+  - position-xl-relative
+  :absolute:
+  - position-absolute
+  - position-sm-absolute
+  - position-md-absolute
+  - position-lg-absolute
+  - position-xl-absolute
+  :fixed:
+  - position-fixed
+  - position-sm-fixed
+  - position-md-fixed
+  - position-lg-fixed
+  - position-xl-fixed
+  :sticky:
+  - position-sticky
+  - position-sm-sticky
+  - position-md-sticky
+  - position-lg-sticky
+  - position-xl-sticky
 :float:
   :left:
   - float-left

--- a/app/lib/primer/classify/utilities.yml
+++ b/app/lib/primer/classify/utilities.yml
@@ -53,6 +53,19 @@
   - position-md-sticky
   - position-lg-sticky
   - position-xl-sticky
+:vertical_align:
+  :middle:
+  - v-align-middle
+  :top:
+  - v-align-top
+  :bottom:
+  - v-align-bottom
+  :text_top:
+  - v-align-text-top
+  :text_bottom:
+  - v-align-text-bottom
+  :baseline:
+  - v-align-baseline
 :float:
   :left:
   - float-left
@@ -1190,6 +1203,63 @@
   - py-md-12
   - py-lg-12
   - py-xl-12
+:word_break:
+  :break_all:
+  - wb-break-all
+:display:
+  :block:
+  - d-block
+  - d-sm-block
+  - d-md-block
+  - d-lg-block
+  - d-xl-block
+  :flex:
+  - d-flex
+  - d-sm-flex
+  - d-md-flex
+  - d-lg-flex
+  - d-xl-flex
+  :inline:
+  - d-inline
+  - d-sm-inline
+  - d-md-inline
+  - d-lg-inline
+  - d-xl-inline
+  :inline_block:
+  - d-inline-block
+  - d-sm-inline-block
+  - d-md-inline-block
+  - d-lg-inline-block
+  - d-xl-inline-block
+  :inline_flex:
+  - d-inline-flex
+  - d-sm-inline-flex
+  - d-md-inline-flex
+  - d-lg-inline-flex
+  - d-xl-inline-flex
+  :none:
+  - d-none
+  - d-sm-none
+  - d-md-none
+  - d-lg-none
+  - d-xl-none
+  :table:
+  - d-table
+  - d-sm-table
+  - d-md-table
+  - d-lg-table
+  - d-xl-table
+  :table_cell:
+  - d-table-cell
+  - d-sm-table-cell
+  - d-md-table-cell
+  - d-lg-table-cell
+  - d-xl-table-cell
+:visibility:
+  :hidden:
+  - v-hidden
+  :visible:
+  - v-visible
 :hide:
   :sm:
   - hide-sm

--- a/app/lib/primer/classify/utilities.yml
+++ b/app/lib/primer/classify/utilities.yml
@@ -1,4 +1,27 @@
 ---
+:animation:
+  :fade_in:
+  - anim-fade-in
+  :fade_out:
+  - anim-fade-out
+  :fade_up:
+  - anim-fade-up
+  :fade_down:
+  - anim-fade-down
+  :grow_x:
+  - anim-grow-x
+  :shrink_x:
+  - anim-shrink-x
+  :scale_in:
+  - anim-scale-in
+  :pulse:
+  - anim-pulse
+  :pulse_in:
+  - anim-pulse-in
+  :hover_grow:
+  - anim-hover-grow
+  :rotate:
+  - anim-rotate
 :float:
   :left:
   - float-left

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -95,7 +95,7 @@ System arguments include most HTML attributes. For example:
 | `display` | Symbol | One of `:block`, `:flex`, `:inline`, `:inline_block`, `:inline_flex`, `:none`, `:table`, or `:table_cell`. |
 | `height` | Symbol | One of `:fit`. |
 | `hide` | Symbol | Hide the element at a specific breakpoint. One of `:lg`, `:md`, `:sm`, or `:xl`. |
-| `v` | Symbol | Visibility. One of `:hidden` and `:visible`. |
+| `visibility` | Symbol | Visibility. One of `:hidden` and `:visible`. |
 | `vertical_align` | Symbol | One of `:baseline`, `:bottom`, `:middle`, `:text_bottom`, `:text_top`, or `:top`. |
 
 ## Position
@@ -139,7 +139,7 @@ System arguments include most HTML attributes. For example:
 | `text_align` | Symbol | Text alignment. One of `:center`, `:left`, or `:right`. |
 | `text_transform` | Symbol | Text alignment. One of `:uppercase`. |
 | `underline` | Boolean | Whether text should be underlined. |
-| `word_break` | Symbol | Whether to break words on line breaks. Can only be `:break_all`. |
+| `word_break` | Symbol | Whether to break words on line breaks. One of `:break_all`. |
 
 ## Other
 

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -44,7 +44,7 @@ System arguments include most HTML attributes. For example:
 
 | Name | Type | Description |
 | :- | :- | :- |
-| `animation` | Symbol | One of `:fade_down`, `:fade_in`, `:fade_out`, `:fade_up`, `:grow`, `:grow_x`, `:pulse`, or `:scale_in`. |
+| `animation` | Symbol | One of `:fade_down`, `:fade_in`, `:fade_out`, `:fade_up`, `:grow_x`, `:hover_grow`, `:pulse`, `:pulse_in`, `:rotate`, `:scale_in`, or `:shrink_x`. |
 
 ## Border
 
@@ -105,7 +105,7 @@ System arguments include most HTML attributes. For example:
 | `bottom` | Boolean | If `false`, sets `bottom: 0`. |
 | `float` | Symbol | One of `:left`, `:none`, or `:right`. |
 | `left` | Boolean | If `false`, sets `left: 0`. |
-| `position` | Symbol | One of `:absolute`, `:fixed`, or `:relative`. |
+| `position` | Symbol | One of `:absolute`, `:fixed`, `:relative`, `:static`, or `:sticky`. |
 | `right` | Boolean | If `false`, sets `right: 0`. |
 | `top` | Boolean | If `false`, sets `top: 0`. |
 

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -8,14 +8,16 @@ namespace :utilities do
 
     # Keys that are looked for to be included in the utilities.yml file
     SUPPORTED_KEYS = %i[
-      hide
+      anim
       float
+      hide
       m mt mr mb ml mx my
       p pt pr pb pl px py
     ].freeze
 
     # Replacements for some classnames that end up being a different argument key
     REPLACEMENT_KEYS = {
+      "^anim" => "animation",
       "^v-align" => "vertical_align",
       "^d" => "display",
       "^wb" => "word_break",

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -13,6 +13,7 @@ namespace :utilities do
       hide
       m mt mr mb ml mx my
       p pt pr pb pl px py
+      position
     ].freeze
 
     # Replacements for some classnames that end up being a different argument key

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -9,11 +9,14 @@ namespace :utilities do
     # Keys that are looked for to be included in the utilities.yml file
     SUPPORTED_KEYS = %i[
       anim
+      d
       float
       hide
       m mt mr mb ml mx my
       p pt pr pb pl px py
       position
+      wb
+      v
     ].freeze
 
     # Replacements for some classnames that end up being a different argument key

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@github/prettier-config": "0.0.4",
-    "@primer/css": "^17.2.1",
+    "@primer/css": "^17.3.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-typescript": "^8.2.0",
     "@typescript-eslint/eslint-plugin": "^4.15.2",

--- a/stories/primer/utilities/animation_stories.rb
+++ b/stories/primer/utilities/animation_stories.rb
@@ -9,7 +9,7 @@ class Primer::Utilities::AnimationStories < ViewComponent::Storybook::Stories
 
   story(:animation) do
     controls do
-      select(:animation, [:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :grow], :fade_in)
+      select(:animation, [:fade_in, :fade_out, :fade_up, :fade_down, :scale_in, :pulse, :grow_x, :hover_grow], :fade_in)
     end
 
     content do |c|

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations 97 do
+    assert_allocations 92 do
       Primer::Classify.call(**@values)
     end
   ensure
@@ -51,7 +51,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.preload!
     Primer::Classify.call(**@values)
 
-    assert_allocations 30 do
+    assert_allocations 25 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations 92 do
+    assert_allocations 74 do
       Primer::Classify.call(**@values)
     end
   ensure

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -662,7 +662,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("anim-fade-down", { animation: :fade_down })
     assert_generated_class("anim-scale-in", { animation: :scale_in })
     assert_generated_class("anim-grow-x", { animation: :grow_x })
-    assert_generated_class("hover-grow", { animation: :hover_grow })
+    assert_generated_class("anim-hover-grow", { animation: :hover_grow })
   end
 
   def test_raises_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -660,7 +660,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("anim-fade-out", { animation: :fade_out })
     assert_generated_class("anim-fade-up", { animation: :fade_up })
     assert_generated_class("anim-fade-down", { animation: :fade_down })
-    assert_generated_class("anim-fade-scale-in", { animation: :fade_scale_in })
+    assert_generated_class("anim-scale-in", { animation: :scale_in })
     assert_generated_class("anim-grow-x", { animation: :grow_x })
     assert_generated_class("hover-grow", { animation: :hover_grow })
   end

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -662,7 +662,7 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("anim-fade-down", { animation: :fade_down })
     assert_generated_class("anim-fade-scale-in", { animation: :fade_scale_in })
     assert_generated_class("anim-grow-x", { animation: :grow_x })
-    assert_generated_class("hover-grow", { animation: :grow })
+    assert_generated_class("hover-grow", { animation: :hover_grow })
   end
 
   def test_raises_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,10 +102,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/css@^17.2.1":
-  version "17.2.1"
-  resolved "https://registry.yarnpkg.com/@primer/css/-/css-17.2.1.tgz#1822bff2fc8a3fcbfdf085c2d2e25e2c0d63b88b"
-  integrity sha512-taxClJ79UnLNZPbH4ejgO5sLCsJ5LKiZLCWTqBIbFU+CbIdzW71tq4js5flFhmIRZkLUwqwA7eT+UXYnsx/R8g==
+"@primer/css@^17.3.0":
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/@primer/css/-/css-17.3.0.tgz#992d6724db287bb4c5947b798007d6f46bce0ad7"
+  integrity sha512-fKxMh6CixHxRI/0zQmEkQ2eP0960TeIsHsc2oKFvGVDwaIi7Dm1BOC10lrC9aEMxsvRG3rfCW2HXgsaua+iGKA==
   dependencies:
     "@primer/primitives" "^4.3.5"
 


### PR DESCRIPTION
Adding more support for arguments in the utilities class. This adds more of the easy 1:1 mappings. As well as an update to primer/css to support animation.

There's more work that will need to be done in primer/css to add more utilities. These are the added arguments:

* `animation` – There are some cleanup tasks we'll need to do on dotcom for this change. `animation: :grow` is now `animation: :hover_grow` this was a change because we changed the class name in primer.
* `vertical_align`
* `word_break`
* `display` 
* `visibility`
* `position`