### PR TITLE
Create linter for CloseButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### New
+
+* Add linter suggestions for `CloseButton` component.
+
+    *Manuel Puyol*
+
 ### Breaking changes
 
 * Update to `octicons` `v15`, removing open-ended dependency. See [https://github.com/primer/octicons/releases/tag/v15.0.0] for icon name changes in release.

--- a/lib/primer/view_components/linters/close_button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/close_button_component_migration_counter.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "helpers"
+
+module ERBLint
+  module Linters
+    # Counts the number of times a HTML clipboard-copy is used instead of the component.
+    class CloseButtonComponentMigrationCounter < Linter
+      include Helpers
+
+      TAGS = %w[button].freeze
+      CLASSES = %w[close-button].freeze
+      MESSAGE = "We are migrating clipboard-copy to use [Primer::CloseButton](https://primer.style/view-components/components/closebutton), please try to use that instead of raw HTML."
+    end
+  end
+end

--- a/lib/primer/view_components/linters/close_button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/close_button_component_migration_counter.rb
@@ -10,7 +10,7 @@ module ERBLint
 
       TAGS = %w[button].freeze
       CLASSES = %w[close-button].freeze
-      MESSAGE = "We are migrating clipboard-copy to use [Primer::CloseButton](https://primer.style/view-components/components/closebutton), please try to use that instead of raw HTML."
+      MESSAGE = "We are migrating close-button to use [Primer::CloseButton](https://primer.style/view-components/components/closebutton), please try to use that instead of raw HTML."
     end
   end
 end

--- a/test/linters/close_button_component_migration_counter_test.rb
+++ b/test/linters/close_button_component_migration_counter_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class CloseButtonComponentMigrationCounterTest < LinterTestCase
+  def linter_class
+    ERBLint::Linters::CloseButtonComponentMigrationCounter
+  end
+
+  def test_warns_if_there_is_a_html_close_button
+    @file = "<button class=\"close-button\">close-button</button>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_suggests_ignoring_with_correct_number_of_close_buttons
+    @file = "<button class=\"close-button\">close-button</button><button class=\"close-button\">close-button</button><button class=\"not-a-close-button\">close-button</button>"
+
+    assert_equal "<%# erblint:counter CloseButtonComponentMigrationCounter 2 %>\n#{@file}", corrected_content
+  end
+
+  def test_does_not_warn_if_wrong_tag
+    @file = "<div class=\"close_button\">close-button</div>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+end


### PR DESCRIPTION
This linter is not autocorrectable (yet), because I'm not sure how to deal with cases where the `aria-label` is being set in the button's content. Since the component has a default aria-label, it may override the one being set.

```erb
<button class="close-button"><%= primer_octicon(:x, "aria-label": "Some Label") %></button>
```

This would become:

```erb
<%= render Primer::CloseButton.new do %>
  <%= primer_octicon(:x, "aria-label": "Some Label") %>
<% end %>
```

Which translates to:

```erb
<button class="close-button" aria-label="Close"><%= primer_octicon(:x, "aria-label": "Some Label") %></button>
```