### PR TITLE
Ensure tab panels and tab are associated with aria-controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Breaking changes
+
+* Require tab with panels to have `panel_id` so `aria-controls` can be set.
+
+    *Kate Higa*
+
 ### Updates
 
 * Update the `Truncate` component to accept `:strong` as a tag.
@@ -40,6 +46,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+### Misc
+
+* Extract example tag parsing into helper.
+
+    *Kate Higa*
+
 ## 0.0.48
 
 ### Breaking changes
@@ -49,10 +61,6 @@ The category for changes related to documentation, testing and tooling. Also, fo
     *Kate Higa*
 
 ### Misc
-
-* Extract example tag parsing into helper.
-
-    *Kate Higa*
 
 * Expose custom cops and default config for erblint.
 

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -20,6 +20,7 @@ module Primer
       renders_one :panel, lambda { |**system_arguments|
         return unless @with_panel
 
+        system_arguments[:id] = @panel_id
         system_arguments[:tag] = :div
         system_arguments[:role] ||= :tabpanel
         system_arguments[:tabindex] = 0
@@ -98,10 +99,11 @@ module Primer
       # @param list [Boolean] Whether the Tab is an item in a `<ul>` list.
       # @param selected [Boolean] Whether the Tab is selected or not.
       # @param with_panel [Boolean] Whether the Tab has an associated panel.
+      # @param panel_id [String] Only applies if `with_panel` is `true`. Unique id of panel.
       # @param icon_classes [Boolean] Classes that must always be applied to icons.
       # @param wrapper_arguments [Hash] <%= link_to_system_arguments_docs %> to be used in the `<li>` wrapper when the tab is an item in a list.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(list: false, selected: false, with_panel: false, icon_classes: "", wrapper_arguments: {}, **system_arguments)
+      def initialize(list: false, selected: false, with_panel: false, panel_id: "", icon_classes: "", wrapper_arguments: {}, **system_arguments)
         @selected = selected
         @icon_classes = icon_classes
         @list = list
@@ -114,6 +116,7 @@ module Primer
           @system_arguments[:tag] = :button
           @system_arguments[:type] = :button
           @system_arguments[:role] = :tab
+          panel_id(panel_id)
         else
           @system_arguments[:tag] = :a
         end
@@ -140,6 +143,17 @@ module Primer
 
         render(Primer::BaseComponent.new(**@wrapper_arguments)) do
           yield
+        end
+      end
+
+      private
+
+      def panel_id(panel_id)
+        if panel_id.blank?
+          raise ArgumentError, "`panel_id` is required" unless Rails.env.production?
+        else
+          @panel_id = panel_id
+          @system_arguments[:"aria-controls"] = @panel_id
         end
       end
     end

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -13,7 +13,7 @@ module Primer
     # Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
     # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
-    # @param panel_id [String] Only applies if `with_panel` is `true`. Unique id of panel.
+    # @param panel_id [String] Only applies if `with_panel` is `true`. Unique ID of panel.
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     renders_many :tabs, lambda { |selected: false, **system_arguments|

--- a/app/components/primer/tab_nav_component.rb
+++ b/app/components/primer/tab_nav_component.rb
@@ -13,6 +13,7 @@ module Primer
     # Tabs to be rendered. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
     # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
+    # @param panel_id [String] Only applies if `with_panel` is `true`. Unique id of panel.
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     renders_many :tabs, lambda { |selected: false, **system_arguments|
@@ -63,19 +64,19 @@ module Primer
     #
     # @example With panels
     #   <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
-    #     <% c.tab(selected: true, id: "tab-1") do |t| %>
+    #     <% c.tab(selected: true, panel_id: "panel-1", id: "tab-1") do |t| %>
     #       <% t.text { "Tab 1" } %>
     #       <% t.panel do %>
     #         Panel 1
     #       <% end %>
     #     <% end %>
-    #     <% c.tab(id: "tab-2") do |t| %>
+    #     <% c.tab(id: "tab-2", panel_id: "panel-2") do |t| %>
     #       <% t.text { "Tab 2" } %>
     #       <% t.panel do %>
     #         Panel 2
     #       <% end %>
     #     <% end %>
-    #     <% c.tab(id: "tab-3") do |t| %>
+    #     <% c.tab(id: "tab-3", panel_id: "panel-3") do |t| %>
     #       <% t.text { "Tab 3" } %>
     #       <% t.panel do %>
     #         Panel 3

--- a/app/components/primer/underline_nav_component.rb
+++ b/app/components/primer/underline_nav_component.rb
@@ -19,6 +19,7 @@ module Primer
     # Use the tabs to list navigation items. When `with_panel` is set on the parent, a button is rendered for panel navigation. Otherwise,
     # an anchor tag is rendered for page navigation. For more information, refer to <%= link_to_component(Primer::Navigation::TabComponent) %>.
     #
+    # @param panel_id [String] Only applies if `with_panel` is `true`. Unique id of panel.
     # @param selected [Boolean] Whether the tab is selected.
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     renders_many :tabs, lambda { |selected: false, **system_arguments|
@@ -104,13 +105,13 @@ module Primer
     #
     # @example With panels
     #   <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-    #     <% component.tab(selected: true, id: "tab-1") do |t| %>
+    #     <% component.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t| %>
     #       <% t.text { "Item 1" } %>
     #       <% t.panel do %>
     #         Panel 1
     #       <% end %>
     #     <% end %>
-    #     <% component.tab(id: "tab-2") do |t| %>
+    #     <% component.tab(id: "tab-2", panel_id: "panel-2") do |t| %>
     #       <% t.text { "Item 2" } %>
     #       <% t.panel do %>
     #         Panel 2

--- a/demo/test/components/previews/primer/tab_nav_component_preview.rb
+++ b/demo/test/components/previews/primer/tab_nav_component_preview.rb
@@ -2,15 +2,15 @@ module Primer
   class TabNavComponentPreview < ViewComponent::Preview
     def default
       render(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-        c.tab(selected: true, id: "tab-1") do |t|
+        c.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
           t.panel { "Panel 1" }
           t.text { "Tab 1" }
         end
-        c.tab(id: "tab-2") do |t|
+        c.tab(id: "tab-2", panel_id: "panel-2") do |t|
           t.panel { "Panel 2" }
           t.text { "Tab 2" }
         end
-        c.tab(id: "tab-3") do |t|
+        c.tab(id: "tab-3", panel_id: "panel-3") do |t|
           t.panel { "Panel 3" }
           t.text { "Tab 3" }
         end

--- a/demo/test/components/previews/primer/underline_nav_component_preview.rb
+++ b/demo/test/components/previews/primer/underline_nav_component_preview.rb
@@ -2,15 +2,15 @@ module Primer
   class UnderlineNavComponentPreview < ViewComponent::Preview
     def default
       render(Primer::UnderlineNavComponent.new(label: "Test navigation", with_panel: true)) do |c|
-        c.tab(selected: true, id: "tab-1") do |t|
+        c.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
           t.panel { "Panel 1" }
           t.text { "Tab 1" }
         end
-        c.tab(id: "tab-2") do |t|
+        c.tab(id: "tab-2", panel_id: "panel-2") do |t|
           t.panel { "Panel 2" }
           t.text { "Tab 2" }
         end
-        c.tab(id: "tab-3") do |t|
+        c.tab(id: "tab-3", panel_id: "panel-3") do |t|
           t.panel { "Panel 3" }
           t.text { "Tab 3" }
         end

--- a/docs/content/components/navigationtab.md
+++ b/docs/content/components/navigationtab.md
@@ -25,6 +25,7 @@ and `Primer::UnderlineNavComponent` and should not be used by itself.
 | `list` | `Boolean` | `false` | Whether the Tab is an item in a `<ul>` list. |
 | `selected` | `Boolean` | `false` | Whether the Tab is selected or not. |
 | `with_panel` | `Boolean` | `false` | Whether the Tab has an associated panel. |
+| `panel_id` | `String` | `""` | Only applies if `with_panel` is `true`. Unique id of panel. |
 | `icon_classes` | `Boolean` | `""` | Classes that must always be applied to icons. |
 | `wrapper_arguments` | `Hash` | `{}` | [System arguments](/system-arguments) to be used in the `<li>` wrapper when the tab is an item in a list. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -34,7 +34,7 @@ an anchor tag is rendered for page navigation. For more information, refer to [N
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `panel_id` | `String` | N/A | Only applies if `with_panel` is `true`. Unique id of panel. |
+| `panel_id` | `String` | N/A | Only applies if `with_panel` is `true`. Unique ID of panel. |
 | `selected` | `Boolean` | N/A | Whether the tab is selected. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 

--- a/docs/content/components/tabnav.md
+++ b/docs/content/components/tabnav.md
@@ -34,6 +34,7 @@ an anchor tag is rendered for page navigation. For more information, refer to [N
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `panel_id` | `String` | N/A | Only applies if `with_panel` is `true`. Unique id of panel. |
 | `selected` | `Boolean` | N/A | Whether the tab is selected. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
@@ -83,23 +84,23 @@ Renders extra content to the `TabNav`. This will be rendered after the tabs.
 
 ### With panels
 
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <div aria-label='With panels' role='tablist' data-view-component='true' class='tabnav-tabs'>          <button id='tab-1' type='button' role='tab' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button>          <button id='tab-2' type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button>          <button id='tab-3' type='button' role='tab' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></div>    </div>      <div role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-3' data-view-component='true'>      Panel 3</div></tab-container>" />
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='tabnav'>        <div aria-label='With panels' role='tablist' data-view-component='true' class='tabnav-tabs'>          <button id='tab-1' type='button' role='tab' aria-controls='panel-1' aria-selected='true' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 1</span>    </button>          <button id='tab-2' type='button' role='tab' aria-controls='panel-2' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 2</span>    </button>          <button id='tab-3' type='button' role='tab' aria-controls='panel-3' data-view-component='true' class='tabnav-tab'>          <span data-view-component='true'>Tab 3</span>    </button></div>    </div>      <div id='panel-1' role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div id='panel-2' role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div>      <div id='panel-3' role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-3' data-view-component='true'>      Panel 3</div></tab-container>" />
 
 ```erb
 <%= render(Primer::TabNavComponent.new(label: "With panels", with_panel: true)) do |c| %>
-  <% c.tab(selected: true, id: "tab-1") do |t| %>
+  <% c.tab(selected: true, panel_id: "panel-1", id: "tab-1") do |t| %>
     <% t.text { "Tab 1" } %>
     <% t.panel do %>
       Panel 1
     <% end %>
   <% end %>
-  <% c.tab(id: "tab-2") do |t| %>
+  <% c.tab(id: "tab-2", panel_id: "panel-2") do |t| %>
     <% t.text { "Tab 2" } %>
     <% t.panel do %>
       Panel 2
     <% end %>
   <% end %>
-  <% c.tab(id: "tab-3") do |t| %>
+  <% c.tab(id: "tab-3", panel_id: "panel-3") do |t| %>
     <% t.text { "Tab 3" } %>
     <% t.panel do %>
       Panel 3

--- a/docs/content/components/underlinenav.md
+++ b/docs/content/components/underlinenav.md
@@ -37,6 +37,7 @@ an anchor tag is rendered for page navigation. For more information, refer to [N
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `panel_id` | `String` | N/A | Only applies if `with_panel` is `true`. Unique id of panel. |
 | `selected` | `Boolean` | N/A | Whether the tab is selected. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
@@ -128,17 +129,17 @@ Use actions for a call to action.
 
 ### With panels
 
-<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <div role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body'>          <button id='tab-1' type='button' role='tab' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button>          <button id='tab-2' type='button' role='tab' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div></tab-container>" />
+<Example src="<tab-container data-view-component='true'>  <div data-view-component='true' class='UnderlineNav'>    <div role='tablist' aria-label='With panels' data-view-component='true' class='UnderlineNav-body'>          <button id='tab-1' type='button' role='tab' aria-controls='panel-1' aria-selected='true' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 1</span>    </button>          <button id='tab-2' type='button' role='tab' aria-controls='panel-2' data-view-component='true' class='UnderlineNav-item'>          <span data-view-component='true'>Item 2</span>    </button></div>      <div data-view-component='true' class='UnderlineNav-actions'>    <button type='button' data-view-component='true' class='btn'>    Button!  </button></div></div>      <div id='panel-1' role='tabpanel' tabindex='0' aria-labelledby='tab-1' data-view-component='true'>      Panel 1</div>      <div id='panel-2' role='tabpanel' tabindex='0' hidden='hidden' aria-labelledby='tab-2' data-view-component='true'>      Panel 2</div></tab-container>" />
 
 ```erb
 <%= render(Primer::UnderlineNavComponent.new(label: "With panels", with_panel: true)) do |component| %>
-  <% component.tab(selected: true, id: "tab-1") do |t| %>
+  <% component.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t| %>
     <% t.text { "Item 1" } %>
     <% t.panel do %>
       Panel 1
     <% end %>
   <% end %>
-  <% component.tab(id: "tab-2") do |t| %>
+  <% component.tab(id: "tab-2", panel_id: "panel-2") do |t| %>
     <% t.text { "Item 2" } %>
     <% t.panel do %>
       Panel 2

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -707,6 +707,10 @@
     type: Boolean
     default: "`false`"
     description: Whether the Tab has an associated panel.
+  - name: panel_id
+    type: String
+    default: '`""`'
+    description: Only applies if `with_panel` is `true`. Unique id of panel.
   - name: icon_classes
     type: Boolean
     default: '`""`'

--- a/test/components/navigation/tab_component_test.rb
+++ b/test/components/navigation/tab_component_test.rb
@@ -17,7 +17,7 @@ class PrimerNavigationTabComponentTest < Minitest::Test
   end
 
   def test_renders_role_only_if_with_panel
-    render_inline Primer::Navigation::TabComponent.new(with_panel: true) do |c|
+    render_inline Primer::Navigation::TabComponent.new(with_panel: true, panel_id: "panel-1") do |c|
       c.text { "Title" }
     end
 
@@ -28,13 +28,24 @@ class PrimerNavigationTabComponentTest < Minitest::Test
 
   def test_raises_if_panel_has_no_label
     err = assert_raises ArgumentError do
-      render_inline Primer::Navigation::TabComponent.new(with_panel: true) do |c|
+      render_inline Primer::Navigation::TabComponent.new(with_panel: true, panel_id: "panel-1") do |c|
         c.text { "Title" }
         c.panel { "content" }
       end
     end
 
     assert_equal("Panels must be labelled. Either set a unique `id` on the tab, or set an `aria-label` directly on the panel", err.message)
+  end
+
+  def test_raises_if_with_panel_and_no_panel_id
+    err = assert_raises ArgumentError do
+      render_inline Primer::Navigation::TabComponent.new(with_panel: true) do |c|
+        c.text { "Title" }
+        c.panel { "content" }
+      end
+    end
+
+    assert_equal("`panel_id` is required", err.message)
   end
 
   def test_renders_octicon
@@ -83,11 +94,11 @@ class PrimerNavigationTabComponentTest < Minitest::Test
   end
 
   def test_renders_as_button_if_has_panel
-    render_inline Primer::Navigation::TabComponent.new(with_panel: true) do |c|
+    render_inline Primer::Navigation::TabComponent.new(with_panel: true, panel_id: "panel-1") do |c|
       c.text { "Title" }
     end
 
-    assert_selector("button[role='tab'][type='button']") do
+    assert_selector("button[role='tab'][type='button'][aria-controls='panel-1']") do
       assert_selector("span", text: "Title")
     end
   end
@@ -104,7 +115,7 @@ class PrimerNavigationTabComponentTest < Minitest::Test
   end
 
   def test_renders_aria_selected_if_button_and_selected
-    render_inline Primer::Navigation::TabComponent.new(selected: true, with_panel: true) do |c|
+    render_inline Primer::Navigation::TabComponent.new(selected: true, with_panel: true, panel_id: "panel-1") do |c|
       c.text { "Title" }
     end
 

--- a/test/components/tab_nav_component_test.rb
+++ b/test/components/tab_nav_component_test.rb
@@ -37,25 +37,25 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_renders_tabs_as_buttons
     render_inline(Primer::TabNavComponent.new(label: "label")) do |c|
-      c.tab(tag: :button, selected: true) { "Tab 1" }
-      c.tab(tag: :button) { "Tab 2" }
+      c.tab(tag: :button, selected: true, panel_id: "panel-1") { "Tab 1" }
+      c.tab(tag: :button, panel_id: "panel-2") { "Tab 2" }
     end
 
     assert_selector(".tabnav") do
       assert_selector("nav.tabnav-tabs[aria-label='label']") do
-        assert_selector("button.tabnav-tab[aria-selected='true']", text: "Tab 1")
-        assert_selector("button.tabnav-tab", text: "Tab 2")
+        assert_selector("button.tabnav-tab[aria-selected='true'][aria-controls='panel-1']", text: "Tab 1")
+        assert_selector("button.tabnav-tab[aria-controls='panel-2']", text: "Tab 2")
       end
     end
   end
 
   def test_renders_tab_panels_with_tabs_as_button
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-      c.tab(selected: true, id: "tab-1") do |t|
+      c.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab(id: "tab-2") do |t|
+      c.tab(id: "tab-2", panel_id: "panel-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -73,20 +73,20 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_only_renders_panels_for_tabs_with_content
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true)) do |c|
-      c.tab(tag: :button, selected: true, id: "tab-1") do |t|
+      c.tab(tag: :button, selected: true, id: "tab-1", panel_id: "panel-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      c.tab(tag: :button, id: "tab-2") { "Tab 2" }
+      c.tab(tag: :button, id: "tab-2", panel_id: "panel-2") { "Tab 2" }
     end
 
     assert_selector(".tabnav") do
       assert_selector("div.tabnav-tabs[role='tablist']") do
-        assert_selector("button.tabnav-tab[aria-selected='true'][role='tab']", text: "Tab 1")
-        assert_selector("button.tabnav-tab[role='tab']", text: "Tab 2")
+        assert_selector("button.tabnav-tab[aria-selected='true'][role='tab'][aria-controls='panel-1']", text: "Tab 1")
+        assert_selector("button.tabnav-tab[role='tab'][aria-controls='panel-2']", text: "Tab 2")
       end
     end
-    assert_selector("div[role='tabpanel']", count: 1)
+    assert_selector("div[id='panel-1'][role='tabpanel']", count: 1)
   end
 
   def test_does_not_render_panels_when_with_panel_is_false
@@ -144,7 +144,7 @@ class PrimerTabNavComponentTest < Minitest::Test
 
   def test_customizes_tab_container
     render_inline(Primer::TabNavComponent.new(label: "label", with_panel: true, wrapper_arguments: { m: 2, classes: "custom-class" })) do |component|
-      component.tab(selected: true, id: "tab-1") do |t|
+      component.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end

--- a/test/components/underline_nav_component_test.rb
+++ b/test/components/underline_nav_component_test.rb
@@ -136,11 +136,11 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_renders_panels_and_tab_container
     render_inline(Primer::UnderlineNavComponent.new(label: "label", with_panel: true)) do |component|
-      component.tab(selected: true, id: "tab-1") do |t|
+      component.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end
-      component.tab(id: "tab-2") do |t|
+      component.tab(id: "tab-2", panel_id: "panel-2") do |t|
         t.panel { "Panel 2" }
         t.text { "Tab 2" }
       end
@@ -152,13 +152,13 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
     assert_selector("tab-container") do
       assert_selector("div.UnderlineNav") do
         assert_selector("div.UnderlineNav-body[role='tablist'][aria-label='label']") do
-          assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true']", text: "Tab 1")
-          assert_selector("button.UnderlineNav-item[role='tab']", text: "Tab 2")
+          assert_selector("button.UnderlineNav-item[role='tab'][aria-selected='true'][aria-controls='panel-1']", text: "Tab 1")
+          assert_selector("button.UnderlineNav-item[role='tab'][aria-controls='panel-2']", text: "Tab 2")
         end
         assert_selector("div.UnderlineNav-actions", text: "Actions content")
       end
-      assert_selector("div[role='tabpanel']", text: "Panel 1")
-      assert_selector("div[role='tabpanel']", text: "Panel 2", visible: false)
+      assert_selector("div[id='panel-1'][role='tabpanel']", text: "Panel 1")
+      assert_selector("div[id='panel-2'][role='tabpanel']", text: "Panel 2", visible: false)
     end
   end
 
@@ -204,7 +204,7 @@ class PrimerUnderlineNavComponentTest < Minitest::Test
 
   def test_customizes_tab_container
     render_inline(Primer::UnderlineNavComponent.new(label: "label", with_panel: true, wrapper_arguments: { m: 2, classes: "custom-class" })) do |component|
-      component.tab(selected: true, id: "tab-1") do |t|
+      component.tab(selected: true, id: "tab-1", panel_id: "panel-1") do |t|
         t.panel { "Panel 1" }
         t.text { "Tab 1" }
       end


### PR DESCRIPTION
#### What
This PR requires `panel_id` to be set when the tab has an associated panel for panel navigation.

#### Why
This is necessary for accessibility. In order for tabs to be associated with the corresponding panel, the tab's `aria-controls` must be set to the `id` of the corresponding panel. 

##### References
-  [Deque ARIA Tab Panel Accessibility: A11y Support Series](https://www.deque.com/blog/a11y-support-series-part-1-aria-tab-panel-accessibility/)
-  [W3 Example of Tabs with Automatic Activation](https://www.w3.org/TR/wai-aria-practices-1.1/examples/tabs/tabs-1/tabs.html)

#### Notes

The API for tab components is getting increasingly complex because we're supporting both page navigation and panel navigation within a single component. See issue #680. 

PR #689  will break down the `UnderlineNavComponent` into `UnderlineNav` and `UnderlinePanel`. While there's some overlap between the two, I think there are greater benefits to splitting this into two components including more tailored documentation, and a simpler API. 

