### PR TITLE
Set the name attribute on `input` to the same value as id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Updates
 
+* Default to matching `name` and `id` of `input`.
+
+    *Kate Higa*
+
 * Restrict usage of padding system arguments on BorderBox, recommending use of `padding` density instead.
 
     *Joel Hawksley*

--- a/app/components/primer/auto_complete.rb
+++ b/app/components/primer/auto_complete.rb
@@ -34,7 +34,8 @@ module Primer
         system_arguments[:aria]&.delete(:label)
       end
 
-      Input.new(id: @input_id, **system_arguments)
+      name = system_arguments[:name] || @input_id
+      Input.new(id: @input_id, name: name, **system_arguments)
     }
 
     # Optional icon to be rendered before the input. Has the same arguments as <%= link_to_component(Primer::OcticonComponent) %>.

--- a/docs/content/components/autocomplete.md
+++ b/docs/content/components/autocomplete.md
@@ -69,7 +69,7 @@ Customizable results list.
 
 ### Default
 
-<Example src="<label for='fruits-input-1' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-1' data-view-component='true' class='position-relative'>  <input id='fruits-input-1' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-1' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<label for='fruits-input-1' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-1' data-view-component='true' class='position-relative'>  <input id='fruits-input-1' name='fruits-input-1' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-1' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-1", list_id: "fruits-popup-1", position: :relative)) do |c| %>
@@ -80,7 +80,7 @@ Customizable results list.
 
 ### With `aria-label`
 
-<Example src="<auto-complete src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-2' aria-label='Fruits' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-2' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<auto-complete src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-2' name='fruits-input-2' aria-label='Fruits' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-2' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", input_id: "fruits-input-2", list_id: "fruits-popup-2", position: :relative)) do |c| %>
@@ -90,7 +90,7 @@ Customizable results list.
 
 ### With `aria-labelledby`
 
-<Example src="<h2 id='search-1' data-view-component='true'>Search</h2><auto-complete src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-3' aria-labelledby='search-1' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-2' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<h2 id='search-1' data-view-component='true'>Search</h2><auto-complete src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-3' name='fruits-input-3' aria-labelledby='search-1' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-2' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::HeadingComponent.new(tag: :h2, id: "search-1")) { "Search" } %>
@@ -101,7 +101,7 @@ Customizable results list.
 
 ### With custom classes for the results
 
-<Example src="<label for='fruits-input-4' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-3' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-3' data-view-component='true' class='autocomplete-results custom-class'>    <li role='option' data-autocomplete-value='apple' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Apple</li>    <li role='option' data-autocomplete-value='orange' data-view-component='true' class='autocomplete-item'>      Orange</li></ul></auto-complete>" />
+<Example src="<label for='fruits-input-4' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-3' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' name='fruits-input-4' type='text' data-view-component='true' class='form-control'></input>    <ul id='fruits-popup-3' data-view-component='true' class='autocomplete-results custom-class'>    <li role='option' data-autocomplete-value='apple' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Apple</li>    <li role='option' data-autocomplete-value='orange' data-view-component='true' class='autocomplete-item'>      Orange</li></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-4", list_id: "fruits-popup-3", position: :relative)) do |c| %>
@@ -120,7 +120,7 @@ Customizable results list.
 
 ### With Icon
 
-<Example src="<label for='fruits-input-4' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-4' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' type='text' data-view-component='true' class='form-control'></input>  <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-search'>    <path fill-rule='evenodd' d='M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z'></path></svg>  <ul id='fruits-popup-4' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<label for='fruits-input-4' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-4' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' name='fruits-input-4' type='text' data-view-component='true' class='form-control'></input>  <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-search'>    <path fill-rule='evenodd' d='M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z'></path></svg>  <ul id='fruits-popup-4' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::AutoComplete.new(src: "/auto_complete", list_id: "fruits-popup-4", input_id: "fruits-input-4", position: :relative)) do |c| %>

--- a/test/components/auto_complete_test.rb
+++ b/test/components/auto_complete_test.rb
@@ -26,6 +26,24 @@ class PrimerAutoCompleteTest < Minitest::Test
     end
   end
 
+  def test_forwards_input_id_on_parent_to_input_slot_id
+    render_inline Primer::AutoComplete.new(src: "/url", input_id: "test-input", list_id: "my-list-id") do |component|
+      component.label(classes: "") { "Fruits" }
+      component.input(name: "something")
+    end
+
+    assert_selector("input[id=\"test-input\"]")
+  end
+
+  def test_forwards_input_id_on_parent_to_input_slot_id_and_name
+    render_inline Primer::AutoComplete.new(src: "/url", input_id: "test-input", list_id: "my-list-id") do |component|
+      component.label(classes: "") { "Fruits" }
+      component.input(classes: "")
+    end
+
+    assert_selector("input[id=\"test-input\"][name=\"test-input\"]")
+  end
+
   def test_applies_parent_aria_label_on_relevant_child_slots
     render_inline Primer::AutoComplete.new(src: "/url", input_id: "test-input", list_id: "my-list-id", "aria-label": "Fruits") do |component|
       component.input(name: "input")


### PR DESCRIPTION
**What**
This defaults the name attribute of the input field on `Autocomplete` to `input_id` if not already set. 

**Why**
This mimics what Rails form helpers such as `text_field_tag` do.

[Slack conversation](https://github.slack.com/archives/CGJTTJ738/p1624473386368900)



