### PR TITLE
Adds a scheme option to BorderBoxComponent rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+* Add a `scheme` option to `BorderBoxComponent` rows.
+
+    *Cameron Dutro*
+
 ## 0.0.51
 
 ### Breaking changes

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -16,9 +16,9 @@ module Primer
     DEFAULT_ROW_SCHEME = :default
     ROW_SCHEME_MAPPINGS = {
       DEFAULT_ROW_SCHEME => "",
-      :yellow => "Box-row--yellow",
-      :blue => "Box-row--blue",
-      :gray => "Box-row--gray"
+      :neutral => "Box-row--gray",
+      :info => "Box-row--blue",
+      :warning => "Box-row--yellow"
     }.freeze
 
     # Optional Header.
@@ -88,7 +88,7 @@ module Primer
     #         Row one
     #       <% end %>
     #     <% end %>
-    #     <% component.row(scheme: :yellow) do %>
+    #     <% component.row do %>
     #       Row two
     #     <% end %>
     #     <% component.footer do %>
@@ -109,6 +109,22 @@ module Primer
     #     <% end %>
     #     <% component.footer do %>
     #       Footer
+    #     <% end %>
+    #   <% end %>
+    #
+    # @example Row colors
+    #   <%= render(Primer::BorderBoxComponent.new) do |component| %>
+    #     <% component.row do %>
+    #       Default
+    #     <% end %>
+    #     <% component.row(scheme: :neutral) do %>
+    #       Neutral
+    #     <% end %>
+    #     <% component.row(scheme: :info) do %>
+    #       Info
+    #     <% end %>
+    #     <% component.row(scheme: :warning) do %>
+    #       Warning
     #     <% end %>
     #   <% end %>
     #

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -88,7 +88,7 @@ module Primer
     #         Row one
     #       <% end %>
     #     <% end %>
-    #     <% component.row do %>
+    #     <% component.row(scheme: :yellow) do %>
     #       Row two
     #     <% end %>
     #     <% component.footer do %>

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -13,6 +13,14 @@ module Primer
     }.freeze
     PADDING_SUGGESTION = "Perhaps you could consider using :padding options of #{PADDING_MAPPINGS.keys.to_sentence}?"
 
+    DEFAULT_ROW_SCHEME = :default
+    ROW_SCHEME_MAPPINGS = {
+      DEFAULT_ROW_SCHEME => "",
+      :yellow => "Box-row--yellow",
+      :blue => "Box-row--blue",
+      :gray => "Box-row--gray"
+    }.freeze
+
     # Optional Header.
     #
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -54,12 +62,14 @@ module Primer
 
     # Use Rows to add rows with borders and maintain the same padding.
     #
+    # @param scheme [Symbol] Color scheme. <%= one_of(Primer::BorderBoxComponent::ROW_SCHEME_MAPPINGS.keys) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    renders_many :rows, lambda { |**system_arguments|
+    renders_many :rows, lambda { |scheme: DEFAULT_ROW_SCHEME, **system_arguments|
       system_arguments[:tag] = :li
       system_arguments[:classes] = class_names(
         "Box-row",
-        system_arguments[:classes]
+        system_arguments[:classes],
+        ROW_SCHEME_MAPPINGS[fetch_or_fallback(ROW_SCHEME_MAPPINGS.keys, scheme, DEFAULT_ROW_SCHEME)]
       )
 
       Primer::BaseComponent.new(**system_arguments)

--- a/app/components/primer/border_box_component.rb
+++ b/app/components/primer/border_box_component.rb
@@ -68,8 +68,8 @@ module Primer
       system_arguments[:tag] = :li
       system_arguments[:classes] = class_names(
         "Box-row",
-        system_arguments[:classes],
-        ROW_SCHEME_MAPPINGS[fetch_or_fallback(ROW_SCHEME_MAPPINGS.keys, scheme, DEFAULT_ROW_SCHEME)]
+        ROW_SCHEME_MAPPINGS[fetch_or_fallback(ROW_SCHEME_MAPPINGS.keys, scheme, DEFAULT_ROW_SCHEME)],
+        system_arguments[:classes]
       )
 
       Primer::BaseComponent.new(**system_arguments)

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -58,7 +58,7 @@ Use Rows to add rows with borders and maintain the same padding.
 
 ### Header, body, rows, and footer
 
-<Example src="<div data-view-component='true' class='Box'>  <div data-view-component='true' class='Box-header'>    Header</div>  <div data-view-component='true' class='Box-body'>    Body</div>    <ul>        <li data-view-component='true' class='Box-row'>      Row one</li>        <li data-view-component='true' class='Box-row'>    Row two</li>    </ul>  <div data-view-component='true' class='Box-footer'>    Footer</div></div>" />
+<Example src="<div data-view-component='true' class='Box'>  <div data-view-component='true' class='Box-header'>    Header</div>  <div data-view-component='true' class='Box-body'>    Body</div>    <ul>        <li data-view-component='true' class='Box-row'>      Row one</li>        <li data-view-component='true' class='Box-row Box-row--yellow'>    Row two</li>    </ul>  <div data-view-component='true' class='Box-footer'>    Footer</div></div>" />
 
 ```erb
 <%= render(Primer::BorderBoxComponent.new) do |component| %>
@@ -73,7 +73,7 @@ Use Rows to add rows with borders and maintain the same padding.
       Row one
     <% end %>
   <% end %>
-  <% component.row do %>
+  <% component.row(scheme: :yellow) do %>
     Row two
   <% end %>
   <% component.footer do %>

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -51,14 +51,14 @@ Use Rows to add rows with borders and maintain the same padding.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `scheme` | `Symbol` | N/A | Color scheme. One of `:blue`, `:default`, `:gray`, or `:yellow`. |
+| `scheme` | `Symbol` | N/A | Color scheme. One of `:default`, `:info`, `:neutral`, or `:warning`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Examples
 
 ### Header, body, rows, and footer
 
-<Example src="<div data-view-component='true' class='Box'>  <div data-view-component='true' class='Box-header'>    Header</div>  <div data-view-component='true' class='Box-body'>    Body</div>    <ul>        <li data-view-component='true' class='Box-row'>      Row one</li>        <li data-view-component='true' class='Box-row Box-row--yellow'>    Row two</li>    </ul>  <div data-view-component='true' class='Box-footer'>    Footer</div></div>" />
+<Example src="<div data-view-component='true' class='Box'>  <div data-view-component='true' class='Box-header'>    Header</div>  <div data-view-component='true' class='Box-body'>    Body</div>    <ul>        <li data-view-component='true' class='Box-row'>      Row one</li>        <li data-view-component='true' class='Box-row'>    Row two</li>    </ul>  <div data-view-component='true' class='Box-footer'>    Footer</div></div>" />
 
 ```erb
 <%= render(Primer::BorderBoxComponent.new) do |component| %>
@@ -73,7 +73,7 @@ Use Rows to add rows with borders and maintain the same padding.
       Row one
     <% end %>
   <% end %>
-  <% component.row(scheme: :yellow) do %>
+  <% component.row do %>
     Row two
   <% end %>
   <% component.footer do %>
@@ -99,6 +99,27 @@ Use Rows to add rows with borders and maintain the same padding.
   <% end %>
   <% component.footer do %>
     Footer
+  <% end %>
+<% end %>
+```
+
+### Row colors
+
+<Example src="<div data-view-component='true' class='Box'>        <ul>        <li data-view-component='true' class='Box-row'>    Default</li>        <li data-view-component='true' class='Box-row Box-row--gray'>    Neutral</li>        <li data-view-component='true' class='Box-row Box-row--blue'>    Info</li>        <li data-view-component='true' class='Box-row Box-row--yellow'>    Warning</li>    </ul>  </div>" />
+
+```erb
+<%= render(Primer::BorderBoxComponent.new) do |component| %>
+  <% component.row do %>
+    Default
+  <% end %>
+  <% component.row(scheme: :neutral) do %>
+    Neutral
+  <% end %>
+  <% component.row(scheme: :info) do %>
+    Info
+  <% end %>
+  <% component.row(scheme: :warning) do %>
+    Warning
   <% end %>
 <% end %>
 ```

--- a/docs/content/components/borderbox.md
+++ b/docs/content/components/borderbox.md
@@ -51,6 +51,7 @@ Use Rows to add rows with borders and maintain the same padding.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
+| `scheme` | `Symbol` | N/A | Color scheme. One of `:blue`, `:default`, `:gray`, or `:yellow`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Examples

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -10,6 +10,8 @@
 - ".Box-footer"
 - ".Box-header"
 - ".Box-row"
+- ".Box-row--blue"
+- ".Box-row--gray"
 - ".Box-row--yellow"
 - ".BtnGroup"
 - ".BtnGroup-item"

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -10,6 +10,7 @@
 - ".Box-footer"
 - ".Box-header"
 - ".Box-row"
+- ".Box-row--yellow"
 - ".BtnGroup"
 - ".BtnGroup-item"
 - ".Counter"

--- a/static/constants.json
+++ b/static/constants.json
@@ -103,9 +103,9 @@
     "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
     "ROW_SCHEME_MAPPINGS": {
       "default": "",
-      "yellow": "Box-row--yellow",
-      "blue": "Box-row--blue",
-      "gray": "Box-row--gray"
+      "neutral": "Box-row--gray",
+      "info": "Box-row--blue",
+      "warning": "Box-row--yellow"
     }
   },
   "Primer::BoxComponent": {

--- a/static/constants.json
+++ b/static/constants.json
@@ -94,12 +94,19 @@
   },
   "Primer::BorderBoxComponent": {
     "DEFAULT_PADDING": "default",
+    "DEFAULT_ROW_SCHEME": "default",
     "PADDING_MAPPINGS": {
       "default": "",
       "condensed": "Box--condensed",
       "spacious": "Box--spacious"
     },
-    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?"
+    "PADDING_SUGGESTION": "Perhaps you could consider using :padding options of default, condensed, and spacious?",
+    "ROW_SCHEME_MAPPINGS": {
+      "default": "",
+      "yellow": "Box-row--yellow",
+      "blue": "Box-row--blue",
+      "gray": "Box-row--gray"
+    }
   },
   "Primer::BoxComponent": {
   },

--- a/test/components/border_box_component_test.rb
+++ b/test/components/border_box_component_test.rb
@@ -93,7 +93,7 @@ class PrimerBorderBoxComponentTest < Minitest::Test
   end
 
   def test_renders_row_with_schemes
-    { neutral: 'gray', info: 'blue', warning: 'yellow' }.each_pair do |scheme, color|
+    { neutral: "gray", info: "blue", warning: "yellow" }.each_pair do |scheme, color|
       render_inline(Primer::BorderBoxComponent.new) do |component|
         component.row(scheme: scheme) { "Row row row your boat" }
       end

--- a/test/components/border_box_component_test.rb
+++ b/test/components/border_box_component_test.rb
@@ -91,4 +91,12 @@ class PrimerBorderBoxComponentTest < Minitest::Test
 
     refute_selector(".p-4")
   end
+
+  def test_renders_row_with_scheme
+    render_inline(Primer::BorderBoxComponent.new) do |component|
+      component.row(scheme: :yellow) { "Row row row your boat" }
+    end
+
+    assert_selector(".Box .Box-row--yellow")
+  end
 end

--- a/test/components/border_box_component_test.rb
+++ b/test/components/border_box_component_test.rb
@@ -92,11 +92,21 @@ class PrimerBorderBoxComponentTest < Minitest::Test
     refute_selector(".p-4")
   end
 
-  def test_renders_row_with_scheme
+  def test_renders_row_with_schemes
+    { neutral: 'gray', info: 'blue', warning: 'yellow' }.each_pair do |scheme, color|
+      render_inline(Primer::BorderBoxComponent.new) do |component|
+        component.row(scheme: scheme) { "Row row row your boat" }
+      end
+
+      assert_selector(".Box .Box-row--#{color}")
+    end
+  end
+
+  def test_renders_row_with_default_scheme
     render_inline(Primer::BorderBoxComponent.new) do |component|
-      component.row(scheme: :yellow) { "Row row row your boat" }
+      component.row { "Row row row your boat" }
     end
 
-    assert_selector(".Box .Box-row--yellow")
+    assert_selector(".Box .Box-row")
   end
 end


### PR DESCRIPTION
Fixes: https://github.com/primer/view_components/issues/662

Enables the following:

```ruby
render(Primer::BorderBoxComponent.new) do |component|
  component.row(scheme: :yellow) { "Row row row your boat" }
end
```