### PR TITLE
Run docs-build on pull_request event rather than on push

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,10 +1,6 @@
 name: Docs Build
 
-on:
-  push:
-    branches-ignore:
-      - main
-
+on: [pull_request]
 
 jobs:
   build-docs:


### PR DESCRIPTION
In https://github.com/primer/view_components/pull/652 the "Docs Build" action is not reporting back to GitHub. Me and @Artemisia-Absinthium are theorizing that it is due to her having fork of the repo and some permissions are getting crossed causing the build to not be reported.

You'll note that other actions are reporting fine though and when viewing the other actions and the "Docs Build" one, the only notible difference seems to be the event that each action is triggered by. The "Docs Build" action is triggered by the `pull_request` event while the others are triggered by `push`.

This change makes the "Docs Build" action run on the `pull_request` event rather than the `push` event to match the other CI actions. We are hoping this will resolve the build issue in https://github.com/primer/view_components/pull/652.