### PR TITLE
Use the allocation_stats gem to count object allocations in our benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Kate Higa*
 
+* Use the allocation_stats gem to count object allocations in our benchmarks.
+
+    *Cameron Dutro*
+
 ## 0.0.54
 
 ### Breaking changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,6 @@ GEM
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.34.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -127,9 +126,6 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (5.3.1)
       nio4r (~> 2.0)
@@ -257,7 +253,6 @@ DEPENDENCIES
   mocha
   primer_view_components!
   pry
-  pry-byebug
   puma (~> 5.3.1)
   rack-cors
   railties (= 6.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    allocation_stats (0.1.5)
     allocation_tracer (0.6.3)
     ansi (1.5.0)
     ast (2.4.2)
@@ -58,6 +59,7 @@ GEM
     bootsnap (1.5.1)
       msgpack (~> 1.0)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.34.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -125,6 +127,9 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (5.3.1)
       nio4r (~> 2.0)
@@ -239,6 +244,7 @@ DEPENDENCIES
   actionview (= 6.1.1)
   activemodel (= 6.1.1)
   activesupport (= 6.1.1)
+  allocation_stats (~> 0.1)
   allocation_tracer (~> 0.6.3)
   axe-core-api (~> 4.1)
   benchmark-ips (~> 2.8.4)
@@ -251,6 +257,7 @@ DEPENDENCIES
   mocha
   primer_view_components!
   pry
+  pry-byebug
   puma (~> 5.3.1)
   rack-cors
   railties (= 6.1.1)

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "octicons", "~> 15"
   spec.add_runtime_dependency     "view_component", [">= 2.0.0", "< 3.0"]
 
+  spec.add_development_dependency "allocation_stats", "~> 0.1"
   spec.add_development_dependency "allocation_tracer", "~> 0.6.3"
   spec.add_development_dependency "axe-core-api", "~> 4.1"
   spec.add_development_dependency "benchmark-ips", "~> 2.8.4"

--- a/test/benchmarks/bench_classify.rb
+++ b/test/benchmarks/bench_classify.rb
@@ -42,7 +42,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.clear!
     Primer::Classify.call(**@values)
 
-    assert_allocations "3.0" => 127, "2.7" => 68, "2.6" => 69, "2.5" => 70 do
+    assert_allocations "3.0" => 61, "2.7" => 61, "2.6" => 62, "2.5" => 62 do
       Primer::Classify.call(**@values)
     end
   ensure
@@ -53,7 +53,7 @@ class BenchClassify < Minitest::Benchmark
     Primer::Classify::Cache.preload!
     Primer::Classify.call(**@values)
 
-    assert_allocations "3.0" => 65, "2.7" => 25, "2.6" => 26, "2.5" => 27 do
+    assert_allocations "3.0" => 20, "2.7" => 20, "2.6" => 21, "2.5" => 21 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -15,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.0" => 39, "2.7" => 40, "2.6" => 45, "2.5" => 47 do
+    assert_allocations "3.0" => 38, "2.7" => 40, "2.6" => 45, "2.5" => 47 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure

--- a/test/benchmarks/bench_octicons.rb
+++ b/test/benchmarks/bench_octicons.rb
@@ -15,7 +15,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::OcticonComponent.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.0" => 60, "2.7" => 43, "2.6" => 50, "2.5" => 54 do
+    assert_allocations "3.0" => 39, "2.7" => 40, "2.6" => 45, "2.5" => 47 do
       Primer::OcticonComponent.new(**@options)
     end
   ensure
@@ -24,7 +24,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations "3.0" => 29, "2.7" => 20, "2.6" => 24, "2.5" => 28 do
+    assert_allocations "3.0" => 17, "2.7" => 19, "2.6" => 23, "2.5" => 25 do
       Primer::OcticonComponent.new(**@options)
     end
   end

--- a/test/test_helpers/assert_allocations_helper.rb
+++ b/test/test_helpers/assert_allocations_helper.rb
@@ -3,18 +3,13 @@
 # This code is exercised by rake bench
 # :nocov:
 
+require "allocation_stats"
+
 module Primer
   module AssertAllocationsHelper
-    def assert_allocations(count_map)
-      GC.disable
-      GC.start
-      GC.compact if GC.respond_to?(:compact)
-      total_start = GC.stat[:total_allocated_objects]
-      yield
-      total_end = GC.stat[:total_allocated_objects]
-      GC.enable
-
-      total = total_end - total_start
+    def assert_allocations(count_map, &block)
+      trace = AllocationStats.trace(&block)
+      total = trace.allocations.all.size
       count = count_map[ruby_version]
 
       assert_equal count, total, "Expected #{count} allocations, got #{total} allocations"


### PR DESCRIPTION
@BlakeWilliams discovered that `GC.compact` likely invalidates internal Ruby caches, so I spent some time looking for a better way to count object allocations. This PR uses the [allocation_stats gem](https://github.com/srawlins/allocation_stats) which uses the internal `ObjectSpace.trace_object_allocations` method available since Ruby 2.1.