### PR TITLE
Sort ADRs when generating nav.yml to make it consistent

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -312,7 +312,7 @@ namespace :docs do
     FileUtils.rm_rf(File.join(adr_content_dir))
     FileUtils.mkdir(adr_content_dir)
 
-    nav_entries = Dir[File.join(*%w[adr *.md])].map do |orig_path|
+    nav_entries = Dir[File.join(*%w[adr *.md])].sort.map do |orig_path|
       orig_file_name = File.basename(orig_path)
       url_name = orig_file_name.chomp(".md")
       title = ActiveSupport::Inflector.titleize(url_name.sub(/\A\d+-/, ""))


### PR DESCRIPTION
When running `docs:build` rake task I was seeing changes to `nav.yml`, which the CI check reverted back. This was probably happening because the files were being loaded in a different order.
Sorting the ADR files before generating `nav.yml` should make it always output the same thing