### PR TITLE
Restrict `Details` and `UnderlineNav` tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Breaking changes
 
-* Restrict `Details` body slot tags to `:div`, `:ul`, `:details-dialog`, or `:details-menu`.
+* Restrict `Details` body slot tags and `UnderlineNav` body slot tags.
 
     *Kate Higa*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Breaking changes
 
+* Restrict `Details` body slot tags to `:div`, `:ul`, `:details-dialog`, or `:details-menu`.
+
+    *Kate Higa*
+
 * Move Primer::Classify from `app/lib/` to `lib/`. This requires an extra `require "primer/classify"` statement for anywhere Classify is needed.
 
     *Manuel Puyol, Jon Rohan*

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -5,6 +5,8 @@ module Primer
   class DetailsComponent < Primer::Component
     status :beta
 
+    BODY_TAG_DEFAULT = :div
+    BODY_TAG_OPTIONS = [:ul, :"details-menu", :"details-dialog", BODY_TAG_DEFAULT].freeze
     NO_OVERLAY = :none
     OVERLAY_MAPPINGS = {
       NO_OVERLAY => "",
@@ -28,8 +30,9 @@ module Primer
     # Use the Body slot as the main content to be shown when triggered by the Summary.
     #
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
-    renders_one :body, lambda { |**system_arguments|
-      system_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+    renders_one :body, lambda { |tag: BODY_TAG_DEFAULT, **system_arguments|
+      system_arguments[:tag] = fetch_or_fallback(BODY_TAG_OPTIONS, tag, BODY_TAG_DEFAULT)
+
       Primer::BaseComponent.new(**system_arguments)
     }
 

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -29,6 +29,7 @@ module Primer
 
     # Use the Body slot as the main content to be shown when triggered by the Summary.
     #
+    # @param tag [String] (Primer::DetailsComponent::BODY_TAG_DEFAULT) <%= one_of(Primer::DetailsComponent::BODY_TAG_OPTIONS) %>
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
     renders_one :body, lambda { |tag: BODY_TAG_DEFAULT, **system_arguments|
       system_arguments[:tag] = fetch_or_fallback(BODY_TAG_OPTIONS, tag, BODY_TAG_DEFAULT)

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -13,6 +13,9 @@ module Primer
     BODY_TAG_DEFAULT = :div
     BODY_TAG_OPTIONS = [BODY_TAG_DEFAULT, :ul].freeze
 
+    ACTIONS_TAG_DEFAULT = :div
+    ACTIONS_TAG_OPTIONS = [ACTIONS_TAG_DEFAULT, :span].freeze
+
     # Use the tabs to list navigation items. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
@@ -34,9 +37,10 @@ module Primer
 
     # Use actions for a call to action.
     #
+    # @param tag [String] (Primer::UnderlineNavComponent::ACTIONS_TAG_DEFAULT) <%= one_of(Primer::UnderlineNavComponent::ACTIONS_TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_one :actions, lambda { |**system_arguments|
-      system_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+    renders_one :actions, lambda { |tag: ACTIONS_TAG_DEFAULT, **system_arguments|
+      system_arguments[:tag] = fetch_or_fallback(ACTIONS_TAG_OPTIONS, tag, ACTIONS_TAG_DEFAULT)
       system_arguments[:classes] = class_names("UnderlineNav-actions", system_arguments[:classes])
 
       Primer::BaseComponent.new(**system_arguments)

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -36,6 +36,7 @@ Use the Body slot as the main content to be shown when triggered by the Summary.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `String` | `:div` | One of `:details-dialog`, `:details-menu`, `:div`, or `:ul`. |
 | `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
 
 ## Examples

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -44,6 +44,7 @@ Use actions for a call to action.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `String` | `:div` | One of `:div` and `:span`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Examples

--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -83,6 +83,18 @@ class PrimerDetailsComponentTest < Minitest::Test
     assert_selector(".btn")
   end
 
+  def test_falls_back_to_default_body_tag_when_invalid_body_tag_is_passed
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::DetailsComponent.new) do |component|
+        component.summary { "Summary" }
+        component.body(tag: :img) { "Body" }
+      end
+    end
+
+    assert_selector("div", text: "Body", visible: false)
+    refute_selector("img", text: "Body", visible: false)
+  end
+
   def test_passes_props_to_button
     render_inline(Primer::DetailsComponent.new) do |component|
       component.summary(variant: :small, scheme: :primary) do

--- a/test/components/underline_nav_component_test.rb
+++ b/test/components/underline_nav_component_test.rb
@@ -47,6 +47,25 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     refute_selector("a[role='tab']")
   end
 
+  def test_actions_tag_falls_back_to_default
+    without_fetch_or_fallback_raises do
+      render_inline(Primer::UnderlineNavComponent.new(label: "label")) do |component|
+        component.tab(selected: true, href: "#") do |t|
+          t.text { "Tab 1" }
+        end
+        component.tab(href: "#") do |t|
+          t.text { "Tab 2" }
+        end
+        component.actions(tag: :h2) do
+          "Actions content"
+        end
+      end
+    end
+
+    assert_selector("div.UnderlineNav-actions")
+    refute_selector("h2.UnderlineNav-actions")
+  end
+
   def test_align_falls_back_to_default
     without_fetch_or_fallback_raises do
       render_inline(Primer::UnderlineNavComponent.new(label: "label", align: :foo)) do |component|


### PR DESCRIPTION
**What**
This PR places tag restrictions on the body slot for `Details` as well as the actions slot for `UnderlineNav`. 
The restrictions were determined by examining current dotcom usecases and considering what seemed appropriate.

**Notes**
Part of #491 
