### PR TITLE
Don't convert html special elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Kristján Oddsson*
 
+### Bug fixes
+
+* Linters won't convert HTML special elements.
+
+    *Manuel Puyol*
+
 ### Misc
 
 * Only run CHANGELOG CI on pull requests.

--- a/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
+++ b/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
@@ -58,7 +58,7 @@ module ERBLint
             end
 
             # we use `source` instead of `value` because it does not convert encoded HTML entities.
-            attribute.value_node.loc.source.gsub('<%=', '#{').gsub('%>', '}')
+            attribute.value_node.loc.source.gsub("<%=", '#{').gsub("%>", "}")
           end
         end
       end

--- a/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
+++ b/lib/primer/view_components/linters/argument_mappers/helpers/erb_block.rb
@@ -57,8 +57,8 @@ module ERBLint
               return m[:rb].strip
             end
 
-            # wrap the result in `""` so it is printed as a string
-            "\"#{attribute.value.gsub('<%=', '#{').gsub('%>', '}')}\""
+            # we use `source` instead of `value` because it does not convert encoded HTML entities.
+            attribute.value_node.loc.source.gsub('<%=', '#{').gsub('%>', '}')
           end
         end
       end

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -128,4 +128,11 @@ class ArgumentMappersBaseTest < LinterTestCase
 
     assert_equal("Cannot convert attribute \"class\" because its value contains an erb block", err.message)
   end
+
+  def test_does_not_convert_special_elements
+    @file = '<div aria-label="&quot;<%= some_call %>&quot;">'
+    args = ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_args
+
+    assert_equal({ '"aria-label"' => "\"&quot;\#{ some_call }&quot;\"" }, args)
+  end
 end


### PR DESCRIPTION
Autocorrection was converting special elements into their value, which could cause errors:

```erb
<clipboard-copy value="some &quot;<%= value %>">
```

was converted to:

```rb
Primer::ClipboardCopy.new(value: "some"value"")
```

which is incorrect Ruby.

Now, the linter will keep the `&` values