### PR TITLE
Add `break_word` as an option for the `word_break` system argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
-### New
+### Updates
 
-* Add `break_word` as an option for the `word_break` system argument.
+* Add support for `word_break: :break_word` to System Arguments.
 
     *antn*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### New
+
+* Add `break_word` as an option for the `word_break` system argument.
+
+    *antn*
+
 ## 0.0.53
 
 ### New

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -44,7 +44,7 @@ system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
 
 ## Testing
 
-Before running the whole test suite with Rake: `bundle exec rake`, you must run `bundle exec docs:preview`.
+Before running the whole test suite with Rake: `bundle exec rake`, you must run `bundle exec rake docs:preview`.
 
 Run a subset of tests by supplying a file glob to the test command: `TESTS="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`
 

--- a/lib/primer/classify/utilities.yml
+++ b/lib/primer/classify/utilities.yml
@@ -1222,6 +1222,8 @@
 :word_break:
   :break_all:
   - wb-break-all
+  :break_word:
+  - break-word
 :display:
   :block:
   - d-block

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -579,6 +579,7 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_word_break
     assert_generated_class("wb-break-all", { word_break: :break_all })
+    assert_generated_class("break-word", { word_break: :break_word })
   end
 
   def test_responsive


### PR DESCRIPTION
When working on https://github.com/github/communities/issues/741, I noticed that we didn't have the ability to specific `break_word` with `word_break`, even though it's part of Primer.

This PR adds that, and also fixes a typo in CONTRIBUTING.