### PR TITLE
Add support for color utilities in linters

### DIFF
--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -165,7 +165,9 @@ module Primer
         return if val.nil? || val == ""
 
         # We still have to support old colors for system arguments.
-        if Primer::Classify::Utilities.supported_key?(key) && key != COLOR_KEY
+        if key == COLOR_KEY
+          memo[:classes] << Primer::Classify::FunctionalTextColors.color(val)
+        elsif Primer::Classify::Utilities.supported_key?(key)
           memo[:classes] << Primer::Classify::Utilities.classname(key, val, breakpoint)
         elsif BOOLEAN_MAPPINGS.key?(key)
           BOOLEAN_MAPPINGS[key][:mappings].each do |m|
@@ -177,8 +179,6 @@ module Primer
           else
             memo[:classes] << Primer::Classify::FunctionalBackgroundColors.color(val)
           end
-        elsif key == COLOR_KEY
-          memo[:classes] << Primer::Classify::FunctionalTextColors.color(val)
         elsif key == BORDER_KEY
           border_value = if val == true
                            "border"

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -164,7 +164,8 @@ module Primer
       def extract_value(memo, key, val, breakpoint)
         return if val.nil? || val == ""
 
-        if Primer::Classify::Utilities.supported_key?(key)
+        # We still have to support old colors for system arguments.
+        if Primer::Classify::Utilities.supported_key?(key) && key != COLOR_KEY
           memo[:classes] << Primer::Classify::Utilities.classname(key, val, breakpoint)
         elsif BOOLEAN_MAPPINGS.key?(key)
           BOOLEAN_MAPPINGS[key][:mappings].each do |m|

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -115,7 +115,11 @@ module Primer
         end
 
         def classes_to_args(classes)
-          classes_to_hash(classes).map do |key, value|
+          hash_to_args(classes_to_hash(classes))
+        end
+
+        def hash_to_args(hash)
+          hash.map do |key, value|
             val = case value
                   when Symbol
                     ":#{value}"

--- a/lib/primer/classify/utilities.yml
+++ b/lib/primer/classify/utilities.yml
@@ -22,6 +22,39 @@
   - anim-hover-grow
   :rotate:
   - anim-rotate
+:color:
+  :text_primary:
+  - color-text-primary
+  :text_secondary:
+  - color-text-secondary
+  :text_tertiary:
+  - color-text-tertiary
+  :text_link:
+  - color-text-link
+  :text_success:
+  - color-text-success
+  :text_warning:
+  - color-text-warning
+  :text_danger:
+  - color-text-danger
+  :text_inverse:
+  - color-text-inverse
+  :text_white:
+  - color-text-white
+  :icon_primary:
+  - color-icon-primary
+  :icon_secondary:
+  - color-icon-secondary
+  :icon_tertiary:
+  - color-icon-tertiary
+  :icon_info:
+  - color-icon-info
+  :icon_danger:
+  - color-icon-danger
+  :icon_success:
+  - color-icon-success
+  :icon_warning:
+  - color-icon-warning
 :position:
   :static:
   - position-static

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -128,10 +128,22 @@ module RuboCop
           string_args = string_args_to_string(node)
 
           args = "#{args}, #{size_attributes_to_string(size_attributes)}" if size_args.present?
-          args = "#{args}, #{::Primer::Classify::Utilities.classes_to_args(classes)}" if classes.present?
+          args = "#{args}, #{utilities_args(classes)}" if classes.present?
           args = "#{args}, #{string_args}" if string_args.present?
 
           args
+        end
+
+        def utilities_args(classes)
+          args = ::Primer::Classify::Utilities.classes_to_hash(classes)
+
+          if args[:color]
+            args[:color] = args[:color].to_s.gsub("text_", "icon_").to_sym
+            # All text_ colors match 1:1 to icon_ colors, except for text_link, which maps to icon_info
+            args[:color] = :icon_info if args[:color] == :icon_link
+          end
+
+          ::Primer::Classify::Utilities.hash_to_args(args)
         end
 
         def size_attributes_to_string(size_attributes)

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -11,6 +11,8 @@ namespace :utilities do
     # rubocop:disable Lint/ConstantDefinitionInBlock
     SUPPORTED_KEYS = %i[
       anim
+      color-icon
+      color-text
       d
       float
       height

--- a/test/lib/classify/utilities_test.rb
+++ b/test/lib/classify/utilities_test.rb
@@ -91,8 +91,8 @@ class PrimerClassifyUtilitiesTest < Minitest::Test
     assert_equal({ mx: :auto }, Primer::Classify::Utilities.classes_to_hash("mx-auto"))
     assert_equal({ mr: [1, 2], classes: "baz bin" }, Primer::Classify::Utilities.classes_to_hash("mr-1 mr-sm-2 baz bin"))
     assert_equal({ mr: [1, nil, 2], classes: "foo bar" }, Primer::Classify::Utilities.classes_to_hash("mr-1 mr-md-2 foo bar"))
-    assert_equal({ color: :text_tertiary}, Primer::Classify::Utilities.classes_to_hash("color-text-tertiary"))
-    assert_equal({ color: :icon_tertiary}, Primer::Classify::Utilities.classes_to_hash("color-icon-tertiary"))
+    assert_equal({ color: :text_tertiary }, Primer::Classify::Utilities.classes_to_hash("color-text-tertiary"))
+    assert_equal({ color: :icon_tertiary }, Primer::Classify::Utilities.classes_to_hash("color-icon-tertiary"))
   end
 
   def test_classes_to_args
@@ -101,6 +101,14 @@ class PrimerClassifyUtilitiesTest < Minitest::Test
     assert_equal("mx: :auto", Primer::Classify::Utilities.classes_to_args("mx-auto"))
     assert_equal('mr: [1, 2], classes: "baz bin"', Primer::Classify::Utilities.classes_to_args("mr-1 mr-sm-2 baz bin"))
     assert_equal('mr: [1, nil, 2], classes: "foo bar"', Primer::Classify::Utilities.classes_to_args("mr-1 mr-md-2 foo bar"))
+  end
+
+  def test_hash_to_args
+    assert_equal('mr: 1, mb: 2, classes: "foo"', Primer::Classify::Utilities.hash_to_args({ mr: 1, mb: 2, classes: "foo" }))
+    assert_equal('classes: "foo"', Primer::Classify::Utilities.hash_to_args({ classes: "foo" }))
+    assert_equal("mx: :auto", Primer::Classify::Utilities.hash_to_args({ mx: :auto }))
+    assert_equal('mr: [1, 2], classes: "baz bin"', Primer::Classify::Utilities.hash_to_args({ mr: [1, 2], classes: "baz bin" }))
+    assert_equal('mr: [1, nil, 2], classes: "foo bar"', Primer::Classify::Utilities.hash_to_args({ mr: [1, nil, 2], classes: "foo bar" }))
   end
 
   def test_classes_to_hash_returns_classes_when_run_in_production

--- a/test/lib/classify/utilities_test.rb
+++ b/test/lib/classify/utilities_test.rb
@@ -91,6 +91,8 @@ class PrimerClassifyUtilitiesTest < Minitest::Test
     assert_equal({ mx: :auto }, Primer::Classify::Utilities.classes_to_hash("mx-auto"))
     assert_equal({ mr: [1, 2], classes: "baz bin" }, Primer::Classify::Utilities.classes_to_hash("mr-1 mr-sm-2 baz bin"))
     assert_equal({ mr: [1, nil, 2], classes: "foo bar" }, Primer::Classify::Utilities.classes_to_hash("mr-1 mr-md-2 foo bar"))
+    assert_equal({ color: :text_tertiary}, Primer::Classify::Utilities.classes_to_hash("color-text-tertiary"))
+    assert_equal({ color: :icon_tertiary}, Primer::Classify::Utilities.classes_to_hash("color-icon-tertiary"))
   end
 
   def test_classes_to_args

--- a/test/linters/support/autocorrectable_linter_shared_tests.rb
+++ b/test/linters/support/autocorrectable_linter_shared_tests.rb
@@ -161,20 +161,20 @@ module Primer
 
     def test_autocorrects_known_system_arguments
       @file = <<~HTML
-        <#{default_tag} class="#{default_class} mr-1 p-3 d-none d-md-block anim-fade-in" #{required_attributes}>
+        <#{default_tag} class="#{default_class} mr-1 p-3 d-none d-md-block anim-fade-in color-text-primary" #{required_attributes}>
           #{default_content}
         </#{default_tag}>
       HTML
 
       expected = if block_correction?
                    <<~HTML
-                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in#{", #{required_arguments}" if required_arguments}) do %>
+                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, color: :text_primary#{", #{required_arguments}" if required_arguments}) do %>
                        #{default_content}
                      <% end %>
                    HTML
                  else
                    <<~HTML
-                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in#{", #{required_arguments}" if required_arguments}) %>
+                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, color: :text_primary#{", #{required_arguments}" if required_arguments}) %>
                    HTML
                  end
 
@@ -183,20 +183,20 @@ module Primer
 
     def test_autocorrects_with_custom_classes
       @file = <<~HTML
-        <#{default_tag} class="#{default_class} mr-1 p-3 d-none d-md-block anim-fade-in custom-1 custom-2" #{required_attributes}>
+        <#{default_tag} class="#{default_class} mr-1 p-3 d-none d-md-block anim-fade-in color-text-primary custom-1 custom-2" #{required_attributes}>
           #{default_content}
         </#{default_tag}>
       HTML
 
       expected = if block_correction?
                    <<~HTML
-                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, classes: "custom-1 custom-2"#{", #{required_arguments}" if required_arguments}) do %>
+                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, color: :text_primary, classes: "custom-1 custom-2"#{", #{required_arguments}" if required_arguments}) do %>
                        #{default_content}
                      <% end %>
                    HTML
                  else
                    <<~HTML
-                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, classes: "custom-1 custom-2"#{", #{required_arguments}" if required_arguments}) %>
+                     <%= render #{linter_class::COMPONENT}.new(mr: 1, p: 3, display: [:none, nil, :block], animation: :fade_in, color: :text_primary, classes: "custom-1 custom-2"#{", #{required_arguments}" if required_arguments}) %>
                    HTML
                  end
 

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -124,18 +124,18 @@ class RubocopPrimerOcticonTest < CopTest
 
   def test_octicon_with_system_arguments
     investigate(cop, <<-RUBY)
-      octicon(:icon, class: "mr-1")
+      octicon(:icon, class: "mr-1 color-icon-primary")
     RUBY
 
-    assert_correction "primer_octicon(:icon, mr: 1)"
+    assert_correction "primer_octicon(:icon, mr: 1, color: :icon_primary)"
   end
 
   def test_octicon_with_custom_class
     investigate(cop, <<-RUBY)
-      octicon(:icon, class: "mr-1 custom")
+      octicon(:icon, class: "mr-1 color-icon-primary custom")
     RUBY
 
-    assert_correction "primer_octicon(:icon, mr: 1, classes: \"custom\")"
+    assert_correction "primer_octicon(:icon, mr: 1, color: :icon_primary, classes: \"custom\")"
   end
 
   def test_octicon_with_class_that_cant_be_converted

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -138,6 +138,22 @@ class RubocopPrimerOcticonTest < CopTest
     assert_correction "primer_octicon(:icon, mr: 1, color: :icon_primary, classes: \"custom\")"
   end
 
+  def test_converts_text_color_into_icon_color
+    investigate(cop, <<-RUBY)
+      octicon(:icon, class: "mr-1 color-text-primary")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, mr: 1, color: :icon_primary)"
+  end
+
+  def test_converts_text_link_into_icon_info
+    investigate(cop, <<-RUBY)
+      octicon(:icon, class: "mr-1 color-text-link")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, mr: 1, color: :icon_info)"
+  end
+
   def test_octicon_with_class_that_cant_be_converted
     investigate(cop, <<-'RUBY')
       octicon(:icon, class: "mr-1 text-center")


### PR DESCRIPTION
This won't affect how system arguments generate classes, so it still supports deprecated colors. But the utilities change will allow linters to know how to convert classes like `color-text-primary` into arguments. This will enable tons of migrations without breaking the user API.

I've also added an extra migration for the PrimerOcticon linter, which will convert `color-text-x` classes into their respective `color: :icon_x` argument