### PR TITLE
Improve classify utilities performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Updates
+
+* Improve `Primer::Classify::Utilities.classes_to_hash` performance.
+
+    *Manuel Puyol*
+
 ## 0.0.48
 
 ### Breaking changes

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "yaml"
+
 # :nodoc:
 module Primer
   class Classify

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -5,6 +5,7 @@ namespace :utilities do
     require "yaml"
     require "json"
     require File.expand_path("./../../demo/config/environment.rb", __dir__)
+    require "primer/classify/utilities"
 
     # Keys that are looked for to be included in the utilities.yml file
     SUPPORTED_KEYS = %i[
@@ -18,15 +19,6 @@ namespace :utilities do
       wb
       v
     ].freeze
-
-    # Replacements for some classnames that end up being a different argument key
-    REPLACEMENT_KEYS = {
-      "^anim" => "animation",
-      "^v-align" => "vertical_align",
-      "^d" => "display",
-      "^wb" => "word_break",
-      "^v" => "visibility"
-    }.freeze
 
     BREAKPOINTS = [nil, "sm", "md", "lg", "xl"].freeze
 
@@ -52,7 +44,7 @@ namespace :utilities do
       key = ""
 
       # Look for a replacement key
-      REPLACEMENT_KEYS.each do |k, v|
+      Primer::Classify::Utilities::REPLACEMENT_KEYS.each do |k, v|
         next unless classname.match?(Regexp.new(k))
 
         key = v


### PR DESCRIPTION
`classes_to_hash` now uses the `utilties.rake` logic to infer a possible key for the selector being analyzed instead of looping through the whole utilities hash. Since the new `SystemArgumentInsteadOfClass` linter uses that utility, it makes sense to improve it where we can 😄.
This changes speeds the helper up ~3 times.

# Benchmark

Benchmark code here https://gist.github.com/manuelpuyol/a0f1b5a2840315e3c7d6fc3144d86ca5

```
Running 10000 times.
       user     system      total        real
Old  1.072237   0.000000   1.072237 (  1.072257)
New  0.375978   0.000000   0.375978 (  0.375981)
Running 50000 times.
       user     system      total        real
Old  5.366870   0.000000   5.366870 (  5.366916)
New  1.890638   0.000000   1.890638 (  1.890662)
Running 100000 times.
       user     system      total        real
Old 10.710371   0.000000  10.710371 ( 10.710519)
New  3.762228   0.000000   3.762228 (  3.762282)
```