### PR TITLE
Restrict avatar stack body and image crop tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Breaking changes
 
+* Restrict `AvatarStack` body slot tag and `ImageCrop` spinner tag.
+
+    *Kate Higa*
+
 * Restrict `Details` body slot tags and `UnderlineNav` body slot tags.
 
     *Kate Higa*

--- a/app/components/primer/avatar_stack_component.rb
+++ b/app/components/primer/avatar_stack_component.rb
@@ -10,6 +10,9 @@ module Primer
 
     DEFAULT_TAG = :div
     TAG_OPTIONS = [DEFAULT_TAG, :span].freeze
+
+    DEFAULT_BODY_TAG = :div
+    BODY_TAG_OPTIONS = TAG_OPTIONS = [DEFAULT_TAG, :span].freeze
     # Required list of stacked avatars.
     #
     # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::AvatarComponent) %>.
@@ -40,6 +43,8 @@ module Primer
     # @param align [Symbol] <%= one_of(Primer::AvatarStackComponent::ALIGN_OPTIONS) %>
     # @param tooltipped [Boolean] Whether to add a tooltip to the stack or not.
     # @param body_arguments [Hash] Parameters to add to the Body. If `tooltipped` is set, has the same arguments as <%= link_to_component(Primer::Tooltip) %>.
+    #   The default tag is <%= pretty_value(Primer::AvatarStackComponent::DEFAULT_BODY_TAG) %> but can be changed using `tag:` to 
+    #    <%= one_of(Primer::AvatarStackComponent::BODY_TAG_OPTIONS).downcase %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(tag: DEFAULT_TAG, align: ALIGN_DEFAULT, tooltipped: false, body_arguments: {}, **system_arguments)
       @align = fetch_or_fallback(ALIGN_OPTIONS, align, ALIGN_DEFAULT)
@@ -47,7 +52,8 @@ module Primer
       @tooltipped = tooltipped
       @body_arguments = body_arguments
 
-      @body_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+      body_tag = @body_arguments[:tag] || DEFAULT_BODY_TAG
+      @body_arguments[:tag] = fetch_or_fallback(BODY_TAG_OPTIONS, body_tag, DEFAULT_BODY_TAG)
       @body_arguments[:classes] = class_names(
         "AvatarStack-body",
         @body_arguments[:classes]

--- a/app/components/primer/avatar_stack_component.rb
+++ b/app/components/primer/avatar_stack_component.rb
@@ -43,8 +43,8 @@ module Primer
     # @param align [Symbol] <%= one_of(Primer::AvatarStackComponent::ALIGN_OPTIONS) %>
     # @param tooltipped [Boolean] Whether to add a tooltip to the stack or not.
     # @param body_arguments [Hash] Parameters to add to the Body. If `tooltipped` is set, has the same arguments as <%= link_to_component(Primer::Tooltip) %>.
-    #   The default tag is <%= pretty_value(Primer::AvatarStackComponent::DEFAULT_BODY_TAG) %> but can be changed using `tag:` to 
-    #    <%= one_of(Primer::AvatarStackComponent::BODY_TAG_OPTIONS).downcase %>
+    #   The default tag is <%= pretty_value(Primer::AvatarStackComponent::DEFAULT_BODY_TAG) %> but can be changed using `tag:`
+    #   to <%= one_of(Primer::AvatarStackComponent::BODY_TAG_OPTIONS, lower: true) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(tag: DEFAULT_TAG, align: ALIGN_DEFAULT, tooltipped: false, body_arguments: {}, **system_arguments)
       @align = fetch_or_fallback(ALIGN_OPTIONS, align, ALIGN_DEFAULT)

--- a/app/components/primer/image_crop.rb
+++ b/app/components/primer/image_crop.rb
@@ -6,7 +6,7 @@ module Primer
     # A loading indicator that is shown while the image is loading.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     renders_one :loading, lambda { |**system_arguments|
-      system_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+      system_arguments[:tag] = :div
       system_arguments[:"data-loading-slot"] = true
 
       Primer::BaseComponent.new(**system_arguments)

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -18,7 +18,7 @@ Use `AvatarStack` to stack multiple avatars together.
 | `tag` | `Symbol` | `:div` | One of `:div` and `:span`. |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. |
 | `tooltipped` | `Boolean` | `false` | Whether to add a tooltip to the stack or not. |
-| `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). |
+| `body_arguments` | `Hash` | `{}` | Parameters to add to the Body. If `tooltipped` is set, has the same arguments as [Tooltip](/components/tooltip). The default tag is `:div` but can be changed using `tag:` to one of `:div` and `:span`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -176,9 +176,9 @@ namespace :docs do
             "name" => tag.name,
             "type" => tag.types.join(", "),
             "default" => default_value,
-            "description" => view_context.render(inline: tag.text)
+            "description" => view_context.render(inline: tag.text.squish)
           }
-          
+
           f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default_value} | #{view_context.render(inline: tag.text.squish)} |")
         end
 

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -178,8 +178,8 @@ namespace :docs do
             "default" => default_value,
             "description" => view_context.render(inline: tag.text)
           }
-
-          f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default_value} | #{view_context.render(inline: tag.text)} |")
+          
+          f.puts("| `#{tag.name}` | `#{tag.types.join(', ')}` | #{default_value} | #{view_context.render(inline: tag.text.squish)} |")
         end
 
         component_args = {

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -200,9 +200,9 @@
   - name: body_arguments
     type: Hash
     default: "`{}`"
-    description: "Parameters to add to the Body. If `tooltipped` is set, has the same
-      arguments as [Tooltip](/components/tooltip).\nThe default tag is `:div` but
-      can be changed using `tag:` to \n one of `:div` and `:span`."
+    description: Parameters to add to the Body. If `tooltipped` is set, has the same
+      arguments as [Tooltip](/components/tooltip). The default tag is `:div` but can
+      be changed using `tag:` to one of `:div` and `:span`.
   - name: system_arguments
     type: Hash
     default: N/A

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -200,8 +200,9 @@
   - name: body_arguments
     type: Hash
     default: "`{}`"
-    description: Parameters to add to the Body. If `tooltipped` is set, has the same
-      arguments as [Tooltip](/components/tooltip).
+    description: "Parameters to add to the Body. If `tooltipped` is set, has the same
+      arguments as [Tooltip](/components/tooltip).\nThe default tag is `:div` but
+      can be changed using `tag:` to \n one of `:div` and `:span`."
   - name: system_arguments
     type: Hash
     default: N/A

--- a/test/components/avatar_stack_component_test.rb
+++ b/test/components/avatar_stack_component_test.rb
@@ -29,6 +29,15 @@ class PrimerAvatarStackComponentTest < Minitest::Test
     end
   end
 
+  def test_falls_back_when_body_tag_isnt_valid
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::AvatarStackComponent.new(body_arguments: { tag: :h1 })) do |c|
+        c.avatar(src: "Foo", alt: "Bar")
+      end
+      assert_selector("div.AvatarStack-body")
+    end
+  end
+
   def test_does_not_render_without_avatars
     render_inline(Primer::AvatarStackComponent.new)
 


### PR DESCRIPTION
**What**
This PR restricts the `AvatarStack` body slot to `:div` and `span`.
This PR also restricts the `ImageCrop` spinner tag to `:div`.

Both these were determined based on tag usage in dotcom.

**Notes**

Part of #491 

