### PR TITLE
Adding octicon test with title attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Updates
+
+* Handling arguments that aren't system arguments or string arguments in primer_octicon.
+
+    *Jon Rohan, Manuel Puyol*
+
 ## 0.0.59
 
 ### Updates

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -32,11 +32,27 @@ class RubocopPrimerOcticonTest < CopTest
   end
 
   def test_octicon_with_title
-    investigate(cop, <<-RUBY)
+    investigate(cop, <<-'RUBY')
       octicon(:icon, title: "hello")
     RUBY
 
     assert_correction "primer_octicon(:icon, title: \"hello\")"
+  end
+
+  def test_octicon_with_title_interpolation
+    investigate(cop, <<-'RUBY')
+      octicon(:icon, title: "hello <%= interpolation %>")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, title: \"hello <%= interpolation %>\")"
+  end
+
+  def test_octicon_with_title_method
+    investigate(cop, <<-'RUBY')
+      octicon(:icon, title: some_method)
+    RUBY
+
+    assert_correction "primer_octicon(:icon, title: some_method)"
   end
 
   def test_octicon_with_number_size

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -31,6 +31,14 @@ class RubocopPrimerOcticonTest < CopTest
     assert_correction "primer_octicon(:icon)"
   end
 
+  def test_octicon_with_title
+    investigate(cop, <<-RUBY)
+      octicon(:icon, title: "hello")
+    RUBY
+
+    assert_correction "primer_octicon(:icon, title: \"hello\")"
+  end
+
   def test_octicon_with_number_size
     investigate(cop, <<-RUBY)
       octicon(:icon, size: 30)


### PR DESCRIPTION
I was noticing that the linter wasn't replacing octicon calls with a title attribute. ie.

```
octicon(:icon, title: "icon")
```

Adding a test in this PR and going to attempt to fix it.