### PR TITLE
Create linter to use `primer_octicon` instead of `octicon`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### New
+
+* Add cop to use `primer_octicon` in favor of `octicon`.
+
+    *Manuel Puyol*
+
 ### Breaking changes
 
 * Rename `width` and `height` System Arguments to `w` and `h`, resolving conflict with HTML attribute names.

--- a/app/lib/primer/view_helper.rb
+++ b/app/lib/primer/view_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# :nocov:
 module Primer
   # Module to allow shorthand calls for Primer components
   module ViewHelper

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -114,6 +114,21 @@ module Primer
           obj
         end
 
+        def classes_to_args(classes)
+          classes_to_hash(classes).map do |key, value|
+            val = case value
+                  when Symbol
+                    ":#{value}"
+                  when String
+                    value.to_json
+                  else
+                    value
+                  end
+
+            "#{key}: #{val}"
+          end.join(", ")
+        end
+
         private
 
         def find_selector(selector)

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -10,3 +10,5 @@ Primer/SystemArgumentInsteadOfClass:
 Primer/NoTagMemoize:
   Enabled: false
 
+Primer/PrimerOcticon:
+  Enabled: true

--- a/lib/rubocop/cop/primer.rb
+++ b/lib/rubocop/cop/primer.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
 
-require "rubocop/cop/primer/no_tag_memoize"
-require "rubocop/cop/primer/system_argument_instead_of_class"
+Dir[File.join(__dir__, "primer", "*.rb")].sort.each { |file| require file }

--- a/lib/rubocop/cop/primer/no_tag_memoize.rb
+++ b/lib/rubocop/cop/primer/no_tag_memoize.rb
@@ -2,6 +2,7 @@
 
 require "rubocop"
 
+# :nocov:
 module RuboCop
   module Cop
     module Primer

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -3,6 +3,7 @@
 require "rubocop"
 require "primer/classify/utilities"
 
+# :nocov:
 module RuboCop
   module Cop
     module Primer

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -18,7 +18,9 @@ module RuboCop
           Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.
         STR
 
-        VALID_ATTRIBUTES = %i[height width size class].freeze
+        SIZE_ATTRIBUTES = %i[height width size].freeze
+        VALID_ATTRIBUTES = [*SIZE_ATTRIBUTES, :class].freeze
+        INVALID_CLASSES = -1
 
         def on_send(node)
           return unless node.method_name == :octicon
@@ -29,16 +31,16 @@ module RuboCop
 
           # Don't convert unknown attributes
           return unless (attributes - VALID_ATTRIBUTES).empty?
+          # Can't convert size
+          return if (SIZE_ATTRIBUTES & attributes).any? && octicon_size(kwargs).nil?
 
           # find class pair
-          class_arg = kwargs.pairs.find { |kwarg| kwarg.key.value == :class }
+          classes = classes(kwargs)
 
-          if class_arg.present?
-            return unless class_arg.value.type == :str
+          return if classes == INVALID_CLASSES
 
-            # get actual classes
-            classes = class_arg.value.value
-
+          # check if classes are convertible
+          if classes.present?
             system_arguments = ::Primer::Classify::Utilities.classes_to_hash(classes)
 
             # no classes are fixable
@@ -48,28 +50,64 @@ module RuboCop
           add_offense(node, message: INVALID_MESSAGE)
         end
 
-        # def autocorrect(node)
-        #   lambda do |corrector|
-        #     system_arguments = ::Primer::Classify::Utilities.classes_to_hash(node.value.value)
-        #     corrector.replace(node.loc.expression, arguments_as_string(system_arguments))
-        #   end
-        # end
+        def autocorrect(node)
+          lambda do |corrector|
+            icon = node.arguments.first.source
+            kwargs = node.arguments.last
+
+            # Converting arguments for the component
+            classes = classes(kwargs)
+            size = transform_size(kwargs)
+            args = arguments_as_string(icon, size, classes)
+
+            corrector.replace(node.loc.expression, "primer_octicon(#{args})")
+          end
+        end
 
         private
 
-        def arguments_as_string(system_arguments)
-          system_arguments.map do |key, value|
-            val = case value
-                  when Symbol
-                    ":#{value}"
-                  when String
-                    value.to_json
-                  else
-                    value
-                  end
+        def transform_size(kwargs)
+          size = octicon_size(kwargs)
 
-            "#{key}: #{val}"
-          end.join(", ")
+          return "" if size.between?(10, 16)
+          return ":medium" if size.between?(22, 26)
+
+          size
+        end
+
+        def octicon_size(kwargs)
+          size = nil
+
+          kwargs.pairs.each do |pair|
+            if SIZE_ATTRIBUTES.include?(pair.key.value) && (pair.value.type == :str || pair.value.type == :int)
+              size = pair.value.source.to_i
+              break
+            end
+          end
+
+          size
+        end
+
+        def classes(kwargs)
+          # find class pair
+          class_arg = kwargs.pairs.find { |kwarg| kwarg.key.value == :class }
+
+          return if class_arg.blank?
+          return INVALID_CLASSES unless class_arg.value.type == :str
+
+          class_arg.value.value
+        end
+
+        def arguments_as_string(icon, size, classes)
+          args = icon
+
+          args += ", size: #{size}" if size.present?
+
+          return args if classes.blank?
+
+          system_args = ::Primer::Classify::Utilities.classes_to_args(classes)
+
+          "#{args}, #{system_args}"
         end
       end
     end

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "primer/classify/utilities"
+
+module RuboCop
+  module Cop
+    module Primer
+      # This cop ensures that components use System Arguments instead of CSS classes.
+      #
+      # bad
+      # octicon("icon")
+      #
+      # good
+      # primer_octicon("icon")
+      class PrimerOcticon < RuboCop::Cop::Cop
+        INVALID_MESSAGE = <<~STR
+          Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.
+        STR
+
+        VALID_ATTRIBUTES = %i[height width size class].freeze
+
+        def on_send(node)
+          return unless node.method_name == :octicon
+          return unless node.arguments?
+
+          kwargs = node.arguments.last
+          attributes = kwargs.keys.map(&:value)
+
+          # Don't convert unknown attributes
+          return unless (attributes - VALID_ATTRIBUTES).empty?
+
+          # find class pair
+          class_arg = kwargs.pairs.find { |kwarg| kwarg.key.value == :class }
+
+          if class_arg.present?
+            return unless class_arg.value.type == :str
+
+            # get actual classes
+            classes = class_arg.value.value
+
+            system_arguments = ::Primer::Classify::Utilities.classes_to_hash(classes)
+
+            # no classes are fixable
+            return if system_arguments[:classes] == classes
+          end
+
+          add_offense(node, message: INVALID_MESSAGE)
+        end
+
+        # def autocorrect(node)
+        #   lambda do |corrector|
+        #     system_arguments = ::Primer::Classify::Utilities.classes_to_hash(node.value.value)
+        #     corrector.replace(node.loc.expression, arguments_as_string(system_arguments))
+        #   end
+        # end
+
+        private
+
+        def arguments_as_string(system_arguments)
+          system_arguments.map do |key, value|
+            val = case value
+                  when Symbol
+                    ":#{value}"
+                  when String
+                    value.to_json
+                  else
+                    value
+                  end
+
+            "#{key}: #{val}"
+          end.join(", ")
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -26,7 +26,7 @@ module RuboCop
           return unless node.method_name == :octicon
           return unless node.arguments?
 
-          kwargs = node.arguments.last
+          kwargs = kwargs(node)
           attributes = kwargs.keys.map(&:value)
 
           # Don't convert unknown attributes
@@ -43,8 +43,8 @@ module RuboCop
           if classes.present?
             system_arguments = ::Primer::Classify::Utilities.classes_to_hash(classes)
 
-            # no classes are fixable
-            return if system_arguments[:classes] == classes
+            # Uses custom classes
+            return if system_arguments[:classes].present?
           end
 
           add_offense(node, message: INVALID_MESSAGE)
@@ -122,6 +122,12 @@ module RuboCop
           size_attributes.map do |key, value|
             "#{key}: #{value}"
           end.join(", ")
+        end
+
+        def kwargs(node)
+          return node.arguments.last if node.arguments.size > 1
+
+          OpenStruct.new(keys: [], pairs: [])
         end
       end
     end

--- a/lib/rubocop/cop/primer/system_argument_instead_of_class.rb
+++ b/lib/rubocop/cop/primer/system_argument_instead_of_class.rb
@@ -48,26 +48,9 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            system_arguments = ::Primer::Classify::Utilities.classes_to_hash(node.value.value)
-            corrector.replace(node.loc.expression, arguments_as_string(system_arguments))
+            args = ::Primer::Classify::Utilities.classes_to_args(node.value.value)
+            corrector.replace(node.loc.expression, args)
           end
-        end
-
-        private
-
-        def arguments_as_string(system_arguments)
-          system_arguments.map do |key, value|
-            val = case value
-                  when Symbol
-                    ":#{value}"
-                  when String
-                    value.to_json
-                  else
-                    value
-                  end
-
-            "#{key}: #{val}"
-          end.join(", ")
         end
       end
     end

--- a/lib/rubocop/cop/primer/system_argument_instead_of_class.rb
+++ b/lib/rubocop/cop/primer/system_argument_instead_of_class.rb
@@ -5,6 +5,7 @@ require "primer/classify/utilities"
 require "primer/view_components/statuses"
 require_relative "../../../../app/lib/primer/view_helper"
 
+# :nocov:
 module RuboCop
   module Cop
     module Primer

--- a/lib/tasks/coverage.rake
+++ b/lib/tasks/coverage.rake
@@ -9,6 +9,10 @@ namespace :coverage do
 
     SimpleCov.collate Dir["simplecov-resultset-*/.resultset.json"], "rails" do
       formatter SimpleCov::Formatter::Console
+
+      add_group "Ignored Code" do |src_file|
+        File.readlines(src_file.filename).grep(/:nocov:/).any?
+      end
     end
   end
 end

--- a/test/cop_test.rb
+++ b/test/cop_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rubocop/cop/primer"
+
+class CopTest < MiniTest::Test
+  def cop_class
+    raise NotImplementedError
+  end
+
+  attr_reader :cop
+
+  def setup
+    config = RuboCop::Config.new
+    @cop = cop_class.new(config)
+  end
+
+  def investigate(cop, src, filename = nil)
+    processed_source = RuboCop::ProcessedSource.new(src, RUBY_VERSION.to_f, filename)
+    commissioner = RuboCop::Cop::Commissioner.new([cop], [], raise_error: true)
+    commissioner.investigate(processed_source)
+    commissioner
+  end
+end

--- a/test/primer/view_helper_test.rb
+++ b/test/primer/view_helper_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require_relative "../../app/lib/primer/view_helper"
 
 class Primer::ViewHelperTest < Minitest::Test
   include Primer::ViewHelper

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "cop_test"
+
+class RubocopPrimerOcticonTest < CopTest
+  def cop_class
+    RuboCop::Cop::Primer::PrimerOcticon
+  end
+
+  def test_primer_octicon
+    investigate(cop, <<-RUBY)
+      primer_octicon(:icon)
+    RUBY
+
+    assert_empty cop.offenses.map(&:message)
+  end
+
+  def test_octicon
+    investigate(cop, <<-RUBY)
+      octicon(:icon)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", cop.offenses.first.message
+  end
+
+  def test_octicon_with_size
+    investigate(cop, <<-RUBY)
+      octicon(:icon, size: 10)
+      octicon(:icon, size: '10')
+    RUBY
+
+    assert_equal 2, cop.offenses.count
+    cop.offenses.each do |offense|
+      assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
+    end
+  end
+
+  def test_octicon_with_invalid_size
+    investigate(cop, <<-RUBY)
+      octicon(:icon, size: some_call)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_octicon_with_width
+    investigate(cop, <<-RUBY)
+      octicon(:icon, width: 10)
+      octicon(:icon, width: '10')
+    RUBY
+
+    assert_equal 2, cop.offenses.count
+    cop.offenses.each do |offense|
+      assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
+    end
+  end
+
+  def test_octicon_with_invalid_width
+    investigate(cop, <<-RUBY)
+      octicon(:icon, width: some_call)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_octicon_with_height
+    investigate(cop, <<-RUBY)
+      octicon(:icon, height: 10)
+      octicon(:icon, height: '10')
+    RUBY
+
+    assert_equal 2, cop.offenses.count
+    cop.offenses.each do |offense|
+      assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
+    end
+  end
+
+  def test_octicon_with_invalid_height
+    investigate(cop, <<-RUBY)
+      octicon(:icon, height: some_call)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_octicon_with_system_arguments
+    investigate(cop, <<-RUBY)
+      octicon(:icon, class: "mr-1")
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", cop.offenses.first.message
+  end
+
+  def test_octicon_with_custom_class
+    investigate(cop, <<-RUBY)
+      octicon(:icon, class: "mr-1 custom")
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_octicon_with_icon_string
+    investigate(cop, <<-RUBY)
+      octicon("icon")
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", cop.offenses.first.message
+  end
+
+  def test_octicon_with_icon_block
+    investigate(cop, <<-RUBY)
+      octicon(some_call ? :icon : :other_icon)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", cop.offenses.first.message
+  end
+
+  def test_octicon_with_unknown_attribute
+    investigate(cop, <<-RUBY)
+      octicon(:icon, some_attribute: :value)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+end

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -37,8 +37,9 @@ class RubocopPrimerOcticonTest < CopTest
   end
 
   def test_octicon_with_invalid_size
-    investigate(cop, <<-RUBY)
+    investigate(cop, <<-'RUBY')
       octicon(:icon, size: some_call)
+      octicon(:icon, size: "interpolation-#{aux}")
     RUBY
 
     assert_empty cop.offenses
@@ -57,8 +58,9 @@ class RubocopPrimerOcticonTest < CopTest
   end
 
   def test_octicon_with_invalid_width
-    investigate(cop, <<-RUBY)
+    investigate(cop, <<-'RUBY')
       octicon(:icon, width: some_call)
+      octicon(:icon, width: "interpolation-#{aux}")
     RUBY
 
     assert_empty cop.offenses
@@ -77,8 +79,9 @@ class RubocopPrimerOcticonTest < CopTest
   end
 
   def test_octicon_with_invalid_height
-    investigate(cop, <<-RUBY)
+    investigate(cop, <<-'RUBY')
       octicon(:icon, height: some_call)
+      octicon(:icon, height: "interpolation-#{aux}")
     RUBY
 
     assert_empty cop.offenses
@@ -96,6 +99,14 @@ class RubocopPrimerOcticonTest < CopTest
   def test_octicon_with_custom_class
     investigate(cop, <<-RUBY)
       octicon(:icon, class: "mr-1 custom")
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_octicon_with_class_interpolation
+    investigate(cop, <<-'RUBY')
+      octicon(:icon, class: "mr-1 #{aux}")
     RUBY
 
     assert_empty cop.offenses

--- a/test/rubocop/system_arguments_instead_of_class_test.rb
+++ b/test/rubocop/system_arguments_instead_of_class_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "cop_test"
+
+class RubocopSystemArgumentInsteadOfClassTest < CopTest
+  def cop_class
+    RuboCop::Cop::Primer::SystemArgumentInsteadOfClass
+  end
+
+  def test_non_primer_component
+    investigate(cop, <<-RUBY)
+      Component.new(classes: "mr-1")
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_primer_component
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new(classes: "mr-1")
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Avoid using CSS classes when you can use System Arguments: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
+
+  def test_non_primer_view_helper
+    investigate(cop, <<-RUBY)
+      octicon(classes: "mr-1")
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_primer_view_helper
+    investigate(cop, <<-RUBY)
+      primer_octicon(classes: "mr-1")
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Avoid using CSS classes when you can use System Arguments: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
+
+  def test_custom_class
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new(classes: "mr-1 custom")
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Avoid using CSS classes when you can use System Arguments: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
+
+  def test_no_classes
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new
+    RUBY
+
+    assert_empty cop.offenses
+  end
+end


### PR DESCRIPTION
This linter will check all calls to `octicon()` and suggest to use `primer_octicon` instead.
It will only suggest if:

1. no custom classes are used
2. no arguments other than `size, width, height, class` are used
3. `size, width, height` are either String or Int
4. `class` is a String