### PR TITLE
Autocorrect components with known SystemArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Updates
+
+* Improve autocorrectable linters to convert known SystemArgument classes.
+
+    *Manuel Puyol*
+
 ## 0.0.49
 
 ### New

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -48,7 +48,7 @@ module ERBLint
 
         # Override this with your component's mappings
         def classes_to_args(classes)
-          raise ConversionError, "Cannot convert classes" if classes.present?
+          raise ConversionError, "Cannot convert classes `#{classes}`" if classes.present?
 
           {}
         end

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -30,10 +30,10 @@ module ERBLint
           @tag.attributes.each do |attribute|
             attr_name = attribute.name
 
-            if attr_name == "class"
-              args.merge!(map_classes(attribute))
-            elsif self.class::ATTRIBUTES.include?(attr_name)
+            if self.class::ATTRIBUTES.include?(attr_name)
               args.merge!(attribute_to_args(attribute))
+            elsif attr_name == "class"
+              args.merge!(map_classes(attribute))
             else
               # Assume the attribute is a system argument.
               args.merge!(SystemArguments.new(attribute).to_args)

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
+require "primer/view_components/constants"
+require "primer/classify/utilities"
 require_relative "conversion_error"
 require_relative "system_arguments"
-require "primer/view_components/constants"
 
 module ERBLint
   module Linters
@@ -26,13 +27,40 @@ module ERBLint
           args[:tag] = ":#{@tag.name}" unless self.class::DEFAULT_TAG.nil? || @tag.name == self.class::DEFAULT_TAG
 
           @tag.attributes.each do |attribute|
-            args.merge!(attribute_to_args(attribute))
+            if attribute.name == "class"
+              args.merge!(map_classes(attribute))
+            else
+              args.merge!(attribute_to_args(attribute))
+            end
           end
 
           args
         end
 
         def attribute_to_args(attribute); end
+
+        def map_classes(classes)
+          system_arguments = system_arguments_to_args(classes.value)
+          args = classes_to_args(system_arguments[:classes])
+
+          system_arguments.except(:classes).merge(args)
+        end
+
+        # Override this with your component's mappings
+        def classes_to_args(classes)
+          raise ConversionError, "Cannot convert classes" if classes.present?
+
+          {}
+        end
+
+        def system_arguments_to_args(classes)
+          system_arguments = Primer::Classify::Utilities.classes_to_hash(classes)
+
+          # need to transform symbols to strings with leading `:`
+          system_arguments.transform_values do |v|
+            v.is_a?(Symbol) ? ":#{v}" : v
+          end
+        end
       end
     end
   end

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -43,7 +43,7 @@ module ERBLint
           system_arguments = system_arguments_to_args(classes.value)
           args = classes_to_args(system_arguments[:classes])
 
-          system_arguments.except(:classes).merge(args)
+          args.merge(system_arguments.except(:classes))
         end
 
         # Override this with your component's mappings

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -12,6 +12,7 @@ module ERBLint
       # Override attribute_to_args in a child class to customize its mapping behavior.
       class Base
         DEFAULT_TAG = nil
+        ATTRIBUTES = [].freeze
 
         def initialize(tag)
           @tag = tag
@@ -27,10 +28,15 @@ module ERBLint
           args[:tag] = ":#{@tag.name}" unless self.class::DEFAULT_TAG.nil? || @tag.name == self.class::DEFAULT_TAG
 
           @tag.attributes.each do |attribute|
-            if attribute.name == "class"
+            attr_name = attribute.name
+
+            if attr_name == "class"
               args.merge!(map_classes(attribute))
-            else
+            elsif self.class::ATTRIBUTES.include?(attr_name)
               args.merge!(attribute_to_args(attribute))
+            else
+              # Assume the attribute is a system argument.
+              args.merge!(SystemArguments.new(attribute).to_args)
             end
           end
 

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -30,12 +30,12 @@ module ERBLint
           constant: "DEFAULT_TAG"
         ).freeze
 
+        ATTRIBUTES = %w[disabled type].freeze
+
         def attribute_to_args(attribute)
           attr_name = attribute.name
 
-          if attr_name == "class"
-            classes_to_args(attribute)
-          elsif attr_name == "disabled"
+          if attr_name == "disabled"
             { disabled: true }
           elsif attr_name == "type"
             # button is the default type, so we don't need to do anything.
@@ -44,9 +44,6 @@ module ERBLint
             raise ConversionError, "Button component does not support type \"#{attribute.value}\"" unless TYPE_OPTIONS.include?(attribute.value)
 
             { type: ":#{attribute.value}" }
-          else
-            # Assume the attribute is a system argument.
-            SystemArguments.new(attribute).to_args
           end
         end
 

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -51,7 +51,7 @@ module ERBLint
         end
 
         def classes_to_args(classes)
-          classes.value.split(" ").each_with_object({}) do |class_name, acc|
+          classes.split(" ").each_with_object({}) do |class_name, acc|
             next if class_name == "btn"
 
             if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -8,16 +8,10 @@ module ERBLint
       # Maps attributes in the clipboard-copy element to arguments for the ClipboardCopy component.
       class ClipboardCopy < Base
         DEFAULT_TAG = "clipboard-copy"
+        ATTRIBUTES = %w[value].freeze
 
         def attribute_to_args(attribute)
-          attr_name = attribute.name
-
-          if attr_name == "value"
-            { value: attribute.value.to_json }
-          else
-            # Assume the attribute is a system argument.
-            SystemArguments.new(attribute).to_args
-          end
+          { value: attribute.value.to_json }
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -24,15 +24,10 @@ module ERBLint
           constant: "DEFAULT_TAG"
         ).freeze
 
-        def attribute_to_args(attribute)
-          attr_name = attribute.name
+        ATTRIBUTES = %w[title].freeze
 
-          if attr_name == "title"
-            { title: attribute.value.to_json }
-          else
-            # Assume the attribute is a system argument.
-            SystemArguments.new(attribute).to_args
-          end
+        def attribute_to_args(attribute)
+          { title: attribute.value.to_json }
         end
 
         def classes_to_args(classes)

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -27,9 +27,7 @@ module ERBLint
         def attribute_to_args(attribute)
           attr_name = attribute.name
 
-          if attr_name == "class"
-            classes_to_args(attribute)
-          elsif attr_name == "title"
+          if attr_name == "title"
             { title: attribute.value.to_json }
           else
             # Assume the attribute is a system argument.
@@ -38,7 +36,7 @@ module ERBLint
         end
 
         def classes_to_args(classes)
-          classes.value.split(" ").each_with_object({}) do |class_name, acc|
+          classes.split(" ").each_with_object({}) do |class_name, acc|
             next if class_name == "Label"
 
             if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -21,4 +21,20 @@ class ArgumentMappersBaseTest < LinterTestCase
                    animation: ":fade_in"
                  }, args)
   end
+
+  def test_returns_known_system_arguments_as_string
+    @file = '<div class="mr-1 p-3 d-none d-md-block anim-fade-in"></div>'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_s
+
+    assert_equal("mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in", args)
+  end
+
+  def test_raises_if_a_class_is_unknown
+    @file = '<div class="mr-1 p-3 d-none d-md-block anim-fade-in custom"></div>'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_s
+    end
+
+    assert_equal("Cannot convert classes `custom`", err.message)
+  end
 end

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -37,4 +37,75 @@ class ArgumentMappersBaseTest < LinterTestCase
 
     assert_equal("Cannot convert classes `custom`", err.message)
   end
+
+  def test_returns_aria_arguments_as_string_symbols
+    @file = '<div aria-label="label" aria-boolean>'
+
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    assert_equal({ '"aria-label"' => '"label"', '"aria-boolean"' => '""' }, args)
+  end
+
+  def test_returns_data_arguments_as_string_symbols
+    @file = '<div data-action="click" data-pjax>'
+
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    assert_equal({ '"data-action"' => '"click"', '"data-pjax"' => '""' }, args)
+  end
+
+  def test_converts_data_test_selector
+    @file = '<div data-test-selector="some-selector">'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_equal({ test_selector: '"some-selector"' }, args)
+  end
+
+  def test_converts_erb_test_selector_call
+    @file = '<div <%= test_selector("some-selector") %>>'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_equal({ test_selector: '"some-selector"' }, args)
+  end
+
+  def test_raises_if_unsupported_erb_block
+    @file = '<div <%= some_method("some-selector") %>>'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert erb block", err.message
+  end
+
+  def test_raises_if_attribute_has_erb_value
+    @file = '<div aria-label="<%= some_call %>">'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
+  end
+
+  def test_raises_if_attribute_has_erb_interpolation
+    @file = '<div aria-label="interpolating <%= some_call %>">'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
+  end
+
+  def test_returns_arguments_as_string
+    @file = '<div aria-label="some label" aria-boolean data-pjax data-action="click">'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_s
+
+    assert_equal '"aria-label": "some label", "aria-boolean": "", "data-pjax": "", "data-action": "click"', args
+  end
+
+  def test_raises_if_cannot_map_attribute
+    @file = '<div some-attribute="some-value">'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert attribute \"some-attribute\"", err.message
+  end
 end

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class ArgumentMappersBaseTest < LinterTestCase
+  def test_returns_no_arguments_no_attributes
+    @file = "<div></div>"
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_empty args
+  end
+
+  def test_returns_known_system_arguments
+    @file = '<div class="mr-1 p-3 d-none d-md-block anim-fade-in"></div>'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_equal({
+                   mr: 1,
+                   p: 3,
+                   display: [:none, nil, :block],
+                   animation: ":fade_in"
+                 }, args)
+  end
+end

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -10,27 +10,6 @@ class ArgumentMappersButtonTest < LinterTestCase
     assert_empty args
   end
 
-  def test_returns_aria_arguments_as_string_symbols
-    @file = '<button aria-label="label" aria-disabled="true" aria-boolean>Button</button>'
-    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
-
-    assert_equal({
-                   '"aria-label"' => '"label"',
-                   '"aria-disabled"' => '"true"',
-                   '"aria-boolean"' => '""'
-                 }, args)
-  end
-
-  def test_returns_data_arguments_as_string_symbols
-    @file = '<button data-action="click" data-pjax>Button</button>'
-    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
-
-    assert_equal({
-                   '"data-action"' => '"click"',
-                   '"data-pjax"' => '""'
-                 }, args)
-  end
-
   def test_returns_disabled_argument_as_boolean
     @file = "<button disabled>Button</button>"
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
@@ -125,13 +104,6 @@ class ArgumentMappersButtonTest < LinterTestCase
     assert_equal "Cannot convert attribute \"some-attribute\"", err.message
   end
 
-  def test_converts_data_test_selector
-    @file = '<button data-test-selector="some-selector">Button</button>'
-    args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
-
-    assert_equal({ test_selector: '"some-selector"' }, args)
-  end
-
   def test_converts_erb_test_selector_call
     @file = '<button class="btn" <%= test_selector("some-selector") %>>Button</button>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
@@ -152,10 +124,6 @@ class ArgumentMappersButtonTest < LinterTestCase
     @file = '
       <button
         class="btn btn-primary btn-sm btn-block BtnGroup-item"
-        aria-label="some label"
-        data-pjax
-        data-click="click"
-        <%= test_selector("some_selector") %>
         disabled
         type="submit"
       >Button</button>'
@@ -163,23 +131,19 @@ class ArgumentMappersButtonTest < LinterTestCase
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
     assert_equal({
-                   :scheme => ":primary",
-                   :variant => ":small",
-                   :block => true,
-                   :group_item => true,
-                   '"aria-label"' => '"some label"',
-                   '"data-pjax"' => '""',
-                   '"data-click"' => '"click"',
-                   :test_selector => '"some_selector"',
-                   :disabled => true,
-                   :type => ":submit"
+                   scheme: ":primary",
+                   variant: ":small",
+                   block: true,
+                   group_item: true,
+                   disabled: true,
+                   type: ":submit"
                  }, args)
   end
 
   def test_returns_arguments_as_string
-    @file = '<a class="btn btn-primary" aria-label="some label">Link</a>'
+    @file = '<a class="btn btn-primary">Link</a>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_s
 
-    assert_equal 'tag: :a, scheme: :primary, "aria-label": "some label"', args
+    assert_equal 'tag: :a, scheme: :primary', args
   end
 end

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -120,10 +120,10 @@ class ArgumentMappersButtonTest < LinterTestCase
     assert_equal "Cannot convert erb block", err.message
   end
 
-  def test_complex_case
+  def test_with_system_arguments
     @file = '
       <button
-        class="btn btn-primary btn-sm btn-block BtnGroup-item"
+        class="btn btn-primary btn-sm btn-block BtnGroup-item mr-1 p-3 d-md-block d-none anim-fade-in"
         disabled
         type="submit"
       >Button</button>'
@@ -135,6 +135,10 @@ class ArgumentMappersButtonTest < LinterTestCase
                    variant: ":small",
                    block: true,
                    group_item: true,
+                   mr: 1,
+                   p: 3,
+                   display: [:none, nil, :block],
+                   animation: ":fade_in",
                    disabled: true,
                    type: ":submit"
                  }, args)

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -144,6 +144,6 @@ class ArgumentMappersButtonTest < LinterTestCase
     @file = '<a class="btn btn-primary">Link</a>'
     args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_s
 
-    assert_equal 'tag: :a, scheme: :primary', args
+    assert_equal "tag: :a, scheme: :primary", args
   end
 end

--- a/test/linters/argument_mappers/clipboard_copy_test.rb
+++ b/test/linters/argument_mappers/clipboard_copy_test.rb
@@ -16,4 +16,22 @@ class ArgumentMappersClipboardCopyTest < LinterTestCase
 
     assert_equal 'value: "some value"', args
   end
+
+  def test_with_system_arguments
+    @file = '
+      <clipboard-copy
+        class="mr-1 p-3 d-md-block d-none anim-fade-in"
+        value="some value"
+      ></clipboard-copy>'
+
+    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
+
+    assert_equal({
+                   value: '"some value"',
+                   mr: 1,
+                   p: 3,
+                   display: [:none, nil, :block],
+                   animation: ":fade_in"
+                 }, args)
+  end
 end

--- a/test/linters/argument_mappers/clipboard_copy_test.rb
+++ b/test/linters/argument_mappers/clipboard_copy_test.rb
@@ -10,74 +10,10 @@ class ArgumentMappersClipboardCopyTest < LinterTestCase
     assert_equal({ value: '"some value"' }, args)
   end
 
-  def test_returns_aria_arguments_as_string_symbols
-    @file = '<clipboard-copy aria-label="label" aria-boolean>'
-
-    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    assert_equal({ '"aria-label"' => '"label"', '"aria-boolean"' => '""' }, args)
-  end
-
-  def test_returns_data_arguments_as_string_symbols
-    @file = '<clipboard-copy data-action="click" data-pjax>'
-
-    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    assert_equal({ '"data-action"' => '"click"', '"data-pjax"' => '""' }, args)
-  end
-
-  def test_raises_if_cannot_map_attribute
-    @file = '<clipboard-copy some-attribute="some-value">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert attribute \"some-attribute\"", err.message
-  end
-
-  def test_converts_data_test_selector
-    @file = '<clipboard-copy data-test-selector="some-selector">'
-    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-
-    assert_equal({ test_selector: '"some-selector"' }, args)
-  end
-
-  def test_converts_erb_test_selector_call
-    @file = '<clipboard-copy <%= test_selector("some-selector") %>>'
-    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-
-    assert_equal({ test_selector: '"some-selector"' }, args)
-  end
-
-  def test_raises_if_unsupported_erb_block
-    @file = '<clipboard-copy <%= some_method("some-selector") %>>'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert erb block", err.message
-  end
-
-  def test_raises_if_attribute_has_erb_value
-    @file = '<clipboard-copy aria-label="<%= some_call %>">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
-  end
-
-  def test_raises_if_attribute_has_erb_interpolation
-    @file = '<clipboard-copy aria-label="interpolating <%= some_call %>">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
-  end
-
   def test_returns_arguments_as_string
-    @file = '<clipboard-copy aria-label="some label" aria-boolean data-pjax data-action="click">Link</clipboard-copy>'
+    @file = "<clipboard-copy value=\"some value\"></clipboard-copy>"
     args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_s
 
-    assert_equal '"aria-label": "some label", "aria-boolean": "", "data-pjax": "", "data-action": "click"', args
+    assert_equal 'value: "some value"', args
   end
 end

--- a/test/linters/argument_mappers/label_test.rb
+++ b/test/linters/argument_mappers/label_test.rb
@@ -64,6 +64,6 @@ class ArgumentMappersLabelTest < LinterTestCase
     @file = '<div class="Label Label--primary">Link</div>'
     args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_s
 
-    assert_equal 'tag: :div, scheme: :primary', args
+    assert_equal "tag: :div, scheme: :primary", args
   end
 end

--- a/test/linters/argument_mappers/label_test.rb
+++ b/test/linters/argument_mappers/label_test.rb
@@ -10,27 +10,6 @@ class ArgumentMappersLabelTest < LinterTestCase
     assert_empty args
   end
 
-  def test_returns_aria_arguments_as_string_symbols
-    @file = '<span aria-label="label" aria-disabled="true" aria-boolean>Label</span>'
-    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-
-    assert_equal({
-                   '"aria-label"' => '"label"',
-                   '"aria-disabled"' => '"true"',
-                   '"aria-boolean"' => '""'
-                 }, args)
-  end
-
-  def test_returns_data_arguments_as_string_symbols
-    @file = '<span data-action="click" data-pjax>Label</span>'
-    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-
-    assert_equal({
-                   '"data-action"' => '"click"',
-                   '"data-pjax"' => '""'
-                 }, args)
-  end
-
   def test_returns_title_argument
     @file = "<span title=\"some title\">Label</span>"
     args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
@@ -81,64 +60,10 @@ class ArgumentMappersLabelTest < LinterTestCase
     assert_equal "Cannot convert class \"some-class\"", err.message
   end
 
-  def test_raises_if_cannot_map_attribute
-    @file = '<span some-attribute="some-value">Label</span>'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert attribute \"some-attribute\"", err.message
-  end
-
-  def test_converts_data_test_selector
-    @file = '<span data-test-selector="some-selector">Label</span>'
-    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-
-    assert_equal({ test_selector: '"some-selector"' }, args)
-  end
-
-  def test_converts_erb_test_selector_call
-    @file = '<span class="Label" <%= test_selector("some-selector") %>>Label</span>'
-    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-
-    assert_equal({ test_selector: '"some-selector"' }, args)
-  end
-
-  def test_raises_if_unsupported_erb_block
-    @file = '<span class="Label" <%= some_method("some-selector") %>>Label</span>'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-    end
-
-    assert_equal "Cannot convert erb block", err.message
-  end
-
-  def test_complex_case
-    @file = '
-      <span
-        class="Label Label--primary Label--large"
-        aria-label="some label"
-        data-pjax
-        data-click="click"
-        <%= test_selector("some_selector") %>
-      >Label</span>'
-
-    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
-
-    assert_equal({
-                   :scheme => ":primary",
-                   :variant => ":large",
-                   '"aria-label"' => '"some label"',
-                   '"data-pjax"' => '""',
-                   '"data-click"' => '"click"',
-                   :test_selector => '"some_selector"'
-                 }, args)
-  end
-
   def test_returns_arguments_as_string
-    @file = '<div class="Label Label--primary" aria-label="some label">Link</div>'
+    @file = '<div class="Label Label--primary">Link</div>'
     args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_s
 
-    assert_equal 'tag: :div, scheme: :primary, "aria-label": "some label"', args
+    assert_equal 'tag: :div, scheme: :primary', args
   end
 end

--- a/test/linters/argument_mappers/label_test.rb
+++ b/test/linters/argument_mappers/label_test.rb
@@ -60,6 +60,26 @@ class ArgumentMappersLabelTest < LinterTestCase
     assert_equal "Cannot convert class \"some-class\"", err.message
   end
 
+  def test_complex_case
+    @file = '
+      <span
+        class="Label Label--primary Label--large mr-1 p-3 d-md-block d-none anim-fade-in"
+        title="some title"
+      >Label</span>'
+
+    args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
+
+    assert_equal({
+                   scheme: ":primary",
+                   variant: ":large",
+                   title: '"some title"',
+                   mr: 1,
+                   p: 3,
+                   display: [:none, nil, :block],
+                   animation: ":fade_in"
+                 }, args)
+  end
+
   def test_returns_arguments_as_string
     @file = '<div class="Label Label--primary">Link</div>'
     args = ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_s

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -214,4 +214,27 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
 
     assert_equal expected, corrected_content
   end
+
+  def test_autocorrects_known_system_arguments
+    @file = <<~HTML
+      <button class="btn btn-primary mr-1 p-3 d-none d-md-block anim-fade-in">
+        button 1
+      </button>
+      <button class="btn btn-primary mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        button 2
+      </button>
+    HTML
+
+    expected = <<~HTML
+      <%# erblint:counter ButtonComponentMigrationCounter 1 %>
+      <%= render Primer::ButtonComponent.new(scheme: :primary, mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in) do %>
+        button 1
+      <% end %>
+      <button class="btn btn-primary mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        button 2
+      </button>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
 end

--- a/test/linters/clipboard_copy_component_migration_counter_test.rb
+++ b/test/linters/clipboard_copy_component_migration_counter_test.rb
@@ -159,4 +159,27 @@ class ClipboardCopyComponentMigrationCounterTest < LinterTestCase
 
     assert_equal expected, corrected_content
   end
+
+  def test_autocorrects_known_system_arguments
+    @file = <<~HTML
+      <clipboard-copy class="mr-1 p-3 d-none d-md-block anim-fade-in">
+        clipboard-copy 1
+      </clipboard-copy>
+      <clipboard-copy class="mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        clipboard-copy 2
+      </clipboard-copy>
+    HTML
+
+    expected = <<~HTML
+      <%# erblint:counter ClipboardCopyComponentMigrationCounter 1 %>
+      <%= render Primer::ClipboardCopy.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in) do %>
+        clipboard-copy 1
+      <% end %>
+      <clipboard-copy class="mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        clipboard-copy 2
+      </clipboard-copy>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
 end

--- a/test/linters/label_component_migration_counter_test.rb
+++ b/test/linters/label_component_migration_counter_test.rb
@@ -200,4 +200,27 @@ class LabelComponentMigrationCounterTest < LinterTestCase
 
     assert_equal expected, corrected_content
   end
+
+  def test_autocorrects_known_system_arguments
+    @file = <<~HTML
+      <span class="Label Label--primary mr-1 p-3 d-none d-md-block anim-fade-in">
+        Label 1
+      </span>
+      <span class="Label Label--primary mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        Label 2
+      </span>
+    HTML
+
+    expected = <<~HTML
+      <%# erblint:counter LabelComponentMigrationCounter 1 %>
+      <%= render Primer::LabelComponent.new(scheme: :primary, mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in) do %>
+        Label 1
+      <% end %>
+      <span class="Label Label--primary mr-1 p-3 d-none d-md-block anim-fade-in custom">
+        Label 2
+      </span>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
 end


### PR DESCRIPTION
With the `classes_to_hash` utility, we can now autocorrect components that use known system arguments, such as `mr-1`, `p-3`, etc..
This will expand the coverage of our autocorrectors and will also automatically update them when we migrate more utility classes to use the `utilities.yml`.

To simplify the implementation (and DRY), I moved most of the logic to `Base`. Now each mapper will only have to implement a `class -> args` mapper and a mapper of a specific set of HTML attributes (defined by the ATTRIBUTES constant).
Moving everything to `Base` makes it easier to reuse logic like the SystemArguments conversion and `aria- / data-` arguments.