### PR TITLE
Ensure tab panels are labelled and have `tabindex` set to 0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Breaking changes
 
+* Ensure panels in `Navigation::Tab` have a label.
+
+    *Kate Higa*
+
 * Restrict tag for `Popover` to `:div` and `Popover` heading slot to headings.
 
     *Kate Higa*

--- a/app/components/primer/beta/auto_complete.rb
+++ b/app/components/primer/beta/auto_complete.rb
@@ -29,7 +29,7 @@ module Primer
       # @param type [Symbol] <%= one_of(Primer::Beta::AutoComplete::Input::TYPE_OPTIONS) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :input, lambda { |**system_arguments|
-        aria_label = system_arguments[:"aria-label"] || system_arguments.dig(:aria, :label) || @aria_label
+        aria_label = aria("label", system_arguments) || @aria_label
         if aria_label.present?
           system_arguments[:"aria-label"] = aria_label
           system_arguments[:aria]&.delete(:label)
@@ -106,7 +106,7 @@ module Primer
       def initialize(src:, list_id:, input_id:, **system_arguments)
         @list_id = list_id
         @input_id = input_id
-        @aria_label = system_arguments[:"aria-label"] || system_arguments.dig(:aria, :label)
+        @aria_label = aria("label", system_arguments)
 
         system_arguments.delete(:"aria-label") && system_arguments[:aria]&.delete(:label)
 

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -29,8 +29,12 @@ module Primer
       ActiveSupport::Deprecation.warn(message)
     end
 
+    def aria(val, system_arguments)
+      system_arguments[:"aria-#{val}"] || system_arguments.dig(:aria, val.to_sym)
+    end
+
     def validate_aria_label
-      aria_label = @system_arguments[:"aria-label"] || @system_arguments.dig(:aria, :label)
+      aria_label = aria("label", @system_arguments)
       raise ArgumentError, "`aria-label` is required." if aria_label.nil? && !Rails.env.production?
     end
 

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -25,7 +25,7 @@ module Primer
         system_arguments[:tabindex] = 0
         system_arguments[:hidden] = true unless @selected
 
-        label_present = aria("label", system_arguments) || system_arguments[:"aria-labelledby"] || system_arguments.dig(:aria, :labelledby)
+        label_present = aria("label", system_arguments) || aria("labelledby", system_arguments)
         unless label_present
           if @id.present?
             system_arguments[:"aria-labelledby"] = @id

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -25,7 +25,7 @@ module Primer
         system_arguments[:tabindex] = 0
         system_arguments[:hidden] = true unless @selected
 
-        label_present = system_arguments[:"aria-label"] || system_arguments.dig(:aria, :label) || system_arguments[:"aria-labelledby"] || system_arguments.dig(:aria, :labelledby)
+        label_present = aria("label", system_arguments) || system_arguments[:"aria-labelledby"] || system_arguments.dig(:aria, :labelledby)
         unless label_present
           if @id.present?
             system_arguments[:"aria-labelledby"] = @id
@@ -125,7 +125,7 @@ module Primer
         return unless @selected
 
         if @system_arguments[:tag] == :a
-          aria_current = @system_arguments[:"aria-current"] || @system_arguments.dig(:aria, :current) || DEFAULT_ARIA_CURRENT_FOR_ANCHOR
+          aria_current = aria("current", system_arguments) || DEFAULT_ARIA_CURRENT_FOR_ANCHOR
           @system_arguments[:"aria-current"] = fetch_or_fallback(ARIA_CURRENT_OPTIONS_FOR_ANCHOR, aria_current, DEFAULT_ARIA_CURRENT_FOR_ANCHOR)
         else
           @system_arguments[:"aria-selected"] = true

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -63,19 +63,19 @@ module Primer
     #
     # @example With panels
     #   <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
-    #     <% c.tab(selected: true) do |t| %>
+    #     <% c.tab(selected: true, id: "tab-1") do |t| %>
     #       <% t.text { "Tab 1" } %>
     #       <% t.panel do %>
     #         Panel 1
     #       <% end %>
     #     <% end %>
-    #     <% c.tab do |t| %>
+    #     <% c.tab(id: "tab-2") do |t| %>
     #       <% t.text { "Tab 2" } %>
     #       <% t.panel do %>
     #         Panel 2
     #       <% end %>
     #     <% end %>
-    #     <% c.tab do |t| %>
+    #     <% c.tab(id: "tab-3") do |t| %>
     #       <% t.text { "Tab 3" } %>
     #       <% t.panel do %>
     #         Panel 3

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -104,13 +104,13 @@ module Primer
     #
     # @example With panels
     #   <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-    #     <% component.tab(selected: true) do |t| %>
+    #     <% component.tab(selected: true, id: "tab-1") do |t| %>
     #       <% t.text { "Item 1" } %>
     #       <% t.panel do %>
     #         Panel 1
     #       <% end %>
     #     <% end %>
-    #     <% component.tab do |t| %>
+    #     <% component.tab(id: "tab-2") do |t| %>
     #       <% t.text { "Item 2" } %>
     #       <% t.panel do %>
     #         Panel 2

--- a/demo/test/components/previews/primer/tab_nav_component_preview.rb
+++ b/demo/test/components/previews/primer/tab_nav_component_preview.rb
@@ -2,15 +2,15 @@ module Primer
   class TabNavComponentPreview < ViewComponent::Preview
     def default
       render(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-        c.tab(selected: true) do |t|
+        c.tab(selected: true, id: "tab-1") do |t|
           t.panel { "Panel 1" }
           t.text { "Tab 1" }
         end
-        c.tab do |t|
+        c.tab(id: "tab-2") do |t|
           t.panel { "Panel 2" }
           t.text { "Tab 2" }
         end
-        c.tab do |t|
+        c.tab(id: "tab-3") do |t|
           t.panel { "Panel 3" }
           t.text { "Tab 3" }
         end

--- a/demo/test/components/previews/primer/underline_nav_component_preview.rb
+++ b/demo/test/components/previews/primer/underline_nav_component_preview.rb
@@ -2,15 +2,15 @@ module Primer
   class UnderlineNavComponentPreview < ViewComponent::Preview
     def default
       render(Primer::UnderlineNavComponent.new(label: "Test navigation", with_panel: true)) do |c|
-        c.tab(selected: true) do |t|
+        c.tab(selected: true, id: "tab-1") do |t|
           t.panel { "Panel 1" }
           t.text { "Tab 1" }
         end
-        c.tab do |t|
+        c.tab(id: "tab-2") do |t|
           t.panel { "Panel 2" }
           t.text { "Tab 2" }
         end
-        c.tab do |t|
+        c.tab(id: "tab-3") do |t|
           t.panel { "Panel 3" }
           t.text { "Tab 3" }
         end

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -82,23 +82,23 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### With panels
 
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <div aria-label='With panels' role='tablist' data-view-component='true' class='tabnav-tabs'>          <button type='button' role='tab' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button>          <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button>          <button type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></div>    </div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 3</div></tab-container>" />
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <div aria-label='With panels' role='tablist' data-view-component='true' class='tabnav-tabs'>          <button id='tab-1' type='button' role='tab' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button>          <button id='tab-2' type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button>          <button id='tab-3' type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></div>    </div>      <div role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-3' data-view-component='true'>      Panel 3</div></tab-container>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
-  <% c.tab(selected: true) do |t| %>
+  <% c.tab(selected: true, id: "tab-1") do |t| %>
     <% t.text { "Tab 1" } %>
     <% t.panel do %>
       Panel 1
     <% end %>
   <% end %>
-  <% c.tab do |t| %>
+  <% c.tab(id: "tab-2") do |t| %>
     <% t.text { "Tab 2" } %>
     <% t.panel do %>
       Panel 2
     <% end %>
   <% end %>
-  <% c.tab do |t| %>
+  <% c.tab(id: "tab-3") do |t| %>
     <% t.text { "Tab 3" } %>
     <% t.panel do %>
       Panel 3

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -127,17 +127,17 @@ Use actions for a call to action.
 
 ### With panels
 
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <div role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body'>          <button type='button' role='tab' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button>          <button type='button' role='tab' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div role='tabpanel' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' hidden='hidden' data-view-component='true'>      Panel 2</div></tab-container>" />
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <div role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body'>          <button id='tab-1' type='button' role='tab' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button>          <button id='tab-2' type='button' role='tab' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div></tab-container>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-  <% component.tab(selected: true) do |t| %>
+  <% component.tab(selected: true, id: "tab-1") do |t| %>
     <% t.text { "Item 1" } %>
     <% t.panel do %>
       Panel 1
     <% end %>
   <% end %>
-  <% component.tab do |t| %>
+  <% component.tab(id: "tab-2") do |t| %>
     <% t.text { "Item 2" } %>
     <% t.panel do %>
       Panel 2

--- a/stories/primer/tab_nav_component_stories.rb
+++ b/stories/primer/tab_nav_component_stories.rb
@@ -10,15 +10,15 @@ class Primer::TabNavComponentStories < ViewComponent::Storybook::Stories
     end
 
     content do |c|
-      c.tab(selected: true) do |t|
+      c.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-3") do |t|
         t.panel { "Panel 3" }
         t.text { "Tab 3" }
       end

--- a/stories/primer/underline_nav_component_stories.rb
+++ b/stories/primer/underline_nav_component_stories.rb
@@ -12,15 +12,15 @@ class Primer::UnderlineNavComponentStories < ViewComponent::Storybook::Stories
     end
 
     content do |c|
-      c.tab(selected: true) do |t|
+      c.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-3") do |t|
         t.panel { "Panel 3" }
         t.text { "Tab 3" }
       end

--- a/test/components/navigation/tab_component_test.rb
+++ b/test/components/navigation/tab_component_test.rb
@@ -26,6 +26,17 @@ class PrimerNavigationTabComponentTest < Minitest::Test
     end
   end
 
+  def test_raises_if_panel_has_no_label
+    err = assert_raises ArgumentError do
+      render_inline Primer::Navigation::TabComponent.new(with_panel: true) do |c|
+        c.text { "Title" }
+        c.panel { "content" }
+      end
+    end
+
+    assert_equal("Panels must be labelled. Either set a unique `id` on the tab, or set an `aria-label` directly on the panel", err.message)
+  end
+
   def test_renders_octicon
     render_inline Primer::Navigation::TabComponent.new do |c|
       c.icon(icon: :star)

--- a/test/components/tab_nav_component_test.rb
+++ b/test/components/tab_nav_component_test.rb
@@ -51,11 +51,11 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_renders_tab_panels_with_tabs_as_button
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-      c.tab(selected: true) do |t|
+      c.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -73,11 +73,11 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_only_renders_panels_for_tabs_with_content
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-      c.tab(tag: :button, selected: true) do |t|
+      c.tab(tag: :button, selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab(tag: :button) { "Tab 2" }
+      c.tab(tag: :button, id: "tab-2") { "Tab 2" }
     end
 
     assert_selector(".tabnav") do
@@ -91,11 +91,11 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_does_not_render_panels_when_with_panel_is_false
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: false)) do |c|
-      c.tab(selected: true) do |t|
+      c.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab do |t|
+      c.tab(id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -144,7 +144,7 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_customizes_tab_container
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true, wrapper_arguments: { m: 2, classes: "custom-class" })) do |component|
-      component.tab(selected: true) do |t|
+      component.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end

--- a/test/components/underline_nav_component_test.rb
+++ b/test/components/underline_nav_component_test.rb
@@ -23,11 +23,11 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_does_not_add_tab_roles_and_does_not_render_panels_if_with_panel_is_false
     render_inline(Primer::UnderlineNavComponent.new(label: "label")) do |component|
-      component.tab(selected: true, href: "#") do |t|
+      component.tab(selected: true, href: "#", id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      component.tab(href: "#") do |t|
+      component.tab(href: "#", id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -136,11 +136,11 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_renders_panels_and_tab_container
     render_inline(Primer::UnderlineNavComponent.new(label: "label", with_panel: true)) do |component|
-      component.tab(selected: true) do |t|
+      component.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      component.tab do |t|
+      component.tab(id: "tab-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -164,7 +164,7 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_renders_tab_icon_with_correct_classes
     render_inline(Primer::UnderlineNavComponent.new(label: "label", align: :right)) do |component|
-      component.tab(selected: true, href: "#") do |t|
+      component.tab(selected: true, href: "#", id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
         t.icon(icon: :star)
@@ -204,7 +204,7 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_customizes_tab_container
     render_inline(Primer::UnderlineNavComponent.new(label: "label", with_panel: true, wrapper_arguments: { m: 2, classes: "custom-class" })) do |component|
-      component.tab(selected: true) do |t|
+      component.tab(selected: true, id: "tab-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end


### PR DESCRIPTION
## What
- Updates panel slot in `Navigation::Tab` to ensure there's a label. For ease, if `id` is set on the tab, we auto-label the panel with the tab text using `aria-labelledby`. Consumers may alternatively pass in an `aria-label`.
- Sets panel `tabindex="0"`. 

## Why
According to [WAI-ARIA Roles, States, and Properties for tabs](https://www.w3.org/TR/wai-aria-practices/#wai-aria-roles-states-and-properties-20) and [Example of Tabs](https://www.w3.org/TR/wai-aria-practices/examples/tabs/tabs-2/tabs.html), tab panels should be labelled. Additionally, tab panel should have a tabindex set to 0.

## Notes

- There are a lot of updates I want to make with the tab components but I also want to keep the diffs small for ease of review. Ultimately, I think we need to move towards separating the current `UnderlineNav` into `UnderlinePanelNav` and `UnderlinePageNav`. Same thing with `TabNav`. [Related issue](https://github.com/primer/view_components/issues/680)