### PR TITLE
Ruby version benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,9 @@ jobs:
   benchmark:
     needs: lint
     runs-on: ubuntu-latest
-    matrix:
-      ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
+    strategy:
+      matrix:
+        ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,6 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         rails_version: [5.2.3, 6.1.1, main]
         ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,8 @@ jobs:
   benchmark:
     needs: lint
     runs-on: ubuntu-latest
+    matrix:
+      ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         bundle update actionview activemodel activesupport railties
         bundle exec rake bench
       env:
+        RUBY_VERSION: ${{ matrix.ruby_version }}
         RAILS_VERSION: ${{ matrix.rails_version }}
   stories:
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         rails_version: [5.2.3, 6.1.1, main]
         ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
     - name: Setup Ruby
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 3.0
+        ruby-version: ${{ matrix.ruby_version }}
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-build-bench-ruby-3.0-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-bench-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
     - name: Build and test with Rake
       run: |
         gem install bundler:2.2.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,25 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        rails_version: [5.2.3, 6.1.1, main]
         ruby_version: [2.5.x, 2.6.x, 2.7.x, 3.0.x]
+        exclude:
+          - rails_version: 5.2.3
+            ruby_version: 2.6.x
+          - rails_version: 5.2.3
+            ruby_version: 2.7.x
+          - rails_version: 5.2.3
+            ruby_version: 3.0.x
+          - rails_version: 6.1.1
+            ruby_version: 2.5.x
+          - rails_version: 6.1.1
+            ruby_version: 2.7.x
+          - rails_version: 6.1.1
+            ruby_version: 3.0.x
+          - rails_version: main
+            ruby_version: 2.5.x
+          - rails_version: main
+            ruby_version: 2.6.x
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby
@@ -90,7 +108,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: gems-build-bench-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
+        key: gems-build-bench-rails-${{ matrix.rails_version }}-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
     - name: Build and test with Rake
       run: |
         gem install bundler:2.2.9
@@ -98,7 +116,7 @@ jobs:
         bundle update actionview activemodel activesupport railties
         bundle exec rake bench
       env:
-        RAILS_VERSION: main
+        RAILS_VERSION: ${{ matrix.rails_version }}
   stories:
     needs: lint
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+### Misc
+
+* Update benchmarks to run in every supported Ruby version.
+
+    *Manuel Puyol*
+
 ## 0.0.51
 
 ### Breaking changes

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -6,6 +6,13 @@ require "test_helper"
 class BenchClassify < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
+  EXPECTATIONS = {
+    "2.7.3" => {
+      without_cache: 68,
+      with_cache: 25
+    }
+  }.freeze
+
   def setup
     @values = {
       align_items: :center,
@@ -42,7 +49,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations 69 do
+    assert_allocations expectations_for(:without_cache) do
       Primer::Classify.call(**@values)
     end
   ensure
@@ -53,8 +60,14 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.preload!
     Primer::Classify.call(**@values)
 
-    assert_allocations 26..27 do
+    assert_allocations expectations_for(:with_cache) do
       Primer::Classify.call(**@values)
     end
+  end
+
+  private
+
+  def expectations_for(type)
+    EXPECTATIONS[ENV["RUBY_VERSION"]][type]
   end
 end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -7,9 +7,21 @@ class BenchClassify < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
   EXPECTATIONS = {
-    "2.7.3" => {
+    "2.5.x" => {
+      without_cache: 70,
+      with_cache: 27
+    },
+    "2.6.x" => {
+      without_cache: 69,
+      with_cache: 26
+    },
+    "2.7.x" => {
       without_cache: 68,
       with_cache: 25
+    },
+    "3.0.x" => {
+      without_cache: 69..70,
+      with_cache: 26
     }
   }.freeze
 
@@ -63,11 +75,5 @@ class BenchClassify < Minitest::Benchmark
     assert_allocations expectations_for(:with_cache) do
       Primer::Classify.call(**@values)
     end
-  end
-
-  private
-
-  def expectations_for(type)
-    EXPECTATIONS[ENV["RUBY_VERSION"]][type]
   end
 end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -6,6 +6,13 @@ require "test_helper"
 class BenchOcticons < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
+  EXPECTATIONS = {
+    "2.7.3" => {
+      without_cache: 43,
+      with_cache: 19..21
+    }
+  }.freeze
+
   def setup
     @options = {
       icon: :alert
@@ -15,7 +22,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations 50 do
+    assert_allocations expectations_for(:without_cache) do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -24,8 +31,14 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations 19..21 do
+    assert_allocations expectations_for(:with_cache) do
       Primer::OcticonComponent.new(**@options)
     end
+  end
+
+  private
+
+  def expectations_for(type)
+    EXPECTATIONS[ENV["RUBY_VERSION"]][type]
   end
 end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -16,7 +16,7 @@ class BenchOcticons < Minitest::Benchmark
       with_cache: 24
     },
     "2.7.x" => {
-      without_cache: 43..45,
+      without_cache: 42..45,
       with_cache: 19..21
     },
     "3.0.x" => {

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -8,8 +8,8 @@ class BenchOcticons < Minitest::Benchmark
 
   EXPECTATIONS = {
     "2.5.x" => {
-      without_cache: 53,
-      with_cache: 27
+      without_cache: 54,
+      with_cache: 28
     },
     "2.6.x" => {
       without_cache: 49,
@@ -20,7 +20,7 @@ class BenchOcticons < Minitest::Benchmark
       with_cache: 19..21
     },
     "3.0.x" => {
-      without_cache: 50..51,
+      without_cache: 43,
       with_cache: 19..21
     }
   }.freeze

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -7,8 +7,20 @@ class BenchOcticons < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
   EXPECTATIONS = {
-    "2.7.3" => {
-      without_cache: 43,
+    "2.5.x" => {
+      without_cache: 53,
+      with_cache: 27
+    },
+    "2.6.x" => {
+      without_cache: 49,
+      with_cache: 24
+    },
+    "2.7.x" => {
+      without_cache: 43..45,
+      with_cache: 19..21
+    },
+    "3.0.x" => {
+      without_cache: 50..51,
       with_cache: 19..21
     }
   }.freeze
@@ -34,11 +46,5 @@ class BenchOcticons < Minitest::Benchmark
     assert_allocations expectations_for(:with_cache) do
       Primer::OcticonComponent.new(**@options)
     end
-  end
-
-  private
-
-  def expectations_for(type)
-    EXPECTATIONS[ENV["RUBY_VERSION"]][type]
   end
 end

--- a/test/test_helpers/assert_allocations_helper.rb
+++ b/test/test_helpers/assert_allocations_helper.rb
@@ -26,5 +26,18 @@ module Primer
 
       assert_includes range, total, msg
     end
+
+    def expectations_for(type)
+      self.class::EXPECTATIONS[ruby_version][type]
+    end
+
+    def ruby_version
+      return @ruby_version if defined? @ruby_version
+
+      @ruby_version = ENV["RUBY_VERSION"].dup
+      @ruby_version.gsub!("ruby-", "")
+      @ruby_version[-1] = "x"
+      @ruby_version
+    end
   end
 end


### PR DESCRIPTION
Updates the benchmark CI to run in all supported Ruby versions: 2.5.x, 2.6.x, 2.7.x, 3.0.x