### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 * Improve `Primer::Classify::Utilities.classes_to_hash` performance.
 
     *Manuel Puyol*
+
 ### Misc
 
 * Add a `CHANGELOG.md` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ The category for changes related to documentation, testing and tooling. Also, fo
 * Improve `Primer::Classify::Utilities.classes_to_hash` performance.
 
     *Manuel Puyol*
-    
 ### Misc
 
 * Add a `CHANGELOG.md` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 * Improve `Primer::Classify::Utilities.classes_to_hash` performance.
 
     *Manuel Puyol*
+    
+### Misc
+
+* Add a `CHANGELOG.md` file.
+
+    *Simon Taranto*
 
 ## 0.0.48
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see the [contributing docs](https://primer.style/view-components/contributing).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-Please see the [contributing docs](https://primer.style/view-components/contributing).
+/workspaces/view_components/docs/content/contributing.md


### PR DESCRIPTION
Our own community score said we were missing a contributing guide - https://github.com/primer/view_components/community. This PR adds a file with a pointer to the docs we already have on the live site.