### PR TITLE
Restrict menu heading slot tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking changes
 
+* Restrict `Menu` heading slot tags to heading tags and require `tag` argument.
+
+    *Kate Higa*
+
 * Adding animation, vertical_align, word_break, display, visibility, & position arguments to the utilities class. `animation: :grow` is now `animation: :hover_grow` this was a change because we changed the class name in primer.
 
     *Jon Rohan*

--- a/app/components/primer/menu_component.rb
+++ b/app/components/primer/menu_component.rb
@@ -3,11 +3,15 @@
 module Primer
   # Use `Menu` to create vertical lists of navigational links.
   class MenuComponent < Primer::Component
+    HEADING_TAG_OPTIONS = [:h1, :h2, :h3, :h4, :h5, :h6].freeze
+    HEADING_TAG_FALLBACK = :h2
+
     # Optional menu heading
     #
+    # @param tag [Symbol] <%= one_of(Primer::MenuComponent::HEADING_TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_one :heading, lambda { |**system_arguments|
-      system_arguments[:tag] ||= :span # rubocop:disable Primer/NoTagMemoize
+    renders_one :heading, lambda { |tag:, **system_arguments|
+      system_arguments[:tag] = fetch_or_fallback(HEADING_TAG_OPTIONS, tag, HEADING_TAG_FALLBACK)
       system_arguments[:classes] = class_names(
         "menu-heading",
         system_arguments[:classes]
@@ -35,7 +39,7 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::MenuComponent.new) do |c| %>
-    #     <% c.heading do %>
+    #     <% c.heading(tag: :h2) do %>
     #       Heading
     #     <% end %>
     #     <% c.item(selected: true, href: "#url") do %>

--- a/docs/content/components/menu.md
+++ b/docs/content/components/menu.md
@@ -25,6 +25,7 @@ Optional menu heading
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | N/A | One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `Items`
@@ -41,11 +42,11 @@ Required list of navigational links
 
 ### Default
 
-<Example src="<nav data-view-component='true' class='menu'>  <span data-view-component='true' class='menu-heading'>    Heading</span>    <a href='#url' aria-current='page' data-view-component='true' class='menu-item'>    Item 1</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon and Counter    <span title='25' data-view-component='true' class='Counter'>25</span></a></nav>" />
+<Example src="<nav data-view-component='true' class='menu'>  <h2 data-view-component='true' class='menu-heading'>    Heading</h2>    <a href='#url' aria-current='page' data-view-component='true' class='menu-item'>    Item 1</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon</a>    <a href='#url' data-view-component='true' class='menu-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-check'>    <path fill-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z'></path></svg>    With Icon and Counter    <span title='25' data-view-component='true' class='Counter'>25</span></a></nav>" />
 
 ```erb
 <%= render(Primer::MenuComponent.new) do |c| %>
-  <% c.heading do %>
+  <% c.heading(tag: :h2) do %>
     Heading
   <% end %>
   <% c.item(selected: true, href: "#url") do %>

--- a/test/components/menu_component_test.rb
+++ b/test/components/menu_component_test.rb
@@ -25,15 +25,27 @@ class PrimerMenuComponentTest < Minitest::Test
 
   def test_renders_heading
     render_inline(Primer::MenuComponent.new) do |c|
-      c.heading { "Heading" }
+      c.heading(tag: :h3) { "Heading" }
       c.item(selected: true, href: "#url") { "Item 1" }
       c.item(href: "#url") { "Item 2" }
     end
 
     assert_selector("nav.menu") do
-      assert_selector("span.menu-heading", text: "Heading")
-      assert_selector("a.menu-item[href=\"#url\"][aria-current=\"page\"]", text: "Item 1")
-      assert_selector("a.menu-item[href=\"#url\"]", text: "Item 2")
+      assert_selector("h3.menu-heading", text: "Heading")
+    end
+  end
+
+  def test_falls_back_to_h2_when_heading_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::MenuComponent.new) do |c|
+        c.heading(tag: :div) { "Heading" }
+        c.item(selected: true, href: "#url") { "Item 1" }
+        c.item(href: "#url") { "Item 2" }
+      end
+
+      assert_selector("nav.menu") do
+        assert_selector("h2.menu-heading", text: "Heading")
+      end
     end
   end
 end


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/644 

**What**
This PR updates the heading slot of the `MenuComponent` to require the `tag:` argument to be passed in. The tag must be one of the heading tags. 

**Why**
This menu heading looks like a heading and functions as a heading so we should be using a heading tag rather than a `:div`. This will allow assistive technology users to navigate to the heading more quickly. 

**Notes**
As a reference, a similar vertical menu menu heading on [this w3 headings page](https://www.w3.org/WAI/tutorials/page-structure/headings/) is rendered with a heading tag. 

