### PR TITLE
Fix: Rubocop primer_octicon replacement not correcting with their receiver calls

### DIFF
--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -75,8 +75,11 @@ module RuboCop
             classes = classes(kwargs)
             size_attributes = transform_sizes(kwargs)
             args = arguments_as_string(node, size_attributes, classes)
-
-            corrector.replace(node.loc.expression, "primer_octicon(#{args})")
+            if node.dot?
+              corrector.replace(node.loc.expression, "#{node.receiver.source}.primer_octicon(#{args})")
+            else
+              corrector.replace(node.loc.expression, "primer_octicon(#{args})")
+            end
           end
         end
 

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -15,6 +15,14 @@ class RubocopPrimerOcticonTest < CopTest
     assert_empty cop.offenses.map(&:message)
   end
 
+  def test_octicon_method_call
+    investigate(cop, <<-RUBY)
+      helpers.octicon(:icon)
+    RUBY
+
+    assert_correction "helpers.primer_octicon(:icon)"
+  end
+
   def test_octicon
     investigate(cop, <<-RUBY)
       octicon(:icon)


### PR DESCRIPTION
In https://github.com/github/github/pull/192446/checks?check_run_id=3680708010 I turned on the rubocop linters in PVC for dotcom. For the `primer_octicon` cop, there was replacements suggested that was catching calls with a `helpers.` defined.

```
C: [Correctable] Primer/PrimerOcticon: Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.

  helpers.octicon("shield-lock"),
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Upon replacement, I found it was replacing all of the call with `primer_octicon`.

```diff
-helpers.octicon("shield-lock")
+primer_octicon("shield-lock")
```
---

In this PR, I added a test for this, and fixed the corrector to take into account `dot?`. I'm not sure if this is the best approach so open to ideas if you know something better.

