### PR TITLE
Ensure preview generator parses example tag correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Misc
 
+* Extract example tag parsing into helper.
+
+    *Kate Higa*
+
 * Expose custom cops and default config for erblint.
 
     *Manuel Puyol*

--- a/docs/content/components/beta/autocomplete.md
+++ b/docs/content/components/beta/autocomplete.md
@@ -38,7 +38,7 @@ always be used unless there is compelling reason not to. A placeholder is not a 
 
 ### `Label`
 
-Optionally render a visible label. See [Accessibility](#system-arguments)
+Optionally render a visible label. See [Accessibility](#accessibility)
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -227,23 +227,12 @@ namespace :docs do
         f.puts("## Examples")
 
         initialize_method.tags(:example).each do |tag|
-          name = tag.name
-          description = nil
-          code = nil
-
-          if tag.text.include?("@description")
-            splitted = tag.text.split(/@description|@code/)
-            description = splitted.second.gsub(/^[ \t]{2}/, "").strip
-            code = splitted.last.gsub(/^[ \t]{2}/, "").strip
-          else
-            code = tag.text
-          end
-
+          name, description, code = parse_example_tag(tag)
           f.puts
           f.puts("### #{name}")
           if description
             f.puts
-            f.puts(description)
+            f.puts(view_context.render(inline: description.squish))
           end
           f.puts
           html = view_context.render(inline: code)
@@ -330,13 +319,14 @@ namespace :docs do
         f.puts("    class #{short_name}Preview < ViewComponent::Preview")
 
         yard_example_tags.each_with_index do |tag, index|
-          method_name = tag.name.split("|").first.downcase.parameterize.underscore
+          name, _, code = parse_example_tag(tag)
+          method_name = name.split("|").first.downcase.parameterize.underscore
           f.puts("      def #{method_name}; end")
           f.puts unless index == yard_example_tags.size - 1
           path = Pathname.new("demo/test/components/previews/primer/docs/#{short_name.underscore}_preview/#{method_name}.html.erb")
           path.dirname.mkdir unless path.dirname.exist?
           File.open(path, "w") do |view_file|
-            view_file.puts(tag.text.to_s)
+            view_file.puts(code.to_s)
           end
         end
 
@@ -372,6 +362,22 @@ namespace :docs do
     registry = YARD::RegistryStore.new
     registry.load!(".yardoc")
     registry
+  end
+
+  def parse_example_tag(tag)
+    name = tag.name
+    description = nil
+    code = nil
+
+    if tag.text.include?("@description")
+      splitted = tag.text.split(/@description|@code/)
+      description = splitted.second.gsub(/^[ \t]{2}/, "").strip
+      code = splitted.last.gsub(/^[ \t]{2}/, "").strip
+    else
+      code = tag.text
+    end
+
+    [name, description, code]
   end
 
   def pretty_default_value(tag, component)

--- a/lib/yard/docs_helper.rb
+++ b/lib/yard/docs_helper.rb
@@ -29,7 +29,7 @@ module YARD
     end
 
     def link_to_accessibility
-      "[Accessibility](#system-arguments)"
+      "[Accessibility](#accessibility)"
     end
 
     def link_to_system_arguments_docs


### PR DESCRIPTION
## What 

- Ensures preview generation code accounts for when `@example` has `@code` and `@description`. 
- Extracts example tag parsing into a method. 

## Why

Currently the generated preview view code can look something like:

```
@description
  Add an `icon` to give additional context. Refer to the [Octicons](https://primer.style/octicons/) documentation to choose an icon.
@code
  <%= render Primer::BlankslateComponent.new(
    icon: :globe,
    title: "Title",
    description: "Description",
  ) %>
``` 

which we don't want. We only care about the code. 