### PR TITLE
Add script to make running test easier

### DIFF
--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -44,9 +44,14 @@ system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
 
 ## Testing
 
-Before running the whole test suite with Rake: `bundle exec rake`, you must run `bundle exec rake docs:preview`.
+Before running the whole test suite with: `script/test`, you must run `bundle exec rake docs:preview`.
 
-Run a subset of tests by supplying a file glob to the test command: `TESTS="test/components/YOUR_COMPONENT_test.rb" bundle exec rake`
+Run a subset of tests by supplying arguments to `script/test`:
+
+1. `script/test FILE` runs all tests in the file.
+1. `script/test FILE:LINE` runs test in specific line of the file.
+1. `script/test 'GLOB'` runs all tests for matching glob.
+    * make sure to wrap the `GLOB` in single quotes `''`.
 
 ### System tests
 

--- a/script/test
+++ b/script/test
@@ -1,0 +1,26 @@
+#!/bin/bash
+#/ Usage: script/test <filename:test_line>
+#/ 1. `script/test FILE` runs all tests in the file.
+#/ 1. `script/test FILE:LINE` runs test in specific line of the file.
+#/ 1. `script/test 'GLOB'` runs all tests for matching glob.
+#/     * make sure to wrap the `GLOB` in single quotes `''`.
+
+if ! [ $# -eq 0 ]; then
+  export TEST=$(echo "$1" | cut -d ":" -f 1)
+
+  if [[ "$1" == *":"* ]]; then
+    LINE=$(echo "$1" | cut -d ":" -f 2)
+    LINE=$(head -n $LINE $TEST | tail -1)
+    NAME=$(echo "$LINE" | sed "s/.*def //")
+
+    if ! [[ "$NAME" == "test_"* ]]; then
+      echo
+      echo "ERROR: Line provided does not define a test case"
+      exit 1
+    fi
+
+    export TESTOPTS="--name=$NAME"
+  fi
+fi
+
+bundle exec rake


### PR DESCRIPTION
I find myself wanting to run single tests and writing `TEST=filename TESTOPTS="--name=test_name"` is super annoying, so I'm introducing a script to make it more user friendly.
Instructions:

1. `script/test FILE` runs all tests in the file.
1. `script/test FILE:LINE` runs test in specific line of the file.
1. `script/test 'GLOB'` runs all tests for matching glob.
    * make sure to wrap the `GLOB` in single quotes `''`.