### PR TITLE
Use .text-small instead of .btn-sm for small-variant link ButtonComponent

### DIFF
--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -24,6 +24,12 @@ module Primer
       :large => "btn-large"
     }.freeze
     VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
+    
+    LINK_VARIANT_MAPPINGS = {
+      :small => "text-small",
+      DEFAULT_VARIANT => ""
+    }.freeze
+    LINK_VARIANT_OPTIONS = LINK_VARIANT_MAPPINGS.keys
 
     # Icon to be rendered in the button.
     #
@@ -99,7 +105,7 @@ module Primer
       @system_arguments[:classes] = class_names(
         system_arguments[:classes],
         SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)],
-        VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)],
+        variant_class_names,
         "btn" => !link?,
         "btn-block" => block,
         "BtnGroup-item" => group_item
@@ -110,6 +116,14 @@ module Primer
 
     def link?
       @scheme == LINK_SCHEME
+    end
+    
+    def variant_class_names
+      if link?
+        LINK_VARIANT_MAPPINGS[fetch_or_fallback(LINK_VARIANT_OPTIONS, variant, DEFAULT_VARIANT)]
+      else
+        VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)]
+      end
     end
   end
 end

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -24,7 +24,7 @@ module Primer
       :large => "btn-large"
     }.freeze
     VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
-    
+
     LINK_VARIANT_MAPPINGS = {
       :small => "text-small",
       DEFAULT_VARIANT => ""
@@ -118,7 +118,7 @@ module Primer
     def link?
       @scheme == LINK_SCHEME
     end
-    
+
     def variant_class_names
       if link?
         LINK_VARIANT_MAPPINGS[fetch_or_fallback(LINK_VARIANT_OPTIONS, @variant, DEFAULT_VARIANT)]

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -100,6 +100,7 @@ module Primer
     )
       @scheme = scheme
       @caret = caret
+      @variant = variant
 
       @system_arguments = system_arguments
       @system_arguments[:classes] = class_names(
@@ -120,9 +121,9 @@ module Primer
     
     def variant_class_names
       if link?
-        LINK_VARIANT_MAPPINGS[fetch_or_fallback(LINK_VARIANT_OPTIONS, variant, DEFAULT_VARIANT)]
+        LINK_VARIANT_MAPPINGS[fetch_or_fallback(LINK_VARIANT_OPTIONS, @variant, DEFAULT_VARIANT)]
       else
-        VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)]
+        VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, @variant, DEFAULT_VARIANT)]
       end
     end
   end

--- a/test/components/button_component_test.rb
+++ b/test/components/button_component_test.rb
@@ -78,6 +78,12 @@ class PrimerButtonComponentTest < Minitest::Test
     refute_selector(".btn")
   end
 
+  def test_applies_text_small_for_link_button
+    render_inline(Primer::ButtonComponent.new(scheme: :link, variant: :small)) { "content" }
+
+    assert_selector(".text-small.btn-link")
+  end
+
   def test_renders_button_block
     render_inline(Primer::ButtonComponent.new(block: true)) { "content" }
 


### PR DESCRIPTION
This modifies the class that gets applied when you have a `variant: small, scheme: :link` ButtonComponent. Instead of applying `.btn-sm`, which doesn't affect the appearance of a link button, it applies `.text-small`. I hit this as a point of confusion; I felt like passing `variant: :small` would work regardless of my ButtonComponent's `scheme`.

I wasn't sure of a good class to apply for `variant: :large, scheme: :link`, so I omitted that from being a valid `variant` option for scheme=link. Suggestions welcome!