### PR TITLE
Restricted allowed heading for popover slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Breaking changes
 
-* Restrict tag for `Popover` to `:div`.
+* Restrict tag for `Popover` to `:div` and `Popover` heading slot to headings.
 
     *Kate Higa*
 

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -29,7 +29,7 @@ module Primer
 
     # Use the Body slot as the main content to be shown when triggered by the Summary.
     #
-    # @param tag [String] (Primer::DetailsComponent::BODY_TAG_DEFAULT) <%= one_of(Primer::DetailsComponent::BODY_TAG_OPTIONS) %>
+    # @param tag [Symbol] (Primer::DetailsComponent::BODY_TAG_DEFAULT) <%= one_of(Primer::DetailsComponent::BODY_TAG_OPTIONS) %>
     # @param kwargs [Hash] The same arguments as <%= link_to_system_arguments_docs %>.
     renders_one :body, lambda { |tag: BODY_TAG_DEFAULT, **system_arguments|
       system_arguments[:tag] = fetch_or_fallback(BODY_TAG_OPTIONS, tag, BODY_TAG_DEFAULT)

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -23,12 +23,15 @@ module Primer
       :top_right => "Popover-message--top-right"
     }.freeze
 
+    DEFAULT_HEADING_TAG = :h4
+
     # The heading
     #
+    # @param tag [Symbol] (Primer::PopoverComponent::DEFAULT_HEADING_TAG) <%= one_of(Primer::HeadingComponent::TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_one :heading, lambda { |**system_arguments|
+    renders_one :heading, lambda { |tag: DEFAULT_HEADING_TAG, **system_arguments|
+      system_arguments[:tag] = tag
       system_arguments[:mb] ||= 2
-      system_arguments[:tag] ||= :h4 # rubocop:disable Primer/NoTagMemoize
 
       Primer::HeadingComponent.new(**system_arguments)
     }

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -38,7 +38,7 @@ module Primer
 
     # Use actions for a call to action.
     #
-    # @param tag [String] (Primer::UnderlineNavComponent::ACTIONS_TAG_DEFAULT) <%= one_of(Primer::UnderlineNavComponent::ACTIONS_TAG_OPTIONS) %>
+    # @param tag [Symbol] (Primer::UnderlineNavComponent::ACTIONS_TAG_DEFAULT) <%= one_of(Primer::UnderlineNavComponent::ACTIONS_TAG_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     renders_one :actions, lambda { |tag: ACTIONS_TAG_DEFAULT, **system_arguments|
       system_arguments[:tag] = fetch_or_fallback(ACTIONS_TAG_OPTIONS, tag, ACTIONS_TAG_DEFAULT)

--- a/docs/content/components/details.md
+++ b/docs/content/components/details.md
@@ -36,7 +36,7 @@ Use the Body slot as the main content to be shown when triggered by the Summary.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `tag` | `String` | `:div` | One of `:details-dialog`, `:details-menu`, `:div`, or `:ul`. |
+| `tag` | `Symbol` | `:div` | One of `:details-dialog`, `:details-menu`, `:div`, or `:ul`. |
 | `kwargs` | `Hash` | N/A | The same arguments as [System arguments](/system-arguments). |
 
 ## Examples

--- a/docs/content/components/popover.md
+++ b/docs/content/components/popover.md
@@ -27,6 +27,7 @@ The heading
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `tag` | `Symbol` | `:h4` | One of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, or `:h6`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ### `Body`

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -45,7 +45,7 @@ Use actions for a call to action.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `tag` | `String` | `:div` | One of `:div` and `:span`. |
+| `tag` | `Symbol` | `:div` | One of `:div` and `:span`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Examples


### PR DESCRIPTION
Closes #491 

## What

This PR restricts the allowed tags for popover component heading slot to heading tags. This is the last of components and slots needing tag restrictions. 

## Notes

Usually, I don't think it's great to have a default for heading since the appropriate heading level tends to be context-dependent. However,  I think `Popover` might be a special case, similar to a modal dialog. `Popover` appears temporarily on mousehover and doesn't fall within a normal page structure. 

There seems to be a lot of debate around what the most appropriate heading level for a modal dialog is but nothing prescriptive. 
There's a comment in [w3 aria-practices discussion](https://github.com/w3c/aria-practices/issues/551): 
> It is helpful if there is a consistent approach across dialogs in an application.
> There is not necessarily a need for the APG to prescribe a specific approach.

I think we can think of `Popover` similarly where maybe it's more important to have consistency across `Popover`. For now, I will leave the `:h4` default though we may want to revisit this in the future. Additionally, in dotcom, `Popover` is actually not accessible at all for keyboard-only users so that is a whole other can of worms we need to address...