### PR TITLE
Remove extra constants left over in `UnderlineNav`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Misc
+
+* Clean up extra constants in `UnderlineNav`.
+
+    *Kate Higa*
+
 ## 0.0.54
 
 ### Breaking changes

--- a/app/components/primer/alpha/underline_nav.rb
+++ b/app/components/primer/alpha/underline_nav.rb
@@ -17,16 +17,10 @@ module Primer
       include Primer::TabbedComponentHelper
       include Primer::UnderlineNavHelper
 
-      ALIGN_DEFAULT = :left
-      ALIGN_OPTIONS = [ALIGN_DEFAULT, :right].freeze
-
       BODY_TAG_DEFAULT = :ul
 
       TAG_DEFAULT = :nav
       TAG_OPTIONS = [TAG_DEFAULT, :div].freeze
-
-      ACTIONS_TAG_DEFAULT = :div
-      ACTIONS_TAG_OPTIONS = [ACTIONS_TAG_DEFAULT, :span].freeze
 
       # Use the tabs to list page links.
       #

--- a/static/constants.json
+++ b/static/constants.json
@@ -34,16 +34,6 @@
     ]
   },
   "Primer::Alpha::UnderlineNav": {
-    "ACTIONS_TAG_DEFAULT": "div",
-    "ACTIONS_TAG_OPTIONS": [
-      "div",
-      "span"
-    ],
-    "ALIGN_DEFAULT": "left",
-    "ALIGN_OPTIONS": [
-      "left",
-      "right"
-    ],
     "BODY_TAG_DEFAULT": "ul",
     "TAG_DEFAULT": "nav",
     "TAG_OPTIONS": [


### PR DESCRIPTION
These extra constants should have been removed in https://github.com/primer/view_components/pull/689/. These constants are shared with `UnderlinePanels` and live in `Primer::UnderlineNavHelper`. 
