### PR TITLE
Don't use ButtonComponent if the element has close-button

### DIFF
--- a/lib/primer/view_components/linters/base_linter.rb
+++ b/lib/primer/view_components/linters/base_linter.rb
@@ -17,6 +17,7 @@ module ERBLint
       ].freeze
 
       DUMP_FILE = ".erblint-counter-ignore.json"
+      DISALOWED_CLASSES = [].freeze
       CLASSES = [].freeze
       REQUIRED_ARGUMENTS = [].freeze
 
@@ -43,7 +44,8 @@ module ERBLint
           classes = tag.attributes["class"]&.value&.split(" ") || []
           tag_tree[tag][:offense] = false
 
-          next unless self.class::CLASSES.blank? || (classes & self.class::CLASSES).any?
+          next if (classes & self.class::DISALOWED_CLASSES).any?
+          next unless (classes & self.class::CLASSES).any?
 
           args = map_arguments(tag, tag_tree[tag])
           correction = correction(args)

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -15,6 +15,8 @@ module ERBLint
         constant: "TAG_OPTIONS"
       ).freeze
 
+      # CloseButton component has preference when this class is seen in conjuction with `btn`.
+      DISALOWED_CLASSES = %w[close-button].freeze
       CLASSES = %w[btn btn-link].freeze
       MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Button

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -6,6 +6,13 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
   include Primer::BasicLinterSharedTests
   include Primer::AutocorrectableLinterSharedTests
 
+  def test_does_not_want_if_close_button
+    @file = "<button class=\"btn close-button\">Button</button>"
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
   def test_warns_if_there_is_a_html_link_button
     @file = "<button class=\"btn-link\">Button</button>"
     @linter.run(processed_source)


### PR DESCRIPTION
I'm seeing some clashes between `ButtonComponent` and `CloseButton` when an element has both `btn` and `close-button`.
I'm making `CloseButton` have priority, since the content is always the `x` octicon in those cases, so it makes more sense to use that component.

At some point we should verify why `btn` is being used in those cases