### PR TITLE
Update the height and width argument docs to pull the arguments from Utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+* Fix `:height` and `:width` docs to pull from Utilities
+
+    *Jon Rohan*
+
 ## 0.0.49
 
 ### New

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -93,8 +93,8 @@ module Primer
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | `display` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:display)) %> |
-    # | `width` | Symbol | <%= one_of([:fit, :full]) %>. Also supports integer values. |
-    # | `height` | Symbol | <%= one_of([:fit, :full]) %>. Also supports integer values. |
+    # | `width` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:width)) %>. Also supports integer values. |
+    # | `height` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:height)) %>. Also supports integer values. |
     # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of(Primer::Classify::Utilities.mappings(:hide)) %> |
     # | `visibility` | Symbol | Visibility. <%= one_of(Primer::Classify::Utilities.mappings(:visibility)) %> |
     # | `vertical_align` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:vertical_align)) %> |

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -92,7 +92,7 @@ System arguments include most HTML attributes. For example:
 | Name | Type | Description |
 | :- | :- | :- |
 | `display` | Symbol | One of `:block`, `:flex`, `:inline`, `:inline_block`, `:inline_flex`, `:none`, `:table`, or `:table_cell`. |
-| `width` | Symbol | One of `:fit` and `:full`.. Also supports integer values. |
+| `width` | Symbol | One of `:auto`, `:fit`, or `:full`.. Also supports integer values. |
 | `height` | Symbol | One of `:fit` and `:full`.. Also supports integer values. |
 | `hide` | Symbol | Hide the element at a specific breakpoint. One of `:lg`, `:md`, `:sm`, or `:xl`. |
 | `visibility` | Symbol | Visibility. One of `:hidden` and `:visible`. |


### PR DESCRIPTION
Follow up to https://github.com/primer/view_components/pull/715

I noticed we're manually adding the arguments here, but we can pull them directly from Utilities so that they're always up to date.