### PR TITLE
Don't require `title` for `LabelComponent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Updates
+
+* Don't require `title` for `Label`.
+
+    *Manuel Puyol*
+
 ## 0.0.49
 
 ### New

--- a/app/components/primer/label_component.rb
+++ b/app/components/primer/label_component.rb
@@ -2,6 +2,9 @@
 
 module Primer
   # Use `Label` to add contextual metadata to a design.
+  #
+  # @accessibility
+  #   Use `aria-label` if the `Label` or the context around it don't explain the label.
   class LabelComponent < Primer::Component
     status :beta
 
@@ -29,27 +32,25 @@ module Primer
     VARIANT_OPTIONS = VARIANT_MAPPINGS.keys << nil
 
     # @example Schemes
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :primary)) { "Primary" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :secondary)) { "Secondary" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :info)) { "Info" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :success)) { "Success" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :warning)) { "Warning" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :danger)) { "Danger" } %>
+    #   <%= render(Primer::LabelComponent.new) { "Default" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :primary)) { "Primary" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :secondary)) { "Secondary" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :info)) { "Info" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :success)) { "Success" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :warning)) { "Warning" } %>
+    #   <%= render(Primer::LabelComponent.new( scheme: :danger)) { "Danger" } %>
     #
     # @example Variants
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
-    #   <%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
+    #   <%= render(Primer::LabelComponent.new) { "Default" } %>
+    #   <%= render(Primer::LabelComponent.new( variant: :large)) { "Large" } %>
     #
     # @param tag [Symbol] <%= one_of(Primer::LabelComponent::TAG_OPTIONS) %>
-    # @param title [String] `title` attribute for the component element.
     # @param scheme [Symbol] <%= one_of(Primer::LabelComponent::SCHEME_MAPPINGS.keys) %>
     # @param variant [Symbol] <%= one_of(Primer::LabelComponent::VARIANT_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(tag: DEFAULT_TAG, title:, scheme: nil, variant: nil, **system_arguments)
+    def initialize(tag: DEFAULT_TAG, scheme: nil, variant: nil, **system_arguments)
       @system_arguments = system_arguments
       @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
-      @system_arguments[:title] = title
       @system_arguments[:classes] = class_names(
         "Label",
         system_arguments[:classes],

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -12,12 +12,15 @@ import Example from '../../src/@primer/gatsby-theme-doctocat/components/example'
 
 Use `Label` to add contextual metadata to a design.
 
+## Accessibility
+
+Use `aria-label` if the `Label` or the context around it don't explain the label.
+
 ## Arguments
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `tag` | `Symbol` | `:span` | One of `:a`, `:div`, `:span`, or `:summary`. |
-| `title` | `String` | N/A | `title` attribute for the component element. |
 | `scheme` | `Symbol` | `nil` | One of `:danger`, `:info`, `:orange`, `:primary`, `:purple`, `:secondary`, `:success`, or `:warning`. |
 | `variant` | `Symbol` | `nil` | One of `nil`, `:inline`, or `:large`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
@@ -26,23 +29,23 @@ Use `Label` to add contextual metadata to a design.
 
 ### Schemes
 
-<Example src="<span title='Label: Label' data-view-component='true' class='Label'>Default</span><span title='Label: Label' data-view-component='true' class='Label Label--primary'>Primary</span><span title='Label: Label' data-view-component='true' class='Label Label--secondary'>Secondary</span><span title='Label: Label' data-view-component='true' class='Label Label--info'>Info</span><span title='Label: Label' data-view-component='true' class='Label Label--success'>Success</span><span title='Label: Label' data-view-component='true' class='Label Label--warning'>Warning</span><span title='Label: Label' data-view-component='true' class='Label Label--danger'>Danger</span>" />
+<Example src="<span data-view-component='true' class='Label'>Default</span><span data-view-component='true' class='Label Label--primary'>Primary</span><span data-view-component='true' class='Label Label--secondary'>Secondary</span><span data-view-component='true' class='Label Label--info'>Info</span><span data-view-component='true' class='Label Label--success'>Success</span><span data-view-component='true' class='Label Label--warning'>Warning</span><span data-view-component='true' class='Label Label--danger'>Danger</span>" />
 
 ```erb
-<%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :primary)) { "Primary" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :secondary)) { "Secondary" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :info)) { "Info" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :success)) { "Success" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :warning)) { "Warning" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", scheme: :danger)) { "Danger" } %>
+<%= render(Primer::LabelComponent.new) { "Default" } %>
+<%= render(Primer::LabelComponent.new( scheme: :primary)) { "Primary" } %>
+<%= render(Primer::LabelComponent.new( scheme: :secondary)) { "Secondary" } %>
+<%= render(Primer::LabelComponent.new( scheme: :info)) { "Info" } %>
+<%= render(Primer::LabelComponent.new( scheme: :success)) { "Success" } %>
+<%= render(Primer::LabelComponent.new( scheme: :warning)) { "Warning" } %>
+<%= render(Primer::LabelComponent.new( scheme: :danger)) { "Danger" } %>
 ```
 
 ### Variants
 
-<Example src="<span title='Label: Label' data-view-component='true' class='Label'>Default</span><span title='Label: Label' data-view-component='true' class='Label Label--large'>Large</span>" />
+<Example src="<span data-view-component='true' class='Label'>Default</span><span data-view-component='true' class='Label Label--large'>Large</span>" />
 
 ```erb
-<%= render(Primer::LabelComponent.new(title: "Label: Label")) { "Default" } %>
-<%= render(Primer::LabelComponent.new(title: "Label: Label", variant: :large)) { "Large" } %>
+<%= render(Primer::LabelComponent.new) { "Default" } %>
+<%= render(Primer::LabelComponent.new( variant: :large)) { "Large" } %>
 ```

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -562,10 +562,6 @@
     type: Symbol
     default: "`:span`"
     description: One of `:a`, `:div`, `:span`, or `:summary`.
-  - name: title
-    type: String
-    default: N/A
-    description: "`title` attribute for the component element."
   - name: scheme
     type: Symbol
     default: "`nil`"

--- a/stories/primer/label_component_stories.rb
+++ b/stories/primer/label_component_stories.rb
@@ -5,7 +5,6 @@ class Primer::LabelComponentStories < ViewComponent::Storybook::Stories
 
   story(:label) do
     controls do
-      title "this is a label"
       select(:scheme, Primer::LabelComponent::SCHEME_MAPPINGS.keys, :success)
       select(:variant, Primer::LabelComponent::VARIANT_MAPPINGS.keys, :large)
     end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -46,7 +46,7 @@ class PrimerComponentTest < Minitest::Test
     [Primer::FlexItemComponent, { flex_auto: true }],
     [Primer::HeadingComponent, { tag: :h1 }],
     [Primer::HiddenTextExpander, {}],
-    [Primer::LabelComponent, { title: "Hello!" }],
+    [Primer::LabelComponent, {}],
     [Primer::LayoutComponent, {}],
     [Primer::LinkComponent, { href: "https://www.google.com" }],
     [Primer::Markdown, {}],

--- a/test/components/label_component_test.rb
+++ b/test/components/label_component_test.rb
@@ -6,47 +6,47 @@ class PrimerLabelComponentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
   def test_renders_content
-    render_inline(Primer::LabelComponent.new(title: "private-badge")) { "private" }
+    render_inline(Primer::LabelComponent.new) { "private" }
 
     assert_text("private")
   end
 
   def test_falls_back_when_tag_isnt_valid
     without_fetch_or_fallback_raises do
-      render_inline(Primer::LabelComponent.new(title: "foo", tag: :h1))
+      render_inline(Primer::LabelComponent.new(tag: :h1))
       assert_selector("span.Label")
     end
   end
 
   def test_supports_functional_schemes
-    render_inline(Primer::LabelComponent.new(title: "foo", scheme: :danger)) { "private" }
+    render_inline(Primer::LabelComponent.new(scheme: :danger)) { "private" }
 
     assert_selector(".Label--danger")
   end
 
   def test_deprecated_schemes
     Primer::LabelComponent::DEPRECATED_SCHEME_OPTIONS.each do |scheme|
-      render_inline(Primer::LabelComponent.new(title: "foo", scheme: scheme)) { "scheme" }
+      render_inline(Primer::LabelComponent.new(scheme: scheme)) { "scheme" }
     end
   end
 
   def test_falls_back_when_scheme_isn_t_valid
     without_fetch_or_fallback_raises do
-      render_inline(Primer::LabelComponent.new(title: "title", scheme: :pink)) { "content" }
+      render_inline(Primer::LabelComponent.new(scheme: :pink)) { "content" }
     end
 
     assert_text("content")
   end
 
   def test_renders_with_the_css_class_variant_mapping_to_the_provided_variant
-    render_inline(Primer::LabelComponent.new(title: "title", variant: :large)) { "private" }
+    render_inline(Primer::LabelComponent.new(variant: :large)) { "private" }
 
     assert_selector(".Label.Label--large")
   end
 
   def test_falls_back_when_variant_isn_t_valid
     without_fetch_or_fallback_raises do
-      render_inline(Primer::LabelComponent.new(title: "title", variant: :xxl)) { "content" }
+      render_inline(Primer::LabelComponent.new(variant: :xxl)) { "content" }
     end
 
     assert_text("content")


### PR DESCRIPTION
A11y context:

> i think the key thing is context, if the label is on it's own does a good enough job describing itself then i wouldn't use title for a11y reasons.
> if the label is used, and it's surrounding context does a good job of explaining the label or adding more context to the label then i would avoid title again
> if the label is used and the label lacks good information in the surrounding context then i would think about adding a better accessible name
> if title is the only option then use that
> if not, then consider using aria-labelledby  or aria-label

It looks like `title` is not a good attribute for labels, so I'm removing its requirement in favor of an accessibility guideline towards `aria-label` when necessary