### PR TITLE
Stabilize allocation counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       uses: actions/upload-artifact@master
       if: always()
       with:
-        name: simplecov-resultset-v2-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
+        name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
   coverage:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
       uses: actions/upload-artifact@master
       if: always()
       with:
-        name: simplecov-resultset-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
+        name: simplecov-resultset-v2-rails${{matrix.rails_version}}-ruby${{matrix.ruby_version}}
         path: coverage
   coverage:
     needs: test

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -6,25 +6,6 @@ require "test_helper"
 class BenchClassify < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
-  EXPECTATIONS = {
-    "2.5.x" => {
-      without_cache: 70,
-      with_cache: 27
-    },
-    "2.6.x" => {
-      without_cache: 69,
-      with_cache: 26
-    },
-    "2.7.x" => {
-      without_cache: 68,
-      with_cache: 25
-    },
-    "3.0.x" => {
-      without_cache: 69..70,
-      with_cache: 26
-    }
-  }.freeze
-
   def setup
     @values = {
       align_items: :center,
@@ -61,7 +42,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations expectations_for(:without_cache) do
+    assert_allocations '3.0' => 127, '2.7' => 68, '2.6' => 69, '2.5' => 70 do
       Primer::Classify.call(**@values)
     end
   ensure
@@ -72,7 +53,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.preload!
     Primer::Classify.call(**@values)
 
-    assert_allocations expectations_for(:with_cache) do
+    assert_allocations '3.0' => 65, '2.7' => 25, '2.6' => 26, '2.5' => 27 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -42,7 +42,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations '3.0' => 127, '2.7' => 68, '2.6' => 69, '2.5' => 70 do
+    assert_allocations "3.0" => 127, "2.7" => 68, "2.6" => 69, "2.5" => 70 do
       Primer::Classify.call(**@values)
     end
   ensure
@@ -53,7 +53,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.preload!
     Primer::Classify.call(**@values)
 
-    assert_allocations '3.0' => 65, '2.7' => 25, '2.6' => 26, '2.5' => 27 do
+    assert_allocations "3.0" => 65, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -15,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations '3.0' => 60, '2.7' => 44, '2.6' => 50, '2.5' => 53 do
+    assert_allocations "3.0" => 60, "2.7" => 44, "2.6" => 50, "2.5" => 53 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -24,7 +24,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations '3.0' => 29, '2.7' => 20, '2.6' => 24, '2.5' => 27 do
+    assert_allocations "3.0" => 29, "2.7" => 20, "2.6" => 24, "2.5" => 27 do
       Primer::OcticonComponent.new(**@options)
     end
   end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -15,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.0" => 60, "2.7" => 44, "2.6" => 50, "2.5" => 54 do
+    assert_allocations "3.0" => 60, "2.7" => 43, "2.6" => 50, "2.5" => 54 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -6,25 +6,6 @@ require "test_helper"
 class BenchOcticons < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
-  EXPECTATIONS = {
-    "2.5.x" => {
-      without_cache: 54,
-      with_cache: 28
-    },
-    "2.6.x" => {
-      without_cache: 49,
-      with_cache: 24
-    },
-    "2.7.x" => {
-      without_cache: 42..45,
-      with_cache: 19..21
-    },
-    "3.0.x" => {
-      without_cache: 43,
-      with_cache: 19..21
-    }
-  }.freeze
-
   def setup
     @options = {
       icon: :alert
@@ -34,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations expectations_for(:without_cache) do
+    assert_allocations '3.0' => 60, '2.7' => 44, '2.6' => 50, '2.5' => 53 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -43,7 +24,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations expectations_for(:with_cache) do
+    assert_allocations '3.0' => 29, '2.7' => 20, '2.6' => 24, '2.5' => 27 do
       Primer::OcticonComponent.new(**@options)
     end
   end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -15,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.0" => 60, "2.7" => 44, "2.6" => 50, "2.5" => 53 do
+    assert_allocations "3.0" => 60, "2.7" => 44, "2.6" => 50, "2.5" => 54 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -24,7 +24,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations "3.0" => 29, "2.7" => 20, "2.6" => 24, "2.5" => 27 do
+    assert_allocations "3.0" => 29, "2.7" => 20, "2.6" => 24, "2.5" => 28 do
       Primer::OcticonComponent.new(**@options)
     end
   end

--- a/test/test_helpers/assert_allocations_helper.rb
+++ b/test/test_helpers/assert_allocations_helper.rb
@@ -2,42 +2,25 @@
 
 module Primer
   module AssertAllocationsHelper
-    def assert_allocations(range_or_count)
-      range = case range_or_count
-              when Integer
-                range_or_count..range_or_count
-              else
-                range_or_count
-              end
-
+    def assert_allocations(count_map)
       GC.disable
+      GC.start
+      GC.compact if GC.respond_to?(:compact)
       total_start = GC.stat[:total_allocated_objects]
       yield
       total_end = GC.stat[:total_allocated_objects]
       GC.enable
 
       total = total_end - total_start
+      count = count_map[ruby_version]
 
-      msg = if range.size > 1
-              "Expected between #{range.first} and #{range.last} allocations, got #{total} allocations"
-            else
-              "Expected #{range.first} allocations, got #{total} allocations"
-            end
-
-      assert_includes range, total, msg
+      assert_equal count, total, "Expected #{count} allocations, got #{total} allocations"
     end
 
-    def expectations_for(type)
-      self.class::EXPECTATIONS[ruby_version][type]
-    end
+    private
 
     def ruby_version
-      return @ruby_version if defined? @ruby_version
-
-      @ruby_version = ENV["RUBY_VERSION"].dup
-      @ruby_version.gsub!("ruby-", "")
-      @ruby_version[-1] = "x"
-      @ruby_version
+      @ruby_version ||= RUBY_VERSION.split('.').take(2).join('.')
     end
   end
 end

--- a/test/test_helpers/assert_allocations_helper.rb
+++ b/test/test_helpers/assert_allocations_helper.rb
@@ -20,7 +20,7 @@ module Primer
     private
 
     def ruby_version
-      @ruby_version ||= RUBY_VERSION.split('.').take(2).join('.')
+      @ruby_version ||= RUBY_VERSION.split(".").take(2).join(".")
     end
   end
 end


### PR DESCRIPTION
This PR makes allocation counting more stable, as test order can affect the numbers and lead to flaky tests. I also refactored things a little to move the allocation counts per Ruby version inside the test.

Worryingly, it appears Ruby 3 allocates more objects in every benchmark than Ruby 2.7. In the classify without cache case, Ruby 3 produces _many_ more allocations, 127 vs 70 😱  Accordingly, I'm going to look into improving classify.