### PR TITLE
Always generate navigation links within list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Breaking changes
 
+* Always generate `TabNav` and `UnderlineNav` as a list and deprecate `list:` from `Navigation::Tab`.
+
+    *Kate Higa*
+
 * Restrict tag for `Popover` to `:div` and `Popover` heading slot to headings.
 
     *Kate Higa*

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -71,11 +71,6 @@ module Primer
       #     <% c.counter(count: 10) %>
       #   <% end %>
       #
-      # @example Inside a list
-      #   <%= render(Primer::Navigation::TabComponent.new(list: true)) do |c| %>
-      #     <% c.text { "Tab" } %>
-      #   <% end %>
-      #
       # @example With custom HTML
       #   <%= render(Primer::Navigation::TabComponent.new) do %>
       #     <div>
@@ -83,30 +78,30 @@ module Primer
       #     </div>
       #   <% end %>
       #
-      # @param list [Boolean] Whether the Tab is an item in a `<ul>` list.
       # @param selected [Boolean] Whether the Tab is selected or not.
       # @param with_panel [Boolean] Whether the Tab has an associated panel.
       # @param icon_classes [Boolean] Classes that must always be applied to icons.
-      # @param wrapper_arguments [Hash] <%= link_to_system_arguments_docs %> to be used in the `<li>` wrapper when the tab is an item in a list.
+      # @param wrapper_arguments [Hash] <%= link_to_system_arguments_docs %> to be used in the `<li>` wrapper.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(list: false, selected: false, with_panel: false, icon_classes: "", wrapper_arguments: {}, **system_arguments)
+      def initialize(selected: false, with_panel: false, icon_classes: "", wrapper_arguments: {}, **system_arguments)
         @selected = selected
         @icon_classes = icon_classes
-        @list = list
 
         @system_arguments = system_arguments
+        @wrapper_arguments = wrapper_arguments
 
         if with_panel || @system_arguments[:tag] == :button
           @system_arguments[:tag] = :button
           @system_arguments[:type] = :button
           @system_arguments[:role] = :tab
+          # https://www.w3.org/TR/wai-aria-practices/#presentation_role
+          @wrapper_arguments[:role] = :presentation
         else
           @system_arguments[:tag] = :a
         end
 
-        @wrapper_arguments = wrapper_arguments
         @wrapper_arguments[:tag] = :li
-        @wrapper_arguments[:display] ||= :flex
+        @wrapper_arguments[:display] ||= :inline_flex
 
         return unless @selected
 
@@ -119,11 +114,6 @@ module Primer
       end
 
       def wrapper
-        unless @list
-          yield
-          return # returning `yield` caused a double render
-        end
-
         render(Primer::BaseComponent.new(**@wrapper_arguments)) do
           yield
         end

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use `TabNav` to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
+  # Use `TabNav` to style navigation with a tab-based selected state. There are two main ways this component can be rendered:
+  #
+  # - With tabs that hold links for page navigation. This is the default.
+  # - With tabs that hold buttons and a configurable panel for panel navigation. This is configured with `with_panel` and has associated JavaScript behavior.
   class TabNavComponent < Primer::Component
     include Primer::TabbedComponentHelper
 
@@ -10,8 +13,8 @@ module Primer
     DEFAULT_EXTRA_ALIGN = :left
     EXTRA_ALIGN_OPTIONS = [DEFAULT_EXTRA_ALIGN, :right].freeze
 
-    # Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
-    # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Use the tabs to list navigation items. By default, an anchor tag is rendered for page navigation. When `with_panel` is set on the parent, this renders as a button
+    # with a configurable panel slot. See the example below or refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -44,23 +47,6 @@ module Primer
     #     <% c.tab(href: "#") { "Tab 3" } %>
     #   <% end %>
     #
-    # @example With icons and counters
-    #   <%= render(Primer::TabNavComponent.new(label: "With icons and counters")) do |component| %>
-    #     <% component.tab(href: "#", selected: true) do |t| %>
-    #       <% t.icon(icon: :star) %>
-    #       <% t.text { "Item 1" } %>
-    #     <% end %>
-    #     <% component.tab(href: "#") do |t| %>
-    #       <% t.icon(icon: :star) %>
-    #       <% t.text { "Item 2" } %>
-    #       <% t.counter(count: 10) %>
-    #     <% end %>
-    #     <% component.tab(href: "#") do |t| %>
-    #       <% t.text { "Item 3" } %>
-    #       <% t.counter(count: 10) %>
-    #     <% end %>
-    #   <% end %>
-    #
     # @example With panels
     #   <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
     #     <% c.tab(selected: true) do |t| %>
@@ -80,6 +66,23 @@ module Primer
     #       <% t.panel do %>
     #         Panel 3
     #       <% end %>
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example With icons and counters
+    #   <%= render(Primer::TabNavComponent.new(label: "With icons and counters")) do |component| %>
+    #     <% component.tab(href: "#", selected: true) do |t| %>
+    #       <% t.icon(icon: :star) %>
+    #       <% t.text { "Item 1" } %>
+    #     <% end %>
+    #     <% component.tab(href: "#") do |t| %>
+    #       <% t.icon(icon: :star) %>
+    #       <% t.text { "Item 2" } %>
+    #       <% t.counter(count: 10) %>
+    #     <% end %>
+    #     <% component.tab(href: "#") do |t| %>
+    #       <% t.text { "Item 3" } %>
+    #       <% t.counter(count: 10) %>
     #     <% end %>
     #   <% end %>
     #
@@ -119,7 +122,7 @@ module Primer
     #     <% c.tab(href: "#") { "Tab 3" } %>
     #   <% end %>
     #
-    # @param label [String] Used to set the `aria-label` on the top level `<nav>` element.
+    # @param label [String] Used to set the `aria-label` on the top level element.
     # @param with_panel [Boolean] Whether the TabNav should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %>
     #   is rendered along with JavaScript behavior. Additionally, the `tab` slot will render as a button as opposed to an anchor.
     # @param body_arguments [Hash] <%= link_to_system_arguments_docs %> for the body wrapper.
@@ -132,19 +135,23 @@ module Primer
       @body_arguments = body_arguments
       @wrapper_arguments = wrapper_arguments
 
-      @system_arguments[:tag] = :div
+      @system_arguments[:tag] = navigation_tag(with_panel)
       @system_arguments[:classes] = class_names(
         "tabnav",
         system_arguments[:classes]
       )
 
-      @body_arguments[:tag] = navigation_tag(with_panel)
-      @body_arguments[:"aria-label"] = label
-      @body_arguments[:role] = :tablist if @with_panel
+      @body_arguments[:tag] = :ul
       @body_arguments[:classes] = class_names(
         "tabnav-tabs",
         body_arguments[:classes]
       )
+      if @with_panel
+        @body_arguments[:role] = :tablist
+        @body_arguments[:"aria-label"] = label
+      else
+        @system_arguments[:"aria-label"] = label
+      end
     end
   end
 end

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 module Primer
-  # Use `UnderlineNav` to style navigation with a minimal
-  # underlined selected state, typically used for navigation placed at the top
-  # of the page.
+  # Use `UnderlineNav` to style navigation with a minimal underlined selected state. There are two main ways this component can be rendered:
+  #
+  # - With tabs that hold links for page navigation. This is the default.
+  # - With tabs that hold buttons and a configurable panel for panel navigation. This is configured with `with_panel` and has associated JavaScript behavior.
   class UnderlineNavComponent < Primer::Component
     include Primer::TabbedComponentHelper
 
@@ -16,8 +17,8 @@ module Primer
     ACTIONS_TAG_DEFAULT = :div
     ACTIONS_TAG_OPTIONS = [ACTIONS_TAG_DEFAULT, :span].freeze
 
-    # Use the tabs to list navigation items. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
-    # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
+    # Use the tabs to list navigation items. By default, an anchor tag is rendered for page navigation. When `with_panel` is set on the parent, this renders as a button
+    # with a configurable panel slot. See the example below or refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -28,7 +29,6 @@ module Primer
       )
 
       Primer::Navigation::TabComponent.new(
-        list: list?,
         selected: selected,
         with_panel: @with_panel,
         icon_classes: "UnderlineNav-octicon",
@@ -51,6 +51,25 @@ module Primer
     #   <%= render(Primer::UnderlineNavComponent.new(label: "Default")) do |component| %>
     #     <% component.tab(href: "#", selected: true) { "Item 1" } %>
     #     <% component.tab(href: "#") { "Item 2" } %>
+    #     <% component.actions do %>
+    #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example With panels
+    #   <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
+    #     <% component.tab(selected: true) do |t| %>
+    #       <% t.text { "Item 1" } %>
+    #       <% t.panel do %>
+    #         Panel 1
+    #       <% end %>
+    #     <% end %>
+    #     <% component.tab do |t| %>
+    #       <% t.text { "Item 2" } %>
+    #       <% t.panel do %>
+    #         Panel 2
+    #       <% end %>
+    #     <% end %>
     #     <% component.actions do %>
     #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
     #     <% end %>
@@ -89,40 +108,8 @@ module Primer
     #     <% end %>
     #   <% end %>
     #
-    # @example As a list
-    #   <%= render(Primer::UnderlineNavComponent.new(label: "As a list", body_arguments: { tag: :ul })) do |component| %>
-    #     <% component.tab(href: "#", selected: true) do |t| %>
-    #       <% t.text { "Item 1" } %>
-    #     <% end %>
-    #     <% component.tab(href: "#") do |t| %>
-    #       <% t.text { "Item 2" } %>
-    #     <% end %>
-    #     <% component.actions do %>
-    #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
-    #     <% end %>
-    #   <% end %>
-    #
-    # @example With panels
-    #   <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-    #     <% component.tab(selected: true) do |t| %>
-    #       <% t.text { "Item 1" } %>
-    #       <% t.panel do %>
-    #         Panel 1
-    #       <% end %>
-    #     <% end %>
-    #     <% component.tab do |t| %>
-    #       <% t.text { "Item 2" } %>
-    #       <% t.panel do %>
-    #         Panel 2
-    #       <% end %>
-    #     <% end %>
-    #     <% component.actions do %>
-    #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
-    #     <% end %>
-    #   <% end %>
-    #
     # @example Customizing the body
-    #   <%= render(Primer::UnderlineNavComponent.new(label: "Default", body_arguments: { tag: :ul, classes: "custom-class", border: true, border_color: :info })) do |c| %>
+    #   <%= render(Primer::UnderlineNavComponent.new(label: "Default", body_arguments: { classes: "custom-class", border: true, border_color: :info })) do |c| %>
     #     <% c.tab(selected: true, href: "#") { "Tab 1" }%>
     #     <% c.tab(href: "#") { "Tab 2" } %>
     #     <% c.tab(href: "#") { "Tab 3" } %>
@@ -135,7 +122,7 @@ module Primer
     #     <% c.tab(href: "#") { "Tab 3" } %>
     #   <% end %>
     #
-    # @param label [String] The `aria-label` on top level `<nav>` element.
+    # @param label [String] Used to set the `aria-label` on top level element.
     # @param with_panel [Boolean] Whether the `UnderlineNav` should navigate through pages or panels. When true, <%= link_to_component(Primer::TabContainerComponent) %> is
     #   rendered along with JavaScript behavior.
     # @param align [Symbol] <%= one_of(Primer::UnderlineNavComponent::ALIGN_OPTIONS) %> - Defaults to <%= Primer::UnderlineNavComponent::ALIGN_DEFAULT %>
@@ -156,13 +143,11 @@ module Primer
       )
 
       @body_arguments = body_arguments
-      @body_tag = fetch_or_fallback(BODY_TAG_OPTIONS, body_arguments[:tag]&.to_sym, BODY_TAG_DEFAULT)
-
-      @body_arguments[:tag] = @body_tag
+      @body_arguments[:tag] = :ul
       @body_arguments[:classes] = class_names(
         "UnderlineNav-body",
         @body_arguments[:classes],
-        "list-style-none" => list?
+        "list-style-none"
       )
 
       if with_panel
@@ -174,10 +159,6 @@ module Primer
     end
 
     private
-
-    def list?
-      @body_tag == :ul
-    end
 
     def body
       Primer::BaseComponent.new(**@body_arguments)

--- a/docs/content/components/navigationtab.md
+++ b/docs/content/components/navigationtab.md
@@ -21,11 +21,10 @@ and `Primer::UnderlineNavComponent` and should not be used by itself.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `list` | `Boolean` | `false` | Whether the Tab is an item in a `<ul>` list. |
 | `selected` | `Boolean` | `false` | Whether the Tab is selected or not. |
 | `with_panel` | `Boolean` | `false` | Whether the Tab has an associated panel. |
 | `icon_classes` | `Boolean` | `""` | Classes that must always be applied to icons. |
-| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) to be used in the `<li>` wrapper when the tab is an item in a list. |
+| `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) to be used in the `<li>` wrapper. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots
@@ -69,7 +68,7 @@ Counter to be rendered in the Tab right.
 
 ### Default
 
-<Example src="  <a aria-current='page' data-view-component='true'>          <span data-view-component='true'>Selected</span>    </a>  <a data-view-component='true'>          <span data-view-component='true'>Not selected</span>    </a>" />
+<Example src="<li data-view-component='true' class='d-inline-flex'>  <a aria-current='page' data-view-component='true'>          <span data-view-component='true'>Selected</span>    </a></li><li data-view-component='true' class='d-inline-flex'>  <a data-view-component='true'>          <span data-view-component='true'>Not selected</span>    </a></li>" />
 
 ```erb
 <%= render(Primer::Navigation::TabComponent.new(selected: true)) do |c| %>
@@ -82,7 +81,7 @@ Counter to be rendered in the Tab right.
 
 ### With icons and counters
 
-<Example src="  <a data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Tab</span>    </a>  <a data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Tab</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a>  <a data-view-component='true'>          <span data-view-component='true'>Tab</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a>" />
+<Example src="<li data-view-component='true' class='d-inline-flex'>  <a data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Tab</span>    </a></li><li data-view-component='true' class='d-inline-flex'>  <a data-view-component='true'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Tab</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li><li data-view-component='true' class='d-inline-flex'>  <a data-view-component='true'>          <span data-view-component='true'>Tab</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li>" />
 
 ```erb
 <%= render(Primer::Navigation::TabComponent.new) do |c| %>
@@ -97,22 +96,12 @@ Counter to be rendered in the Tab right.
 <%= render(Primer::Navigation::TabComponent.new) do |c| %>
   <% c.text { "Tab" } %>
   <% c.counter(count: 10) %>
-<% end %>
-```
-
-### Inside a list
-
-<Example src="<li data-view-component='true' class='d-flex'>  <a data-view-component='true'>          <span data-view-component='true'>Tab</span>    </a></li>" />
-
-```erb
-<%= render(Primer::Navigation::TabComponent.new(list: true)) do |c| %>
-  <% c.text { "Tab" } %>
 <% end %>
 ```
 
 ### With custom HTML
 
-<Example src="  <a data-view-component='true'>            <div>    This is my <strong>custom HTML</strong>  </div>    </a>" />
+<Example src="<li data-view-component='true' class='d-inline-flex'>  <a data-view-component='true'>            <div>    This is my <strong>custom HTML</strong>  </div>    </a></li>" />
 
 ```erb
 <%= render(Primer::Navigation::TabComponent.new) do %>

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -12,13 +12,16 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use `TabNav` to style navigation with a tab-based selected state, typically used for navigation placed at the top of the page.
+Use `TabNav` to style navigation with a tab-based selected state. There are two main ways this component can be rendered:
+
+- With tabs that hold links for page navigation. This is the default.
+- With tabs that hold buttons and a configurable panel for panel navigation. This is configured with `with_panel` and has associated JavaScript behavior.
 
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `label` | `String` | N/A | Used to set the `aria-label` on the top level `<nav>` element. |
+| `label` | `String` | N/A | Used to set the `aria-label` on the top level element. |
 | `with_panel` | `Boolean` | `false` | Whether the TabNav should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. Additionally, the `tab` slot will render as a button as opposed to an anchor. |
 | `body_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the body wrapper. |
 | `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) for the `TabContainer` wrapper. Only applies if `with_panel` is `true`. |
@@ -28,8 +31,8 @@ Use `TabNav` to style navigation with a tab-based selected state, typically used
 
 ### `Tabs`
 
-Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
-an anchor tag is rendered for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
+Use the tabs to list navigation items. By default, an anchor tag is rendered for page navigation. When `with_panel` is set on the parent, this renders as a button
+with a configurable panel slot. See the example below or refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
@@ -48,7 +51,7 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### Default
 
-<Example src="  <div data-view-component='true' class='tabnav'>        <nav aria-label='Default' data-view-component='true' class='tabnav-tabs'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></nav>    </div>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='tabnav'>        <ul data-view-component='true' class='tabnav-tabs'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></li></ul>    </nav>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "Default")) do |c| %>
@@ -58,31 +61,9 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 <% end %>
 ```
 
-### With icons and counters
-
-<Example src="  <div data-view-component='true' class='tabnav'>        <nav aria-label='With icons and counters' data-view-component='true' class='tabnav-tabs'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 1</span>    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 2</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a>          <a href='#' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Item 3</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></nav>    </div>" />
-
-```erb
-<%= render(Primer::TabNavComponent.new(label: "With icons and counters")) do |component| %>
-  <% component.tab(href: "#", selected: true) do |t| %>
-    <% t.icon(icon: :star) %>
-    <% t.text { "Item 1" } %>
-  <% end %>
-  <% component.tab(href: "#") do |t| %>
-    <% t.icon(icon: :star) %>
-    <% t.text { "Item 2" } %>
-    <% t.counter(count: 10) %>
-  <% end %>
-  <% component.tab(href: "#") do |t| %>
-    <% t.text { "Item 3" } %>
-    <% t.counter(count: 10) %>
-  <% end %>
-<% end %>
-```
-
 ### With panels
 
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <div aria-label='With panels' role='tablist' data-view-component='true' class='tabnav-tabs'>          <button type='button' role='tab' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button>          <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button>          <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></div>    </div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 3</div></tab-container>" />
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <ul role='tablist' aria-label='With panels' data-view-component='true' class='tabnav-tabs'>        <li role='presentation' data-view-component='true' class='d-inline-flex'>  <button type='button' role='tab' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button></li>        <li role='presentation' data-view-component='true' class='d-inline-flex'>  <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button></li>        <li role='presentation' data-view-component='true' class='d-inline-flex'>  <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></li></ul>    </div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 3</div></tab-container>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
@@ -107,9 +88,31 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 <% end %>
 ```
 
+### With icons and counters
+
+<Example src="  <nav aria-label='With icons and counters' data-view-component='true' class='tabnav'>        <ul data-view-component='true' class='tabnav-tabs'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 1</span>    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 2</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Item 3</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li></ul>    </nav>" />
+
+```erb
+<%= render(Primer::TabNavComponent.new(label: "With icons and counters")) do |component| %>
+  <% component.tab(href: "#", selected: true) do |t| %>
+    <% t.icon(icon: :star) %>
+    <% t.text { "Item 1" } %>
+  <% end %>
+  <% component.tab(href: "#") do |t| %>
+    <% t.icon(icon: :star) %>
+    <% t.text { "Item 2" } %>
+    <% t.counter(count: 10) %>
+  <% end %>
+  <% component.tab(href: "#") do |t| %>
+    <% t.text { "Item 3" } %>
+    <% t.counter(count: 10) %>
+  <% end %>
+<% end %>
+```
+
 ### With extra content
 
-<Example src="  <div data-view-component='true' class='tabnav'>        <button type='button' data-view-component='true' class='btn float-right'>    Button  </button>    <nav aria-label='With extra content' data-view-component='true' class='tabnav-tabs'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></nav>    </div>" />
+<Example src="  <nav aria-label='With extra content' data-view-component='true' class='tabnav'>        <button type='button' data-view-component='true' class='btn float-right'>    Button  </button>    <ul data-view-component='true' class='tabnav-tabs'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></li></ul>    </nav>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "With extra content")) do |c| %>
@@ -124,7 +127,7 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### Adding extra content after the tabs
 
-<Example src="  <div data-view-component='true' class='tabnav d-flex'>        <nav aria-label='Adding extra content after the tabs' data-view-component='true' class='tabnav-tabs flex-1'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></nav>        <div>      <button type='button' data-view-component='true' class='btn'>    Button  </button>    </div></div>" />
+<Example src="  <nav aria-label='Adding extra content after the tabs' data-view-component='true' class='tabnav d-flex'>        <ul data-view-component='true' class='tabnav-tabs flex-1'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></li></ul>        <div>      <button type='button' data-view-component='true' class='btn'>    Button  </button>    </div></nav>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "Adding extra content after the tabs", display: :flex, body_arguments: { flex: 1 })) do |c| %>
@@ -141,7 +144,7 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### Customizing the body
 
-<Example src="  <div data-view-component='true' class='tabnav'>        <nav aria-label='Default' data-view-component='true' class='tabnav-tabs custom-class border color-border-info'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></nav>    </div>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='tabnav'>        <ul data-view-component='true' class='tabnav-tabs custom-class border color-border-info'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></li></ul>    </nav>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "Default", body_arguments: { classes: "custom-class", border: true, border_color: :info })) do |c| %>
@@ -153,7 +156,7 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### Customizing the wrapper
 
-<Example src="  <div data-view-component='true' class='tabnav'>        <nav aria-label='Default' data-view-component='true' class='tabnav-tabs'>          <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a>          <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></nav>    </div>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='tabnav'>        <ul data-view-component='true' class='tabnav-tabs'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='tabnav-tab'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='tabnav-tab'>          Tab 3    </a></li></ul>    </nav>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "Default", wrapper_arguments: { classes: "custom-class", border: true, border_color: :info })) do |c| %>

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -12,15 +12,16 @@ import RequiresJSFlash from '../../src/@primer/gatsby-theme-doctocat/components/
 
 <!-- Warning: AUTO-GENERATED file, do not edit. Add code comments to your Ruby instead <3 -->
 
-Use `UnderlineNav` to style navigation with a minimal
-underlined selected state, typically used for navigation placed at the top
-of the page.
+Use `UnderlineNav` to style navigation with a minimal underlined selected state. There are two main ways this component can be rendered:
+
+- With tabs that hold links for page navigation. This is the default.
+- With tabs that hold buttons and a configurable panel for panel navigation. This is configured with `with_panel` and has associated JavaScript behavior.
 
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `label` | `String` | N/A | The `aria-label` on top level `<nav>` element. |
+| `label` | `String` | N/A | Used to set the `aria-label` on top level element. |
 | `with_panel` | `Boolean` | `false` | Whether the `UnderlineNav` should navigate through pages or panels. When true, [TabContainer](/components/tabcontainer) is rendered along with JavaScript behavior. |
 | `align` | `Symbol` | `:left` | One of `:left` and `:right`. - Defaults to left |
 | `body_arguments` | `Hash` | `{ tag: BODY_TAG_DEFAULT }` | [System arguments](/system-arguments) for the body wrapper. |
@@ -31,8 +32,8 @@ of the page.
 
 ### `Tabs`
 
-Use the tabs to list navigation items. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
-an anchor tag is rendered for page navigation. For more information, refer to [NavigationTab](/components/navigationtab).
+Use the tabs to list navigation items. By default, an anchor tag is rendered for page navigation. When `with_panel` is set on the parent, this renders as a button
+with a configurable panel slot. See the example below or refer to [NavigationTab](/components/navigationtab).
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
@@ -52,7 +53,7 @@ Use actions for a call to action.
 
 ### Default
 
-<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <div data-view-component='true' class='UnderlineNav-body'>          <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Item 1    </a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>          Item 2    </a></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></nav>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body list-style-none'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Item 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Item 2    </a></li></ul>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></nav>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "Default")) do |component| %>
@@ -64,9 +65,33 @@ Use actions for a call to action.
 <% end %>
 ```
 
+### With panels
+
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <ul role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body list-style-none'>        <li role='presentation' data-view-component='true' class='d-inline-flex'>  <button type='button' role='tab' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button></li>        <li role='presentation' data-view-component='true' class='d-inline-flex'>  <button type='button' role='tab' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></li></ul>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div></tab-container>" />
+
+```erb
+<%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
+  <% component.tab(selected: true) do |t| %>
+    <% t.text { "Item 1" } %>
+    <% t.panel do %>
+      Panel 1
+    <% end %>
+  <% end %>
+  <% component.tab do |t| %>
+    <% t.text { "Item 2" } %>
+    <% t.panel do %>
+      Panel 2
+    <% end %>
+  <% end %>
+  <% component.actions do %>
+    <%= render(Primer::ButtonComponent.new) { "Button!" } %>
+  <% end %>
+<% end %>
+```
+
 ### With icons and counters
 
-<Example src="  <nav aria-label='With icons and counters' data-view-component='true' class='UnderlineNav'>    <div data-view-component='true' class='UnderlineNav-body'>          <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star UnderlineNav-octicon'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 1</span>    </a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star UnderlineNav-octicon'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 2</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 3</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></nav>" />
+<Example src="  <nav aria-label='With icons and counters' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body list-style-none'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star UnderlineNav-octicon'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 1</span>    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>    <svg aria-hidden='true' viewBox='0 0 16 16' version='1.1' data-view-component='true' height='16' width='16' class='octicon octicon-star UnderlineNav-octicon'>    <path fill-rule='evenodd' d='M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25zm0 2.445L6.615 5.5a.75.75 0 01-.564.41l-3.097.45 2.24 2.184a.75.75 0 01.216.664l-.528 3.084 2.769-1.456a.75.75 0 01.698 0l2.77 1.456-.53-3.084a.75.75 0 01.216-.664l2.24-2.183-3.096-.45a.75.75 0 01-.564-.41L8 2.694v.001z'></path></svg>      <span data-view-component='true'>Item 2</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 3</span>    <span title='10' data-view-component='true' class='Counter'>10</span></a></li></ul>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></nav>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "With icons and counters")) do |component| %>
@@ -91,7 +116,7 @@ Use actions for a call to action.
 
 ### Align right
 
-<Example src="  <nav aria-label='Align right' data-view-component='true' class='UnderlineNav UnderlineNav--right'>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div>    <div data-view-component='true' class='UnderlineNav-body'>          <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </a></div></nav>" />
+<Example src="  <nav aria-label='Align right' data-view-component='true' class='UnderlineNav UnderlineNav--right'>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div>    <ul data-view-component='true' class='UnderlineNav-body list-style-none'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </a></li></ul></nav>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "Align right", align: :right)) do |component| %>
@@ -107,54 +132,12 @@ Use actions for a call to action.
 <% end %>
 ```
 
-### As a list
-
-<Example src="  <nav aria-label='As a list' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body list-style-none'>        <li data-view-component='true' class='d-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </a></li>        <li data-view-component='true' class='d-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </a></li></ul>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></nav>" />
-
-```erb
-<%= render(Primer::UnderlineNavComponent.new(label: "As a list", body_arguments: { tag: :ul })) do |component| %>
-  <% component.tab(href: "#", selected: true) do |t| %>
-    <% t.text { "Item 1" } %>
-  <% end %>
-  <% component.tab(href: "#") do |t| %>
-    <% t.text { "Item 2" } %>
-  <% end %>
-  <% component.actions do %>
-    <%= render(Primer::ButtonComponent.new) { "Button!" } %>
-  <% end %>
-<% end %>
-```
-
-### With panels
-
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <div role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body'>          <button type='button' role='tab' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button>          <button type='button' role='tab' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div></tab-container>" />
-
-```erb
-<%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-  <% component.tab(selected: true) do |t| %>
-    <% t.text { "Item 1" } %>
-    <% t.panel do %>
-      Panel 1
-    <% end %>
-  <% end %>
-  <% component.tab do |t| %>
-    <% t.text { "Item 2" } %>
-    <% t.panel do %>
-      Panel 2
-    <% end %>
-  <% end %>
-  <% component.actions do %>
-    <%= render(Primer::ButtonComponent.new) { "Button!" } %>
-  <% end %>
-<% end %>
-```
-
 ### Customizing the body
 
-<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body custom-class list-style-none border color-border-info'>        <li data-view-component='true' class='d-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Tab 1    </a></li>        <li data-view-component='true' class='d-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 2    </a></li>        <li data-view-component='true' class='d-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 3    </a></li></ul>      </nav>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body custom-class list-style-none border color-border-info'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 3    </a></li></ul>      </nav>" />
 
 ```erb
-<%= render(Primer::UnderlineNavComponent.new(label: "Default", body_arguments: { tag: :ul, classes: "custom-class", border: true, border_color: :info })) do |c| %>
+<%= render(Primer::UnderlineNavComponent.new(label: "Default", body_arguments: { classes: "custom-class", border: true, border_color: :info })) do |c| %>
   <% c.tab(selected: true, href: "#") { "Tab 1" }%>
   <% c.tab(href: "#") { "Tab 2" } %>
   <% c.tab(href: "#") { "Tab 3" } %>
@@ -163,7 +146,7 @@ Use actions for a call to action.
 
 ### Customizing the wrapper
 
-<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <div data-view-component='true' class='UnderlineNav-body'>          <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Tab 1    </a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 2    </a>          <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 3    </a></div>      </nav>" />
+<Example src="  <nav aria-label='Default' data-view-component='true' class='UnderlineNav'>    <ul data-view-component='true' class='UnderlineNav-body list-style-none'>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' aria-current='page' data-view-component='true' class='UnderlineNav-item'>          Tab 1    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 2    </a></li>        <li data-view-component='true' class='d-inline-flex'>  <a href='#' data-view-component='true' class='UnderlineNav-item'>          Tab 3    </a></li></ul>      </nav>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "Default", wrapper_arguments: { classes: "custom-class", border: true, border_color: :info })) do |c| %>

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -692,10 +692,6 @@
 - component: NavigationTab
   source: https://github.com/primer/view_components/tree/main/app/components/primer/tab_component.rb
   parameters:
-  - name: list
-    type: Boolean
-    default: "`false`"
-    description: Whether the Tab is an item in a `<ul>` list.
   - name: selected
     type: Boolean
     default: "`false`"
@@ -711,8 +707,7 @@
   - name: wrapper_arguments
     type: Hash
     default: "`{}`"
-    description: "[System arguments](/system-arguments) to be used in the `<li>` wrapper
-      when the tab is an item in a list."
+    description: "[System arguments](/system-arguments) to be used in the `<li>` wrapper."
   - name: system_arguments
     type: Hash
     default: N/A
@@ -826,7 +821,7 @@
   - name: label
     type: String
     default: N/A
-    description: Used to set the `aria-label` on the top level `<nav>` element.
+    description: Used to set the `aria-label` on the top level element.
   - name: with_panel
     type: Boolean
     default: "`false`"
@@ -947,7 +942,7 @@
   - name: label
     type: String
     default: N/A
-    description: The `aria-label` on top level `<nav>` element.
+    description: Used to set the `aria-label` on top level element.
   - name: with_panel
     type: Boolean
     default: "`false`"

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -107,6 +107,7 @@
 - ".custom-class"
 - ".d-flex"
 - ".d-inline-block"
+- ".d-inline-flex"
 - ".details-overlay"
 - ".details-reset"
 - ".dropdown"

--- a/test/components/navigation/tab_component_test.rb
+++ b/test/components/navigation/tab_component_test.rb
@@ -115,7 +115,7 @@ class PrimerNavigationTabComponentTest < Minitest::Test
       c.text { "Title" }
     end
 
-    assert_selector("li.d-flex") do
+    assert_selector("li.d-inline-flex") do
       assert_selector("a") do
         assert_selector("span", text: "Title")
       end

--- a/test/components/tab_nav_component_test.rb
+++ b/test/components/tab_nav_component_test.rb
@@ -27,8 +27,8 @@ class PrimerTabNavComponentTest < Minitest::Test
       c.tab { "Tab 2" }
     end
 
-    assert_selector(".tabnav") do
-      assert_selector("nav.tabnav-tabs[aria-label='label']") do
+    assert_selector("nav.tabnav[aria-label='label']") do
+      assert_selector("ul.tabnav-tabs") do
         assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
         assert_selector("a.tabnav-tab", text: "Tab 2")
       end
@@ -41,8 +41,8 @@ class PrimerTabNavComponentTest < Minitest::Test
       c.tab(tag: :button) { "Tab 2" }
     end
 
-    assert_selector(".tabnav") do
-      assert_selector("nav.tabnav-tabs[aria-label='label']") do
+    assert_selector("nav.tabnav[aria-label='label']") do
+      assert_selector("ul.tabnav-tabs") do
         assert_selector("button.tabnav-tab[aria-selected='true']", text: "Tab 1")
         assert_selector("button.tabnav-tab", text: "Tab 2")
       end
@@ -62,9 +62,13 @@ class PrimerTabNavComponentTest < Minitest::Test
     end
 
     assert_selector(".tabnav") do
-      assert_selector("div.tabnav-tabs[role='tablist'][aria-label='label']") do
-        assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
-        assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+      assert_selector("ul.tabnav-tabs[role='tablist'][aria-label='label']") do
+        assert_selector("li") do
+          assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+        end
       end
     end
     assert_selector("div[role='tabpanel']", text: "Panel 1")
@@ -81,9 +85,13 @@ class PrimerTabNavComponentTest < Minitest::Test
     end
 
     assert_selector(".tabnav") do
-      assert_selector("div.tabnav-tabs[role='tablist']") do
-        assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
-        assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+      assert_selector("ul.tabnav-tabs[role='tablist']") do
+        assert_selector("li[role='presentation']") do
+          assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
+        end
+        assert_selector("li[role='presentation']") do
+          assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+        end
       end
     end
     assert_selector("div[role='tabpanel']", count: 1)
@@ -101,10 +109,14 @@ class PrimerTabNavComponentTest < Minitest::Test
       end
     end
 
-    assert_selector(".tabnav") do
-      assert_selector("nav.tabnav-tabs[aria-label='label']") do
-        assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
-        assert_selector("a.tabnav-tab", text: "Tab 2")
+    assert_selector("nav.tabnav[aria-label='label']") do
+      assert_selector("ul.tabnav-tabs") do
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab", text: "Tab 2")
+        end
       end
     end
     refute_selector("div[role='tabpanel']")
@@ -117,10 +129,14 @@ class PrimerTabNavComponentTest < Minitest::Test
       c.extra { "Extra" }
     end
 
-    assert_selector(".tabnav") do
-      assert_selector("nav.tabnav-tabs[aria-label='label']") do
-        assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
-        assert_selector("a.tabnav-tab", text: "Tab 2")
+    assert_selector("nav.tabnav[aria-label='label']") do
+      assert_selector("ul.tabnav-tabs") do
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab", text: "Tab 2")
+        end
       end
       assert_text("Extra")
     end
@@ -133,10 +149,14 @@ class PrimerTabNavComponentTest < Minitest::Test
       c.extra(align: :right) { "Extra" }
     end
 
-    assert_selector(".tabnav") do
-      assert_selector("nav.tabnav-tabs[aria-label='label']") do
-        assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
-        assert_selector("a.tabnav-tab", text: "Tab 2")
+    assert_selector("nav.tabnav[aria-label='label']") do
+      assert_selector("ul.tabnav-tabs") do
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab[aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.tabnav-tab", text: "Tab 2")
+        end
       end
       assert_text("Extra")
     end

--- a/test/components/underline_nav_component_test.rb
+++ b/test/components/underline_nav_component_test.rb
@@ -37,9 +37,13 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     end
 
     assert_selector("nav.UnderlineNav[aria-label='label']") do
-      assert_selector("div.UnderlineNav-body") do
-        assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
-        assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+      assert_selector("ul.UnderlineNav-body") do
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+        end
       end
       assert_selector("div.UnderlineNav-actions", text: "Actions content")
     end
@@ -86,9 +90,13 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     refute_selector("tab-container")
 
     assert_selector("nav.UnderlineNav[aria-label='label']") do
-      assert_selector("div.UnderlineNav-body") do
-        assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
-        assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+      assert_selector("ul.UnderlineNav-body") do
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+        end
       end
       assert_selector("div.UnderlineNav-actions", text: "Actions content")
     end
@@ -110,9 +118,13 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     refute_selector("div[role='tabpanel']")
     refute_selector("tab-container")
     assert_selector("nav.UnderlineNav.UnderlineNav--right[aria-label='label']") do
-      assert_selector("div.UnderlineNav-body") do
-        assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
-        assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+      assert_selector("ul.UnderlineNav-body") do
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
+        end
+        assert_selector("li") do
+          assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
+        end
       end
       assert_selector("div.UnderlineNav-actions", text: "Actions content")
     end
@@ -151,9 +163,13 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
     assert_selector("tab-container") do
       assert_selector("div.UnderlineNav") do
-        assert_selector("div.UnderlineNav-body[role='tablist'][aria-label='label']") do
-          assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true']", text: "Tab 1")
-          assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 2")
+        assert_selector("ul.UnderlineNav-body[role='tablist'][aria-label='label']") do
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true']", text: "Tab 1")
+          end
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 2")
+          end
         end
         assert_selector("div.UnderlineNav-actions", text: "Actions content")
       end
@@ -172,34 +188,6 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     end
 
     assert_selector(".UnderlineNav-octicon.octicon.octicon-star")
-  end
-
-  def test_renders_navigation_links_in_a_list
-    render_inline(Primer::UnderlineNavComponent.new(label: "label", body_arguments: { tag: :ul })) do |component|
-      component.tab(selected: true, href: "#") do |t|
-        t.text { "Tab 1" }
-      end
-      component.tab(href: "#") do |t|
-        t.text { "Tab 2" }
-      end
-      component.actions do
-        "Actions content"
-      end
-    end
-
-    assert_selector("nav.UnderlineNav[aria-label='label']") do
-      assert_selector("ul.UnderlineNav-body.list-style-none") do
-        assert_selector("li") do
-          assert_selector("a.UnderlineNav-item[href='#'][aria-current='page']", text: "Tab 1")
-        end
-        assert_selector("li") do
-          assert_selector("a.UnderlineNav-item[href='#']", text: "Tab 2")
-        end
-      end
-      assert_selector("div.UnderlineNav-actions", text: "Actions content")
-    end
-    refute_selector("div[role='tablist']")
-    refute_selector("a[role='tab']")
   end
 
   def test_customizes_tab_container

--- a/test/system/tab_nav_component_test.rb
+++ b/test/system/tab_nav_component_test.rb
@@ -6,10 +6,16 @@ class IntegrationTabNavComponentTest < ApplicationSystemTestCase
   def assert_tab_nav_rendered
     assert_selector("tab-container") do
       assert_selector(".tabnav") do
-        assert_selector("div.tabnav-tabs[role='tablist']") do
-          assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
-          assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
-          assert_selector("button.tabnav-tab[role='tab']", text: "Tab 3")
+        assert_selector("ul.tabnav-tabs[role='tablist']") do
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
+          end
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+          end
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.tabnav-tab[role='tab']", text: "Tab 3")
+          end
         end
       end
       assert_selector("div[role='tabpanel']", text: "Panel 1")

--- a/test/system/underline_nav_component_test.rb
+++ b/test/system/underline_nav_component_test.rb
@@ -6,10 +6,16 @@ class IntegrationUnderlineNavComponentTest < ApplicationSystemTestCase
   def assert_underline_nav_rendered
     assert_selector("tab-container") do
       assert_selector("div.UnderlineNav") do
-        assert_selector("div.UnderlineNav-body[role='tablist']") do
-          assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true']", text: "Tab 1")
-          assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 2")
-          assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 3")
+        assert_selector("ul.UnderlineNav-body[role='tablist']") do
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true']", text: "Tab 1")
+          end
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 2")
+          end
+          assert_selector("li[role='presentation']") do
+            assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 3")
+          end
         end
       end
       assert_selector("div[role='tabpanel']", text: "Panel 1")
@@ -30,7 +36,9 @@ class IntegrationUnderlineNavComponentTest < ApplicationSystemTestCase
 
   def assert_shows_panel(panel)
     (1..3).each do |num|
-      assert_selector("div[role='tabpanel']#{'[hidden]' unless panel == num}", text: "Panel #{num}", visible: panel == num)
+      assert_selector("li[role='presentation']") do
+        assert_selector("div[role='tabpanel']#{'[hidden]' unless panel == num}", text: "Panel #{num}", visible: panel == num)
+      end
     end
   end
 


### PR DESCRIPTION
## What 
This PR makes it so we always render links in `TabNav` and `UnderlineNav` within a `<ul>`. 
For instance, the markup for `TabNav` for page navigation which currently looks like:

```.html
<div data-view-component="true" class="tabnav">
  <nav aria-label="Default" data-view-component="true" class="tabnav-tabs">          
    <a href="#" aria-current="page" data-view-component="true" class="tabnav-tab">Tab 1</a>          
    <a href="#" data-view-component="true" class="tabnav-tab">Tab 2</a>          
    <a href="#" data-view-component="true" class="tabnav-tab">Tab 3</a>
  </nav>   
</div>
```

will be updated to:

```.html
<nav aria-label="Default" data-view-component="true" class="tabnav">
  <ul data-view-component="true" class="tabnav-tabs">
    <li data-view-component="true" class="d-flex">  
      <a href="#" aria-current="page" data-view-component="true" class="tabnav-tab">Tab 1</a>
    </li>
    <li data-view-component="true" class="d-flex">
      <a href="#" data-view-component="true" class="tabnav-tab">Tab 2</a>
    </li>
    <li data-view-component="true" class="d-flex">  
      <a href="#" data-view-component="true" class="tabnav-tab"> Tab 3</a>
    </li>
  </ul>    
</nav>
```

When panel navigation is set with `with_panel`, the `li` element will have [role="presentation"](https://www.w3.org/TR/wai-aria-practices/#presentation_role).

```.html
<div data-view-component="true" class="tabnav">
  <ul aria-label="With panels" role="tablist" data-view-component="true" class="tabnav-tabs">
    <li role="presentation" data-view-component="true" class="d-inline-flex">
      <button type="button" role="tab" aria-selected="true" data-view-component="true" class="tabnav-tab" tabindex="0"> <span data-view-component="true">Tab 1</span></button>
    </li>        
    <li role="presentation" data-view-component="true" class="d-inline-flex">
      <button type="button" role="tab" data-view-component="true" class="tabnav-tab" aria-selected="false" tabindex="-1"><span data-view-component="true">Tab 2</span> </button>
    </li>
  </ul>
</div>
```

## Why

- It'd help to simplify the API  if we always rendered the link items within a list rather than having it optional with `list: true`
- There are semantic benefits to rendering these as a list such as allowing the screen reader to announce the number of items available.
- Rendering the links within a list will help to provide semantic structure in places where it's not appropriate to be relying on a `nav` for rendering page links. For instance, in the [Explore page](https://github.com/explore) there's a bunch of `TabNav` being used for rendering repository links. We currently always render page links within a `nav` element. However, `nav` comes with an implicit role of `navigation` which should be reserved for MAJOR links. If we were to eliminate the use of `nav` here, list will provide semantic structure.

## References
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html
