### PR TITLE
Restrict allowed tags for TabNav and Tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ### Breaking changes
 
+* Restrict `TabNav`and `Tab` tags.
+
+    *Kate Higa*
+
 * Restrict `AvatarStack` body slot tag and `ImageCrop` spinner tag.
 
     *Kate Higa*

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -96,7 +96,7 @@ module Primer
 
         @system_arguments = system_arguments
 
-        if with_panel
+        if with_panel || @system_arguments[:tag] == :button
           @system_arguments[:tag] = :button
           @system_arguments[:type] = :button
           @system_arguments[:role] = :tab

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -18,7 +18,7 @@ module Primer
       #
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :panel, lambda { |**system_arguments|
-        system_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+        system_arguments[:tag] = :div
         system_arguments[:role] ||= :tabpanel
         system_arguments[:hidden] = true unless @selected
 
@@ -97,11 +97,11 @@ module Primer
         @system_arguments = system_arguments
 
         if with_panel
-          @system_arguments[:tag] ||= :button # rubocop:disable Primer/NoTagMemoize
+          @system_arguments[:tag] = :button
           @system_arguments[:type] = :button
           @system_arguments[:role] = :tab
         else
-          @system_arguments[:tag] ||= :a # rubocop:disable Primer/NoTagMemoize
+          @system_arguments[:tag] = :a
         end
 
         @wrapper_arguments = wrapper_arguments

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -130,7 +130,7 @@ module Primer
       @body_arguments = body_arguments
       @wrapper_arguments = wrapper_arguments
 
-      @system_arguments[:tag] ||= :div # rubocop:disable Primer/NoTagMemoize
+      @system_arguments[:tag] = :div
       @system_arguments[:classes] = class_names(
         "tabnav",
         system_arguments[:classes]

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -10,7 +10,8 @@ module Primer
     DEFAULT_EXTRA_ALIGN = :left
     EXTRA_ALIGN_OPTIONS = [DEFAULT_EXTRA_ALIGN, :right].freeze
 
-    # Tabs to be rendered. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Tabs to be rendered.  Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
+    # this renders as an anchor tag for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -10,8 +10,8 @@ module Primer
     DEFAULT_EXTRA_ALIGN = :left
     EXTRA_ALIGN_OPTIONS = [DEFAULT_EXTRA_ALIGN, :right].freeze
 
-    # Tabs to be rendered.  Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
-    # this renders as an anchor tag for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
+    # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -120,7 +120,8 @@ module Primer
     #   <% end %>
     #
     # @param label [String] Used to set the `aria-label` on the top level `<nav>` element.
-    # @param with_panel [Boolean] Whether the TabNav should navigate through pages or panels.
+    # @param with_panel [Boolean] Whether the TabNav should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %>
+    #   is rendered along with JavaScript behavior. Additionally, the `tab` slot will render as a button as opposed to an anchor.
     # @param body_arguments [Hash] <%= link_to_system_arguments_docs %> for the body wrapper.
     # @param wrapper_arguments [Hash] <%= link_to_system_arguments_docs %> for the `TabContainer` wrapper. Only applies if `with_panel` is `true`.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -136,7 +136,7 @@ module Primer
     #   <% end %>
     #
     # @param label [String] The `aria-label` on top level `<nav>` element.
-    # @param with_panel [Boolean] Whether the `TabNav` should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %> is
+    # @param with_panel [Boolean] Whether the `UnderlineNav` should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %> is
     #   rendered along with JavaScript behavior.
     # @param align [Symbol] <%= one_of(Primer::UnderlineNavComponent::ALIGN_OPTIONS) %> - Defaults to <%= Primer::UnderlineNavComponent::ALIGN_DEFAULT %>
     # @param body_arguments [Hash] <%= link_to_system_arguments_docs %> for the body wrapper.

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -16,7 +16,8 @@ module Primer
     ACTIONS_TAG_DEFAULT = :div
     ACTIONS_TAG_OPTIONS = [ACTIONS_TAG_DEFAULT, :span].freeze
 
-    # Use the tabs to list navigation items. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Use the tabs to list navigation items. Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
+    # these are rendered as an anchor tag for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -16,8 +16,8 @@ module Primer
     ACTIONS_TAG_DEFAULT = :div
     ACTIONS_TAG_OPTIONS = [ACTIONS_TAG_DEFAULT, :span].freeze
 
-    # Use the tabs to list navigation items. Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
-    # these are rendered as an anchor tag for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Use the tabs to list navigation items. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
+    # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -136,7 +136,8 @@ module Primer
     #   <% end %>
     #
     # @param label [String] The `aria-label` on top level `<nav>` element.
-    # @param with_panel [Boolean] Whether the TabNav should navigate through pages or panels.
+    # @param with_panel [Boolean] Whether the `TabNav` should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %> is
+    #   rendered along with JavaScript behavior.
     # @param align [Symbol] <%= one_of(Primer::UnderlineNavComponent::ALIGN_OPTIONS) %> - Defaults to <%= Primer::UnderlineNavComponent::ALIGN_DEFAULT %>
     # @param body_arguments [Hash] <%= link_to_system_arguments_docs %> for the body wrapper.
     # @param wrapper_arguments [Hash] <%= link_to_system_arguments_docs %> for the `TabContainer` wrapper. Only applies if `with_panel` is `true`.

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -28,7 +28,8 @@ Use `TabNav` to style navigation with a tab-based selected state, typically used
 
 ### `Tabs`
 
-Tabs to be rendered. For more information, refer to [NavigationTab](/components/navigationtab).
+Tabs to be rendered.  Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
+this renders as an anchor tag for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -19,7 +19,7 @@ Use `TabNav` to style navigation with a tab-based selected state, typically used
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `label` | `String` | N/A | Used to set the `aria-label` on the top level `<nav>` element. |
-| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
+| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. Additionally, the `tab` slot will render as a button as opposed to an anchor. |
 | `body_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the body wrapper. |
 | `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
@@ -28,8 +28,8 @@ Use `TabNav` to style navigation with a tab-based selected state, typically used
 
 ### `Tabs`
 
-Tabs to be rendered.  Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
-this renders as an anchor tag for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
+Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
+an anchor tag is rendered for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -21,7 +21,7 @@ of the page.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `label` | `String` | N/A | The `aria-label` on top level `<nav>` element. |
-| `with_panel` | `Boolean` | `false` | Whether the `TabNav` should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. |
+| `with_panel` | `Boolean` | `false` | Whether the `UnderlineNav` should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. - Defaults to left |
 | `body_arguments` | `Hash` | `{ tag: BODY_TAG_DEFAULT }` | [System arguments](/system-arguments) for the body wrapper. |
 | `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -31,7 +31,8 @@ of the page.
 
 ### `Tabs`
 
-Use the tabs to list navigation items. For more information, refer to [NavigationTab](/components/navigationtab).
+Use the tabs to list navigation items. Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
+these are rendered as an anchor tag for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -21,7 +21,7 @@ of the page.
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `label` | `String` | N/A | The `aria-label` on top level `<nav>` element. |
-| `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. |
+| `with_panel` | `Boolean` | `false` | Whether the `TabNav` should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. - Defaults to left |
 | `body_arguments` | `Hash` | `{ tag: BODY_TAG_DEFAULT }` | [System arguments](/system-arguments) for the body wrapper. |
 | `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
@@ -31,8 +31,8 @@ of the page.
 
 ### `Tabs`
 
-Use the tabs to list navigation items. Set `with_panel` on the parent to render these as a button for panel navigation. Otherwise,
-these are rendered as an anchor tag for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
+Use the tabs to list navigation items. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
+an anchor tag is rendered for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -830,7 +830,10 @@
   - name: with_panel
     type: Boolean
     default: "`false`"
-    description: Whether the TabNav should navigate through pages or panels.
+    description: Whether the TabNav should navigate through pages or panels. When
+      true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript
+      behavior. Additionally, the `tab` slot will render as a button as opposed to
+      an anchor.
   - name: body_arguments
     type: Hash
     default: "`{}`"
@@ -948,7 +951,9 @@
   - name: with_panel
     type: Boolean
     default: "`false`"
-    description: Whether the TabNav should navigate through pages or panels.
+    description: Whether the `TabNav` should navigate through pages or panels. When
+      true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript
+      behavior.
   - name: align
     type: Symbol
     default: "`:left`"

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -951,8 +951,8 @@
   - name: with_panel
     type: Boolean
     default: "`false`"
-    description: Whether the `TabNav` should navigate through pages or panels. When
-      true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript
+    description: Whether the `UnderlineNav` should navigate through pages or panels.
+      When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript
       behavior.
   - name: align
     type: Symbol


### PR DESCRIPTION
**What**
This PR removes the flexible tag syntax for `TabNav` and `Tab` and updates documentation to be more descriptive with what is expected by setting `with_panel`. 

**Notes**
I found the API for these components quite complex. It's hard to know what gets rendered, what each of the parts are, and what API attributes cause what change.

From what I understand, `TabNav` and `UnderlineNav` are both dependent on `Navigation::Tab`. If `with_panel` is set on these components, `Navigation::Tab` will be rendered as a button and may also render a panel. Also, if `with_panel` is set, `Primer::TabContainer` is rendered as the wrapper and this comes with associated javascript behavior that allow panel navigation. However, by default, `Navigation::Tab` simply renders as an anchor. For now, I'm updating the documentation to be more descriptive but I think we should explore if it's possible to simplify the API. 
  
Part of #491 