### PR TITLE
Deprecate button `variant` in favor of `size`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Deprecations
 
-* Deprecate `variant` in favor of `size` in `ButtonComponent`.
+* Deprecate `variant` in favor of `size` in `ButtonComponent` and `ButtonGroup`.
 
     *Manuel Puyol*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Deprecations
+
+* Deprecate `variant` in favor of `size` in `ButtonComponent`.
+
+    *Manuel Puyol*
+
 ## 0.0.63
 
 ### Breaking Changes

--- a/app/components/primer/beta/blankslate.rb
+++ b/app/components/primer/beta/blankslate.rb
@@ -81,7 +81,7 @@ module Primer
         system_arguments[:tag] = :a
         system_arguments[:href] = href
         system_arguments[:mt] = 5
-        system_arguments[:variant] = :medium
+        system_arguments[:size] = :medium
         system_arguments[:scheme] ||= :primary
 
         Primer::ButtonComponent.new(**system_arguments)

--- a/app/components/primer/button_component.html.erb
+++ b/app/components/primer/button_component.html.erb
@@ -1,3 +1,3 @@
 <%= render Primer::BaseButton.new(**@system_arguments) do -%>
-  <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", mr: -1) if @dropdown %>
+  <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", ml: 2, mr: -1) if @dropdown %>
 <% end -%>

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -17,12 +17,12 @@ module Primer
     }.freeze
     SCHEME_OPTIONS = SCHEME_MAPPINGS.keys
 
-    DEFAULT_VARIANT = :medium
-    VARIANT_MAPPINGS = {
+    DEFAULT_SIZE = :medium
+    SIZE_MAPPINGS = {
       :small => "btn-sm",
-      DEFAULT_VARIANT => ""
+      DEFAULT_SIZE => ""
     }.freeze
-    VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
+    SIZE_OPTIONS = SIZE_MAPPINGS.keys
 
     # Leading visuals appear to the left of the button text.
     #
@@ -64,9 +64,9 @@ module Primer
     #   <%= render(Primer::ButtonComponent.new(scheme: :invisible)) { "Invisible" } %>
     #   <%= render(Primer::ButtonComponent.new(scheme: :link)) { "Link" } %>
     #
-    # @example Variants
-    #   <%= render(Primer::ButtonComponent.new(variant: :small)) { "Small" } %>
-    #   <%= render(Primer::ButtonComponent.new(variant: :medium)) { "Medium" } %>
+    # @example Sizes
+    #   <%= render(Primer::ButtonComponent.new(size: :small)) { "Small" } %>
+    #   <%= render(Primer::ButtonComponent.new(size: :medium)) { "Medium" } %>
     #
     # @example Block
     #   <%= render(Primer::ButtonComponent.new(block: :true)) { "Block" } %>
@@ -97,7 +97,8 @@ module Primer
     #   <% end %>
     #
     # @param scheme [Symbol] <%= one_of(Primer::ButtonComponent::SCHEME_OPTIONS) %>
-    # @param variant [Symbol] <%= one_of(Primer::ButtonComponent::VARIANT_OPTIONS) %>
+    # @param variant [Symbol] DEPRECATED. <%= one_of(Primer::ButtonComponent::SIZE_OPTIONS) %>
+    # @param size [Symbol] <%= one_of(Primer::ButtonComponent::SIZE_OPTIONS) %>
     # @param tag [Symbol] (Primer::BaseButton::DEFAULT_TAG) <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
     # @param type [Symbol] (Primer::BaseButton::DEFAULT_TYPE) <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
     # @param group_item [Boolean] Whether button is part of a ButtonGroup.
@@ -106,7 +107,8 @@ module Primer
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(
       scheme: DEFAULT_SCHEME,
-      variant: DEFAULT_VARIANT,
+      variant: nil,
+      size: DEFAULT_SIZE,
       group_item: false,
       block: false,
       dropdown: false,
@@ -119,7 +121,7 @@ module Primer
       @system_arguments[:classes] = class_names(
         system_arguments[:classes],
         SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)],
-        VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)],
+        SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, variant || size, DEFAULT_SIZE)],
         "btn" => !link?,
         "btn-block" => block,
         "BtnGroup-item" => group_item

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -7,10 +7,10 @@ module Primer
 
     # Required list of buttons to be rendered.
     #
-    # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::ButtonComponent) %> except for `variant` and `group_item`.
+    # @param kwargs [Hash] The same arguments as <%= link_to_component(Primer::ButtonComponent) %> except for `size` and `group_item`.
     renders_many :buttons, lambda { |**kwargs|
       kwargs[:group_item] = true
-      kwargs[:variant] = @variant
+      kwargs[:size] = @size
 
       Primer::ButtonComponent.new(**kwargs)
     }
@@ -25,19 +25,20 @@ module Primer
     #     <% component.button(classes: "custom-class") { "Custom class" } %>
     #   <% end %>
     #
-    # @example Variants
+    # @example Sizes
     #
-    #   <%= render(Primer::ButtonGroup.new(variant: :small)) do |component| %>
+    #   <%= render(Primer::ButtonGroup.new(size: :small)) do |component| %>
     #     <% component.button { "Default" } %>
     #     <% component.button(scheme: :primary) { "Primary" } %>
     #     <% component.button(scheme: :danger) { "Danger" } %>
     #     <% component.button(scheme: :outline) { "Outline" } %>
     #   <% end %>
     #
-    # @param variant [Symbol] <%= one_of(Primer::ButtonComponent::VARIANT_OPTIONS) %>
+    # @param variant [Symbol] DEPRECATED. <%= one_of(Primer::ButtonComponent::SIZE_OPTIONS) %>
+    # @param size [Symbol] <%= one_of(Primer::ButtonComponent::SIZE_OPTIONS) %>
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-    def initialize(variant: Primer::ButtonComponent::DEFAULT_VARIANT, **system_arguments)
-      @variant = variant
+    def initialize(variant: nil, size: Primer::ButtonComponent::DEFAULT_SIZE, **system_arguments)
+      @size = variant || size
       @system_arguments = deny_tag_argument(**system_arguments)
       @system_arguments[:tag] = :div
 

--- a/app/components/primer/dropdown.rb
+++ b/app/components/primer/dropdown.rb
@@ -88,7 +88,7 @@ module Primer
     #
     # @example Customizing the button
     #   <%= render(Primer::Dropdown.new) do |c| %>
-    #     <% c.button(scheme: :primary, variant: :small) do %>
+    #     <% c.button(scheme: :primary, size: :small) do %>
     #       Dropdown
     #     <% end %>
     #

--- a/app/components/primer/flash_component.rb
+++ b/app/components/primer/flash_component.rb
@@ -42,7 +42,7 @@ module Primer
     #   <%= render(Primer::FlashComponent.new) do |component| %>
     #     This is a flash message with actions!
     #     <% component.action do %>
-    #       <%= render(Primer::ButtonComponent.new(variant: :small)) { "Take action" } %>
+    #       <%= render(Primer::ButtonComponent.new(size: :small)) { "Take action" } %>
     #     <% end %>
     #   <% end %>
     #

--- a/docs/content/components/button.md
+++ b/docs/content/components/button.md
@@ -17,7 +17,8 @@ Use `Button` for actions (e.g. in forms). Use links for destinations, or moving 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
 | `scheme` | `Symbol` | `:default` | One of `:danger`, `:default`, `:invisible`, `:link`, `:outline`, or `:primary`. |
-| `variant` | `Symbol` | `:medium` | One of `:medium` and `:small`. |
+| `variant` | `Symbol` | `nil` | DEPRECATED. One of `:medium` and `:small`. |
+| `size` | `Symbol` | `:medium` | One of `:medium` and `:small`. |
 | `tag` | `Symbol` | `:button` | One of `:a`, `:button`, or `:summary`. |
 | `type` | `Symbol` | `:button` | One of `:button`, `:reset`, or `:submit`. |
 | `group_item` | `Boolean` | `false` | Whether button is part of a ButtonGroup. |
@@ -66,13 +67,13 @@ Use:
 <%= render(Primer::ButtonComponent.new(scheme: :link)) { "Link" } %>
 ```
 
-### Variants
+### Sizes
 
 <Example src="<button type='button' data-view-component='true' class='btn-sm btn'>  Small</button><button type='button' data-view-component='true' class='btn'>  Medium</button>" />
 
 ```erb
-<%= render(Primer::ButtonComponent.new(variant: :small)) { "Small" } %>
-<%= render(Primer::ButtonComponent.new(variant: :medium)) { "Medium" } %>
+<%= render(Primer::ButtonComponent.new(size: :small)) { "Small" } %>
+<%= render(Primer::ButtonComponent.new(size: :medium)) { "Medium" } %>
 ```
 
 ### Block
@@ -120,7 +121,7 @@ Use:
 
 ### With dropdown caret
 
-<Example src="<button type='button' data-view-component='true' class='btn'>  Button<svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-triangle-down mr-n1'>    <path d='M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z'></path></svg></button>" />
+<Example src="<button type='button' data-view-component='true' class='btn'>  Button<svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-triangle-down ml-2 mr-n1'>    <path d='M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z'></path></svg></button>" />
 
 ```erb
 <%= render(Primer::ButtonComponent.new(dropdown: true)) do %>

--- a/docs/content/components/buttongroup.md
+++ b/docs/content/components/buttongroup.md
@@ -16,7 +16,8 @@ Use `ButtonGroup` to render a series of buttons.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `variant` | `Symbol` | `:medium` | One of `:medium` and `:small`. |
+| `variant` | `Symbol` | `nil` | DEPRECATED. One of `:medium` and `:small`. |
+| `size` | `Symbol` | `:medium` | One of `:medium` and `:small`. |
 | `system_arguments` | `Hash` | N/A | [System arguments](/system-arguments) |
 
 ## Slots
@@ -27,7 +28,7 @@ Required list of buttons to be rendered.
 
 | Name | Type | Default | Description |
 | :- | :- | :- | :- |
-| `kwargs` | `Hash` | N/A | The same arguments as [Button](/components/button) except for `variant` and `group_item`. |
+| `kwargs` | `Hash` | N/A | The same arguments as [Button](/components/button) except for `size` and `group_item`. |
 
 ## Examples
 
@@ -46,13 +47,13 @@ Required list of buttons to be rendered.
 <% end %>
 ```
 
-### Variants
+### Sizes
 
 <Example src="<div data-view-component='true' class='BtnGroup'>    <button type='button' data-view-component='true' class='btn-sm btn BtnGroup-item'>  Default</button>    <button type='button' data-view-component='true' class='btn-primary btn-sm btn BtnGroup-item'>  Primary</button>    <button type='button' data-view-component='true' class='btn-danger btn-sm btn BtnGroup-item'>  Danger</button>    <button type='button' data-view-component='true' class='btn-outline btn-sm btn BtnGroup-item'>  Outline</button></div>" />
 
 ```erb
 
-<%= render(Primer::ButtonGroup.new(variant: :small)) do |component| %>
+<%= render(Primer::ButtonGroup.new(size: :small)) do |component| %>
   <% component.button { "Default" } %>
   <% component.button(scheme: :primary) { "Primary" } %>
   <% component.button(scheme: :danger) { "Danger" } %>

--- a/docs/content/components/dropdown.md
+++ b/docs/content/components/dropdown.md
@@ -109,7 +109,7 @@ Dividers can be used to separate a group of items. They don't have any content.
 
 ### With caret
 
-<Example src="<details data-view-component='true' class='dropdown details-overlay details-reset'>  <summary role='button' data-view-component='true' class='btn'>  Dropdown<svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-triangle-down mr-n1'>    <path d='M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z'></path></svg></summary>  <div data-view-component='true'>    <details-menu role='menu' data-view-component='true' class='dropdown-menu dropdown-menu-se'>    <div class='dropdown-header'>      Options    </div>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 1</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 2</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 3</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 4</a></details-menu></div></details>" />
+<Example src="<details data-view-component='true' class='dropdown details-overlay details-reset'>  <summary role='button' data-view-component='true' class='btn'>  Dropdown<svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-triangle-down ml-2 mr-n1'>    <path d='M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z'></path></svg></summary>  <div data-view-component='true'>    <details-menu role='menu' data-view-component='true' class='dropdown-menu dropdown-menu-se'>    <div class='dropdown-header'>      Options    </div>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 1</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 2</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 3</a>      <a role='menuitem' data-view-component='true' class='dropdown-item'>Item 4</a></details-menu></div></details>" />
 
 ```erb
 <%= render(Primer::Dropdown.new(with_caret: true)) do |c| %>
@@ -132,7 +132,7 @@ Dividers can be used to separate a group of items. They don't have any content.
 
 ```erb
 <%= render(Primer::Dropdown.new) do |c| %>
-  <% c.button(scheme: :primary, variant: :small) do %>
+  <% c.button(scheme: :primary, size: :small) do %>
     Dropdown
   <% end %>
 

--- a/docs/content/components/flash.md
+++ b/docs/content/components/flash.md
@@ -78,7 +78,7 @@ Optional action content showed on the right side of the component.
 <%= render(Primer::FlashComponent.new) do |component| %>
   This is a flash message with actions!
   <% component.action do %>
-    <%= render(Primer::ButtonComponent.new(variant: :small)) { "Take action" } %>
+    <%= render(Primer::ButtonComponent.new(size: :small)) { "Take action" } %>
   <% end %>
 <% end %>
 ```

--- a/lib/primer/view_components/linters/argument_mappers/button.rb
+++ b/lib/primer/view_components/linters/argument_mappers/button.rb
@@ -13,9 +13,9 @@ module ERBLint
           symbolize: true
         ).freeze
 
-        VARIANT_MAPPINGS = Primer::ViewComponents::Constants.get(
+        SIZE_MAPPINGS = Primer::ViewComponents::Constants.get(
           component: "Primer::ButtonComponent",
-          constant: "VARIANT_MAPPINGS",
+          constant: "SIZE_MAPPINGS",
           symbolize: true
         ).freeze
 
@@ -55,8 +55,8 @@ module ERBLint
 
             if SCHEME_MAPPINGS[class_name] && acc[:scheme].nil?
               acc[:scheme] = SCHEME_MAPPINGS[class_name]
-            elsif VARIANT_MAPPINGS[class_name] && acc[:variant].nil?
-              acc[:variant] = VARIANT_MAPPINGS[class_name]
+            elsif SIZE_MAPPINGS[class_name] && acc[:size].nil?
+              acc[:size] = SIZE_MAPPINGS[class_name]
             elsif class_name == "btn-block"
               acc[:block] = true
             elsif class_name == "BtnGroup-item"

--- a/lib/rubocop/cop/primer/deprecated_button_arguments.rb
+++ b/lib/rubocop/cop/primer/deprecated_button_arguments.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+# :nocov:
+module RuboCop
+  module Cop
+    module Primer
+      # This cop ensures that `ButtonComponent` doesn't use deprecated arguments.
+      #
+      # bad
+      # ButtonComponent.new(variant: :small)
+      #
+      # good
+      # ButtonComponent.new(size: :small)
+      class DeprecatedButtonArguments < BaseCop
+        INVALID_MESSAGE = <<~STR
+          `variant` is deprecated. Use `size` instead.
+        STR
+
+        def_node_matcher :button_component?, <<~PATTERN
+          (send (const (const nil? :Primer) :ButtonComponent) :new ...)
+        PATTERN
+
+        DEPRECATIONS = {
+          variant: :size
+        }.freeze
+
+        def on_send(node)
+          return unless button_component?(node)
+
+          kwargs = node.arguments.last
+
+          return if kwargs.nil?
+
+          pair = kwargs.pairs.find { |x| x.key.value == :variant }
+
+          return if pair.nil?
+
+          add_offense(pair.key, message: INVALID_MESSAGE)
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(node, DEPRECATIONS[node.value])
+          end
+        end
+      end
+    end
+  end
+end

--- a/static/arguments.yml
+++ b/static/arguments.yml
@@ -325,6 +325,10 @@
       or `:primary`.
   - name: variant
     type: Symbol
+    default: "`nil`"
+    description: DEPRECATED. One of `:medium` and `:small`.
+  - name: size
+    type: Symbol
     default: "`:medium`"
     description: One of `:medium` and `:small`.
   - name: tag
@@ -355,6 +359,10 @@
   source: https://github.com/primer/view_components/tree/main/app/components/primer/button_group.rb
   parameters:
   - name: variant
+    type: Symbol
+    default: "`nil`"
+    description: DEPRECATED. One of `:medium` and `:small`.
+  - name: size
     type: Symbol
     default: "`:medium`"
     description: One of `:medium` and `:small`.

--- a/static/constants.json
+++ b/static/constants.json
@@ -279,7 +279,7 @@
   },
   "Primer::ButtonComponent": {
     "DEFAULT_SCHEME": "default",
-    "DEFAULT_VARIANT": "medium",
+    "DEFAULT_SIZE": "medium",
     "LINK_SCHEME": "link",
     "SCHEME_MAPPINGS": {
       "default": "",
@@ -297,11 +297,11 @@
       "invisible",
       "link"
     ],
-    "VARIANT_MAPPINGS": {
+    "SIZE_MAPPINGS": {
       "small": "btn-sm",
       "medium": ""
     },
-    "VARIANT_OPTIONS": [
+    "SIZE_OPTIONS": [
       "small",
       "medium"
     ]

--- a/stories/primer/button_component_stories.rb
+++ b/stories/primer/button_component_stories.rb
@@ -6,7 +6,7 @@ class Primer::ButtonComponentStories < ViewComponent::Storybook::Stories
   story(:button) do
     controls do
       select(:scheme, Primer::ButtonComponent::SCHEME_OPTIONS, :primary)
-      select(:variant, Primer::ButtonComponent::VARIANT_OPTIONS, :medium)
+      select(:size, Primer::ButtonComponent::SIZE_OPTIONS, :medium)
       select(:tag, Primer::BaseButton::TAG_OPTIONS, :button)
       select(:type, Primer::BaseButton::TYPE_OPTIONS, :button)
       group_item false
@@ -22,7 +22,7 @@ class Primer::ButtonComponentStories < ViewComponent::Storybook::Stories
   story(:with_leading_visual) do
     controls do
       select(:scheme, Primer::ButtonComponent::SCHEME_OPTIONS, :primary)
-      select(:variant, Primer::ButtonComponent::VARIANT_OPTIONS, :medium)
+      select(:size, Primer::ButtonComponent::SIZE_OPTIONS, :medium)
       select(:tag, Primer::BaseButton::TAG_OPTIONS, :button)
       select(:type, Primer::BaseButton::TYPE_OPTIONS, :button)
       group_item false
@@ -39,7 +39,7 @@ class Primer::ButtonComponentStories < ViewComponent::Storybook::Stories
   story(:with_trailing_visual) do
     controls do
       select(:scheme, Primer::ButtonComponent::SCHEME_OPTIONS, :primary)
-      select(:variant, Primer::ButtonComponent::VARIANT_OPTIONS, :medium)
+      select(:size, Primer::ButtonComponent::SIZE_OPTIONS, :medium)
       select(:tag, Primer::BaseButton::TAG_OPTIONS, :button)
       select(:type, Primer::BaseButton::TYPE_OPTIONS, :button)
       group_item false
@@ -56,7 +56,7 @@ class Primer::ButtonComponentStories < ViewComponent::Storybook::Stories
   story(:full) do
     controls do
       select(:scheme, Primer::ButtonComponent::SCHEME_OPTIONS, :primary)
-      select(:variant, Primer::ButtonComponent::VARIANT_OPTIONS, :medium)
+      select(:size, Primer::ButtonComponent::SIZE_OPTIONS, :medium)
       select(:tag, Primer::BaseButton::TAG_OPTIONS, :button)
       select(:type, Primer::BaseButton::TYPE_OPTIONS, :button)
       group_item false

--- a/stories/primer/button_group_stories.rb
+++ b/stories/primer/button_group_stories.rb
@@ -5,7 +5,7 @@ class Primer::ButtonGroupStories < ViewComponent::Storybook::Stories
 
   story(:button_group) do
     controls do
-      select(:variant, Primer::ButtonComponent::VARIANT_OPTIONS, :medium)
+      select(:size, Primer::ButtonComponent::SIZE_OPTIONS, :medium)
     end
 
     content do |c|

--- a/stories/primer/details_component_stories.rb
+++ b/stories/primer/details_component_stories.rb
@@ -21,7 +21,7 @@ class Primer::DetailsComponentStories < ViewComponent::Storybook::Stories
     end
 
     content do |component|
-      component.summary(variant: :small, scheme: :primary) { "Click me" }
+      component.summary(size: :small, scheme: :primary) { "Click me" }
       component.body { "Body" }
     end
   end

--- a/test/components/button_component_test.rb
+++ b/test/components/button_component_test.rb
@@ -59,15 +59,21 @@ class PrimerButtonComponentTest < Minitest::Test
     assert_selector(".btn.btn-primary")
   end
 
-  def test_falls_back_when_variant_isn_t_valid
+  def test_falls_back_when_size_isn_t_valid
     without_fetch_or_fallback_raises do
-      render_inline(Primer::ButtonComponent.new(variant: :invalid)) { "content" }
+      render_inline(Primer::ButtonComponent.new(size: :invalid)) { "content" }
 
       assert_selector(".btn")
     end
   end
 
-  def test_renders_with_the_css_class_variant_mapping_to_the_provided_variant
+  def test_renders_with_the_css_class_size_mapping_to_the_provided_size
+    render_inline(Primer::ButtonComponent.new(size: :small)) { "content" }
+
+    assert_selector(".btn.btn-sm")
+  end
+
+  def test_renders_with_the_css_class_size_mapping_to_the_provided_variant
     render_inline(Primer::ButtonComponent.new(variant: :small)) { "content" }
 
     assert_selector(".btn.btn-sm")

--- a/test/components/button_component_test.rb
+++ b/test/components/button_component_test.rb
@@ -74,6 +74,7 @@ class PrimerButtonComponentTest < Minitest::Test
   end
 
   def test_renders_with_the_css_class_size_mapping_to_the_provided_variant
+    # rubocop:disable Primer/DeprecatedButtonArguments
     render_inline(Primer::ButtonComponent.new(variant: :small)) { "content" }
 
     assert_selector(".btn.btn-sm")

--- a/test/components/button_component_test.rb
+++ b/test/components/button_component_test.rb
@@ -74,8 +74,7 @@ class PrimerButtonComponentTest < Minitest::Test
   end
 
   def test_renders_with_the_css_class_size_mapping_to_the_provided_variant
-    # rubocop:disable Primer/DeprecatedButtonArguments
-    render_inline(Primer::ButtonComponent.new(variant: :small)) { "content" }
+    render_inline(Primer::ButtonComponent.new(variant: :small)) { "content" } # rubocop:disable Primer/DeprecatedButtonArguments
 
     assert_selector(".btn.btn-sm")
   end

--- a/test/components/button_group_test.rb
+++ b/test/components/button_group_test.rb
@@ -43,9 +43,19 @@ class PrimerButtonGroupTest < Minitest::Test
     refute_text("content")
   end
 
+  def test_all_buttons_with_same_size
+    render_inline(Primer::ButtonGroup.new(size: :small)) do |c|
+      c.button(size: :medium) { "Medium" }
+    end
+
+    assert_selector("div.BtnGroup") do
+      assert_selector("button.btn.BtnGroup-item.btn-sm", text: "Medium")
+    end
+  end
+
   def test_all_buttons_with_same_variant
     render_inline(Primer::ButtonGroup.new(variant: :small)) do |c|
-      c.button(variant: :medium) { "Medium" }
+      c.button(size: :medium) { "Medium" }
     end
 
     assert_selector("div.BtnGroup") do

--- a/test/components/details_component_test.rb
+++ b/test/components/details_component_test.rb
@@ -97,7 +97,7 @@ class PrimerDetailsComponentTest < Minitest::Test
 
   def test_passes_props_to_button
     render_inline(Primer::DetailsComponent.new) do |component|
-      component.summary(variant: :small, scheme: :primary) do
+      component.summary(size: :small, scheme: :primary) do
         "Summary"
       end
       component.body do

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -42,14 +42,14 @@ class ArgumentMappersButtonTest < LinterTestCase
     end
   end
 
-  def test_returns_variant_argument
-    Primer::ButtonComponent::VARIANT_MAPPINGS.each do |value, class_name|
+  def test_returns_size_argument
+    Primer::ButtonComponent::SIZE_MAPPINGS.each do |value, class_name|
       next if class_name.blank?
 
       @file = "<button class=\"#{class_name}\">Button</button>"
       args = ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
 
-      assert_equal({ variant: ":#{value}" }, args)
+      assert_equal({ size: ":#{value}" }, args)
     end
   end
 
@@ -132,7 +132,7 @@ class ArgumentMappersButtonTest < LinterTestCase
 
     assert_equal({
                    scheme: ":primary",
-                   variant: ":small",
+                   size: ":small",
                    block: true,
                    group_item: true,
                    mr: 1,

--- a/test/linters/button_component_migration_counter_test.rb
+++ b/test/linters/button_component_migration_counter_test.rb
@@ -24,7 +24,7 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
     @file = "<button class=\"btn btn-sm btn-primary\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(variant: :small, scheme: :primary)")
+    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(size: :small, scheme: :primary)")
   end
 
   def test_suggests_how_to_use_the_component_as_link
@@ -84,7 +84,7 @@ class ButtonComponentMigrationCounterTest < LinterTestCase
           <%= render Primer::ButtonComponent.new(scheme: :outline) do %>
             button 3
             <a>not a button</a>
-            <%= render Primer::ButtonComponent.new(tag: :summary, variant: :small) do %>
+            <%= render Primer::ButtonComponent.new(tag: :summary, size: :small) do %>
               summary
               <%= render Primer::ButtonComponent.new(tag: :a, test_selector: "test selector") do %>
                 a

--- a/test/rubocop/deprecated_button_arguments_test.rb
+++ b/test/rubocop/deprecated_button_arguments_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "cop_test"
+
+class RubocopDeprecatedButtonArgumentsTest < CopTest
+  def cop_class
+    RuboCop::Cop::Primer::DeprecatedButtonArguments
+  end
+
+  def test_no_deprecated_arguments
+    investigate(cop, <<-RUBY)
+      Primer::ButtonComponent.new(scheme: :danger)
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_using_variant
+    investigate(cop, <<-RUBY)
+      Primer::ButtonComponent.new(variant: :small)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Primer::ButtonComponent.new(size: :small)", cop.offenses.first.corrector.rewrite.strip
+  end
+end


### PR DESCRIPTION
`size` is **not** an HTML attribute for `<button>` so it should be fine to have a `size` argument in the component.
Here, I'm deprecating `variant` instead of removing it so we can have more time to migrate buttons in dotcom. I'm also adding a new linter to migrate deprecated arguments