### PR TITLE
Change force_system_arguments to raise_on_invalid_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     *Owen Niblock*
 
+### Breaking Changes
+
+* Rename `force_system_arguments` to `raise_on_invalid_options` to better reflect its functionality
+
+    *Owen Niblock*
+
 ### Deprecations
 
 * Deprecate `Primer::BlankslateComponent` in favor of `Primer::Beta::Blankslate`.

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -156,7 +156,7 @@ module Primer
       raise ArgumentError, "`class` is an invalid argument. Use `classes` instead." if system_arguments.key?(:class) && !Rails.env.production?
 
       if (denylist = system_arguments[:system_arguments_denylist])
-        if force_system_arguments? && !ENV["PRIMER_WARNINGS_DISABLED"]
+        if raise_on_invalid_options? && !ENV["PRIMER_WARNINGS_DISABLED"]
           # Convert denylist from:
           # { [:p, :pt] => "message" } to:
           # { p: "message", pt: "message" }

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -16,8 +16,8 @@ module Primer
 
     private
 
-    def force_system_arguments?
-      Rails.application.config.primer_view_components.force_system_arguments
+    def raise_on_invalid_options?
+      Rails.application.config.primer_view_components.raise_on_invalid_options
     end
 
     def deprecated_component_warning(new_class: nil, version: nil)

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -43,5 +43,5 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.primer_view_components.silence_deprecations = true
-  config.primer_view_components.force_system_arguments = false
+  config.primer_view_components.raise_on_invalid_options = false
 end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -105,7 +105,7 @@ module Primer
       def validated_class_names(classes)
         return if classes.blank?
 
-        if force_system_arguments? && !ENV["PRIMER_WARNINGS_DISABLED"]
+        if raise_on_invalid_options? && !ENV["PRIMER_WARNINGS_DISABLED"]
           invalid_class_names =
             classes.split.each_with_object([]) do |class_name, memo|
               memo << class_name if Primer::Classify::Validation.invalid?(class_name)
@@ -211,8 +211,8 @@ module Primer
         end
       end
 
-      def force_system_arguments?
-        Rails.application.config.primer_view_components.force_system_arguments
+      def raise_on_invalid_options?
+        Rails.application.config.primer_view_components.raise_on_invalid_options
       end
     end
 

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -15,7 +15,7 @@ module Primer
 
       config.primer_view_components = ActiveSupport::OrderedOptions.new
 
-      config.primer_view_components.force_system_arguments = false
+      config.primer_view_components.raise_on_invalid_options = false
       config.primer_view_components.silence_deprecations = false
       config.primer_view_components.validate_class_names = !Rails.env.production?
 

--- a/static/constants.json
+++ b/static/constants.json
@@ -276,7 +276,8 @@
     }
   },
   "Primer::Dropdown": {
-    "Menu": "Primer::Dropdown::Menu"
+    "Menu": "Primer::Dropdown::Menu",
+    "MenuTest": "Primer::Dropdown::MenuTest"
   },
   "Primer::Dropdown::Menu": {
     "AS_DEFAULT": "default",

--- a/static/constants.json
+++ b/static/constants.json
@@ -276,8 +276,7 @@
     }
   },
   "Primer::Dropdown": {
-    "Menu": "Primer::Dropdown::Menu",
-    "MenuTest": "Primer::Dropdown::MenuTest"
+    "Menu": "Primer::Dropdown::Menu"
   },
   "Primer::Dropdown::Menu": {
     "AS_DEFAULT": "default",

--- a/test/components/base_component_test.rb
+++ b/test/components/base_component_test.rb
@@ -134,7 +134,7 @@ class PrimerBaseComponentTest < Minitest::Test
   end
 
   def test_restricts_allowed_system_arguments
-    with_force_system_arguments(true) do
+    with_raise_on_invalid_options(true) do
       error = assert_raises(ArgumentError) do
         render_inline(
           Primer::BaseComponent.new(
@@ -152,7 +152,7 @@ class PrimerBaseComponentTest < Minitest::Test
   end
 
   def test_strips_denied_system_arguments
-    with_force_system_arguments(false) do
+    with_raise_on_invalid_options(false) do
       render_inline(
         Primer::BaseComponent.new(
           tag: :div,

--- a/test/components/border_box_component_test.rb
+++ b/test/components/border_box_component_test.rb
@@ -71,7 +71,7 @@ class PrimerBorderBoxComponentTest < Minitest::Test
   end
 
   def test_restricts_allowed_system_arguments
-    with_force_system_arguments(true) do
+    with_raise_on_invalid_options(true) do
       error = assert_raises(ArgumentError) do
         render_inline(Primer::BorderBoxComponent.new(p: 4)) do |component|
           component.body { "Body" }
@@ -83,7 +83,7 @@ class PrimerBorderBoxComponentTest < Minitest::Test
   end
 
   def test_strips_denied_system_arguments
-    with_force_system_arguments(false) do
+    with_raise_on_invalid_options(false) do
       render_inline(Primer::BorderBoxComponent.new(p: 4)) do |component|
         component.body { "Body" }
       end

--- a/test/components/breadcrumbs_test.rb
+++ b/test/components/breadcrumbs_test.rb
@@ -12,7 +12,7 @@ class PrimerBreadcrumbsTest < Minitest::Test
   end
 
   def test_system_argument_restriction
-    with_force_system_arguments(true) do
+    with_raise_on_invalid_options(true) do
       error = assert_raises(ArgumentError) do
         render_inline(Primer::Beta::Breadcrumbs.new(p: 0)) do |component|
           component.item(href: "/") { "Home" }

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -425,7 +425,7 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_raises_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set
     ENV["PRIMER_WARNINGS_DISABLED"] = "1"
-    with_force_system_arguments(true) do
+    with_raise_on_invalid_options(true) do
       assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
     end
   ensure
@@ -442,8 +442,8 @@ class PrimerClassifyTest < Minitest::Test
     refute(generated_class.end_with?(" "))
   end
 
-  def test_raises_if_not_using_system_arguments_when_force_system_arguments_is_true
-    with_force_system_arguments(true) do
+  def test_raises_if_not_using_system_arguments_when_raise_on_invalid_options_is_true
+    with_raise_on_invalid_options(true) do
       exception = assert_raises ArgumentError do
         Primer::Classify.call(classes: "d-block")
       end
@@ -452,8 +452,8 @@ class PrimerClassifyTest < Minitest::Test
     end
   end
 
-  def test_does_not_raise_if_not_using_system_arguments_when_force_system_arguments_is_false
-    with_force_system_arguments(false) do
+  def test_does_not_raise_if_not_using_system_arguments_when_raise_on_invalid_options_is_false
+    with_raise_on_invalid_options(false) do
       assert_generated_class("d-block", { classes: "d-block" })
     end
   end

--- a/test/test_helpers/component_test_helpers.rb
+++ b/test/test_helpers/component_test_helpers.rb
@@ -16,12 +16,12 @@ module Primer
       FetchOrFallbackHelper.fallback_raises = true
     end
 
-    def with_force_system_arguments(new_value)
-      old_value = Rails.application.config.primer_view_components.force_system_arguments
-      Rails.application.config.primer_view_components.force_system_arguments = new_value
+    def with_raise_on_invalid_options(new_value)
+      old_value = Rails.application.config.primer_view_components.raise_on_invalid_options
+      Rails.application.config.primer_view_components.raise_on_invalid_options = new_value
       yield
     ensure
-      Rails.application.config.primer_view_components.force_system_arguments = old_value
+      Rails.application.config.primer_view_components.raise_on_invalid_options = old_value
     end
 
     def with_silence_deprecations(new_value)


### PR DESCRIPTION
# Motivation

After discussion around [adding a warning for users sending ignored :tag parameters](https://github.com/primer/view_components/issues/656) it was decided that we should change `force_system_arguments` to `raise_on_invalid_options` to better reflect the functionality that this setting now represents.