### PR TITLE
Fix branch name check in release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -97,7 +97,7 @@ main() {
     exit 1
   fi
 
-  if [ "$(branch_name)" !== "main" ]; then
+  if [[ "$(branch_name)" != "main" ]]; then
     echo "Error: can only make a release on the main branch"
     exit 1
   fi


### PR DESCRIPTION
I get the following bash error when I try to run script/release:

```
script/release: line 100: [: !==: binary operator expected
```

This PR should fix it.