### PR TITLE
Primer Octicon linter updates

### DIFF
--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -35,6 +35,9 @@ module RuboCop
           return unless node.arguments?
 
           kwargs = kwargs(node)
+
+          return unless kwargs.type == :hash
+
           attributes = kwargs.keys.map(&:value)
 
           # Don't convert unknown attributes
@@ -135,7 +138,7 @@ module RuboCop
         def kwargs(node)
           return node.arguments.last if node.arguments.size > 1
 
-          OpenStruct.new(keys: [], pairs: [])
+          OpenStruct.new(keys: [], pairs: [], type: :hash)
         end
 
         def icon(node)

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -96,9 +96,14 @@ module RuboCop
             next unless SIZE_ATTRIBUTES.include?(pair.key.value)
 
             # We only support string or int values.
-            return INVALID_ATTRIBUTE if pair.value.type != :str && pair.value.type != :int
-
-            h[pair.key.value] = pair.value.source.to_i
+            case pair.value.type
+            when :int
+              h[pair.key.value] = pair.value.source.to_i
+            when :str
+              h[pair.key.value] = pair.value.value.to_i
+            else
+              return INVALID_ATTRIBUTE
+            end
           end
         end
 

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -28,9 +28,10 @@ class RubocopPrimerOcticonTest < CopTest
     investigate(cop, <<-RUBY)
       octicon(:icon, size: 10)
       octicon(:icon, size: '10')
+      octicon(:icon, size: '10px')
     RUBY
 
-    assert_equal 2, cop.offenses.count
+    assert_equal 3, cop.offenses.count
     cop.offenses.each do |offense|
       assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
     end
@@ -49,9 +50,10 @@ class RubocopPrimerOcticonTest < CopTest
     investigate(cop, <<-RUBY)
       octicon(:icon, width: 10)
       octicon(:icon, width: '10')
+      octicon(:icon, width: '10px')
     RUBY
 
-    assert_equal 2, cop.offenses.count
+    assert_equal 3, cop.offenses.count
     cop.offenses.each do |offense|
       assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
     end
@@ -70,9 +72,10 @@ class RubocopPrimerOcticonTest < CopTest
     investigate(cop, <<-RUBY)
       octicon(:icon, height: 10)
       octicon(:icon, height: '10')
+      octicon(:icon, height: '10px')
     RUBY
 
-    assert_equal 2, cop.offenses.count
+    assert_equal 3, cop.offenses.count
     cop.offenses.each do |offense|
       assert_equal "Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.\n", offense.message
     end

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -137,4 +137,12 @@ class RubocopPrimerOcticonTest < CopTest
 
     assert_empty cop.offenses
   end
+
+  def test_octicon_kwargs_as_method_call
+    investigate(cop, <<-RUBY)
+      octicon(:icon, some_call)
+    RUBY
+
+    assert_empty cop.offenses
+  end
 end


### PR DESCRIPTION
This change has some fixes for the linter:

1. Linter will avoid converting calls like `octicon(:icon, some_method)` since we don't know what the method will return and may cause a System Argument error
2. Linter will convert width/height/size from `px` to int