### PR TITLE
Add basic autocorrection for `Flash` linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### New
+
+* Add autocorrection to `FlashComponent` linter when the context is basic text.
+
+    *Manuel Puyol*
+
 ### Updates
 
 * Linters won't mark offenses when the ignore count is correct unless explicitly configured to do so.

--- a/lib/primer/view_components/linters/argument_mappers/flash.rb
+++ b/lib/primer/view_components/linters/argument_mappers/flash.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module ERBLint
+  module Linters
+    module ArgumentMappers
+      # Maps classes in a flash element to arguments for the Flash component.
+      class Flash < Base
+        SCHEME_MAPPINGS = Primer::ViewComponents::Constants.get(
+          component: "Primer::FlashComponent",
+          constant: "SCHEME_MAPPINGS",
+          symbolize: true
+        ).freeze
+
+        def classes_to_args(classes)
+          classes.each_with_object({ classes: [] }) do |class_name, acc|
+            next if class_name == "flash"
+
+            if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
+              acc[:scheme] = SCHEME_MAPPINGS[class_name]
+            elsif class_name == "flash-full"
+              acc[:full] = true
+            else
+              acc[:classes] << class_name
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/autocorrectable.rb
+++ b/lib/primer/view_components/linters/autocorrectable.rb
@@ -8,7 +8,7 @@ module ERBLint
     # * `ARGUMENT_MAPPER` - required - The class responsible for transforming classes and attributes into arguments for the component.
     # * `COMPONENT` - required - The component name for the linter. It will be used to generate the correction.
     module Autocorrectable
-      def map_arguments(tag)
+      def map_arguments(tag, _tag_tree)
         self.class::ARGUMENT_MAPPER.new(tag).to_s
       rescue ArgumentMappers::ConversionError
         nil

--- a/lib/primer/view_components/linters/base_linter.rb
+++ b/lib/primer/view_components/linters/base_linter.rb
@@ -92,7 +92,7 @@ module ERBLint
       #
       # @return [Hash] if possible to map all attributes to arguments.
       # @return [Nil] if cannot map to arguments.
-      def map_arguments(_tag)
+      def map_arguments(_tag, _tag_tree)
         nil
       end
 

--- a/lib/primer/view_components/linters/base_linter.rb
+++ b/lib/primer/view_components/linters/base_linter.rb
@@ -146,9 +146,11 @@ module ERBLint
 
           tag_tree[tag] = {
             closing: self_closing ? tag : nil,
-            parent: current_opened_tag
+            parent: current_opened_tag,
+            children: []
           }
 
+          tag_tree[current_opened_tag][:children] << tag_tree[tag] if current_opened_tag
           current_opened_tag = tag unless self_closing
         end
 

--- a/lib/primer/view_components/linters/base_linter.rb
+++ b/lib/primer/view_components/linters/base_linter.rb
@@ -43,7 +43,7 @@ module ERBLint
 
           next unless self.class::CLASSES.blank? || (classes & self.class::CLASSES).any?
 
-          args = map_arguments(tag)
+          args = map_arguments(tag, tag_tree[tag])
           correction = correction(args)
 
           attributes = tag.attributes.each.map(&:name).join(" ")

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 require_relative "base_linter"
+require_relative "autocorrectable"
+require_relative "argument_mappers/flash"
 
 module ERBLint
   module Linters
     # Counts the number of times a HTML flash is used instead of the component.
     class FlashComponentMigrationCounter < BaseLinter
+      include Autocorrectable
+
       TAGS = %w[div].freeze
       CLASSES = %w[flash].freeze
       MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
+      ARGUMENT_MAPPER = ArgumentMappers::Flash
+
+      def map_arguments(tag, tag_tree)
+        # We can only autocorrect elements with simple text as content.
+        return nil if tag_tree[:children].any?
+
+        ARGUMENT_MAPPER.new(tag).to_s
+      rescue ArgumentMappers::ConversionError
+        nil
+      end
     end
   end
 end

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -14,6 +14,7 @@ module ERBLint
       CLASSES = %w[flash].freeze
       MESSAGE = "We are migrating flashes to use [Primer::FlashComponent](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Flash
+      COMPONENT = "Primer::FlashComponent"
 
       def map_arguments(tag, tag_tree)
         # We can only autocorrect elements with simple text as content.

--- a/test/linters/argument_mappers/flash_test.rb
+++ b/test/linters/argument_mappers/flash_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class ArgumentMappersFlashTest < LinterTestCase
+  def test_returns_no_arguments_if_only_flash
+    @file = '<div class="flash">flash</div>'
+    args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+
+    assert_empty args
+  end
+
+  def test_returns_full_argument
+    @file = "<div class=\"flash-full\">flash</div>"
+    args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+
+    assert_equal({ full: true }, args)
+  end
+
+  def test_returns_scheme_argument
+    Primer::FlashComponent::SCHEME_MAPPINGS.each do |value, class_name|
+      next if class_name.blank?
+
+      @file = "<div class=\"#{class_name}\">flash</div>"
+      args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+
+      assert_equal({ scheme: ":#{value}" }, args)
+    end
+  end
+
+  def test_raises_if_cannot_map_class
+    @file = '<div class="text-center">flash</div>'
+    err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
+      ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+    end
+
+    assert_equal "Cannot convert class text-center", err.message
+  end
+
+  def test_complex_case
+    @file = '
+      <div
+        class="flash flash-full flash-warn mr-1 p-3 d-md-block d-none anim-fade-in"
+      >flash</div>'
+
+    args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+
+    assert_equal({
+                   scheme: ":warning",
+                   full: true,
+                   mr: 1,
+                   p: 3,
+                   display: [:none, nil, :block],
+                   animation: ":fade_in"
+                 }, args)
+  end
+
+  def test_returns_arguments_as_string
+    @file = '<div class="flash flash-warn flash-full">flash</div>'
+    args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_s
+
+    assert_equal "scheme: :warning, full: true", args
+  end
+
+  def test_returns_custom_classes_as_string
+    @file = '<div class="flash custom-1 custom-2">flash</div>'
+    args = ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
+
+    assert_equal({ classes: "\"custom-1 custom-2\"" }, args)
+  end
+end

--- a/test/linters/base_linter.rb
+++ b/test/linters/base_linter.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class BaseLinterTest < LinterTestCase
+  def linter_class
+    ERBLint::Linters::BaseLinter
+  end
+
+  def tags
+    @linter.send(:tags, processed_source)
+  end
+
+  def build_tag_tree(tags)
+    @linter.send(:build_tag_tree, tags)
+  end
+
+  def test_text_is_not_a_tag_children
+    @file = <<~HTML
+      <div>
+        some text
+      </div>
+    HTML
+
+    processed_tags = tags
+    tree = build_tag_tree(processed_tags)
+
+    assert_equal [processed_tags.first], tree.keys
+    assert_equal processed_tags.last, tree[processed_tags.first][:closing]
+    assert_empty tree[processed_tags.first][:children]
+  end
+
+  def test_tree_with_children
+    @file = <<~HTML
+      <div>
+        <div>text</div>
+        other text
+      </div>
+    HTML
+
+    processed_tags = tags
+    tree = build_tag_tree(processed_tags)
+
+    assert_equal [processed_tags.first, processed_tags.second], tree.keys
+    assert_equal processed_tags.last, tree[processed_tags.first][:closing]
+    assert_equal processed_tags.third, tree[processed_tags.second][:closing]
+    assert_equal [tree[processed_tags.second]], tree[processed_tags.first][:children]
+  end
+
+  def test_tree_with_multiple_children
+    @file = <<~HTML
+      <div>
+        <div>text</div>
+        <div>text</div>
+        <div>text</div>
+      </div>
+    HTML
+
+    processed_tags = tags
+    tree = build_tag_tree(processed_tags)
+
+    assert_equal 3, tree[processed_tags.first][:children].size
+  end
+
+  def test_tree_with_nested_children
+    @file = <<~HTML
+      <div>
+        <div>
+          <div>text</div>
+          <div>text</div>
+        </div>
+        <div>
+          <div>text</div>
+          <div>text</div>
+          <div>text</div>
+        </div>
+      </div>
+    HTML
+
+    processed_tags = tags
+    tree = build_tag_tree(processed_tags)
+
+    assert_equal 2, tree[processed_tags.first][:children].first[:children].size
+    assert_equal 3, tree[processed_tags.first][:children].last[:children].size
+  end
+end

--- a/test/linters/base_linter_test.rb
+++ b/test/linters/base_linter_test.rb
@@ -47,6 +47,22 @@ class BaseLinterTest < LinterTestCase
     assert_equal [tree[processed_tags.second]], tree[processed_tags.first][:children]
   end
 
+  def test_tree_with_children_between_text
+    @file = <<~HTML
+      <div>
+        some <strong>bold</strong> text
+      </div>
+    HTML
+
+    processed_tags = tags
+    tree = build_tag_tree(processed_tags)
+
+    assert_equal [processed_tags.first, processed_tags.second], tree.keys
+    assert_equal processed_tags.last, tree[processed_tags.first][:closing]
+    assert_equal processed_tags.third, tree[processed_tags.second][:closing]
+    assert_equal [tree[processed_tags.second]], tree[processed_tags.first][:children]
+  end
+
   def test_tree_with_multiple_children
     @file = <<~HTML
       <div>

--- a/test/linters/flash_component_migration_counter_test.rb
+++ b/test/linters/flash_component_migration_counter_test.rb
@@ -15,15 +15,145 @@ class FlashComponentMigrationCounterTest < LinterTestCase
   end
 
   def test_suggests_ignoring_with_correct_number_of_flashes
-    @file = "<div class=\"flash\">flash</div><div class=\"flash\">flash</div><div class=\"not-a-flash\">flash</div>"
+    @file = "<div class=\"flash\" invalid-attr>flash</div><div class=\"flash\" invalid-attr>flash</div><div class=\"not-a-flash\">flash</div>"
 
     assert_equal "<%# erblint:counter FlashComponentMigrationCounter 2 %>\n#{@file}", corrected_content
   end
 
+  def test_suggests_updating_the_number_of_ignored_labels
+    @file = "<%# erblint:counter FlashComponentMigrationCounter 1 %>\n<div class=\"flash\" invalid-attr>flash</div><div class=\"flash\" invalid-attr>flash</div><div class=\"not-a-flash\">flash</div>"
+    @linter.run(processed_source)
+
+    assert_equal "<%# erblint:counter FlashComponentMigrationCounter 2 %>", offenses.last.context
+  end
+
   def test_does_not_warn_if_wrong_tag
-    @file = "<span class=\"flash\">flash</span>"
+    @file = "<a class=\"flash\">flash</a>"
     @linter.run(processed_source)
 
     assert_empty @linter.offenses
+  end
+
+  def test_suggests_how_to_use_the_component_with_arguments
+    @file = "<div class=\"flash flash-warn flash-full\">flash</div>"
+    @linter.run(processed_source)
+
+    assert_includes(offenses.first.message, "render Primer::FlashComponent.new(scheme: :warning, full: true)")
+  end
+
+  def test_suggests_how_to_use_the_component_with_aria_arguments
+    @file = "<div class=\"flash\" aria-label=\"Some label\">flash</div>"
+    @linter.run(processed_source)
+
+    assert_includes(offenses.first.message, "render Primer::FlashComponent.new(\"aria-label\": \"Some label\")")
+  end
+
+  def test_suggests_how_to_use_the_component_with_data_arguments
+    @file = "<div class=\"flash\" data-confirm=\"Some confirmation\">flash</div>"
+    @linter.run(processed_source)
+
+    assert_includes(offenses.first.message, "render Primer::FlashComponent.new(\"data-confirm\": \"Some confirmation\")")
+  end
+
+  def test_does_not_suggest_if_using_unsupported_arguments
+    @file = "<div class=\"flash\" onclick>flash</div>"
+    @linter.run(processed_source)
+
+    refute_includes(offenses.first.message, "render Primer::FlashComponent.new")
+  end
+
+  def test_does_not_suggest_if_cannot_convert_class
+    @file = "<div class=\"flash text-center\">flash</div>"
+    @linter.run(processed_source)
+
+    refute_includes(offenses.first.message, "render Primer::FlashComponent.new")
+  end
+
+  def test_does_not_autocorrects_when_ignores_are_correct
+    @file = <<~HTML
+      <%# erblint:counter FlashComponentMigrationCounter 2 %>
+      <div class="flash flash-warn">
+        flash 1
+      </div>
+      <div class="flash">
+        flash 1
+      </div>
+    HTML
+
+    assert_equal @file, corrected_content
+  end
+
+  def test_autocorrects_ignore_counts_if_override_enabled
+    @linter = linter_with_override
+    @file = <<~HTML
+      <%# erblint:counter FlashComponentMigrationCounter 2 %>
+      <div class="flash flash-warn">
+        flash 1
+      </div>
+      <div invalid-attr class="flash">
+        flash 1
+      </div>
+    HTML
+
+    expected = <<~HTML
+      <%# erblint:counter FlashComponentMigrationCounter 1 %>
+      <%= render Primer::FlashComponent.new(scheme: :warning) do %>
+        flash 1
+      <% end %>
+      <div invalid-attr class="flash">
+        flash 1
+      </div>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
+
+  def test_autocorrects_known_system_arguments
+    @file = <<~HTML
+      <div class="flash flash-warn mr-1 p-3 d-none d-md-block anim-fade-in">
+        flash
+      </div>
+      <div invalid-attr class="flash flash-warn mr-1 p-3 d-none d-md-block anim-fade-in">
+        Label 2
+      </div>
+    HTML
+
+    expected = <<~HTML
+      <%# erblint:counter FlashComponentMigrationCounter 1 %>
+      <%= render Primer::FlashComponent.new(scheme: :warning, mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in) do %>
+        flash
+      <% end %>
+      <div invalid-attr class="flash flash-warn mr-1 p-3 d-none d-md-block anim-fade-in">
+        Label 2
+      </div>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
+
+  def test_autocorrects_with_custom_classes
+    @file = <<~HTML
+      <div class="flash flash-warn mr-1 p-3 d-none d-md-block anim-fade-in custom-1 custom-2">
+        flash
+      </div>
+    HTML
+
+    expected = <<~HTML
+      <%= render Primer::FlashComponent.new(scheme: :warning, mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, classes: "custom-1 custom-2") do %>
+        flash
+      <% end %>
+    HTML
+
+    assert_equal expected, corrected_content
+  end
+
+  def test_does_not_autocorrect_with_html_content
+    @file = <<~HTML
+      <div class="flash">
+        <div>some content</div>
+      </div>
+    HTML
+
+    assert_equal "<%# erblint:counter FlashComponentMigrationCounter 1 %>\n#{@file}", corrected_content
   end
 end


### PR DESCRIPTION
Adds autocorrection for Flashes that have simple text content:

```html
<!-- corrects -->
<div class="flash">some text</div>
<!-- doesn't correct -->
<div class="flash">
  <span>some text</span>
</div>
```