### PR TITLE
WIP script for standardizing component naming

### DIFF
--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -57,6 +57,8 @@ namespace :renamer do
     puts mv_result
 
     # TODO: rename template filename too
+    # TODO: rename story too
+    # TODO: rename nav.yml
 
     # rename in codebase for status and suffix
     if target_component_name.end_with?("Component")

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -64,7 +64,7 @@ namespace :renamer do
       template_filepath_with_status = template_filepath.gsub("/primer/", "/primer/#{target_status}/")
 
       # drop component suffix in filepath if presen't
-      template_filepath_with_status.gsub!("_component.html.erb", ".html.erb") if filepath_with_status.end_with?("component.html.erb")
+      template_filepath_with_status.gsub!("_component.html.erb", ".html.erb") if template_filepath_with_status.end_with?("component.html.erb")
 
       puts "moving from #{template_filepath} to #{template_filepath_with_status}"
       mv_result = %x(`git mv #{template_filepath} #{template_filepath_with_status}`)
@@ -76,7 +76,7 @@ namespace :renamer do
       story_filepath_with_status = story_filepath.gsub("/primer/", "/primer/#{target_status}/")
 
       # drop component suffix in filepath if presen't
-      story_filepath_with_status.gsub!("_component_stories", "_stories") if filepath_with_status.end_with?("component_stories.rb")
+      story_filepath_with_status.gsub!("_component_stories", "_stories") if story_filepath_with_status.end_with?("component_stories.rb")
 
       puts "moving from #{story_filepath} to #{story_filepath_with_status}"
       mv_result = %x(`git mv #{story_filepath} #{story_filepath_with_status}`)
@@ -89,6 +89,7 @@ namespace :renamer do
       updated_component_name = target_component_name.gsub("Component", "")
 
       # TODO: don't add Beta:: in class definition
+      # TODO: don't mangle test class declaration
       puts "greping to drop Component suffix"
       rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
       puts rename_result

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -14,10 +14,13 @@ namespace :renamer do
     # find the file
     filepath = File.join("app/components/primer/#{target_component_name.underscore}.rb")
     test_filepath = File.join("test/components/#{target_component_name.underscore}_test.rb")
+    template_filepath = File.join("app/components/primer/#{target_component_name.underscore}.html.erb")
+    story_filepath = File.join("stories/primer/#{target_component_name.underscore}_stories.rb")
 
     exists = File.file?(filepath)
-
     raise "can't find component file" unless exists
+
+    template_file_exists = File.file?(template_filepath)
 
     # add module <status>
     component_file = File.open(filepath, "r")
@@ -56,8 +59,29 @@ namespace :renamer do
     mv_result = %x(`git mv #{test_filepath} #{test_filepath_with_status}`)
     puts mv_result
 
-    # TODO: rename template filename too
-    # TODO: rename story too
+    # rename template filename too
+    if template_file_exists
+      template_filepath_with_status = template_filepath.gsub("/primer/", "/primer/#{target_status}/")
+
+      # drop component suffix in filepath if presen't
+      template_filepath_with_status.gsub!("_component.html.erb", ".html.erb") if filepath_with_status.end_with?("component.html.erb")
+
+      puts "moving from #{template_filepath} to #{template_filepath_with_status}"
+      mv_result = %x(`git mv #{template_filepath} #{template_filepath_with_status}`)
+      puts mv_result
+    end
+
+    # rename story too
+    if story_filepath
+      story_filepath_with_status = story_filepath.gsub("/primer/", "/primer/#{target_status}/")
+
+      # drop component suffix in filepath if presen't
+      story_filepath_with_status.gsub!("_component_stories", "_stories") if filepath_with_status.end_with?("component_stories.rb")
+
+      puts "moving from #{story_filepath} to #{story_filepath_with_status}"
+      mv_result = %x(`git mv #{story_filepath} #{story_filepath_with_status}`)
+      puts mv_result
+    end
 
     # rename in codebase for status and suffix
     updated_component_name = target_component_name

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -71,7 +71,7 @@ namespace :renamer do
     end
 
     # rename nav.yml entry
-    sed_cmd = "'s/components\/#{updated_component_name.downcase}/components\/#{target_status.downcase}\/#{updated_component_name.downcase}/g' ./docs/src/@primer/gatsby-theme-doctocat/nav.yml"
+    sed_cmd = "'s/components\\\/#{updated_component_name.downcase}/components\\\/#{target_status.downcase}\\\/#{updated_component_name.downcase}/g' ./docs/src/@primer/gatsby-theme-doctocat/nav.yml"
     puts "running sed with #{sed_cmd}"
     %x(`sed -i #{sed_cmd}`)
 

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -58,9 +58,9 @@ namespace :renamer do
 
     # TODO: rename template filename too
     # TODO: rename story too
-    # TODO: rename nav.yml
 
     # rename in codebase for status and suffix
+    updated_component_name = target_component_name
     if target_component_name.end_with?("Component")
       updated_component_name = target_component_name.gsub("Component", "")
 
@@ -69,6 +69,11 @@ namespace :renamer do
       rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
       puts rename_result
     end
+
+    # rename nav.yml entry
+    sed_cmd = "'s/components\/#{updated_component_name.downcase}/components\/#{target_status.downcase}\/#{updated_component_name.downcase}/g' ./docs/src/@primer/gatsby-theme-doctocat/nav.yml"
+    puts "running sed with #{sed_cmd}"
+    %x(`sed -i #{sed_cmd}`)
 
     puts "updates done"
 

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -43,7 +43,7 @@ namespace :renamer do
         filepath_with_status.gsub!("_component.rb", ".rb")
     end
 
-    # TODO: rename test file too
+    # TODO: rename test filename too
     # TODO: rename template filename too
 
     puts "moving from #{filepath} to #{filepath_with_status}"

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -13,6 +13,7 @@ namespace :renamer do
 
     # find the file
     filepath = File.join("app/components/primer/#{target_component_name.underscore}.rb")
+    test_filepath = File.join("test/components/#{target_component_name.underscore}_test.rb")
 
     exists = File.file?(filepath)
 
@@ -43,12 +44,23 @@ namespace :renamer do
         filepath_with_status.gsub!("_component.rb", ".rb")
     end
 
-    # TODO: rename test filename too
-    # TODO: rename template filename too
-
     puts "moving from #{filepath} to #{filepath_with_status}"
     mv_result = %x(`git mv #{filepath} #{filepath_with_status}`)
     puts mv_result
+
+    # rename test filename too
+    test_filepath_with_status = test_filepath.gsub("/components/", "/components/#{target_status}/")
+
+    # drop component suffix in filepath if presen't
+    if test_filepath_with_status.end_with?("component_test.rb")
+      test_filepath_with_status.gsub!("_component_test.rb", "_test.rb")
+    end
+
+    puts "moving from #{test_filepath} to #{test_filepath_with_status}"
+    mv_result = %x(`git mv #{test_filepath} #{test_filepath_with_status}`)
+    puts mv_result
+
+    # TODO: rename template filename too
 
     # rename in codebase for status and suffix
     if target_component_name.end_with?("Component")

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-# bundle exec rake renamer:add_status[AvatarStackComponent,beta]
+# bundle exec rake renamer:add_status[AvatarStack,beta]
 namespace :renamer do
-    task :add_status, [:target_component_name, :target_status] do |task, args|
-      require File.expand_path("./../../demo/config/environment.rb", __dir__)
-      require "primer/view_components"
-      # Loads all components for `.descendants` to work properly
-      Dir["./app/components/primer/**/*.rb"].sort.each { |file| require file }
-
-      target_component_name = args[:target_component_name]
-      target_status = args[:target_status]
+  task :add_status, [:target_component_name, :target_status] do |task, args|
+    require File.expand_path("./../../demo/config/environment.rb", __dir__)
+    require "primer/view_components"
+    # Loads all components for `.descendants` to work properly
+    Dir["./app/components/primer/**/*.rb"].sort.each { |file| require file }
+    
+    target_component_name = args[:target_component_name]
+    target_status = args[:target_status]
 
     # find the file
     filepath = File.join("app/components/primer/#{target_component_name.underscore}.rb")
@@ -38,13 +38,23 @@ namespace :renamer do
     filepath_with_status = filepath.gsub("/primer/", "/primer/#{target_status}/")
 
     puts "moving from #{filepath} to #{filepath_with_status}"
+    mv_result = %x(`git mv #{filepath} #{filepath_with_status}`)
+    puts mv_result
 
-    did_move = system(`git mv #{filepath} #{filepath_with_status}`)
-    raise "error git mving file" unless did_move
-
-    # drop component suffix in file if present
-    # drop component suffix in filepath if present
-    # rename in codebase for status and suffix
-
+    # drop component suffix in filepath if presen't
+    if filepath_with_status.end_with?("component.rb")
+        filepath_with_status.gsub!("component.rb", ".rb")
     end
+
+    # rename in codebase for status and suffix
+    if target_component_name.end_with?("Component")
+      updated_component_name = target_component_name.gsub("Component", "")
+      
+      puts "greping to drop Component suffix"
+      rename_result = %x(`grep -rl #{target_component_name} | xargs sed -i 's/#{target_component_name}/#{updated_component_name}/g'`)
+      puts rename_result
+    end
+
+    puts "tada"
+  end
 end

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -30,6 +30,7 @@ namespace :renamer do
 
     puts "adding module <status> line"
     lines.insert(module_primer_line_index+1, "module #{target_status.capitalize}")
+    lines.push("end")
 
     File.open(filepath, mode: "w") do |f|
       lines.each { |line| f.puts(line) }
@@ -37,21 +38,25 @@ namespace :renamer do
 
     filepath_with_status = filepath.gsub("/primer/", "/primer/#{target_status}/")
 
+    # drop component suffix in filepath if presen't
+    if filepath_with_status.end_with?("component.rb")
+        filepath_with_status.gsub!("_component.rb", ".rb")
+    end
+
+    # TODO: rename test file too
+    # TODO: rename template filename too
+
     puts "moving from #{filepath} to #{filepath_with_status}"
     mv_result = %x(`git mv #{filepath} #{filepath_with_status}`)
     puts mv_result
-
-    # drop component suffix in filepath if presen't
-    if filepath_with_status.end_with?("component.rb")
-        filepath_with_status.gsub!("component.rb", ".rb")
-    end
 
     # rename in codebase for status and suffix
     if target_component_name.end_with?("Component")
       updated_component_name = target_component_name.gsub("Component", "")
       
+      # TODO: don't add Beta:: in class definition
       puts "greping to drop Component suffix"
-      rename_result = %x(`grep -rl #{target_component_name} | xargs sed -i 's/#{target_component_name}/#{updated_component_name}/g'`)
+      rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
       puts rename_result
     end
 

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# bundle exec rake renamer:add_status[AvatarStackComponent,beta]
+namespace :renamer do
+    task :add_status, [:target_component_name, :target_status] do |task, args|
+      require File.expand_path("./../../demo/config/environment.rb", __dir__)
+      require "primer/view_components"
+      # Loads all components for `.descendants` to work properly
+      Dir["./app/components/primer/**/*.rb"].sort.each { |file| require file }
+
+      target_component_name = args[:target_component_name]
+      target_status = args[:target_status]
+
+    # find the file
+    filepath = File.join("app/components/primer/#{target_component_name.underscore}.rb")
+
+    exists = File.file?(filepath)
+
+    raise "can't find component file" unless exists
+
+    # add module <status>
+    component_file = File.open(filepath, "r")
+    lines = component_file.readlines
+
+    module_primer_line_index = 0
+    lines.each_with_index do |line, i|
+      module_primer_line_index = i if line.include?("module Primer")
+    end
+    raise "can't find 'module Primer' line" if module_primer_line_index.zero?
+
+    puts "adding module <status> line"
+    lines.insert(module_primer_line_index+1, "module #{target_status.capitalize}")
+
+    File.open(filepath, mode: "w") do |f|
+      lines.each { |line| f.puts(line) }
+    end
+
+    filepath_with_status = filepath.gsub("/primer/", "/primer/#{target_status}/")
+
+    puts "moving from #{filepath} to #{filepath_with_status}"
+
+    did_move = system(`git mv #{filepath} #{filepath_with_status}`)
+    raise "error git mving file" unless did_move
+
+    # drop component suffix in file if present
+    # drop component suffix in filepath if present
+    # rename in codebase for status and suffix
+
+    end
+end

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -88,14 +88,12 @@ namespace :renamer do
     if target_component_name.end_with?("Component")
       updated_component_name = target_component_name.gsub("Component", "")
 
+      # TODO: don't add Beta:: in class definition
+      # TODO: don't mangle test class declaration
       puts "greping to drop Component suffix"
-      rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{updated_component_name}/g'`)
+      rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
       puts rename_result
     end
-
-    puts "grepping to add status prefix"
-    rename_result = %x(`grep -rl (?<!class |Primer)#{updated_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{updated_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
-    puts rename_result
 
     # rename nav.yml entry
     sed_cmd = "'s/components\\\/#{updated_component_name.downcase}/components\\\/#{target_status.downcase}\\\/#{updated_component_name.downcase}/g' ./docs/src/@primer/gatsby-theme-doctocat/nav.yml"

--- a/lib/tasks/renamer.rake
+++ b/lib/tasks/renamer.rake
@@ -88,12 +88,14 @@ namespace :renamer do
     if target_component_name.end_with?("Component")
       updated_component_name = target_component_name.gsub("Component", "")
 
-      # TODO: don't add Beta:: in class definition
-      # TODO: don't mangle test class declaration
       puts "greping to drop Component suffix"
-      rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
+      rename_result = %x(`grep -rl #{target_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{target_component_name}/#{updated_component_name}/g'`)
       puts rename_result
     end
+
+    puts "grepping to add status prefix"
+    rename_result = %x(`grep -rl (?<!class |Primer)#{updated_component_name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{updated_component_name}/#{target_status.capitalize}::#{updated_component_name}/g'`)
+    puts rename_result
 
     # rename nav.yml entry
     sed_cmd = "'s/components\\\/#{updated_component_name.downcase}/components\\\/#{target_status.downcase}\\\/#{updated_component_name.downcase}/g' ./docs/src/@primer/gatsby-theme-doctocat/nav.yml"


### PR DESCRIPTION
In support of https://github.com/primer/view_components/issues/676

Usage

```
bundle exec rake renamer:add_status[AvatarStackComponent,beta]
```

The script will
* update the class namespace to be within the proper status module - `module Beta`
* update the component's filepath and name to drop the `Component` suffix
* find and replace all instances to include the status prefix and drop the component suffix

The script is far from perfect but should get a dev most of the way to handling each renaming. There are inline TODO's we could work on improving but this might be good enough to have us chug through the list of renames.