### PR TITLE
Convert ERB interpolations in linters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+### Updates
+
+* Linters can convert values with ERB interpolations.
+
+    *Manuel Puyol*
+
 ## 0.0.51
 
 ### Breaking changes

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -68,6 +68,12 @@ module ERBLint
             v.is_a?(Symbol) ? ":#{v}" : v
           end
         end
+
+        private
+
+        def erb_helper
+          @erb_helper ||= Helpers::ErbBlock.new
+        end
       end
     end
   end

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -11,11 +11,7 @@ module ERBLint
         ATTRIBUTES = %w[value].freeze
 
         def attribute_to_args(attribute)
-          if erb_helper.any?(attribute)
-            { value: erb_helper.convert_interpolation(attribute) }
-          else
-            { value: attribute.value.to_json }
-          end
+          { value: erb_helper.convert(attribute) }
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -11,8 +11,11 @@ module ERBLint
         ATTRIBUTES = %w[value].freeze
 
         def attribute_to_args(attribute)
-          Helpers::ErbBlock.raise_if_erb_block(attribute)
-          { value: attribute.value.to_json }
+          if erb_helper.any?(attribute)
+            { value: erb_helper.convert_interpolation(attribute) }
+          else
+            { value: attribute.value.to_json }
+          end
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
+++ b/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
@@ -8,7 +8,7 @@ module ERBLint
       module Helpers
         # provides helpers to identify and deal with ERB blocks.
         class ErbBlock
-          INTERPOLATION_REGEX = /<%=(?<rb>.*)%>/.freeze
+          INTERPOLATION_REGEX = /^<%=(?<rb>.*)%>$/.freeze
 
           def raise_if_erb_block(attribute)
             raise ERBLint::Linters::ArgumentMappers::ConversionError, "Cannot convert attribute \"#{attribute.name}\" because its value contains an erb block" if any?(attribute)
@@ -29,8 +29,12 @@ module ERBLint
           end
 
           def convert_interpolation(attribute)
-            m = attribute.value.match(INTERPOLATION_REGEX)
-            m[:rb].strip
+            if basic?(attribute)
+              m = attribute.value.match(INTERPOLATION_REGEX)
+              return m[:rb].strip
+            end
+
+            attribute.value.gsub("<%=", '#{').gsub("%>", "}").to_json
           end
         end
       end

--- a/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
+++ b/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
@@ -14,6 +14,14 @@ module ERBLint
             raise ERBLint::Linters::ArgumentMappers::ConversionError, "Cannot convert attribute \"#{attribute.name}\" because its value contains an erb block" if any?(attribute)
           end
 
+          def convert(attribute)
+            if any?(attribute)
+              convert_interpolation(attribute)
+            else
+              attribute.value.to_json
+            end
+          end
+
           def any?(attribute)
             erb_blocks(attribute).any?
           end

--- a/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
+++ b/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
@@ -22,6 +22,8 @@ module ERBLint
             end
           end
 
+          private
+
           def any?(attribute)
             erb_blocks(attribute).any?
           end

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -27,7 +27,7 @@ module ERBLint
         ATTRIBUTES = %w[title].freeze
 
         def attribute_to_args(attribute)
-          Helpers::ErbBlock.raise_if_erb_block(attribute)
+          erb_helper.raise_if_erb_block(attribute)
           { title: attribute.value.to_json }
         end
 

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -27,8 +27,7 @@ module ERBLint
         ATTRIBUTES = %w[title].freeze
 
         def attribute_to_args(attribute)
-          erb_helper.raise_if_erb_block(attribute)
-          { title: attribute.value.to_json }
+          { title: erb_helper.convert(attribute) }
         end
 
         def classes_to_args(classes)

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -11,9 +11,10 @@ module ERBLint
         STRING_PARAMETERS = %w[aria- data-].freeze
         TEST_SELECTOR_REGEX = /test_selector\((?<selector>.+)\)$/.freeze
 
-        attr_reader :attribute
+        attr_reader :attribute, :erb_helper
         def initialize(attribute)
           @attribute = attribute
+          @erb_helper = Helpers::ErbBlock.new
         end
 
         def to_args
@@ -29,11 +30,11 @@ module ERBLint
 
             { test_selector: m[:selector].tr("'", '"') }
           elsif attr_name == "data-test-selector"
-            Helpers::ErbBlock.raise_if_erb_block(attribute)
+            erb_helper.raise_if_erb_block(attribute)
 
             { test_selector: attribute.value.to_json }
           elsif attr_name.start_with?(*STRING_PARAMETERS)
-            Helpers::ErbBlock.raise_if_erb_block(attribute)
+            erb_helper.raise_if_erb_block(attribute)
 
             { "\"#{attr_name}\"" => attribute.value.to_json }
           else

--- a/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
+++ b/lib/primer/view_components/linters/argument_mappers/system_arguments.rb
@@ -30,13 +30,9 @@ module ERBLint
 
             { test_selector: m[:selector].tr("'", '"') }
           elsif attr_name == "data-test-selector"
-            erb_helper.raise_if_erb_block(attribute)
-
-            { test_selector: attribute.value.to_json }
+            { test_selector: erb_helper.convert(attribute) }
           elsif attr_name.start_with?(*STRING_PARAMETERS)
-            erb_helper.raise_if_erb_block(attribute)
-
-            { "\"#{attr_name}\"" => attribute.value.to_json }
+            { "\"#{attr_name}\"" => erb_helper.convert(attribute) }
           else
             raise ConversionError, "Cannot convert attribute \"#{attr_name}\""
           end

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -75,22 +75,25 @@ class ArgumentMappersBaseTest < LinterTestCase
     assert_equal "Cannot convert erb block", err.message
   end
 
-  def test_raises_if_attribute_has_erb_value
+  def test_converts_aria_label_with_basic_interpolation
     @file = '<div aria-label="<%= some_call %>">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
-    end
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
 
-    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
+    assert_equal({ '"aria-label"' => "some_call" }, args)
   end
 
-  def test_raises_if_attribute_has_erb_interpolation
-    @file = '<div aria-label="interpolating <%= some_call %>">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
-    end
+  def test_converts_aria_label_with_interpolation_with_string
+    @file = '<div aria-label="string-<%= some_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
 
-    assert_equal "Cannot convert attribute \"aria-label\" because its value contains an erb block", err.message
+    assert_equal({ '"aria-label"' => "\"string-\#{ some_call }\"" }, args)
+  end
+
+  def test_converts_aria_label_with_multiple_interpolations
+    @file = '<div aria-label="string-<%= some_call %><%= other_call %>-more-<%= another_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_equal({ '"aria-label"' => "\"string-\#{ some_call }\#{ other_call }-more-\#{ another_call }\"" }, args)
   end
 
   def test_returns_arguments_as_string

--- a/test/linters/argument_mappers/clipboard_copy_test.rb
+++ b/test/linters/argument_mappers/clipboard_copy_test.rb
@@ -35,12 +35,10 @@ class ArgumentMappersClipboardCopyTest < LinterTestCase
                  }, args)
   end
 
-  def test_raises_if_value_has_erb_value
+  def test_converts_basic_interpolation
     @file = '<clipboard-copy value="<%= some_call %>">'
-    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
-      ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
-    end
+    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
 
-    assert_equal "Cannot convert attribute \"value\" because its value contains an erb block", err.message
+    assert_equal({ value: "some_call" }, args)
   end
 end

--- a/test/linters/argument_mappers/clipboard_copy_test.rb
+++ b/test/linters/argument_mappers/clipboard_copy_test.rb
@@ -41,4 +41,18 @@ class ArgumentMappersClipboardCopyTest < LinterTestCase
 
     assert_equal({ value: "some_call" }, args)
   end
+
+  def test_converts_interpolation_with_string
+    @file = '<clipboard-copy value="string-<%= some_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
+
+    assert_equal({ value: "\"string-\#{ some_call }\"" }, args)
+  end
+
+  def test_converts_multiple_interpolations
+    @file = '<clipboard-copy value="string-<%= some_call %><%= other_call %>-more-<%= another_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
+
+    assert_equal({ value: "\"string-\#{ some_call }\#{ other_call }-more-\#{ another_call }\"" }, args)
+  end
 end

--- a/test/linters/argument_mappers/helpers/erb_block_test.rb
+++ b/test/linters/argument_mappers/helpers/erb_block_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class ArgumentMappersButtonTest < LinterTestCase
+  def test_converts_basic_interpolation
+    @file = '<div attribute="<%= some_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.convert(tags.first.attributes["attribute"])
+
+    assert_equal("some_call", args)
+  end
+
+  def test_converts_interpolation_with_string
+    @file = '<div attribute="string-<%= some_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.convert(tags.first.attributes["attribute"])
+
+    assert_equal("\"string-\#{ some_call }\"", args)
+  end
+
+  def test_converts_multiple_interpolations
+    @file = '<div attribute="string-<%= some_call %><%= other_call %>-more-<%= another_call %>">'
+    args = ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.convert(tags.first.attributes["attribute"])
+
+    assert_equal("\"string-\#{ some_call }\#{ other_call }-more-\#{ another_call }\"", args)
+  end
+
+  def test_converts_to_json_if_no_interpolation
+    @file = '<div attribute="some_value">'
+    args = ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.convert(tags.first.attributes["attribute"])
+
+    assert_equal('"some_value"', args)
+  end
+
+  def test_raises_if_erb_block
+    @file = '<div attribute="<%= some_call %>">'
+
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.raise_if_erb_block(tags.first.attributes["attribute"])
+    end
+
+    assert_equal("Cannot convert attribute \"attribute\" because its value contains an erb block", err.message)
+  end
+
+  def test_does_not_raise_if_no_erb_block
+    @file = '<div attribute="some_value">'
+
+    ERBLint::Linters::ArgumentMappers::Helpers::ErbBlock.new.raise_if_erb_block(tags.first.attributes["attribute"])
+  end
+end

--- a/test/linters/clipboard_copy_component_migration_counter_test.rb
+++ b/test/linters/clipboard_copy_component_migration_counter_test.rb
@@ -198,4 +198,36 @@ class ClipboardCopyComponentMigrationCounterTest < LinterTestCase
 
     assert_equal expected, corrected_content
   end
+
+  def test_autocorrects_interpolation_with_string
+    @file = <<~HTML
+      <clipboard-copy value="string-<%= some_call %>">
+        clipboard-copy
+      </clipboard-copy>
+    HTML
+
+    expected = <<~'HTML'
+      <%= render Primer::ClipboardCopy.new(value: "string-#{ some_call }") do %>
+        clipboard-copy
+      <% end %>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
+
+  def test_autocorrects_multiple_interpolations
+    @file = <<~HTML
+      <clipboard-copy value="string-<%= some_call %><%= other_call %>-more-<%= another_call %>">
+        clipboard-copy
+      </clipboard-copy>
+    HTML
+
+    expected = <<~'HTML'
+      <%= render Primer::ClipboardCopy.new(value: "string-#{ some_call }#{ other_call }-more-#{ another_call }") do %>
+        clipboard-copy
+      <% end %>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
 end

--- a/test/linters/clipboard_copy_component_migration_counter_test.rb
+++ b/test/linters/clipboard_copy_component_migration_counter_test.rb
@@ -182,4 +182,20 @@ class ClipboardCopyComponentMigrationCounterTest < LinterTestCase
 
     assert_equal expected, corrected_content
   end
+
+  def test_autocorrects_basic_erb_interpolation
+    @file = <<~HTML
+      <clipboard-copy value="<%= some_call %>">
+        clipboard-copy
+      </clipboard-copy>
+    HTML
+
+    expected = <<~HTML
+      <%= render Primer::ClipboardCopy.new(value: some_call) do %>
+        clipboard-copy
+      <% end %>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
 end


### PR DESCRIPTION
Before, any time we encountered an ERB interpolation, the linter would skip the autocorrection.
Now, we'll support it for **some** values:

1. ClipboardCopy#value
2. LabelComponent#title
3. aria- values
4. data- values
5. test_selector