### PR TITLE
Fix link to JS installation instructions

### DIFF
--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -105,11 +105,11 @@ To minimize the number of restarts, we recommend checking the component in Story
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 
-- Write tests.
-- Write [YARD comments](https://yardoc.org/) for component and slot initializers. Please document the purpose and general use of new components or slots you add, as well as the parameters they accept. See for example the comment style in app/components/primer/counter_component.rb.
-- Add new components to the `components` list in Rakefile in the `docs:build` task, so that Markdown documentation is generated for them within docs/content/components/.
-- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
-- Write a descriptive pull request message.
+* Write tests.
+* Write [YARD comments](https://yardoc.org/) for component and slot initializers. Please document the purpose and general use of new components or slots you add, as well as the parameters they accept. See for example the comment style in app/components/primer/counter_component.rb.
+* Add new components to the `components` list in Rakefile in the `docs:build` task, so that Markdown documentation is generated for them within docs/content/components/.
+* Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+* Write a descriptive pull request message.
 
 ## Deploying to Heroku
 

--- a/docs/src/@primer/gatsby-theme-doctocat/components/requires-js-flash.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/requires-js-flash.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import {Link} from 'gatsby'
-import {Flash} from '@primer/components'
+import Note from '@primer/gatsby-theme-doctocat/src/components/note'
 
 function RequiresJSFlash() {
   return (
-    <Flash mb={3}>
+    <Note>
       This component requires JavaScript to function. Please refer to the{' '}
       <Link to="/#installation">Installation section</Link> to set it up.
-    </Flash>
+    </Note>
   )
 }
 

--- a/docs/src/@primer/gatsby-theme-doctocat/components/requires-js-flash.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/requires-js-flash.js
@@ -1,10 +1,12 @@
 import React from 'react'
-import {Flash, Link} from '@primer/components'
+import {Link} from 'gatsby'
+import {Flash} from '@primer/components'
 
 function RequiresJSFlash() {
   return (
     <Flash mb={3}>
-      This component requires JavaScript to function. Please refer to the <Link href="/#installation">Installation section</Link> to set it up.
+      This component requires JavaScript to function. Please refer to the{' '}
+      <Link to="/#installation">Installation section</Link> to set it up.
     </Flash>
   )
 }


### PR DESCRIPTION
I've been trying to figure out why the 'Please refer to the Installation section to set it up' link on primer.style doesn't work, and through that discovered how the documentation site fits together all the separate mini doc sites!

## Tests

- [x] Locally - Link to JS instructions on Autocomplete page goes to `/#installation`
- [x] Vercel preview - Link to JS instructions on Autocomplete page goes to `/view-components/#installation`