### PR TITLE
Stabilize Ruby 3 allocations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,8 @@ Rake::TestTask.new(:test) do |t|
 end
 
 Rake::TestTask.new(:bench) do |t|
+  # Disable parallel tests since it can interfere with benchmark results and allocation counts
+  ENV["MT_CPU"] = "0"
   t.libs << "test"
   t.test_files = FileList["test/benchmarks/**/bench_*.rb"]
   t.verbose = true

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -38,11 +38,8 @@ class BenchClassify < Minitest::Benchmark
   end
 
   def bench_allocations_without_cache
-    # Preload cache, warm up benchmark
-    Primer::Classify::Cache.clear!
-    Primer::Classify.call(**@values)
-
-    assert_allocations "3.0" => 127, "2.7" => 68, "2.6" => 69, "2.5" => 70 do
+    assert_allocations "3.0" => 68, "2.7" => 68, "2.6" => 69, "2.5" => 70 do
+      Primer::Classify::Cache.clear!
       Primer::Classify.call(**@values)
     end
   ensure
@@ -51,9 +48,8 @@ class BenchClassify < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Classify::Cache.preload!
-    Primer::Classify.call(**@values)
 
-    assert_allocations "3.0" => 65, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
+    assert_allocations "3.0" => 26, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -49,7 +49,7 @@ class BenchClassify < Minitest::Benchmark
   def bench_allocations_with_cache
     Primer::Classify::Cache.preload!
 
-    assert_allocations "3.0" => 26, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
+    assert_allocations "3.0" => 25, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -6,6 +6,10 @@ require "test_helper"
 class BenchClassify < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
+  def test_order
+    "random"
+  end
+
   def setup
     @values = {
       align_items: :center,

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -13,9 +13,8 @@ class BenchOcticons < Minitest::Benchmark
   end
 
   def bench_allocations_without_cache
-    Primer::OcticonComponent.new(**@options)
-    Primer::Octicon::Cache.clear!
-    assert_allocations "3.0" => 60, "2.7" => 43, "2.6" => 50, "2.5" => 54 do
+    assert_allocations "3.0" => 40, "2.7" => 42, "2.6" => 48, "2.5" => 53 do
+      Primer::Octicon::Cache.clear!
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -24,7 +23,8 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations "3.0" => 29, "2.7" => 20, "2.6" => 24, "2.5" => 28 do
+
+    assert_allocations "3.0" => 19, "2.7" => 20, "2.6" => 24, "2.5" => 28 do
       Primer::OcticonComponent.new(**@options)
     end
   end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -6,6 +6,10 @@ require "test_helper"
 class BenchOcticons < Minitest::Benchmark
   include Primer::AssertAllocationsHelper
 
+  def test_order
+    "random"
+  end
+
   def setup
     @options = {
       icon: :alert

--- a/test/test_helpers/assert_allocations_helper.rb
+++ b/test/test_helpers/assert_allocations_helper.rb
@@ -6,9 +6,8 @@
 module Primer
   module AssertAllocationsHelper
     def assert_allocations(count_map)
+      yield
       GC.disable
-      GC.start
-      GC.compact if GC.respond_to?(:compact)
       total_start = GC.stat[:total_allocated_objects]
       yield
       total_end = GC.stat[:total_allocated_objects]


### PR DESCRIPTION
I don't have a great understanding of this, but `GC.compact` likely
invalidates caches which seem to be causing our Ruby 3.0 allocations to
appear larger than they actually are.

This change removes the call to `GC.compact` which drops our allocation
numbers. I think the new numbers should be closer to what we expect when
using these classes in an application.

Thanks @jhawthorn for pointing this out!
