### PR TITLE
Add message about autocorrection

### DIFF
--- a/lib/primer/view_components/linters/autocorrectable.rb
+++ b/lib/primer/view_components/linters/autocorrectable.rb
@@ -20,10 +20,10 @@ module ERBLint
         "#{correction} do %>"
       end
 
-      def message(args)
+      def message(args, processed_source)
         return self.class::MESSAGE if args.nil?
 
-        "#{self.class::MESSAGE}\n\nTry using:\n\n#{correction(args)}\n\nInstead of:\n"
+        "#{self.class::MESSAGE}\nTry using:\n\n#{correction(args)}\n\nYou can also run erblint in autocorrect mode:\n\nbundle exec erblint -a #{processed_source.filename}\n"
       end
     end
   end

--- a/lib/primer/view_components/linters/helpers.rb
+++ b/lib/primer/view_components/linters/helpers.rb
@@ -41,7 +41,7 @@ module ERBLint
 
           tag_tree[tag][:offense] = true
           tag_tree[tag][:correctable] = !correction.nil?
-          tag_tree[tag][:message] = message(args)
+          tag_tree[tag][:message] = message(args, processed_source)
           tag_tree[tag][:correction] = correction
         end
 
@@ -97,7 +97,7 @@ module ERBLint
       # Override this function to customize the linter message.
       #
       # @return [String] message to show on linter error.
-      def message(_tag)
+      def message(_tag, _processed_source)
         self.class::MESSAGE
       end
 


### PR DESCRIPTION
Adds a message informing the user about running erblint in autocorrect mode when the offense is autocorrectable:

![image](https://user-images.githubusercontent.com/11280312/128924341-0624a810-3d32-4802-8694-9b9860588e25.png)
