### PR TITLE
Require fetch_or_fallback helper in classify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Joel Hawksley*
 
+* Require fetch_or_fallback helper in classify
+
+    *Jon Rohan*
+
 ## 0.0.46
 
 ### Updates

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "../../app/lib/primer/fetch_or_fallback_helper"
 require_relative "classify/cache"
 require_relative "classify/flex"
 require_relative "classify/functional_background_colors"


### PR DESCRIPTION
I was trying to use `require "primer/classify"` alone in an erblint and was running into the problem that Flex and other classes in classify use the `fetch_or_fallback` helper resulting in this stacktrace:

```
❯ bundle exec erblint app/views/
warning: parser/current is loading parser/ruby27, which recognizes
warning: 2.7.3-compliant syntax, but you are running 2.7.1.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
NameError: uninitialized constant Primer::FetchOrFallbackHelper
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/flex.rb:7:in `<class:Flex>'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/flex.rb:6:in `<class:Classify>'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/flex.rb:4:in `<module:Primer>'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/flex.rb:3:in `<top (required)>'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/cache.rb:3:in `require_relative'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify/cache.rb:3:in `<top (required)>'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify.rb:4:in `require_relative'
/Users/jonrohan/Code/@github/github/vendor/gems/2.7.1/ruby/2.7.0/gems/primer_view_components-0.0.46/lib/primer/classify.rb:4:in `<top (required)>'
/Users/jonrohan/Code/@github/github/.erb-linters/primer_octicon.rb:3:in `require'
```

So I'm adding a relative require to hook it up for the standalone cases.