### PR TITLE
Fix broken `UnderlinePanels` docs URL

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -107,4 +107,4 @@
     - title: UnderlineNav
       url: /components/alpha/underlinenav
     - title: UnderlinePanels
-      url: /components/alpha/UnderlinePanels
+      url: /components/alpha/underlinepanels


### PR DESCRIPTION
This PR updates the docs URL for `UnderlinePanel`, which is currently broken due to incorrect casing. 
