### PR TITLE
Storybook: bump version to 6.4.x for slightly improved accessibility in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+* Bump Storybook version to include Skip to Content links for keyboard auditors
+
+    *Katie Foster @inkblotty*
+
 ## 0.0.60
 
 ### Updates

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,11 +11,11 @@
   },
   "devDependencies": {
     "@primer/primitives": "^6.0.0",
-    "@storybook/addon-a11y": "^v6.3.12",
-    "@storybook/addon-actions": "^v6.3.12",
-    "@storybook/addon-controls": "^v6.3.12",
-    "@storybook/addon-docs": "^v6.3.12",
-    "@storybook/server": "^v6.3.12",
+    "@storybook/addon-a11y": "^v6.4.0-beta.31",
+    "@storybook/addon-actions": "^v6.4.0-beta.31",
+    "@storybook/addon-controls": "^v6.4.0-beta.31",
+    "@storybook/addon-docs": "^v6.4.0-beta.31",
+    "@storybook/server": "^v6.4.0-beta.31",
     "webpack-dev-server": "^3.11.0"
   },
   "scripts": {


### PR DESCRIPTION
# Context
Version 6.4 of storybook comes with some improvements in navigation, including "Skip to Canvas" and "Skip to Sidebar" navigation links, enabling keyboard users to skip over the sidebar content.

## Demo

https://user-images.githubusercontent.com/14206003/141015397-8e621147-b636-4e26-a974-27d00893c8ef.mov

^ The above video shows a "Skip to Canvas" link appearing when focus is moved to the element after the Header.

This change was introduced in [this PR around Skip to X links](https://github.com/storybookjs/storybook/pull/15740)

Resolves https://github.com/github/accessibility/issues/379

# Notes
6.4 is still in beta, so this will likely need another bump once 6.4 is fully published. However, we want to bump this version for "Skip to" links to enable our auditors who rely on keyboard to navigate our Primer components more easily.

cc @github/accessibility