### PR TITLE
Thor component migrator

### DIFF
--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "thor"
+require "active_support/core_ext/string/inflections"
+
+# Migrates components to their new namespace.
+#
+# Usage:
+#
+# bundle exec thor component_status_migrator MyComponentName
+# bundle exec thor component_status_migrator MyComponentName --status beta
+class ComponentStatusMigrator < Thor::Group
+  include Thor::Actions
+
+  STATUSES = %w[alpha beta].freeze
+
+  # Define arguments and options
+  argument :name
+  class_option :status, default: "alpha", desc: "Status of the component. Either alpha or beta", required: true, type: :string
+
+  def self.source_root
+    File.dirname(__FILE__)
+  end
+
+  def validate_status
+    raise unless STATUSES.include?(status)
+  end
+
+  def move_controller
+    raise unless File.exist?(controller_path)
+
+    copy_file(controller_path, controller_path_with_status)
+    remove_file(controller_path)
+  end
+
+  def move_template
+    if File.exist?(template_path)
+      copy_file(template_path, template_path_with_status)
+      remove_file(template_path)
+    else
+      puts "No template found"
+    end
+  end
+
+  def move_test
+    raise unless File.exist?(test_path)
+
+    copy_file(test_path, test_path_with_status)
+    remove_file(test_path)
+  end
+
+  def move_story
+    raise unless File.exist?(story_path)
+
+    copy_file(story_path, story_path_with_status)
+    remove_file(story_path)
+  end
+
+  def add_module
+    insert_into_file(controller_path_with_status, "  module #{status.capitalize}\n", after: "module Primer\n")
+    insert_into_file(controller_path_with_status, "  end\n", before: /^end$/, force: true)
+  end
+
+  def remove_suffix
+    gsub_file(controller_path_with_status, "class #{name}", "class #{name_without_suffix}")
+  end
+
+  def rename_test_class
+    gsub_file(test_path_with_status, /class .*Test/, "class Primer#{name_without_suffix.gsub('::', '')}Test")
+  end
+
+  def add_require_to_story
+    insert_into_file(story_path_with_status, "require \"primer/#{status}/#{name_without_suffix.underscore}\"\n", after: "# frozen_string_literal: true\n")
+  end
+
+  def rename_nav_entry
+    gsub_file("docs/src/@primer/gatsby-theme-doctocat/nav.yml", "class #{name}", name_without_suffix)
+  end
+
+  def update_all_references
+    run("grep -rl #{name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{name}/#{status.capitalize}::#{name_without_suffix}/g'")
+  end
+
+  def run_rubocop
+    run("bundle exec rubocop -a")
+  end
+
+  def generate_docs
+    run("bundle exec rake docs:build")
+  end
+
+  def dump_static_files
+    run("bundle exec rake statuses:dump")
+  end
+
+  private
+
+  def controller_path
+    "app/components/primer/#{name.underscore}.rb"
+  end
+
+  def controller_path_with_status
+    "app/components/primer/#{status}/#{name_without_suffix.underscore}.rb"
+  end
+
+  def template_path
+    "app/components/primer/#{name.underscore}.html.erb"
+  end
+
+  def template_path_with_status
+    "app/components/primer/#{status}/#{name_without_suffix.underscore}.html.erb"
+  end
+
+  def test_path
+    "test/components/#{name.underscore}_test.rb"
+  end
+
+  def test_path_with_status
+    "test/components/#{status}/#{name_without_suffix.underscore}_test.rb"
+  end
+
+  def story_path
+    "stories/primer/#{name.underscore}_stories.rb"
+  end
+
+  def story_path_with_status
+    "stories/primer/#{status}/#{name_without_suffix.underscore}_stories.rb"
+  end
+
+  def docs_path
+    "/components/#{short_name}.md"
+  end
+
+  def docs_path_with_status
+    "/components/#{status}/#{short_name}.md"
+  end
+
+  def status
+    options[:status].downcase
+  end
+
+  def name_without_suffix
+    name.gsub("Component", "")
+  end
+
+  def short_name
+    name_with_status = name.gsub(/Primer::|Component/, "")
+
+    m = name_with_status.match(/(?<status>Beta|Alpha|Deprecated)?(::)?(?<name>.*)/)
+    m[:name].gsub("::", "").downcase
+  end
+end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -78,7 +78,7 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def update_all_references
-    run("grep -rl #{name} . --exclude=CHANGELOG.md | xargs sed -i 's/Primer::#{name}/#{status.capitalize}::#{name_without_suffix}/g'")
+    run("grep -rl #{name} . --exclude=CHANGELOG.md | xargs sed -i 's/Primer::#{name}/Primer::#{status.capitalize}::#{name_without_suffix}/g'")
   end
 
   def run_rubocop

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -78,7 +78,7 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def update_all_references
-    run("grep -rl #{name} . --exclude=CHANGELOG.md | xargs sed -i 's/#{name}/#{status.capitalize}::#{name_without_suffix}/g'")
+    run("grep -rl #{name} . --exclude=CHANGELOG.md | xargs sed -i 's/Primer::#{name}/#{status.capitalize}::#{name_without_suffix}/g'")
   end
 
   def run_rubocop

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -12,11 +12,11 @@ require "active_support/core_ext/string/inflections"
 class ComponentStatusMigrator < Thor::Group
   include Thor::Actions
 
-  STATUSES = %w[alpha beta].freeze
+  STATUSES = %w[alpha beta deprecated].freeze
 
   # Define arguments and options
   argument :name
-  class_option :status, default: "alpha", desc: "Status of the component. Either alpha or beta", required: true, type: :string
+  class_option :status, default: "alpha", desc: "Status of the component. Either alpha, beta or deprecated", required: true, type: :string
 
   def self.source_root
     File.dirname(__FILE__)

--- a/docs/content/components/avatarstack.md
+++ b/docs/content/components/avatarstack.md
@@ -30,7 +30,7 @@ Required list of stacked avatars.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/avatar). |
+| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/beta/avatar). |
 
 ## Examples
 

--- a/docs/content/components/heading.md
+++ b/docs/content/components/heading.md
@@ -14,7 +14,7 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 - Set tag to one of `:h1`, `:h2`, `:h3`, `:h4`, `:h5`, `:h6` based on what is appropriate for the page context.
 - Use `Heading` as the title of a section or sub section.
-- Do not use `Heading` for styling alone. For simply styling text, consider using [Text](/components/text) with relevant [Typography](/system-arguments#typography)
+- Do not use `Heading` for styling alone. For simply styling text, consider using [Text](/components/beta/text) with relevant [Typography](/system-arguments#typography)
   such as `font_size` and `font_weight`.
 - Do not jump heading levels. For instance, do not follow a `<h1>` with an `<h3>`. Heading levels should increase by one in ascending order.
 

--- a/docs/content/components/navigationtab.md
+++ b/docs/content/components/navigationtab.md
@@ -56,7 +56,7 @@ The Tab's text.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Text](/components/text). |
+| `kwargs` | `Hash` | N/A | The same arguments as [Text](/components/beta/text). |
 
 ### `Counter`
 

--- a/docs/content/components/timelineitem.md
+++ b/docs/content/components/timelineitem.md
@@ -27,7 +27,7 @@ Avatar to be rendered to the left of the Badge.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/avatar). |
+| `kwargs` | `Hash` | N/A | The same arguments as [Avatar](/components/beta/avatar). |
 
 ### `Badge`
 

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -395,13 +395,6 @@ namespace :docs do
     pretty_value(constant_value)
   end
 
-  def status_module_and_short_name(component)
-    name_with_status = component.name.gsub(/Primer::|Component/, "")
-
-    m = name_with_status.match(/(?<status>Beta|Alpha|Deprecated)?(::)?(?<name>.*)/)
-    [m[:status]&.downcase, m[:name].gsub("::", "")]
-  end
-
   def docs_metadata(component)
     (status_module, short_name) = status_module_and_short_name(component)
     status_path = status_module.nil? ? "" : "#{status_module}/"

--- a/lib/yard/docs_helper.rb
+++ b/lib/yard/docs_helper.rb
@@ -41,8 +41,10 @@ module YARD
     end
 
     def link_to_component(component)
-      short_name = component.name.gsub(/Primer|::|Alpha|Beta|Component/, "")
-      "[#{short_name}](/components/#{short_name.downcase})"
+      (status_module, short_name) = status_module_and_short_name(component)
+      status_path = status_module.nil? ? "" : "#{status_module}/"
+
+      "[#{short_name}](/components/#{status_path}#{short_name.downcase})"
     end
 
     def link_to_octicons
@@ -51,6 +53,13 @@ module YARD
 
     def link_to_heading_practices
       "[Learn more about best heading practices (WAI Headings)](https://www.w3.org/WAI/tutorials/page-structure/headings/)"
+    end
+
+    def status_module_and_short_name(component)
+      name_with_status = component.name.gsub(/Primer::|Component/, "")
+
+      m = name_with_status.match(/(?<status>Beta|Alpha|Deprecated)?(::)?(?<name>.*)/)
+      [m[:status]&.downcase, m[:name].gsub("::", "")]
     end
 
     def pretty_value(val)

--- a/test/lib/yard/docs_helper_test.rb
+++ b/test/lib/yard/docs_helper_test.rb
@@ -13,7 +13,7 @@ class YardDocsHelperTest < Minitest::Test
 
   def test_link_to_component
     assert_equal("[Button](/components/button)", link_to_component(Primer::ButtonComponent))
-    assert_equal("[AutoCompleteItem](/components/autocompleteitem)", link_to_component(Primer::Beta::AutoComplete::Item))
+    assert_equal("[AutoCompleteItem](/components/beta/autocompleteitem)", link_to_component(Primer::Beta::AutoComplete::Item))
   end
 
   def test_pretty_value


### PR DESCRIPTION
Related to https://github.com/primer/view_components/issues/676

### Summary

Since we want to migrate all of our components into modules indicating their status, automating the migration task will save us a lot of time.
This PR creates a `thor` runner that does everything needed to move a component in the main `app/components` directory into `app/components/STATUS`.

### How to use

```sh
bundle exec thor component_status_migrator MyComponentName
bundle exec thor component_status_migrator MyComponentName --status beta
```

### What it does

1. Moves component files into a `/STATUS` subdirectory. This includes:
  i. Controller
  ii. Template
  iii. Test
  iv. Story
2. Adds the `STATUS` module to the component and removes the `Component` suffix.
   i. E.g.: `Primer::AvatarStackComponent` becomes `Primer::Beta::AvatarStack`.
3. Renames the test class from `PrimerComponentTest` to `PrimerStatusComponentTest`
4. Adds a `require "primer/status/component_name"` to the story.
  i. This is needed because of a limitation on the storybook gem.
5. Changes the `nav.yml` entry of the component to reflect the new docs path.
6. Updates all references to the component in the project to use the new name with module.
7. Runs rubocop to fix any linting issues.
8. Regenerates the docs.
9. Regenerates static files.

### How it works

This is based on Thor [generators](https://github.com/rails/thor/wiki/Generators. When running the script, thor will call all the **public** methods in the order they are defined in the file.
The big difference between using `thor` and a shell script is the helpers `thor` provides. See the [`Thor::Actions`](https://rubydoc.info/github/wycats/thor/master/Thor/Actions) documentation. It is also easier to read the script since it is all written in ruby and most of our contributors are Ruby developers.
