### PR TITLE
Add `gem "view_component"`

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -21,6 +21,7 @@ Render Primer ViewComponents from templates:
 In `Gemfile`, add:
 
 ```ruby
+gem "view_component"
 gem "primer_view_components"
 ```
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -21,13 +21,13 @@ Render Primer ViewComponents from templates:
 In `Gemfile`, add:
 
 ```ruby
-gem "view_component"
 gem "primer_view_components"
 ```
 
 In `config/application.rb`, add **after the application definition**:
 
 ```ruby
+require "view_component/engine"
 require "primer/view_components/engine"
 ```
 


### PR DESCRIPTION
While setting up a brand new rails project and [template](https://github.com/primer/view_components-template) I've noticed that this gem wouldn't work without `view_component`. I'm not sure if this is a bug where the dependency should come with `primer_view_components` instead because I have no experience with Rails.

(I've accidentally committed this directly on the main branch initially but removed it again. 🥴)