### PR TITLE
Dump component constants into JSON file

### DIFF
--- a/.erb-linters/linters.rb
+++ b/.erb-linters/linters.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-require "primer/view_components/constants"
 require "primer/view_components/linters"

--- a/.erb-linters/linters.rb
+++ b/.erb-linters/linters.rb
@@ -1,1 +1,4 @@
+# frozen_string_literal: true
+
+require "primer/view_components/constants"
 require "primer/view_components/linters"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -34,12 +34,13 @@ jobs:
           bundle exec rake utilities:build
           bundle exec rake docs:build
           bundle exec rake statuses:dump
+          bundle exec rake constants:dump
         env:
           SKIP_STORYBOOK_PRELOAD: 1
       - name: Commit & Push Docs Data
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Actions Auto Build"
-          git add -f lib/primer/classify/utilities.yml docs static/statuses.json static/arguments.yml static/classes.yml
+          git add -f lib/primer/classify/utilities.yml docs static/statuses.json static/constants.json static/arguments.yml static/classes.yml
           git commit -m "docs: build docs" || true
           git push

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -108,6 +108,20 @@
         "reevaluateOnRerun": false
       },
       "problemMatcher": []
+    }
+    {
+      "label": "constants:dump: dump static files",
+      "type": "shell",
+      "group": "build",
+      "command": "bundle exec rake constants:dump",
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated"
+      },
+      "runOptions": {
+        "reevaluateOnRerun": false
+      },
+      "problemMatcher": []
     },
     {
       "label": "rubocop: autofix rubocop errors",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Kate Higa*
 
+* Generate a static constant JSON and use it when defining linters.
+
+    *Manuel Puyol*
+
 ## 0.0.48
 
 ### Breaking changes

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -91,6 +91,7 @@ class ComponentStatusMigrator < Thor::Group
 
   def dump_static_files
     run("bundle exec rake statuses:dump")
+    run("bundle exec rake constants:dump")
   end
 
   private

--- a/lib/primer/view_components.rb
+++ b/lib/primer/view_components.rb
@@ -42,7 +42,7 @@ module Primer
     # all of its constants.
     def self.generate_constants
       Primer::Component.descendants.sort_by(&:name).each_with_object({}) do |component, mem|
-        mem[component.to_s] = component.constants(false).each_with_object({}) do |constant, h|
+        mem[component.to_s] = component.constants(false).sort.each_with_object({}) do |constant, h|
           h[constant] = component.const_get(constant)
         end
       end

--- a/lib/primer/view_components.rb
+++ b/lib/primer/view_components.rb
@@ -48,7 +48,7 @@ module Primer
       end
     end
 
-    # dump_constants generates the constnas hash and then serializes
+    # dump_constants generates the constants hash and then serializes
     # it as json at the given path
     def self.dump_constants(path: DEFAULT_STATIC_PATH)
       require "json"

--- a/lib/primer/view_components.rb
+++ b/lib/primer/view_components.rb
@@ -7,22 +7,21 @@ require "primer/view_components/engine"
 module Primer
   # :nodoc:
   module ViewComponents
-    DEFAULT_STATUSES_PATH = File.expand_path("static")
+    DEFAULT_STATIC_PATH = File.expand_path("static")
     DEFAULT_STATUS_FILE_NAME = "statuses.json"
+    DEFAULT_CONSTANTS_FILE_NAME = "constants.json"
 
     # generate_statuses returns a hash mapping component name to
     # the component's status sorted alphabetically by the component name.
     def self.generate_statuses
-      statuses = Primer::Component.descendants.each_with_object({}) do |component, mem|
+      Primer::Component.descendants.sort_by(&:name).each_with_object({}) do |component, mem|
         mem[component.to_s] = component.status.to_s
       end
-
-      statuses.sort_by { |k, _v| k }.to_h
     end
 
     # dump_statuses generates the status hash and then serializes
     # it as json at the given path
-    def self.dump_statuses(path: DEFAULT_STATUSES_PATH)
+    def self.dump_statuses(path: DEFAULT_STATIC_PATH)
       require "json"
 
       statuses = generate_statuses
@@ -35,8 +34,37 @@ module Primer
 
     # read_statuses returns a JSON string matching the output of
     # generate_statuses
-    def self.read_statuses(path: DEFAULT_STATUSES_PATH)
+    def self.read_statuses(path: DEFAULT_STATIC_PATH)
       File.read(File.join(path, DEFAULT_STATUS_FILE_NAME))
+    end
+
+    # generate_constants returns a hash mapping component name to
+    # all of its constants.
+    def self.generate_constants
+      Primer::Component.descendants.sort_by(&:name).each_with_object({}) do |component, mem|
+        mem[component.to_s] = component.constants(false).each_with_object({}) do |constant, h|
+          h[constant] = component.const_get(constant)
+        end
+      end
+    end
+
+    # dump_constants generates the constnas hash and then serializes
+    # it as json at the given path
+    def self.dump_constants(path: DEFAULT_STATIC_PATH)
+      require "json"
+
+      constants = generate_constants
+
+      File.open(File.join(path, DEFAULT_CONSTANTS_FILE_NAME), "w") do |f|
+        f.write(JSON.pretty_generate(constants))
+        f.write($INPUT_RECORD_SEPARATOR)
+      end
+    end
+
+    # read_constants returns a JSON string matching the output of
+    # generate_constants
+    def self.read_constants(path: DEFAULT_STATIC_PATH)
+      File.read(File.join(path, DEFAULT_CONSTANTS_FILE_NAME))
     end
   end
 end

--- a/lib/primer/view_components/constants.rb
+++ b/lib/primer/view_components/constants.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Primer
+  # :nodoc:
+  module ViewComponents
+    CONSTANTS = JSON.parse(
+      File.read(
+        File.join(File.dirname(__FILE__), "../../../static/constants.json")
+      )
+    ).freeze
+  end
+end

--- a/lib/primer/view_components/constants.rb
+++ b/lib/primer/view_components/constants.rb
@@ -3,12 +3,53 @@
 require "json"
 
 module Primer
-  # :nodoc:
   module ViewComponents
-    CONSTANTS = JSON.parse(
-      File.read(
-        File.join(File.dirname(__FILE__), "../../../static/constants.json")
-      )
-    ).freeze
+    # A module for constants that are used in the view components.
+    class Constants
+      CONSTANTS = JSON.parse(
+        File.read(
+          File.join(File.dirname(__FILE__), "../../../static/constants.json")
+        )
+      ).freeze
+
+      class << self
+        def get(component:, constant:, invert: true, symbolize: false)
+          values = CONSTANTS.dig(component, constant)
+
+          case values
+          when Hash
+            format_hash(values, invert, symbolize)
+          when Array
+            format_array(values, symbolize)
+          else
+            values
+          end
+        end
+
+        private
+
+        def format_hash(values, invert, symbolize)
+          val = values.invert if invert
+          # remove defaults
+          val = val.except("", nil)
+
+          return val.transform_values {|v| symbolize_value(v) } if symbolize
+
+          val
+        end
+
+        def format_array(values, symbolize)
+          val = values.select(&:present?)
+
+          return val.map { |v| symbolize_value(v) } if symbolize
+
+          val
+        end
+
+        def symbolize_value(value)
+          ":#{value}"
+        end
+      end
+    end
   end
 end

--- a/lib/primer/view_components/constants.rb
+++ b/lib/primer/view_components/constants.rb
@@ -33,7 +33,7 @@ module Primer
           # remove defaults
           val = val.except("", nil)
 
-          return val.transform_values {|v| symbolize_value(v) } if symbolize
+          return val.transform_values { |v| symbolize_value(v) } if symbolize
 
           val
         end

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -2,6 +2,7 @@
 
 require_relative "conversion_error"
 require_relative "system_arguments"
+require "primer/view_components/constants"
 
 module ERBLint
   module Linters

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -7,21 +7,28 @@ module ERBLint
     module ArgumentMappers
       # Maps classes in a button element to arguments for the Button component.
       class Button < Base
-        SCHEME_MAPPINGS = {
-          "btn-primary" => ":primary",
-          "btn-danger" => ":danger",
-          "btn-outline" => ":outline",
-          "btn-invisible" => ":invisible",
-          "btn-link" => ":link"
-        }.freeze
+        require "pry"
 
-        VARIANT_MAPPINGS = {
-          "btn-sm" => ":small",
-          "btn-large" => ":large"
-        }.freeze
+        SCHEME_MAPPINGS = Primer::ViewComponents::Constants.get(
+          component: "Primer::ButtonComponent",
+          constant: "SCHEME_MAPPINGS",
+          symbolize: true
+        ).freeze
 
-        TYPE_OPTIONS = %w[button reset submit].freeze
-        DEFAULT_TAG = "button"
+        VARIANT_MAPPINGS = Primer::ViewComponents::Constants.get(
+          component: "Primer::ButtonComponent",
+          constant: "VARIANT_MAPPINGS",
+          symbolize: true
+        ).freeze
+
+        TYPE_OPTIONS = Primer::ViewComponents::Constants.get(
+          component: "Primer::BaseButton",
+          constant: "TYPE_OPTIONS"
+        ).freeze
+        DEFAULT_TAG = Primer::ViewComponents::Constants.get(
+          component: "Primer::BaseButton",
+          constant: "DEFAULT_TAG"
+        ).freeze
 
         def attribute_to_args(attribute)
           attr_name = attribute.name

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -7,23 +7,22 @@ module ERBLint
     module ArgumentMappers
       # Maps classes in a label element to arguments for the Label component.
       class Label < Base
-        SCHEME_MAPPINGS = {
-          "Label--primary" => ":primary",
-          "Label--secondary" => ":secondary",
-          "Label--info" => ":info",
-          "Label--success" => ":success",
-          "Label--warning" => ":warning",
-          "Label--danger" => ":danger",
-          "Label--orange" => ":orange",
-          "Label--purple" => ":purple"
-        }.freeze
+        SCHEME_MAPPINGS = Primer::ViewComponents::Constants.get(
+          component: "Primer::LabelComponent",
+          constant: "SCHEME_MAPPINGS",
+          symbolize: true
+        ).freeze
 
-        VARIANT_MAPPINGS = {
-          "Label--inline" => ":inline",
-          "Label--large" => ":large"
-        }.freeze
+        VARIANT_MAPPINGS = Primer::ViewComponents::Constants.get(
+          component: "Primer::LabelComponent",
+          constant: "VARIANT_MAPPINGS",
+          symbolize: true
+        ).freeze
 
-        DEFAULT_TAG = "span"
+        DEFAULT_TAG = Primer::ViewComponents::Constants.get(
+          component: "Primer::LabelComponent",
+          constant: "DEFAULT_TAG"
+        ).freeze
 
         def attribute_to_args(attribute)
           attr_name = attribute.name

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -11,7 +11,11 @@ module ERBLint
       include Helpers
       include Autocorrectable
 
-      TAGS = %w[button summary a].freeze
+      TAGS = Primer::ViewComponents::Constants.get(
+        component: "Primer::BaseButton",
+        constant: "TAG_OPTIONS"
+      ).freeze
+
       CLASSES = %w[btn btn-link].freeze
       MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Button

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -2,6 +2,7 @@
 
 require "json"
 require "openssl"
+require "primer/view_components/constants"
 
 module ERBLint
   module Linters

--- a/lib/primer/view_components/linters/label_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/label_component_migration_counter.rb
@@ -11,7 +11,11 @@ module ERBLint
       include Helpers
       include Autocorrectable
 
-      TAGS = %w[span summary a div].freeze
+      TAGS = Primer::ViewComponents::Constants.get(
+        component: "Primer::LabelComponent",
+        constant: "TAG_OPTIONS"
+      ).freeze
+
       CLASSES = %w[Label].freeze
       MESSAGE = "We are migrating labels to use [Primer::LabelComponent](https://primer.style/view-components/components/label), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Label

--- a/lib/tasks/constants.rake
+++ b/lib/tasks/constants.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :statuses do
+  task :dump do
+    require File.expand_path("./../../demo/config/environment.rb", __dir__)
+    require "primer/view_components"
+    # Loads all components for `.descendants` to work properly
+    Dir["./app/components/primer/**/*.rb"].sort.each { |file| require file }
+
+    Primer::ViewComponents.dump_statuses
+  end
+end

--- a/lib/tasks/constants.rake
+++ b/lib/tasks/constants.rake
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-namespace :statuses do
+namespace :constants do
   task :dump do
     require File.expand_path("./../../demo/config/environment.rb", __dir__)
     require "primer/view_components"
     # Loads all components for `.descendants` to work properly
     Dir["./app/components/primer/**/*.rb"].sort.each { |file| require file }
 
-    Primer::ViewComponents.dump_statuses
+    Primer::ViewComponents.dump_constants
   end
 end

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/statuses.json"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/**/*"]
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency     "actionview", ">= 5.0.0"

--- a/static/constants.json
+++ b/static/constants.json
@@ -1,12 +1,29 @@
 {
   "Primer::Alpha::ButtonMarketing": {
+    "DEFAULT_SCHEME": "default",
+    "DEFAULT_TAG": "button",
+    "DEFAULT_TYPE": "button",
+    "DEFAULT_VARIANT": "default",
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary-mktg",
+      "outline": "btn-outline-mktg",
+      "transparent": "btn-transparent"
+    },
     "SCHEME_OPTIONS": [
       "default",
       "primary",
       "outline",
       "transparent"
     ],
-    "DEFAULT_VARIANT": "default",
+    "TAG_OPTIONS": [
+      "button",
+      "a"
+    ],
+    "TYPE_OPTIONS": [
+      "button",
+      "submit"
+    ],
     "VARIANT_MAPPINGS": {
       "default": "",
       "large": "btn-large-mktg"
@@ -14,33 +31,16 @@
     "VARIANT_OPTIONS": [
       "default",
       "large"
-    ],
-    "DEFAULT_TAG": "button",
-    "TAG_OPTIONS": [
-      "button",
-      "a"
-    ],
-    "DEFAULT_TYPE": "button",
-    "TYPE_OPTIONS": [
-      "button",
-      "submit"
-    ],
-    "DEFAULT_SCHEME": "default",
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "primary": "btn-primary-mktg",
-      "outline": "btn-outline-mktg",
-      "transparent": "btn-transparent"
-    }
+    ]
   },
   "Primer::BaseButton": {
     "DEFAULT_TAG": "button",
+    "DEFAULT_TYPE": "button",
     "TAG_OPTIONS": [
       "button",
       "a",
       "summary"
     ],
-    "DEFAULT_TYPE": "button",
     "TYPE_OPTIONS": [
       "button",
       "reset",
@@ -50,10 +50,10 @@
   "Primer::BaseComponent": {
   },
   "Primer::Beta::AutoComplete": {
-    "ItemStories": "Primer::Beta::AutoComplete::ItemStories",
-    "InputStories": "Primer::Beta::AutoComplete::InputStories",
     "Input": "Primer::Beta::AutoComplete::Input",
-    "Item": "Primer::Beta::AutoComplete::Item"
+    "InputStories": "Primer::Beta::AutoComplete::InputStories",
+    "Item": "Primer::Beta::AutoComplete::Item",
+    "ItemStories": "Primer::Beta::AutoComplete::ItemStories"
   },
   "Primer::Beta::AutoComplete::Input": {
     "DEFAULT_TYPE": "text",
@@ -73,16 +73,16 @@
       "left",
       "right"
     ],
-    "DEFAULT_TAG": "div",
-    "TAG_OPTIONS": [
-      "div",
-      "span"
-    ],
     "BODY_TAG_OPTIONS": [
       "div",
       "span"
     ],
-    "DEFAULT_BODY_TAG": "div"
+    "DEFAULT_BODY_TAG": "div",
+    "DEFAULT_TAG": "div",
+    "TAG_OPTIONS": [
+      "div",
+      "span"
+    ]
   },
   "Primer::Beta::Text": {
     "DEFAULT_TAG": "span"
@@ -90,13 +90,13 @@
   "Primer::BlankslateComponent": {
   },
   "Primer::BorderBoxComponent": {
+    "DEFAULT_PADDING": "default",
     "PADDING_MAPPINGS": {
       "default": "",
       "condensed": "Box--condensed",
       "spacious": "Box--spacious"
     },
-    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
-    "DEFAULT_PADDING": "default"
+    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?"
   },
   "Primer::BoxComponent": {
   },
@@ -106,6 +106,17 @@
   "Primer::BreadcrumbComponent::ItemComponent": {
   },
   "Primer::ButtonComponent": {
+    "DEFAULT_SCHEME": "default",
+    "DEFAULT_VARIANT": "medium",
+    "LINK_SCHEME": "link",
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary",
+      "danger": "btn-danger",
+      "outline": "btn-outline",
+      "invisible": "btn-invisible",
+      "link": "btn-link"
+    },
     "SCHEME_OPTIONS": [
       "default",
       "primary",
@@ -114,7 +125,6 @@
       "invisible",
       "link"
     ],
-    "DEFAULT_VARIANT": "medium",
     "VARIANT_MAPPINGS": {
       "small": "btn-sm",
       "medium": "",
@@ -124,17 +134,7 @@
       "small",
       "medium",
       "large"
-    ],
-    "LINK_SCHEME": "link",
-    "DEFAULT_SCHEME": "default",
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "primary": "btn-primary",
-      "danger": "btn-danger",
-      "outline": "btn-outline",
-      "invisible": "btn-invisible",
-      "link": "btn-link"
-    }
+    ]
   },
   "Primer::ButtonGroup": {
   },
@@ -148,6 +148,11 @@
     ]
   },
   "Primer::CounterComponent": {
+    "DEFAULT_SCHEME": "default",
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "gray",
+      "light_gray"
+    ],
     "SCHEME_MAPPINGS": {
       "default": "",
       "primary": "Counter--primary",
@@ -159,22 +164,17 @@
       "default",
       "primary",
       "secondary"
-    ],
-    "DEFAULT_SCHEME": "default",
-    "DEPRECATED_SCHEME_OPTIONS": [
-      "gray",
-      "light_gray"
     ]
   },
   "Primer::DetailsComponent": {
     "BODY_TAG_DEFAULT": "div",
-    "NO_OVERLAY": "none",
     "BODY_TAG_OPTIONS": [
       "ul",
       "details-menu",
       "details-dialog",
       "div"
     ],
+    "NO_OVERLAY": "none",
     "OVERLAY_MAPPINGS": {
       "none": "",
       "default": "details-overlay",
@@ -185,13 +185,11 @@
     "Menu": "Primer::Dropdown::Menu"
   },
   "Primer::Dropdown::Menu": {
-    "Item": "Primer::Dropdown::Menu::Item",
     "AS_DEFAULT": "default",
     "AS_OPTIONS": [
       "default",
       "list"
     ],
-    "SCHEME_DEFAULT": "default",
     "DIRECTION_DEFAULT": "se",
     "DIRECTION_OPTIONS": [
       "se",
@@ -201,25 +199,26 @@
       "ne",
       "s"
     ],
+    "Item": "Primer::Dropdown::Menu::Item",
+    "SCHEME_DEFAULT": "default",
     "SCHEME_MAPPINGS": {
       "default": "",
       "dark": "dropdown-menu-dark"
     }
   },
   "Primer::Dropdown::Menu::Item": {
-    "TAG_OPTIONS": [
-      "a",
+    "BUTTON_TAGS": [
       "button",
       "summary"
     ],
     "TAG_DEFAULT": "a",
-    "BUTTON_TAGS": [
+    "TAG_OPTIONS": [
+      "a",
       "button",
       "summary"
     ]
   },
   "Primer::DropdownMenuComponent": {
-    "SCHEME_DEFAULT": "default",
     "DIRECTION_DEFAULT": "se",
     "DIRECTION_OPTIONS": [
       "se",
@@ -229,6 +228,7 @@
       "ne",
       "s"
     ],
+    "SCHEME_DEFAULT": "default",
     "SCHEME_MAPPINGS": {
       "default": "",
       "dark": "dropdown-menu-dark"
@@ -244,36 +244,6 @@
     }
   },
   "Primer::FlexComponent": {
-    "FLEX_WRAP_DEFAULT": null,
-    "FLEX_WRAP_OPTIONS": [
-      null,
-      true,
-      false
-    ],
-    "DEFAULT_DIRECTION": null,
-    "ALLOWED_DIRECTIONS": [
-      null,
-      "column",
-      "column_reverse",
-      "row",
-      "row_reverse"
-    ],
-    "JUSTIFY_CONTENT_DEFAULT": null,
-    "JUSTIFY_CONTENT_MAPPINGS": {
-      "flex_start": "flex-justify-start",
-      "flex_end": "flex-justify-end",
-      "center": "flex-justify-center",
-      "space_between": "flex-justify-between",
-      "space_around": "flex-justify-around"
-    },
-    "JUSTIFY_CONTENT_OPTIONS": [
-      null,
-      "flex_start",
-      "flex_end",
-      "center",
-      "space_between",
-      "space_around"
-    ],
     "ALIGN_ITEMS_DEFAULT": null,
     "ALIGN_ITEMS_MAPPINGS": {
       "start": "flex-items-start",
@@ -290,18 +260,48 @@
       "baseline",
       "stretch"
     ],
+    "ALLOWED_DIRECTIONS": [
+      null,
+      "column",
+      "column_reverse",
+      "row",
+      "row_reverse"
+    ],
+    "DEFAULT_DIRECTION": null,
+    "FLEX_WRAP_DEFAULT": null,
+    "FLEX_WRAP_OPTIONS": [
+      null,
+      true,
+      false
+    ],
     "INLINE_DEFAULT": false,
     "INLINE_OPTIONS": [
       false,
       true
+    ],
+    "JUSTIFY_CONTENT_DEFAULT": null,
+    "JUSTIFY_CONTENT_MAPPINGS": {
+      "flex_start": "flex-justify-start",
+      "flex_end": "flex-justify-end",
+      "center": "flex-justify-center",
+      "space_between": "flex-justify-between",
+      "space_around": "flex-justify-around"
+    },
+    "JUSTIFY_CONTENT_OPTIONS": [
+      null,
+      "flex_start",
+      "flex_end",
+      "center",
+      "space_between",
+      "space_around"
     ]
   },
   "Primer::FlexItemComponent": {
-    "FLEX_AUTO_DEFAULT": false,
     "FLEX_AUTO_ALLOWED_VALUES": [
       false,
       true
-    ]
+    ],
+    "FLEX_AUTO_DEFAULT": false
   },
   "Primer::HeadingComponent": {
     "TAG_FALLBACK": "h2",
@@ -318,44 +318,24 @@
   },
   "Primer::IconButton": {
     "DEFAULT_SCHEME": "default",
-    "SCHEME_OPTIONS": [
-      "default",
-      "danger"
-    ],
     "SCHEME_MAPPINGS": {
       "default": "",
       "danger": "btn-octicon-danger"
-    }
+    },
+    "SCHEME_OPTIONS": [
+      "default",
+      "danger"
+    ]
   },
   "Primer::Image": {
   },
   "Primer::ImageCrop": {
   },
   "Primer::LabelComponent": {
-    "SCHEME_OPTIONS": [
-      "primary",
-      "secondary",
-      "info",
-      "success",
-      "warning",
-      "danger",
-      null
-    ],
-    "VARIANT_MAPPINGS": {
-      "large": "Label--large",
-      "inline": "Label--inline"
-    },
-    "VARIANT_OPTIONS": [
-      "large",
-      "inline",
-      null
-    ],
     "DEFAULT_TAG": "span",
-    "TAG_OPTIONS": [
-      "span",
-      "summary",
-      "a",
-      "div"
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "orange",
+      "purple"
     ],
     "SCHEME_MAPPINGS": {
       "primary": "Label--primary",
@@ -367,13 +347,32 @@
       "orange": "Label--orange",
       "purple": "Label--purple"
     },
-    "DEPRECATED_SCHEME_OPTIONS": [
-      "orange",
-      "purple"
+    "SCHEME_OPTIONS": [
+      "primary",
+      "secondary",
+      "info",
+      "success",
+      "warning",
+      "danger",
+      null
+    ],
+    "TAG_OPTIONS": [
+      "span",
+      "summary",
+      "a",
+      "div"
+    ],
+    "VARIANT_MAPPINGS": {
+      "large": "Label--large",
+      "inline": "Label--inline"
+    },
+    "VARIANT_OPTIONS": [
+      "large",
+      "inline",
+      null
     ]
   },
   "Primer::LayoutComponent": {
-    "DEFAULT_SIDEBAR_COL": 3,
     "ALLOWED_SIDEBAR_COLS": [
       1,
       2,
@@ -387,37 +386,38 @@
       10,
       11
     ],
-    "DEFAULT_SIDE": "right",
     "ALLOWED_SIDES": [
       "right",
       "left"
     ],
+    "DEFAULT_SIDE": "right",
+    "DEFAULT_SIDEBAR_COL": 3,
     "MAX_COL": 12
   },
   "Primer::LinkComponent": {
     "DEFAULT_SCHEME": "default",
     "DEFAULT_TAG": "a",
-    "TAG_OPTIONS": [
-      "a",
-      "span"
-    ],
     "SCHEME_MAPPINGS": {
       "default": "",
       "primary": "Link--primary",
       "secondary": "Link--secondary"
-    }
+    },
+    "TAG_OPTIONS": [
+      "a",
+      "span"
+    ]
   },
   "Primer::LocalTime": {
+    "DEFAULT_DIGIT_TYPE": "numeric",
+    "DEFAULT_TEXT_TYPE": "short",
     "DIGIT_TYPE_OPTIONS": [
       "numeric",
       "2-digit"
     ],
-    "DEFAULT_TEXT_TYPE": "short",
     "TEXT_TYPE_OPTIONS": [
       "short",
       "long"
-    ],
-    "DEFAULT_DIGIT_TYPE": "numeric"
+    ]
   },
   "Primer::Markdown": {
     "DEFAULT_TAG": "div",
@@ -428,6 +428,7 @@
     ]
   },
   "Primer::MenuComponent": {
+    "HEADING_TAG_FALLBACK": "h2",
     "HEADING_TAG_OPTIONS": [
       "h1",
       "h2",
@@ -435,8 +436,7 @@
       "h4",
       "h5",
       "h6"
-    ],
-    "HEADING_TAG_FALLBACK": "h2"
+    ]
   },
   "Primer::Navigation::TabComponent": {
     "ARIA_CURRENT_OPTIONS_FOR_ANCHOR": [
@@ -447,11 +447,11 @@
   },
   "Primer::OcticonComponent": {
     "SIZE_DEFAULT": "small",
-    "SIZE_MEDIUM": "medium",
     "SIZE_MAPPINGS": {
       "small": 16,
       "medium": 24
     },
+    "SIZE_MEDIUM": "medium",
     "SIZE_OPTIONS": [
       "small",
       "medium"
@@ -460,7 +460,6 @@
   "Primer::OcticonSymbolsComponent": {
   },
   "Primer::PopoverComponent": {
-    "DEFAULT_HEADING_TAG": "h4",
     "CARET_DEFAULT": "top",
     "CARET_MAPPINGS": {
       "top": "",
@@ -475,7 +474,8 @@
       "right_top": "Popover-message--right-top",
       "top_left": "Popover-message--top-left",
       "top_right": "Popover-message--top-right"
-    }
+    },
+    "DEFAULT_HEADING_TAG": "h4"
   },
   "Primer::ProgressBarComponent": {
     "SIZE_DEFAULT": "default",
@@ -491,6 +491,7 @@
     ]
   },
   "Primer::SpinnerComponent": {
+    "DEFAULT_SIZE": "medium",
     "DEFAULT_STYLE": "box-sizing: content-box; color: var(--color-icon-primary);",
     "SIZE_MAPPINGS": {
       "small": 16,
@@ -501,10 +502,30 @@
       "small",
       "medium",
       "large"
-    ],
-    "DEFAULT_SIZE": "medium"
+    ]
   },
   "Primer::StateComponent": {
+    "DEPRECATED_SCHEME_MAPPINGS": {
+      "default": "",
+      "green": "State--open",
+      "red": "State--closed",
+      "purple": "State--merged"
+    },
+    "NEW_SCHEME_MAPPINGS": {
+      "open": "State--open",
+      "closed": "State--closed",
+      "merged": "State--merged"
+    },
+    "SCHEME_DEFAULT": "default",
+    "SCHEME_MAPPINGS": {
+      "open": "State--open",
+      "closed": "State--closed",
+      "merged": "State--merged",
+      "default": "",
+      "green": "State--open",
+      "red": "State--closed",
+      "purple": "State--merged"
+    },
     "SCHEME_OPTIONS": [
       "open",
       "closed",
@@ -523,32 +544,11 @@
       "default",
       "small"
     ],
+    "TAG_DEFAULT": "span",
     "TAG_OPTIONS": [
       "span",
       "div"
-    ],
-    "SCHEME_DEFAULT": "default",
-    "NEW_SCHEME_MAPPINGS": {
-      "open": "State--open",
-      "closed": "State--closed",
-      "merged": "State--merged"
-    },
-    "DEPRECATED_SCHEME_MAPPINGS": {
-      "default": "",
-      "green": "State--open",
-      "red": "State--closed",
-      "purple": "State--merged"
-    },
-    "TAG_DEFAULT": "span",
-    "SCHEME_MAPPINGS": {
-      "open": "State--open",
-      "closed": "State--closed",
-      "merged": "State--merged",
-      "default": "",
-      "green": "State--open",
-      "red": "State--closed",
-      "purple": "State--merged"
-    }
+    ]
   },
   "Primer::SubheadComponent": {
     "DEFAULT_HEADING_TAG": "div",
@@ -565,11 +565,11 @@
   "Primer::TabContainerComponent": {
   },
   "Primer::TabNavComponent": {
+    "DEFAULT_EXTRA_ALIGN": "left",
     "EXTRA_ALIGN_OPTIONS": [
       "left",
       "right"
-    ],
-    "DEFAULT_EXTRA_ALIGN": "left"
+    ]
   },
   "Primer::TimeAgoComponent": {
   },
@@ -580,7 +580,6 @@
   },
   "Primer::Tooltip": {
     "ALIGN_DEFAULT": "default",
-    "DIRECTION_DEFAULT": "n",
     "ALIGN_MAPPING": {
       "default": "",
       "left_1": "tooltipped-align-left-1",
@@ -588,8 +587,8 @@
       "left_2": "tooltipped-align-left-2",
       "right_2": "tooltipped-align-right-2"
     },
-    "MULTILINE_DEFAULT": false,
     "DELAY_DEFAULT": false,
+    "DIRECTION_DEFAULT": "n",
     "DIRECTION_OPTIONS": [
       "n",
       "nw",
@@ -599,7 +598,8 @@
       "sw",
       "s",
       "se"
-    ]
+    ],
+    "MULTILINE_DEFAULT": false
   },
   "Primer::Truncate": {
     "DEFAULT_TAG": "div",
@@ -611,6 +611,7 @@
     ]
   },
   "Primer::UnderlineNavComponent": {
+    "ACTIONS_TAG_DEFAULT": "div",
     "ACTIONS_TAG_OPTIONS": [
       "div",
       "span"
@@ -624,7 +625,6 @@
     "BODY_TAG_OPTIONS": [
       "div",
       "ul"
-    ],
-    "ACTIONS_TAG_DEFAULT": "div"
+    ]
   }
 }

--- a/static/constants.json
+++ b/static/constants.json
@@ -1,0 +1,628 @@
+{
+  "Primer::Alpha::ButtonMarketing": {
+    "TAG_OPTIONS": [
+      "button",
+      "a"
+    ],
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary-mktg",
+      "outline": "btn-outline-mktg",
+      "transparent": "btn-transparent"
+    },
+    "VARIANT_OPTIONS": [
+      "default",
+      "large"
+    ],
+    "SCHEME_OPTIONS": [
+      "default",
+      "primary",
+      "outline",
+      "transparent"
+    ],
+    "VARIANT_MAPPINGS": {
+      "default": "",
+      "large": "btn-large-mktg"
+    },
+    "TYPE_OPTIONS": [
+      "button",
+      "submit"
+    ],
+    "DEFAULT_TYPE": "button",
+    "DEFAULT_TAG": "button",
+    "DEFAULT_SCHEME": "default",
+    "DEFAULT_VARIANT": "default"
+  },
+  "Primer::BaseButton": {
+    "DEFAULT_TAG": "button",
+    "DEFAULT_TYPE": "button",
+    "TYPE_OPTIONS": [
+      "button",
+      "reset",
+      "submit"
+    ],
+    "TAG_OPTIONS": [
+      "button",
+      "a",
+      "summary"
+    ]
+  },
+  "Primer::BaseComponent": {
+  },
+  "Primer::Beta::AutoComplete": {
+    "Input": "Primer::Beta::AutoComplete::Input",
+    "Item": "Primer::Beta::AutoComplete::Item"
+  },
+  "Primer::Beta::AutoComplete::Input": {
+    "TYPE_OPTIONS": [
+      "text",
+      "search"
+    ],
+    "DEFAULT_TYPE": "text"
+  },
+  "Primer::Beta::AutoComplete::Item": {
+  },
+  "Primer::Beta::Avatar": {
+    "SMALL_THRESHOLD": 24
+  },
+  "Primer::Beta::AvatarStack": {
+    "ALIGN_DEFAULT": "left",
+    "ALIGN_OPTIONS": [
+      "left",
+      "right"
+    ],
+    "DEFAULT_TAG": "div",
+    "TAG_OPTIONS": [
+      "div",
+      "span"
+    ],
+    "DEFAULT_BODY_TAG": "div",
+    "BODY_TAG_OPTIONS": [
+      "div",
+      "span"
+    ]
+  },
+  "Primer::Beta::Text": {
+    "DEFAULT_TAG": "span"
+  },
+  "Primer::BlankslateComponent": {
+  },
+  "Primer::BorderBoxComponent": {
+    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
+    "DEFAULT_PADDING": "default",
+    "PADDING_MAPPINGS": {
+      "default": "",
+      "condensed": "Box--condensed",
+      "spacious": "Box--spacious"
+    }
+  },
+  "Primer::BoxComponent": {
+  },
+  "Primer::BreadcrumbComponent": {
+    "ItemComponent": "Primer::BreadcrumbComponent::ItemComponent"
+  },
+  "Primer::BreadcrumbComponent::ItemComponent": {
+  },
+  "Primer::ButtonComponent": {
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary",
+      "danger": "btn-danger",
+      "outline": "btn-outline",
+      "invisible": "btn-invisible",
+      "link": "btn-link"
+    },
+    "VARIANT_MAPPINGS": {
+      "small": "btn-sm",
+      "medium": "",
+      "large": "btn-large"
+    },
+    "LINK_SCHEME": "link",
+    "SCHEME_OPTIONS": [
+      "default",
+      "primary",
+      "danger",
+      "outline",
+      "invisible",
+      "link"
+    ],
+    "VARIANT_OPTIONS": [
+      "small",
+      "medium",
+      "large"
+    ],
+    "DEFAULT_SCHEME": "default",
+    "DEFAULT_VARIANT": "medium"
+  },
+  "Primer::ButtonGroup": {
+  },
+  "Primer::ClipboardCopy": {
+  },
+  "Primer::CloseButton": {
+    "TYPE_OPTIONS": [
+      "button",
+      "submit"
+    ],
+    "DEFAULT_TYPE": "button"
+  },
+  "Primer::CounterComponent": {
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "Counter--primary",
+      "secondary": "Counter--secondary",
+      "gray": "Counter--primary",
+      "light_gray": "Counter--secondary"
+    },
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "gray",
+      "light_gray"
+    ],
+    "SCHEME_OPTIONS": [
+      "default",
+      "primary",
+      "secondary"
+    ],
+    "DEFAULT_SCHEME": "default"
+  },
+  "Primer::DetailsComponent": {
+    "NO_OVERLAY": "none",
+    "OVERLAY_MAPPINGS": {
+      "none": "",
+      "default": "details-overlay",
+      "dark": "details-overlay details-overlay-dark"
+    },
+    "BODY_TAG_DEFAULT": "div",
+    "BODY_TAG_OPTIONS": [
+      "ul",
+      "details-menu",
+      "details-dialog",
+      "div"
+    ]
+  },
+  "Primer::Dropdown": {
+    "Menu": "Primer::Dropdown::Menu"
+  },
+  "Primer::Dropdown::Menu": {
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "dark": "dropdown-menu-dark"
+    },
+    "Item": "Primer::Dropdown::Menu::Item",
+    "AS_DEFAULT": "default",
+    "AS_OPTIONS": [
+      "default",
+      "list"
+    ],
+    "DIRECTION_OPTIONS": [
+      "se",
+      "sw",
+      "w",
+      "e",
+      "ne",
+      "s"
+    ],
+    "DIRECTION_DEFAULT": "se",
+    "SCHEME_DEFAULT": "default"
+  },
+  "Primer::Dropdown::Menu::Item": {
+    "TAG_OPTIONS": [
+      "a",
+      "button",
+      "summary"
+    ],
+    "TAG_DEFAULT": "a",
+    "BUTTON_TAGS": [
+      "button",
+      "summary"
+    ]
+  },
+  "Primer::DropdownMenuComponent": {
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "dark": "dropdown-menu-dark"
+    },
+    "DIRECTION_DEFAULT": "se",
+    "DIRECTION_OPTIONS": [
+      "se",
+      "sw",
+      "w",
+      "e",
+      "ne",
+      "s"
+    ],
+    "SCHEME_DEFAULT": "default"
+  },
+  "Primer::FlashComponent": {
+    "DEFAULT_SCHEME": "default",
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "warning": "flash-warn",
+      "danger": "flash-error",
+      "success": "flash-success"
+    }
+  },
+  "Primer::FlexComponent": {
+    "ALLOWED_DIRECTIONS": [
+      null,
+      "column",
+      "column_reverse",
+      "row",
+      "row_reverse"
+    ],
+    "JUSTIFY_CONTENT_DEFAULT": null,
+    "JUSTIFY_CONTENT_MAPPINGS": {
+      "flex_start": "flex-justify-start",
+      "flex_end": "flex-justify-end",
+      "center": "flex-justify-center",
+      "space_between": "flex-justify-between",
+      "space_around": "flex-justify-around"
+    },
+    "JUSTIFY_CONTENT_OPTIONS": [
+      null,
+      "flex_start",
+      "flex_end",
+      "center",
+      "space_between",
+      "space_around"
+    ],
+    "ALIGN_ITEMS_DEFAULT": null,
+    "ALIGN_ITEMS_MAPPINGS": {
+      "start": "flex-items-start",
+      "end": "flex-items-end",
+      "center": "flex-items-center",
+      "baseline": "flex-items-baseline",
+      "stretch": "flex-items-stretch"
+    },
+    "ALIGN_ITEMS_OPTIONS": [
+      null,
+      "start",
+      "end",
+      "center",
+      "baseline",
+      "stretch"
+    ],
+    "INLINE_DEFAULT": false,
+    "INLINE_OPTIONS": [
+      false,
+      true
+    ],
+    "FLEX_WRAP_DEFAULT": null,
+    "FLEX_WRAP_OPTIONS": [
+      null,
+      true,
+      false
+    ],
+    "DEFAULT_DIRECTION": null
+  },
+  "Primer::FlexItemComponent": {
+    "FLEX_AUTO_DEFAULT": false,
+    "FLEX_AUTO_ALLOWED_VALUES": [
+      false,
+      true
+    ]
+  },
+  "Primer::HeadingComponent": {
+    "TAG_FALLBACK": "h2",
+    "TAG_OPTIONS": [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6"
+    ]
+  },
+  "Primer::HiddenTextExpander": {
+  },
+  "Primer::IconButton": {
+    "DEFAULT_SCHEME": "default",
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "danger": "btn-octicon-danger"
+    },
+    "SCHEME_OPTIONS": [
+      "default",
+      "danger"
+    ]
+  },
+  "Primer::Image": {
+  },
+  "Primer::ImageCrop": {
+  },
+  "Primer::LabelComponent": {
+    "SCHEME_MAPPINGS": {
+      "primary": "Label--primary",
+      "secondary": "Label--secondary",
+      "info": "Label--info",
+      "success": "Label--success",
+      "warning": "Label--warning",
+      "danger": "Label--danger",
+      "orange": "Label--orange",
+      "purple": "Label--purple"
+    },
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "orange",
+      "purple"
+    ],
+    "SCHEME_OPTIONS": [
+      "primary",
+      "secondary",
+      "info",
+      "success",
+      "warning",
+      "danger",
+      null
+    ],
+    "VARIANT_MAPPINGS": {
+      "large": "Label--large",
+      "inline": "Label--inline"
+    },
+    "VARIANT_OPTIONS": [
+      "large",
+      "inline",
+      null
+    ],
+    "DEFAULT_TAG": "span",
+    "TAG_OPTIONS": [
+      "span",
+      "summary",
+      "a",
+      "div"
+    ]
+  },
+  "Primer::LayoutComponent": {
+    "ALLOWED_SIDES": [
+      "right",
+      "left"
+    ],
+    "MAX_COL": 12,
+    "DEFAULT_SIDEBAR_COL": 3,
+    "ALLOWED_SIDEBAR_COLS": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11
+    ],
+    "DEFAULT_SIDE": "right"
+  },
+  "Primer::LinkComponent": {
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "Link--primary",
+      "secondary": "Link--secondary"
+    },
+    "DEFAULT_TAG": "a",
+    "DEFAULT_SCHEME": "default",
+    "TAG_OPTIONS": [
+      "a",
+      "span"
+    ]
+  },
+  "Primer::LocalTime": {
+    "DEFAULT_DIGIT_TYPE": "numeric",
+    "DIGIT_TYPE_OPTIONS": [
+      "numeric",
+      "2-digit"
+    ],
+    "DEFAULT_TEXT_TYPE": "short",
+    "TEXT_TYPE_OPTIONS": [
+      "short",
+      "long"
+    ]
+  },
+  "Primer::Markdown": {
+    "TAG_OPTIONS": [
+      "div",
+      "article",
+      "td"
+    ],
+    "DEFAULT_TAG": "div"
+  },
+  "Primer::MenuComponent": {
+    "HEADING_TAG_OPTIONS": [
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6"
+    ],
+    "HEADING_TAG_FALLBACK": "h2"
+  },
+  "Primer::Navigation::TabComponent": {
+    "DEFAULT_ARIA_CURRENT_FOR_ANCHOR": "page",
+    "ARIA_CURRENT_OPTIONS_FOR_ANCHOR": [
+      true,
+      "page"
+    ]
+  },
+  "Primer::OcticonComponent": {
+    "SIZE_MAPPINGS": {
+      "small": 16,
+      "medium": 24
+    },
+    "SIZE_DEFAULT": "small",
+    "SIZE_MEDIUM": "medium",
+    "SIZE_OPTIONS": [
+      "small",
+      "medium"
+    ]
+  },
+  "Primer::OcticonSymbolsComponent": {
+  },
+  "Primer::PopoverComponent": {
+    "CARET_DEFAULT": "top",
+    "CARET_MAPPINGS": {
+      "top": "",
+      "bottom": "Popover-message--bottom",
+      "bottom_right": "Popover-message--bottom-right",
+      "bottom_left": "Popover-message--bottom-left",
+      "left": "Popover-message--left",
+      "left_bottom": "Popover-message--left-bottom",
+      "left_top": "Popover-message--left-top",
+      "right": "Popover-message--right",
+      "right_bottom": "Popover-message--right-bottom",
+      "right_top": "Popover-message--right-top",
+      "top_left": "Popover-message--top-left",
+      "top_right": "Popover-message--top-right"
+    },
+    "DEFAULT_HEADING_TAG": "h4"
+  },
+  "Primer::ProgressBarComponent": {
+    "SIZE_MAPPINGS": {
+      "default": "",
+      "small": "Progress--small",
+      "large": "Progress--large"
+    },
+    "SIZE_DEFAULT": "default",
+    "SIZE_OPTIONS": [
+      "default",
+      "small",
+      "large"
+    ]
+  },
+  "Primer::SpinnerComponent": {
+    "SIZE_MAPPINGS": {
+      "small": 16,
+      "medium": 32,
+      "large": 64
+    },
+    "DEFAULT_SIZE": "medium",
+    "SIZE_OPTIONS": [
+      "small",
+      "medium",
+      "large"
+    ],
+    "DEFAULT_STYLE": "box-sizing: content-box; color: var(--color-icon-primary);"
+  },
+  "Primer::StateComponent": {
+    "NEW_SCHEME_MAPPINGS": {
+      "open": "State--open",
+      "closed": "State--closed",
+      "merged": "State--merged"
+    },
+    "DEPRECATED_SCHEME_MAPPINGS": {
+      "default": "",
+      "green": "State--open",
+      "red": "State--closed",
+      "purple": "State--merged"
+    },
+    "SCHEME_MAPPINGS": {
+      "open": "State--open",
+      "closed": "State--closed",
+      "merged": "State--merged",
+      "default": "",
+      "green": "State--open",
+      "red": "State--closed",
+      "purple": "State--merged"
+    },
+    "SCHEME_OPTIONS": [
+      "open",
+      "closed",
+      "merged",
+      "default",
+      "green",
+      "red",
+      "purple"
+    ],
+    "TAG_DEFAULT": "span",
+    "SIZE_MAPPINGS": {
+      "default": "",
+      "small": "State--small"
+    },
+    "SIZE_DEFAULT": "default",
+    "SIZE_OPTIONS": [
+      "default",
+      "small"
+    ],
+    "TAG_OPTIONS": [
+      "span",
+      "div"
+    ],
+    "SCHEME_DEFAULT": "default"
+  },
+  "Primer::SubheadComponent": {
+    "HEADING_TAG_OPTIONS": [
+      "div",
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6"
+    ],
+    "DEFAULT_HEADING_TAG": "div"
+  },
+  "Primer::TabContainerComponent": {
+  },
+  "Primer::TabNavComponent": {
+    "DEFAULT_EXTRA_ALIGN": "left",
+    "EXTRA_ALIGN_OPTIONS": [
+      "left",
+      "right"
+    ]
+  },
+  "Primer::TimeAgoComponent": {
+  },
+  "Primer::TimelineItemComponent": {
+    "BadgeComponent": "Primer::TimelineItemComponent::BadgeComponent"
+  },
+  "Primer::TimelineItemComponent::BadgeComponent": {
+  },
+  "Primer::Tooltip": {
+    "ALIGN_DEFAULT": "default",
+    "ALIGN_MAPPING": {
+      "default": "",
+      "left_1": "tooltipped-align-left-1",
+      "right_1": "tooltipped-align-right-1",
+      "left_2": "tooltipped-align-left-2",
+      "right_2": "tooltipped-align-right-2"
+    },
+    "DIRECTION_DEFAULT": "n",
+    "MULTILINE_DEFAULT": false,
+    "DELAY_DEFAULT": false,
+    "DIRECTION_OPTIONS": [
+      "n",
+      "nw",
+      "ne",
+      "w",
+      "e",
+      "sw",
+      "s",
+      "se"
+    ]
+  },
+  "Primer::Truncate": {
+    "TAG_OPTIONS": [
+      "div",
+      "span",
+      "p",
+      "strong"
+    ],
+    "DEFAULT_TAG": "div"
+  },
+  "Primer::UnderlineNavComponent": {
+    "ALIGN_DEFAULT": "left",
+    "ALIGN_OPTIONS": [
+      "left",
+      "right"
+    ],
+    "ACTIONS_TAG_OPTIONS": [
+      "div",
+      "span"
+    ],
+    "ACTIONS_TAG_DEFAULT": "div",
+    "BODY_TAG_DEFAULT": "div",
+    "BODY_TAG_OPTIONS": [
+      "div",
+      "ul"
+    ]
+  }
+}

--- a/static/constants.json
+++ b/static/constants.json
@@ -1,64 +1,66 @@
 {
   "Primer::Alpha::ButtonMarketing": {
-    "TAG_OPTIONS": [
-      "button",
-      "a"
-    ],
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "primary": "btn-primary-mktg",
-      "outline": "btn-outline-mktg",
-      "transparent": "btn-transparent"
-    },
-    "VARIANT_OPTIONS": [
-      "default",
-      "large"
-    ],
     "SCHEME_OPTIONS": [
       "default",
       "primary",
       "outline",
       "transparent"
     ],
+    "DEFAULT_VARIANT": "default",
     "VARIANT_MAPPINGS": {
       "default": "",
       "large": "btn-large-mktg"
     },
+    "VARIANT_OPTIONS": [
+      "default",
+      "large"
+    ],
+    "DEFAULT_TAG": "button",
+    "TAG_OPTIONS": [
+      "button",
+      "a"
+    ],
+    "DEFAULT_TYPE": "button",
     "TYPE_OPTIONS": [
       "button",
       "submit"
     ],
-    "DEFAULT_TYPE": "button",
-    "DEFAULT_TAG": "button",
     "DEFAULT_SCHEME": "default",
-    "DEFAULT_VARIANT": "default"
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary-mktg",
+      "outline": "btn-outline-mktg",
+      "transparent": "btn-transparent"
+    }
   },
   "Primer::BaseButton": {
     "DEFAULT_TAG": "button",
+    "TAG_OPTIONS": [
+      "button",
+      "a",
+      "summary"
+    ],
     "DEFAULT_TYPE": "button",
     "TYPE_OPTIONS": [
       "button",
       "reset",
       "submit"
-    ],
-    "TAG_OPTIONS": [
-      "button",
-      "a",
-      "summary"
     ]
   },
   "Primer::BaseComponent": {
   },
   "Primer::Beta::AutoComplete": {
+    "ItemStories": "Primer::Beta::AutoComplete::ItemStories",
+    "InputStories": "Primer::Beta::AutoComplete::InputStories",
     "Input": "Primer::Beta::AutoComplete::Input",
     "Item": "Primer::Beta::AutoComplete::Item"
   },
   "Primer::Beta::AutoComplete::Input": {
+    "DEFAULT_TYPE": "text",
     "TYPE_OPTIONS": [
       "text",
       "search"
-    ],
-    "DEFAULT_TYPE": "text"
+    ]
   },
   "Primer::Beta::AutoComplete::Item": {
   },
@@ -76,11 +78,11 @@
       "div",
       "span"
     ],
-    "DEFAULT_BODY_TAG": "div",
     "BODY_TAG_OPTIONS": [
       "div",
       "span"
-    ]
+    ],
+    "DEFAULT_BODY_TAG": "div"
   },
   "Primer::Beta::Text": {
     "DEFAULT_TAG": "span"
@@ -88,13 +90,13 @@
   "Primer::BlankslateComponent": {
   },
   "Primer::BorderBoxComponent": {
-    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
-    "DEFAULT_PADDING": "default",
     "PADDING_MAPPINGS": {
       "default": "",
       "condensed": "Box--condensed",
       "spacious": "Box--spacious"
-    }
+    },
+    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
+    "DEFAULT_PADDING": "default"
   },
   "Primer::BoxComponent": {
   },
@@ -104,20 +106,6 @@
   "Primer::BreadcrumbComponent::ItemComponent": {
   },
   "Primer::ButtonComponent": {
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "primary": "btn-primary",
-      "danger": "btn-danger",
-      "outline": "btn-outline",
-      "invisible": "btn-invisible",
-      "link": "btn-link"
-    },
-    "VARIANT_MAPPINGS": {
-      "small": "btn-sm",
-      "medium": "",
-      "large": "btn-large"
-    },
-    "LINK_SCHEME": "link",
     "SCHEME_OPTIONS": [
       "default",
       "primary",
@@ -126,24 +114,38 @@
       "invisible",
       "link"
     ],
+    "DEFAULT_VARIANT": "medium",
+    "VARIANT_MAPPINGS": {
+      "small": "btn-sm",
+      "medium": "",
+      "large": "btn-large"
+    },
     "VARIANT_OPTIONS": [
       "small",
       "medium",
       "large"
     ],
+    "LINK_SCHEME": "link",
     "DEFAULT_SCHEME": "default",
-    "DEFAULT_VARIANT": "medium"
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "primary": "btn-primary",
+      "danger": "btn-danger",
+      "outline": "btn-outline",
+      "invisible": "btn-invisible",
+      "link": "btn-link"
+    }
   },
   "Primer::ButtonGroup": {
   },
   "Primer::ClipboardCopy": {
   },
   "Primer::CloseButton": {
+    "DEFAULT_TYPE": "button",
     "TYPE_OPTIONS": [
       "button",
       "submit"
-    ],
-    "DEFAULT_TYPE": "button"
+    ]
   },
   "Primer::CounterComponent": {
     "SCHEME_MAPPINGS": {
@@ -153,46 +155,44 @@
       "gray": "Counter--primary",
       "light_gray": "Counter--secondary"
     },
-    "DEPRECATED_SCHEME_OPTIONS": [
-      "gray",
-      "light_gray"
-    ],
     "SCHEME_OPTIONS": [
       "default",
       "primary",
       "secondary"
     ],
-    "DEFAULT_SCHEME": "default"
+    "DEFAULT_SCHEME": "default",
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "gray",
+      "light_gray"
+    ]
   },
   "Primer::DetailsComponent": {
-    "NO_OVERLAY": "none",
-    "OVERLAY_MAPPINGS": {
-      "none": "",
-      "default": "details-overlay",
-      "dark": "details-overlay details-overlay-dark"
-    },
     "BODY_TAG_DEFAULT": "div",
+    "NO_OVERLAY": "none",
     "BODY_TAG_OPTIONS": [
       "ul",
       "details-menu",
       "details-dialog",
       "div"
-    ]
+    ],
+    "OVERLAY_MAPPINGS": {
+      "none": "",
+      "default": "details-overlay",
+      "dark": "details-overlay details-overlay-dark"
+    }
   },
   "Primer::Dropdown": {
     "Menu": "Primer::Dropdown::Menu"
   },
   "Primer::Dropdown::Menu": {
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "dark": "dropdown-menu-dark"
-    },
     "Item": "Primer::Dropdown::Menu::Item",
     "AS_DEFAULT": "default",
     "AS_OPTIONS": [
       "default",
       "list"
     ],
+    "SCHEME_DEFAULT": "default",
+    "DIRECTION_DEFAULT": "se",
     "DIRECTION_OPTIONS": [
       "se",
       "sw",
@@ -201,8 +201,10 @@
       "ne",
       "s"
     ],
-    "DIRECTION_DEFAULT": "se",
-    "SCHEME_DEFAULT": "default"
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "dark": "dropdown-menu-dark"
+    }
   },
   "Primer::Dropdown::Menu::Item": {
     "TAG_OPTIONS": [
@@ -217,10 +219,7 @@
     ]
   },
   "Primer::DropdownMenuComponent": {
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "dark": "dropdown-menu-dark"
-    },
+    "SCHEME_DEFAULT": "default",
     "DIRECTION_DEFAULT": "se",
     "DIRECTION_OPTIONS": [
       "se",
@@ -230,7 +229,10 @@
       "ne",
       "s"
     ],
-    "SCHEME_DEFAULT": "default"
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "dark": "dropdown-menu-dark"
+    }
   },
   "Primer::FlashComponent": {
     "DEFAULT_SCHEME": "default",
@@ -242,6 +244,13 @@
     }
   },
   "Primer::FlexComponent": {
+    "FLEX_WRAP_DEFAULT": null,
+    "FLEX_WRAP_OPTIONS": [
+      null,
+      true,
+      false
+    ],
+    "DEFAULT_DIRECTION": null,
     "ALLOWED_DIRECTIONS": [
       null,
       "column",
@@ -285,14 +294,7 @@
     "INLINE_OPTIONS": [
       false,
       true
-    ],
-    "FLEX_WRAP_DEFAULT": null,
-    "FLEX_WRAP_OPTIONS": [
-      null,
-      true,
-      false
-    ],
-    "DEFAULT_DIRECTION": null
+    ]
   },
   "Primer::FlexItemComponent": {
     "FLEX_AUTO_DEFAULT": false,
@@ -316,34 +318,20 @@
   },
   "Primer::IconButton": {
     "DEFAULT_SCHEME": "default",
-    "SCHEME_MAPPINGS": {
-      "default": "",
-      "danger": "btn-octicon-danger"
-    },
     "SCHEME_OPTIONS": [
       "default",
       "danger"
-    ]
+    ],
+    "SCHEME_MAPPINGS": {
+      "default": "",
+      "danger": "btn-octicon-danger"
+    }
   },
   "Primer::Image": {
   },
   "Primer::ImageCrop": {
   },
   "Primer::LabelComponent": {
-    "SCHEME_MAPPINGS": {
-      "primary": "Label--primary",
-      "secondary": "Label--secondary",
-      "info": "Label--info",
-      "success": "Label--success",
-      "warning": "Label--warning",
-      "danger": "Label--danger",
-      "orange": "Label--orange",
-      "purple": "Label--purple"
-    },
-    "DEPRECATED_SCHEME_OPTIONS": [
-      "orange",
-      "purple"
-    ],
     "SCHEME_OPTIONS": [
       "primary",
       "secondary",
@@ -368,14 +356,23 @@
       "summary",
       "a",
       "div"
+    ],
+    "SCHEME_MAPPINGS": {
+      "primary": "Label--primary",
+      "secondary": "Label--secondary",
+      "info": "Label--info",
+      "success": "Label--success",
+      "warning": "Label--warning",
+      "danger": "Label--danger",
+      "orange": "Label--orange",
+      "purple": "Label--purple"
+    },
+    "DEPRECATED_SCHEME_OPTIONS": [
+      "orange",
+      "purple"
     ]
   },
   "Primer::LayoutComponent": {
-    "ALLOWED_SIDES": [
-      "right",
-      "left"
-    ],
-    "MAX_COL": 12,
     "DEFAULT_SIDEBAR_COL": 3,
     "ALLOWED_SIDEBAR_COLS": [
       1,
@@ -390,23 +387,27 @@
       10,
       11
     ],
-    "DEFAULT_SIDE": "right"
+    "DEFAULT_SIDE": "right",
+    "ALLOWED_SIDES": [
+      "right",
+      "left"
+    ],
+    "MAX_COL": 12
   },
   "Primer::LinkComponent": {
+    "DEFAULT_SCHEME": "default",
+    "DEFAULT_TAG": "a",
+    "TAG_OPTIONS": [
+      "a",
+      "span"
+    ],
     "SCHEME_MAPPINGS": {
       "default": "",
       "primary": "Link--primary",
       "secondary": "Link--secondary"
-    },
-    "DEFAULT_TAG": "a",
-    "DEFAULT_SCHEME": "default",
-    "TAG_OPTIONS": [
-      "a",
-      "span"
-    ]
+    }
   },
   "Primer::LocalTime": {
-    "DEFAULT_DIGIT_TYPE": "numeric",
     "DIGIT_TYPE_OPTIONS": [
       "numeric",
       "2-digit"
@@ -415,15 +416,16 @@
     "TEXT_TYPE_OPTIONS": [
       "short",
       "long"
-    ]
+    ],
+    "DEFAULT_DIGIT_TYPE": "numeric"
   },
   "Primer::Markdown": {
+    "DEFAULT_TAG": "div",
     "TAG_OPTIONS": [
       "div",
       "article",
       "td"
-    ],
-    "DEFAULT_TAG": "div"
+    ]
   },
   "Primer::MenuComponent": {
     "HEADING_TAG_OPTIONS": [
@@ -437,19 +439,19 @@
     "HEADING_TAG_FALLBACK": "h2"
   },
   "Primer::Navigation::TabComponent": {
-    "DEFAULT_ARIA_CURRENT_FOR_ANCHOR": "page",
     "ARIA_CURRENT_OPTIONS_FOR_ANCHOR": [
       true,
       "page"
-    ]
+    ],
+    "DEFAULT_ARIA_CURRENT_FOR_ANCHOR": "page"
   },
   "Primer::OcticonComponent": {
+    "SIZE_DEFAULT": "small",
+    "SIZE_MEDIUM": "medium",
     "SIZE_MAPPINGS": {
       "small": 16,
       "medium": 24
     },
-    "SIZE_DEFAULT": "small",
-    "SIZE_MEDIUM": "medium",
     "SIZE_OPTIONS": [
       "small",
       "medium"
@@ -458,6 +460,7 @@
   "Primer::OcticonSymbolsComponent": {
   },
   "Primer::PopoverComponent": {
+    "DEFAULT_HEADING_TAG": "h4",
     "CARET_DEFAULT": "top",
     "CARET_MAPPINGS": {
       "top": "",
@@ -472,16 +475,15 @@
       "right_top": "Popover-message--right-top",
       "top_left": "Popover-message--top-left",
       "top_right": "Popover-message--top-right"
-    },
-    "DEFAULT_HEADING_TAG": "h4"
+    }
   },
   "Primer::ProgressBarComponent": {
+    "SIZE_DEFAULT": "default",
     "SIZE_MAPPINGS": {
       "default": "",
       "small": "Progress--small",
       "large": "Progress--large"
     },
-    "SIZE_DEFAULT": "default",
     "SIZE_OPTIONS": [
       "default",
       "small",
@@ -489,20 +491,43 @@
     ]
   },
   "Primer::SpinnerComponent": {
+    "DEFAULT_STYLE": "box-sizing: content-box; color: var(--color-icon-primary);",
     "SIZE_MAPPINGS": {
       "small": 16,
       "medium": 32,
       "large": 64
     },
-    "DEFAULT_SIZE": "medium",
     "SIZE_OPTIONS": [
       "small",
       "medium",
       "large"
     ],
-    "DEFAULT_STYLE": "box-sizing: content-box; color: var(--color-icon-primary);"
+    "DEFAULT_SIZE": "medium"
   },
   "Primer::StateComponent": {
+    "SCHEME_OPTIONS": [
+      "open",
+      "closed",
+      "merged",
+      "default",
+      "green",
+      "red",
+      "purple"
+    ],
+    "SIZE_DEFAULT": "default",
+    "SIZE_MAPPINGS": {
+      "default": "",
+      "small": "State--small"
+    },
+    "SIZE_OPTIONS": [
+      "default",
+      "small"
+    ],
+    "TAG_OPTIONS": [
+      "span",
+      "div"
+    ],
+    "SCHEME_DEFAULT": "default",
     "NEW_SCHEME_MAPPINGS": {
       "open": "State--open",
       "closed": "State--closed",
@@ -514,6 +539,7 @@
       "red": "State--closed",
       "purple": "State--merged"
     },
+    "TAG_DEFAULT": "span",
     "SCHEME_MAPPINGS": {
       "open": "State--open",
       "closed": "State--closed",
@@ -522,33 +548,10 @@
       "green": "State--open",
       "red": "State--closed",
       "purple": "State--merged"
-    },
-    "SCHEME_OPTIONS": [
-      "open",
-      "closed",
-      "merged",
-      "default",
-      "green",
-      "red",
-      "purple"
-    ],
-    "TAG_DEFAULT": "span",
-    "SIZE_MAPPINGS": {
-      "default": "",
-      "small": "State--small"
-    },
-    "SIZE_DEFAULT": "default",
-    "SIZE_OPTIONS": [
-      "default",
-      "small"
-    ],
-    "TAG_OPTIONS": [
-      "span",
-      "div"
-    ],
-    "SCHEME_DEFAULT": "default"
+    }
   },
   "Primer::SubheadComponent": {
+    "DEFAULT_HEADING_TAG": "div",
     "HEADING_TAG_OPTIONS": [
       "div",
       "h1",
@@ -557,17 +560,16 @@
       "h4",
       "h5",
       "h6"
-    ],
-    "DEFAULT_HEADING_TAG": "div"
+    ]
   },
   "Primer::TabContainerComponent": {
   },
   "Primer::TabNavComponent": {
-    "DEFAULT_EXTRA_ALIGN": "left",
     "EXTRA_ALIGN_OPTIONS": [
       "left",
       "right"
-    ]
+    ],
+    "DEFAULT_EXTRA_ALIGN": "left"
   },
   "Primer::TimeAgoComponent": {
   },
@@ -578,6 +580,7 @@
   },
   "Primer::Tooltip": {
     "ALIGN_DEFAULT": "default",
+    "DIRECTION_DEFAULT": "n",
     "ALIGN_MAPPING": {
       "default": "",
       "left_1": "tooltipped-align-left-1",
@@ -585,7 +588,6 @@
       "left_2": "tooltipped-align-left-2",
       "right_2": "tooltipped-align-right-2"
     },
-    "DIRECTION_DEFAULT": "n",
     "MULTILINE_DEFAULT": false,
     "DELAY_DEFAULT": false,
     "DIRECTION_OPTIONS": [
@@ -600,29 +602,29 @@
     ]
   },
   "Primer::Truncate": {
+    "DEFAULT_TAG": "div",
     "TAG_OPTIONS": [
       "div",
       "span",
       "p",
       "strong"
-    ],
-    "DEFAULT_TAG": "div"
+    ]
   },
   "Primer::UnderlineNavComponent": {
+    "ACTIONS_TAG_OPTIONS": [
+      "div",
+      "span"
+    ],
     "ALIGN_DEFAULT": "left",
     "ALIGN_OPTIONS": [
       "left",
       "right"
     ],
-    "ACTIONS_TAG_OPTIONS": [
-      "div",
-      "span"
-    ],
-    "ACTIONS_TAG_DEFAULT": "div",
     "BODY_TAG_DEFAULT": "div",
     "BODY_TAG_OPTIONS": [
       "div",
       "ul"
-    ]
+    ],
+    "ACTIONS_TAG_DEFAULT": "div"
   }
 }

--- a/static/constants.json
+++ b/static/constants.json
@@ -51,9 +51,7 @@
   },
   "Primer::Beta::AutoComplete": {
     "Input": "Primer::Beta::AutoComplete::Input",
-    "InputStories": "Primer::Beta::AutoComplete::InputStories",
-    "Item": "Primer::Beta::AutoComplete::Item",
-    "ItemStories": "Primer::Beta::AutoComplete::ItemStories"
+    "Item": "Primer::Beta::AutoComplete::Item"
   },
   "Primer::Beta::AutoComplete::Input": {
     "DEFAULT_TYPE": "text",

--- a/test/primer/view_components_test.rb
+++ b/test/primer/view_components_test.rb
@@ -16,4 +16,11 @@ class Primer::ViewComponentsTest < Minitest::Test
 
     assert_equal JSON.pretty_generate(Primer::ViewComponents.generate_statuses), Primer::ViewComponents.read_statuses.chomp
   end
+
+  def test_writing_and_reading_constants
+    # we make sure that we can dump to disk and then read back again
+    Primer::ViewComponents.dump_constants
+
+    assert_equal JSON.pretty_generate(Primer::ViewComponents.generate_constants), Primer::ViewComponents.read_constants.chomp
+  end
 end


### PR DESCRIPTION
Dumps all constants defined by the components into a single `static/constants.json` file. That data will be used by linters so we can define mappers in a single place instead of having to rewrite them every time.
This PR also creates a helper class `Primer::ViewComponents::Constants` to get and format the constants to what is expected by the linters