### PR TITLE
Don't suggest empty colors for Octicons when autocorrecting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Bug fixes
+
+* Don't suggest empty colors for Octicons when autocorrecting.
+
+    *Manuel Puyol*
+
 ## 0.0.56
 
 ### Updates

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -142,11 +142,11 @@ module RuboCop
                     :text_white
                   when :text_link
                     :icon_info
-                  else
+                  when Symbol
                     args[:color].to_s.gsub("text_", "icon_").to_sym
                   end
 
-          args[:color] = color
+          args[:color] = color if color
 
           ::Primer::Classify::Utilities.hash_to_args(args)
         end

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -170,6 +170,22 @@ class RubocopPrimerOcticonTest < CopTest
     assert_empty cop.offenses
   end
 
+  def test_autocorrects_unknown_color_to_class
+    investigate(cop, <<-'RUBY')
+      octicon(:icon, class: "mr-1 color-unknown-color")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, mr: 1, classes: \"color-unknown-color\")"
+  end
+
+  def test_corrects_without_color
+    investigate(cop, <<-'RUBY')
+      octicon(:icon, class: "mr-1")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, mr: 1)"
+  end
+
   def test_octicon_with_class_interpolation
     investigate(cop, <<-'RUBY')
       octicon(:icon, class: "mr-1 #{aux}")


### PR DESCRIPTION
Colors that aren't on utilities (like `colors-yellow-7`) were being fixed as `color: `. This PR updates the behavior, not allowing empty color values