### PR TITLE
Flash linter won't autocorrect flashes with ERB in their content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,11 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Manuel Puyol*
 
-* `Button` component linter will autocorrect when button uses `href`, `name`, `value` or `tabindex`.
+* `Button` linter will autocorrect when button uses `href`, `name`, `value` or `tabindex`.
+
+    *Manuel Puyol*
+
+* `Flash` linter won't autocorrect flashes with ERB in their content.
 
     *Manuel Puyol*
 

--- a/lib/primer/view_components/linters/flash_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_component_migration_counter.rb
@@ -22,6 +22,11 @@ module ERBLint
         # Hash children indicates that there are tags in the content.
         return nil if tag_tree[:children].first.is_a?(Hash)
 
+        content = tag_tree[:children].first
+
+        # Don't accept content with ERB blocks
+        return nil if content.type != :text || content.children&.any? { |n| n.try(:type) == :erb }
+
         ARGUMENT_MAPPER.new(tag).to_s
       rescue ArgumentMappers::ConversionError
         nil

--- a/test/linters/flash_component_migration_counter_test.rb
+++ b/test/linters/flash_component_migration_counter_test.rb
@@ -23,6 +23,26 @@ class FlashComponentMigrationCounterTest < LinterTestCase
     assert_equal "<%# erblint:counter FlashComponentMigrationCounter 1 %>\n#{@file}", corrected_content
   end
 
+  def test_does_not_autocorrect_with_erb_content
+    @file = <<~HTML
+      <div class="flash">
+        <%= primer_octicon(:icon) %> some text
+      </div>
+    HTML
+
+    assert_equal "<%# erblint:counter FlashComponentMigrationCounter 1 %>\n#{@file}", corrected_content
+  end
+
+  def test_does_not_autocorrect_with_interpolation
+    @file = <<~HTML
+      <div class="flash">
+        some <%= interpolation %>
+      </div>
+    HTML
+
+    assert_equal "<%# erblint:counter FlashComponentMigrationCounter 1 %>\n#{@file}", corrected_content
+  end
+
   private
 
   def linter_class


### PR DESCRIPTION
To make it as simple as possible, the linter won't autocorrect cases that had some ERB call. It will only fix cases with simple text as content