### PR TITLE
only check for changelog changes on PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,7 @@ name: CHANGELOG
 on: [pull_request]
 
 jobs:
-  changedfiles:
+  changed_files:
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "::set-output name=all::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | xargs)"
           echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
-  checkforchangelog:
+  check_for_changes:
     runs-on: ubuntu-latest
     # require the first job to have ran
     needs: changedfiles

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,34 @@
+name: CHANGELOG
+
+on: [pull_request]
+
+jobs:
+  changedfiles:
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      all: ${{ steps.changes.outputs.all}}
+      markdown: ${{ steps.changes.outputs.markdown }}
+    steps:
+      # Make sure we have some code to diff.
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changes
+        # Set outputs using the command.
+        run: |
+          echo "::set-output name=all::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | xargs)"
+          echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
+  checkforchangelog:
+    runs-on: ubuntu-latest
+    # require the first job to have ran
+    needs: changedfiles
+    steps:
+      - name: echo changed files
+        run: |
+          if [[ ! "${{needs.changedfiles.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
+            echo "::error file=CHANGELOG.md,line=1,col=1::Please make sure that you add a CHANGELOG entry to describe the changes in this pull request."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,35 +17,6 @@ jobs:
       with:
         config: '.github/lint/markdown.json'
         args: '**/*.md'
-  changedfiles:
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      all: ${{ steps.changes.outputs.all}}
-      markdown: ${{ steps.changes.outputs.markdown }}
-    steps:
-      # Make sure we have some code to diff.
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Get changed files
-        id: changes
-        # Set outputs using the command.
-        run: |
-          echo "::set-output name=all::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | xargs)"
-          echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
-  checkforchangelog:
-    runs-on: ubuntu-latest
-    # require the first job to have ran
-    needs: changedfiles
-    steps:
-      - name: echo changed files
-        run: |
-          if [[ ! "${{needs.changedfiles.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
-            echo "::error file=CHANGELOG.md,line=1,col=1::Please make sure that you add a CHANGELOG entry to describe the changes in this pull request."
-            exit 1
-          fi
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -5,7 +5,6 @@ on:
     branches-ignore:
       - main
 
-
 jobs:
   build-docs:
     name: Build Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Kristján Oddsson*
 
+### Misc
+
+* Only run CHANGELOG CI on pull requests.
+
+    *Manuel Puyol*
+
 * Run CI actions on pushes to main.
 
     *Cameron Dutro*


### PR DESCRIPTION
This build would break every time in `main`, so we should only run it on PRs