### PR TITLE
Add arguments to the ClipboardCopy arguments mapper list 

### DIFF
--- a/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
+++ b/lib/primer/view_components/linters/argument_mappers/clipboard_copy.rb
@@ -8,7 +8,7 @@ module ERBLint
       # Maps attributes in the clipboard-copy element to arguments for the ClipboardCopy component.
       class ClipboardCopy < Base
         DEFAULT_TAG = "clipboard-copy"
-        ATTRIBUTES = %w[for value].freeze
+        ATTRIBUTES = %w[role tabindex for value id style].freeze
 
         def attribute_to_args(attribute)
           attr_name = attribute.name


### PR DESCRIPTION
I had to add these attributes to run the migration of some elements in my codebase.