### PR TITLE
Update linter autocorrection to use `""` instead of `true` for boolean attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
     *Kate Higa*
 
+* Update linter autocorrection to use `""` instead of `true` for boolean attributes.
+
+    *Manuel Puyol*
+
 ## 0.0.45
 
 ### Updates

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -33,7 +33,7 @@ module ERBLint
             raise ConversionError, "Cannot convert attribute \"#{attr_name}\" because its value contains an erb block" if attribute.value_node&.children&.any? { |n| n.try(:type) == :erb }
 
             # if attribute has no value_node, it means it is a boolean attribute.
-            { "\"#{attr_name}\"" => attribute.value_node ? attribute.value.to_json : true }
+            { "\"#{attr_name}\"" => attribute.value_node ? attribute.value.to_json : "" }
           else
             raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
           end

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -32,8 +32,7 @@ module ERBLint
           elsif attr_name.start_with?(*STRING_PARAMETERS)
             raise ConversionError, "Cannot convert attribute \"#{attr_name}\" because its value contains an erb block" if attribute.value_node&.children&.any? { |n| n.try(:type) == :erb }
 
-            # if attribute has no value_node, it means it is a boolean attribute.
-            { "\"#{attr_name}\"" => attribute.value_node ? attribute.value.to_json : "" }
+            { "\"#{attr_name}\"" => attribute.value.to_json }
           else
             raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
           end

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -17,7 +17,7 @@ class ArgumentMappersButtonTest < LinterTestCase
     assert_equal({
                    '"aria-label"' => '"label"',
                    '"aria-disabled"' => '"true"',
-                   '"aria-boolean"' => true
+                   '"aria-boolean"' => '""'
                  }, args)
   end
 
@@ -27,7 +27,7 @@ class ArgumentMappersButtonTest < LinterTestCase
 
     assert_equal({
                    '"data-action"' => '"click"',
-                   '"data-pjax"' => true
+                   '"data-pjax"' => '""'
                  }, args)
   end
 
@@ -168,7 +168,7 @@ class ArgumentMappersButtonTest < LinterTestCase
                    :block => true,
                    :group_item => true,
                    '"aria-label"' => '"some label"',
-                   '"data-pjax"' => true,
+                   '"data-pjax"' => '""',
                    '"data-click"' => '"click"',
                    :test_selector => '"some_selector"',
                    :disabled => true,

--- a/test/linters/argument_mappers/system_arguments_test.rb
+++ b/test/linters/argument_mappers/system_arguments_test.rb
@@ -10,7 +10,7 @@ class ArgumentMappersSystemArgumentsTest < LinterTestCase
     assert_equal({ '"aria-label"' => '"label"' }, args)
 
     args = ERBLint::Linters::ArgumentMappers::SystemArguments.new(tags.first.attributes["aria-boolean"]).to_args
-    assert_equal({ '"aria-boolean"' => true }, args)
+    assert_equal({ '"aria-boolean"' => "" }, args)
   end
 
   def test_returns_data_arguments_as_string_symbols
@@ -20,7 +20,7 @@ class ArgumentMappersSystemArgumentsTest < LinterTestCase
     assert_equal({ '"data-action"' => '"click"' }, args)
 
     args = ERBLint::Linters::ArgumentMappers::SystemArguments.new(tags.first.attributes["data-pjax"]).to_args
-    assert_equal({ '"data-pjax"' => true }, args)
+    assert_equal({ '"data-pjax"' => "" }, args)
   end
 
   def test_raises_if_cannot_map_attribute

--- a/test/linters/argument_mappers/system_arguments_test.rb
+++ b/test/linters/argument_mappers/system_arguments_test.rb
@@ -10,7 +10,7 @@ class ArgumentMappersSystemArgumentsTest < LinterTestCase
     assert_equal({ '"aria-label"' => '"label"' }, args)
 
     args = ERBLint::Linters::ArgumentMappers::SystemArguments.new(tags.first.attributes["aria-boolean"]).to_args
-    assert_equal({ '"aria-boolean"' => "" }, args)
+    assert_equal({ '"aria-boolean"' => '""' }, args)
   end
 
   def test_returns_data_arguments_as_string_symbols
@@ -20,7 +20,7 @@ class ArgumentMappersSystemArgumentsTest < LinterTestCase
     assert_equal({ '"data-action"' => '"click"' }, args)
 
     args = ERBLint::Linters::ArgumentMappers::SystemArguments.new(tags.first.attributes["data-pjax"]).to_args
-    assert_equal({ '"data-pjax"' => "" }, args)
+    assert_equal({ '"data-pjax"' => '""' }, args)
   end
 
   def test_raises_if_cannot_map_attribute


### PR DESCRIPTION
While we don't fix https://github.com/primer/view_components/issues/654 it is better for the autocorrection to not use invalid values