### PR TITLE
Add Stats class

### DIFF
--- a/lib/primer/view_components/stats.rb
+++ b/lib/primer/view_components/stats.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Primer
+  # :nodoc:
+  module ViewComponents
+    class Stats
+      class << self
+        def accessibility_tags_count
+          all_components.count do |f|
+            File.read(f).include?("@accessibility")
+          end
+        end
+
+        def components_count
+          all_components.size
+        end
+
+        private
+
+        def all_components
+          @all_components ||= Dir[File.join(__dir__, "../../../app/components/**/*.rb")]
+        end
+      end
+    end
+  end
+end

--- a/test/primer/stats_test.rb
+++ b/test/primer/stats_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "primer/view_components/stats"
+
+class Primer::ViewComponents::StatsTest < Minitest::Test
+  def test_accessibility_tags_count
+    assert_equal 15, Primer::ViewComponents::Stats.accessibility_tags_count
+  end
+end


### PR DESCRIPTION
I'm proposing adding a `Stats` class that can provide users with some metrics related to PVC. The first metric I'm implementing here is the amount of components with the `@accessibility` tag on their docs.
If y'all think it doesn't make sense to have those numbers in PVC, I can reimplement something similar in dotcom, since we'll need to report that number to keep track of it