### PR TITLE
Add example for truncating HTML to `Truncate`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+* Add example for truncating HTML to `Truncate`.
+
+    *Joel Hawksley*
+
 ## 0.0.46
 
 ### Updates

--- a/app/components/primer/truncate.rb
+++ b/app/components/primer/truncate.rb
@@ -22,6 +22,11 @@ module Primer
     # @example Custom size
     #   <%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) { "branch-name-that-is-really-long" } %>
     #
+    # @example With HTML content
+    #   <%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) do %>
+    #     <span>branch-name-that-is-really-long</span>
+    #   <% end %>
+    #
     # @param tag [Symbol] <%= one_of(Primer::Truncate::TAG_OPTIONS) %>
     # @param inline [Boolean] Whether the element is inline (or inline-block).
     # @param expandable [Boolean] Whether the entire string should be revealed on hover. Can only be used in conjunction with `inline`.

--- a/docs/content/components/truncate.md
+++ b/docs/content/components/truncate.md
@@ -56,3 +56,13 @@ Use `Truncate` to shorten overflowing text with an ellipsis.
 ```erb
 <%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) { "branch-name-that-is-really-long" } %>
 ```
+
+### With HTML content
+
+<Example src="<span style='max-width: 100px;' data-view-component='true' class='css-truncate css-truncate-target expandable'>  <span>branch-name-that-is-really-long</span></span>" />
+
+```erb
+<%= render(Primer::Truncate.new(tag: :span, inline: true, expandable: true, max_width: 100)) do %>
+  <span>branch-name-that-is-really-long</span>
+<% end %>
+```


### PR DESCRIPTION
This PR adds an example to `Truncate` for truncating a provided HTML block.