### PR TITLE
Map `for` argument in ClipboardCopy migration linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
+* Map the `for` argument when autofixing `ClipboardCopy` migrations.
+
+    *Kristján Oddsson*
+
 ## 0.0.52
 
 ### New

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -11,7 +11,9 @@ module ERBLint
         ATTRIBUTES = %w[for value].freeze
 
         def attribute_to_args(attribute)
-          { value: erb_helper.convert(attribute) }
+          attr_name = attribute.name
+
+          {attr_name.to_sym => erb_helper.convert(attribute)}
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -13,7 +13,7 @@ module ERBLint
         def attribute_to_args(attribute)
           attr_name = attribute.name
 
-          {attr_name.to_sym => erb_helper.convert(attribute)}
+          { attr_name.to_sym => erb_helper.convert(attribute) }
         end
       end
     end

--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -8,7 +8,7 @@ module ERBLint
       # Maps attributes in the clipboard-copy element to arguments for the ClipboardCopy component.
       class ClipboardCopy < Base
         DEFAULT_TAG = "clipboard-copy"
-        ATTRIBUTES = %w[value].freeze
+        ATTRIBUTES = %w[for value].freeze
 
         def attribute_to_args(attribute)
           { value: erb_helper.convert(attribute) }

--- a/test/linters/argument_mappers/clipboard_copy_test.rb
+++ b/test/linters/argument_mappers/clipboard_copy_test.rb
@@ -10,6 +10,13 @@ class ArgumentMappersClipboardCopyTest < LinterTestCase
     assert_equal({ value: '"some value"' }, args)
   end
 
+  def test_returns_for_argument
+    @file = "<clipboard-copy for=\"some value\"></clipboard-copy>"
+    args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_args
+
+    assert_equal({ for: '"some value"' }, args)
+  end
+
   def test_returns_arguments_as_string
     @file = "<clipboard-copy value=\"some value\"></clipboard-copy>"
     args = ERBLint::Linters::ArgumentMappers::ClipboardCopy.new(tags.first).to_s

--- a/test/linters/clipboard_copy_component_migration_counter_test.rb
+++ b/test/linters/clipboard_copy_component_migration_counter_test.rb
@@ -88,6 +88,24 @@ class ClipboardCopyComponentMigrationCounterTest < LinterTestCase
     assert_equal expected, result
   end
 
+  def test_more_autocorrect
+    @file = <<~HTML
+      <clipboard-copy for="clone-help-step-2" aria-label="Copy to clipboard" class="btn btn-sm zeroclipboard-button">
+        <%= render(Primer::OcticonComponent.new(icon: "paste")) %>
+      </clipboard-copy>
+    HTML
+
+    expected = <<~HTML
+      <%= render Primer::ClipboardCopy.new(for: "clone-help-step-2", "aria-label": "Copy to clipboard", classes: "btn btn-sm zeroclipboard-button") do %>
+        <%= render(Primer::OcticonComponent.new(icon: "paste")) %>
+      <% end %>
+    HTML
+
+    result = corrected_content
+
+    assert_equal expected, result
+  end
+
   def test_does_not_autocorrects_when_ignores_are_correct
     @file = <<~HTML
       <%# erblint:counter ClipboardCopyComponentMigrationCounter 2 %>


### PR DESCRIPTION
The `ClipboardCopyComponetMigrationCounter` linter would fail to lint `<clipboard-copy>` elements with a `for` argument. The reason is that the `for` argument isn't mapped at all. Only `value` is mapped.

This PR adds the `for` argument to the argument mapper for ClipboardCopy so that the linter will auto fix instances of `<clipboard-copy for>`.