### PR TITLE
Add host for Storybook JS

### DIFF
--- a/demo/app/views/layouts/storybook_centered_preview.html.erb
+++ b/demo/app/views/layouts/storybook_centered_preview.html.erb
@@ -7,7 +7,7 @@
     <% if Rails.env.development? %>
       <%= javascript_include_tag "primer_view_components", host: "localhost:4000" %>
     <% else %>
-      <%= javascript_include_tag "primer_view_components" %>
+      <%= javascript_include_tag "primer_view_components", host: "primer.style/rails" %>
     <% end %>
   </head>
 

--- a/demo/app/views/layouts/storybook_preview.html.erb
+++ b/demo/app/views/layouts/storybook_preview.html.erb
@@ -7,7 +7,7 @@
     <% if Rails.env.development? %>
       <%= javascript_include_tag "primer_view_components", host: "localhost:4000" %>
     <% else %>
-      <%= javascript_include_tag "primer_view_components" %>
+      <%= javascript_include_tag "primer_view_components", host: "primer.style/rails" %>
     <% end %>
   </head>
 


### PR DESCRIPTION
In production, Storybook is trying to load assets from `primer.style/assets/asset-name`, which doesn't exist.
I'm proposing a new Vercel redirect specific for rails routes (such as assets and test controllers) https://github.com/primer/primer.style/pull/276

This should fix stories that depend on JS in our Storybook

cc @inkblotty 