### PR TITLE
Update `ClipboardCopy` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## main
 
+### Updates
+
+* Allow copying from elements using `for` in `ClipboardCopy`.
+
+    *Manuel Puyol*
+
+### Breaking changes
+
+* Remove `label` argument in favor of `aria-label` in `ClipboardCopy`.
+
+    *Manuel Puyol*
+
 ### Misc
 
 * Add autocorrect for button linters.

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -6,21 +6,35 @@ module Primer
     status :alpha
 
     # @example Default
-    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) %>
+    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) %>
     #
     # @example With text instead of icons
-    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) do %>
+    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) do %>
     #     Click to copy!
     #   <% end %>
     #
-    # @param label [String] String that will be read to screenreaders when the component is focused
-    # @param value [String] Text to copy into the users clipboard when they click the component
+    # @example Copying from an element
+    #   <%= render(Primer::ClipboardCopy.new(for: "blob-path", "aria-label": "Copy text to the system clipboard")) %>
+    #   <div id="blob-path">src/index.js</div>
+    #
+    # @param value [String] Text to copy into the users clipboard when they click the component.
+    # @param for [String] Element id from where to get the copied value.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(label:, value:, **system_arguments)
+    def initialize(value: nil, **system_arguments)
       @system_arguments = system_arguments
+      @value = value
+
+      validate!
+
       @system_arguments[:tag] = "clipboard-copy"
-      @system_arguments[:value] = value
-      @system_arguments[:"aria-label"] = label
+      @system_arguments[:value] = value if value.present?
+    end
+
+    private
+
+    def validate!
+      validate_aria_label
+      raise ArgumentError, "Must provide either `value` or `for`" if @value.nil? && @system_arguments[:for].nil?
     end
   end
 end

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -2,6 +2,9 @@
 
 module Primer
   # Use `ClipboardCopy` to copy element text content or input values to the clipboard.
+  #
+  # @accessibility
+  #   Always set an accessible label to help the user interact with the component.
   class ClipboardCopy < Primer::Component
     status :alpha
 
@@ -17,6 +20,7 @@ module Primer
     #   <%= render(Primer::ClipboardCopy.new(for: "blob-path", "aria-label": "Copy text to the system clipboard")) %>
     #   <div id="blob-path">src/index.js</div>
     #
+    # @param aria-label [String] String that will be read to screenreaders when the component is focused
     # @param value [String] Text to copy into the users clipboard when they click the component.
     # @param for [String] Element id from where to get the copied value.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -14,10 +14,15 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 Use `ClipboardCopy` to copy element text content or input values to the clipboard.
 
+## Accessibility
+
+Always set an accessible label to help the user interact with the component.
+
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `aria-label` | `String` | N/A | String that will be read to screenreaders when the component is focused |
 | `value` | `String` | `nil` | Text to copy into the users clipboard when they click the component. |
 | `for` | `String` | N/A | Element id from where to get the copied value. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/clipboardcopy.md
+++ b/docs/content/components/clipboardcopy.md
@@ -18,26 +18,35 @@ Use `ClipboardCopy` to copy element text content or input values to the clipboar
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `label` | `String` | N/A | String that will be read to screenreaders when the component is focused |
-| `value` | `String` | N/A | Text to copy into the users clipboard when they click the component |
+| `value` | `String` | `nil` | Text to copy into the users clipboard when they click the component. |
+| `for` | `String` | N/A | Element id from where to get the copied value. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Examples
 
 ### Default
 
-<Example src="<clipboard-copy value='Text to copy' aria-label='Copy text to the system clipboard' data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-clippy'>    <path fill-rule='evenodd' d='M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z'></path></svg>    <svg style='display: none;' aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check color-icon-success'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></clipboard-copy>" />
+<Example src="<clipboard-copy aria-label='Copy text to the system clipboard' value='Text to copy' data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-clippy'>    <path fill-rule='evenodd' d='M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z'></path></svg>    <svg style='display: none;' aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check color-icon-success'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></clipboard-copy>" />
 
 ```erb
-<%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) %>
+<%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) %>
 ```
 
 ### With text instead of icons
 
-<Example src="<clipboard-copy value='Text to copy' aria-label='Copy text to the system clipboard' data-view-component='true'>      Click to copy!</clipboard-copy>" />
+<Example src="<clipboard-copy aria-label='Copy text to the system clipboard' value='Text to copy' data-view-component='true'>      Click to copy!</clipboard-copy>" />
 
 ```erb
-<%= render(Primer::ClipboardCopy.new(value: "Text to copy", label: "Copy text to the system clipboard")) do %>
+<%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) do %>
   Click to copy!
 <% end %>
+```
+
+### Copying from an element
+
+<Example src="<clipboard-copy for='blob-path' aria-label='Copy text to the system clipboard' data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-clippy'>    <path fill-rule='evenodd' d='M5.75 1a.75.75 0 00-.75.75v3c0 .414.336.75.75.75h4.5a.75.75 0 00.75-.75v-3a.75.75 0 00-.75-.75h-4.5zm.75 3V2.5h3V4h-3zm-2.874-.467a.75.75 0 00-.752-1.298A1.75 1.75 0 002 3.75v9.5c0 .966.784 1.75 1.75 1.75h8.5A1.75 1.75 0 0014 13.25v-9.5a1.75 1.75 0 00-.874-1.515.75.75 0 10-.752 1.298.25.25 0 01.126.217v9.5a.25.25 0 01-.25.25h-8.5a.25.25 0 01-.25-.25v-9.5a.25.25 0 01.126-.217z'></path></svg>    <svg style='display: none;' aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check color-icon-success'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg></clipboard-copy><div id='blob-path'>src/index.js</div>" />
+
+```erb
+<%= render(Primer::ClipboardCopy.new(for: "blob-path", "aria-label": "Copy text to the system clipboard")) %>
+<div id="blob-path">src/index.js</div>
 ```

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -390,14 +390,14 @@
 - component: ClipboardCopy
   source: https://github.com/primer/view_components/tree/main/app/components/primer/clipboard_copy.rb
   parameters:
-  - name: label
-    type: String
-    default: N/A
-    description: String that will be read to screenreaders when the component is focused
   - name: value
     type: String
+    default: "`nil`"
+    description: Text to copy into the users clipboard when they click the component.
+  - name: for
+    type: String
     default: N/A
-    description: Text to copy into the users clipboard when they click the component
+    description: Element id from where to get the copied value.
   - name: system_arguments
     type: Hash
     default: N/A

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -390,6 +390,10 @@
 - component: ClipboardCopy
   source: https://github.com/primer/view_components/tree/main/app/components/primer/clipboard_copy.rb
   parameters:
+  - name: aria-label
+    type: String
+    default: N/A
+    description: String that will be read to screenreaders when the component is focused
   - name: value
     type: String
     default: "`nil`"

--- a/stories/primer/clipboard_copy_stories.rb
+++ b/stories/primer/clipboard_copy_stories.rb
@@ -6,7 +6,7 @@ class Primer::ClipboardCopyStories < ViewComponent::Storybook::Stories
   story(:clipboard_copy_simple) do
     controls do
       text(:value, "Text to copy")
-      text(:label, "Copy text to the system clipboard")
+      text("aria-label", "Copy text to the system clipboard")
     end
 
     content
@@ -15,7 +15,7 @@ class Primer::ClipboardCopyStories < ViewComponent::Storybook::Stories
   story(:clipboard_copy_text) do
     controls do
       text(:value, "Text to copy")
-      text(:label, "Copy text to the system clipboard")
+      text("aria-label", "Copy text to the system clipboard")
     end
 
     content do

--- a/test/components/clipboard_copy_test.rb
+++ b/test/components/clipboard_copy_test.rb
@@ -6,7 +6,7 @@ class PrimerClipboardCopyTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_simple
-    render_inline Primer::ClipboardCopy.new(value: "my-branch-name", label: "Copy branch name to clipboard")
+    render_inline Primer::ClipboardCopy.new(value: "my-branch-name", "aria-label": "Copy branch name to clipboard")
 
     assert_selector("clipboard-copy[data-view-component][value=\"my-branch-name\"]") do
       assert_selector("svg[class=\"octicon octicon-clippy\"]")
@@ -15,12 +15,21 @@ class PrimerClipboardCopyTest < Minitest::Test
   end
 
   def test_renders_with_text_contents
-    render_inline Primer::ClipboardCopy.new(value: "my-branch-name", label: "Copy branch name to clipboard") do
+    render_inline Primer::ClipboardCopy.new(value: "my-branch-name", "aria-label": "Copy branch name to clipboard") do
       "Click to copy!"
     end
 
     assert_selector("clipboard-copy[data-view-component][value=\"my-branch-name\"]") do |node|
       assert_equal(node.text.strip, "Click to copy!")
+    end
+  end
+
+  def test_renders_with_for
+    render_inline Primer::ClipboardCopy.new(for: "element-id", "aria-label": "Copy branch name to clipboard")
+
+    assert_selector("clipboard-copy[data-view-component][for=\"element-id\"]") do |node|
+      assert_selector("svg[class=\"octicon octicon-clippy\"]")
+      assert_selector("svg[style=\"display: none;\"][class=\"octicon octicon-check color-icon-success\"]", { visible: false })
     end
   end
 end

--- a/test/components/clipboard_copy_test.rb
+++ b/test/components/clipboard_copy_test.rb
@@ -27,7 +27,7 @@ class PrimerClipboardCopyTest < Minitest::Test
   def test_renders_with_for
     render_inline Primer::ClipboardCopy.new(for: "element-id", "aria-label": "Copy branch name to clipboard")
 
-    assert_selector("clipboard-copy[data-view-component][for=\"element-id\"]") do |node|
+    assert_selector("clipboard-copy[data-view-component][for=\"element-id\"]") do
       assert_selector("svg[class=\"octicon octicon-clippy\"]")
       assert_selector("svg[style=\"display: none;\"][class=\"octicon octicon-check color-icon-success\"]", { visible: false })
     end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -26,7 +26,7 @@ class PrimerComponentTest < Minitest::Test
     [Primer::ButtonComponent, {}],
     [Primer::ButtonGroup, {}, proc { |component| component.button { "Button" } }],
     [Primer::Alpha::ButtonMarketing, {}],
-    [Primer::ClipboardCopy, { label: "String that will be read to screenreaders", value: "String that will be copied" }],
+    [Primer::ClipboardCopy, { "aria-label": "String that will be read to screenreaders", value: "String that will be copied" }],
     [Primer::CloseButton, {}],
     [Primer::CounterComponent, { count: 1 }],
     [Primer::DetailsComponent, {}, lambda do |component|


### PR DESCRIPTION
1. Moves from `label` to `aria-label`
2. Makes it possible to use `for` to copy text from other elements. (based on https://github.com/github/clipboard-copy-element#element-content)