### PR TITLE
Ability to disable rubocop with lint comment

### DIFF
--- a/lib/rubocop/cop/primer/base_cop.rb
+++ b/lib/rubocop/cop/primer/base_cop.rb
@@ -17,6 +17,13 @@ module RuboCop
           view_helpers.include?(node.method_name) || (node.method_name == :new && !node.receiver.nil? && ::Primer::ViewComponents::STATUSES.key?(node.receiver.const_name))
         end
 
+        def add_offense(node_or_range, message: nil, severity: nil, &block)
+          range = range_from_node_or_range(node_or_range)
+          return unless enabled_line?(range.line)
+
+          super(node_or_range, message: message, severity: severity, &block)
+        end
+
         private
 
         def view_helpers

--- a/lib/rubocop/cop/primer/no_tag_memoize.rb
+++ b/lib/rubocop/cop/primer/no_tag_memoize.rb
@@ -16,7 +16,7 @@ module RuboCop
       #
       # good
       # @system_arguments[:tag] = :h2
-      class NoTagMemoize < RuboCop::Cop::Cop
+      class NoTagMemoize < BaseCop
         INVALID_MESSAGE = <<~STR
           Avoid `[:tag] ||=`. Instead, try one of the following:
             - Don't allow consumers to update the tag by having a fixed tag (e.g. `system_arguments[:tag] = :div`)

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -22,7 +22,7 @@ module RuboCop
       # primer_octicon(:"icon-with-daashes")
       # primer_octicon(@ivar)
       # primer_octicon(condition > "icon" : "other-icon")
-      class PrimerOcticon < RuboCop::Cop::Cop
+      class PrimerOcticon < BaseCop
         INVALID_MESSAGE = <<~STR
           Replace the octicon helper with primer_octicon. See https://primer.style/view-components/components/octicon for details.
         STR

--- a/test/rubocop/deprecated_arguments_test.rb
+++ b/test/rubocop/deprecated_arguments_test.rb
@@ -32,6 +32,15 @@ class RubocopDeprecatedArgumentsTest < CopTest
     assert_equal 1, cop.offenses.count
   end
 
+  def test_disabled_rubocop
+    investigate(cop, <<-RUBY)
+      # rubocop:disable Primer/DeprecatedArguments
+      Primer::BaseComponent.new(color: :blue)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
   def test_deprecated_argument_as_a_string
     investigate(cop, <<-RUBY)
       Primer::BaseComponent.new(color: "blue")


### PR DESCRIPTION
Currently in order to disable our erblint rubocop rules, you have to [configure .erb-lint.yml](https://github.com/github/github/blob/master/.erb-lint.yml#L105-L113) to ignore the files. This breaks how we track these disables because we usually track them with template comments. Like `<%# erblint:disable RuleName %>`

This PR addresses that problem by adding to the BaseCop an `add_offense` method to check if the lines are disabled. Currently this can be done by including a `<%# rubocop:disable RuleName %>` comment in the file.