### PR TITLE
Contributor documentation - setup, adding components, releasing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+contributor-docs/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+
+If you have any substantial changes that you would like to make, please [open an issue](issues/new) to start a discussion.
+
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.txt).
+
+Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+
+## Submitting a pull request
+
+1. [Read through our extended contributor docs](./contributor-docs/) for information on setup and our development practices
+1. [Fork](fork) and clone the repository
+1. Create a new branch: `git switch -n your-username/your-feature`
+1. Make your change, add tests, and make sure all the tests still pass
+1. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading
+1. Push to your fork and [submit a pull request](compare)
+1. Pat yourself on the back and wait for your pull request to be reviewed and merged, after merging it will be included in the next release
+
+### PR tips
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+* Write a descriptive pull request message
+* Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent on one other consider submitting them as separate pull requests
+* Write comprehensive [documentation](./contributor-docs/documentation.md) and make sure the generated documentation is committed
+* Write thorough [tests](./contributor-docs/component-tests.md)

--- a/contributor-docs/README.md
+++ b/contributor-docs/README.md
@@ -10,7 +10,7 @@ Please note that this project is released with a [Contributor Code of Conduct](C
 
 ## Submitting a pull request
 
-1. [Read through our extended contributor docs](./contributor-docs/) for information on setup and our development practices
+1. Read through the docs in this folder for information on setup and our development practices
 1. [Fork](fork) and clone the repository
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass

--- a/contributor-docs/adding-components.md
+++ b/contributor-docs/adding-components.md
@@ -1,0 +1,52 @@
+# Adding components
+
+## Criteria for adding a component
+
+We recommend building new Primer ViewComponents in an application that uses them first, upstreaming them when:
+
+- The Design Infrastructure team has approved the component for inclusion in Primer
+- The CSS for the component has been added in a release of Primer CSS
+- The component is used in production, using all proposed APIs and their permutations
+- The component is compatible with [System arguments](https://primer.style/view-components/system-arguments) as appropriate
+- The API is consistent with existing components
+
+### Component status
+
+We classify our components into alpha, beta and stable statuses. You can read more about these milestones in the [Primer’s component lifecycle](https://primer.style/contribute/component-lifecycle). In addition to the criteria listed there, to promote a Primer ViewComponent from alpha to beta it must not use any deprecated [view_component](https://viewcomponent.org/CHANGELOG.html) framework features, such as Slots v1.
+
+## Process for adding a component
+
+Use the following generator script to scaffold a new component:
+
+```bash
+bundle exec thor component_generator <component_name>
+```
+
+The generator script has several flags:
+
+- `status` can be `alpha`, `beta` or `stable` (defaults to `alpha`)
+- `inline` creates a `#call` method instead of generating an ERB template
+- `js` can be passed the name of an npm package dependency
+
+### Generated files
+
+Running the component generator script creates several files across the codebase:
+
+- `app/components/<status>/<component_name>.rb` is where the component logic is defined, and where you’ll write the component’s [documentation] in the form of YARD comments
+  - [Read about writing documents with YARD comments](./documentation.md#yard-setup)
+- `app/components/<status>/<component_name>.html.erb` is the component’s template file (omitted if the `inline` flag is passed to the generator)
+- `stories/primer/<status>/<component_name>.rb` defines the Storybook stories for the component
+  - [Read about writing stories](./documentation.md#writing-storybook-stories)
+- `test/components/primer/<status>/<component_name>.rb` contains the component’s unit tests
+  - [Read about writing component tests](./component-tests.md)
+
+If the `js` flag is passed in it will create some extra files:
+
+- `app/components/<status>/<component_name>.ts` contains the imports for any specified npm dependencies
+- `test/system/<status>/<component_name>.rb` contains the component’s system tests
+- `demo/test/components/preview/primer/<status>/<component_name>_preview.rb` contains the component’s preview tests
+
+The script also edits some files:
+
+- The component is added to the list of components in `lib/tasks/docs.rake` and `test/component/component_test.rb`, in the latter you need to add examples for all the required arguments of the component
+- The component is added to `docs/src/@primer/gatsby-theme-doctocat/nav.yml` which defines the sidebar structure of the documentation website, you need to reorder the item or delete it if you don’t want the component to be visible on the website

--- a/contributor-docs/releasing.md
+++ b/contributor-docs/releasing.md
@@ -1,0 +1,45 @@
+# Releasing
+
+## When to make a release
+
+All changes that effect library output should be documented in [the Changelog](https://github.com/primer/view_components/blob/main/CHANGELOG.md) as part of the pull request process, so when the `main` branch has changes that aren't released yet they will be documented under the 'main' title in the Changelog.
+
+We use [semver](https://semver.org/) for our release naming but we’re currently pre-v1 so every change is a patch release, and may contain breaking changes.
+
+It's preferable to group changes so we don't release a new version for every small change, but for fixes or urgent features it's okay to make releases for a small amount of changes.
+
+## Release process
+
+### Authentication
+
+Before publishing you need to authenticate with [npm](https://www.npmjs.com/) and [RubyGems](https://rubygems.org/).
+
+For [RubyGems](https://rubygems.org/) create an account with your personal email and set up two factor authentication. Ask an owner of the [`primer_view_components` gem](https://rubygems.org/gems/primer_view_components) to add you as a contributor, and then run `gem signin` to authenticate with the CLI.
+
+For [npm](https://www.npmjs.com/) create an account with your personal email and set up two factor authentication. Ask one of the collaborators on the [`@primer/view-components` package](https://www.npmjs.com/package/@primer/view-components) to add you to the Primer team, then run `npm adduser` to authenticate with the CLI. You can confirm your authentication with `npm whoami`.
+
+### Preparing a release
+
+Run `script/release` to prepare a release. This will check you're on the latest version of the `main` branch, bump the gem and npm package versions, tag the Changelog, and open a pull request with the changes. Even if no changes have been made to the JavaScript package we make a release anyway so the version numbers are always in sync. Once the tests have passed you can merge this pull request.
+
+### Publishing a release
+
+When the release pull request is merged into `main`, pull the changes and run `script/publish` to publish the library on rubygems and npm. This will also open a pre-filled release on GitHub, if you’re happy with the release notes hit ‘Publish’.
+
+## Revert plan
+
+If you’ve released a version of the library that introduces significant visual regressions or unintended breaking changes the best thing to do is make a new release which reverts the offending changes. Do not include any other unreleased changes besides the reverts, as they could have unintended side-effects.
+
+[Process TBC]
+
+## Docs deployment
+
+The documentation site is deployed to [primer.style/view-components](https://primer.style/view-components/) (aliased from [view-components.vercel.app](https://view-components.vercel.app/)) by a Vercel integration, it is automatically deployed with changes to `main`.
+
+## Storybook deployment
+
+Storybook is deployed manually using chatops to [primer.style/view-components/stories](https://primer.style/view-components/stories/) (aliased from [primer-view-components.herokuapp.com](https://primer-view-components.herokuapp.com/view-components/stories)). To deploy run the following in *#primer-rails-ops*:
+
+```text
+.deploy primer-view-components[/<branch>]
+```

--- a/contributor-docs/setup.md
+++ b/contributor-docs/setup.md
@@ -1,0 +1,19 @@
+# Setup
+
+The easiest way to get started contributing to Primer ViewComponents is with [Codespaces](https://github.com/features/codespaces), Codespace environments come fully set up for development.
+
+## Setup for local development
+
+1. Clone `git@github.com:primer/view_components.git`
+2. Install [Overmind](https://github.com/DarthSim/overmind) and [Yarn](https://classic.yarnpkg.com/lang/en/docs/install)
+3. Run `script/setup` to install dependencies
+4. Run `script/dev`, this will run the documentation site on [localhost:5400](localhost:5400) and Storybook on [localhost:5000](localhost:5000)
+
+## Running tests
+
+Before running tests make sure you run `bundle exec rake docs:preview`, this will build all the code examples used for accessibility and system tests.
+
+- `script/test` runs the full test suite
+- `script/test <file>` runs all the tests in one file
+- `script/test <file>:<line>` runs the test defined on the specified line of a file
+- `script/test '<glob>'` runs tests in all the files matching the glob


### PR DESCRIPTION
This adds new extended contributor internal documentation, following the structure of [this FigJam](https://www.figma.com/file/HYcitzh7y1LmLB5Tz4CnOQ/PVC-Documentation?node-id=0%3A1) as proposed in https://github.com/github/primer/issues/534.

I think the best workflow would be to merge this in at 80%, and then update [the public pages on primer.style](https://primer.style/view-components/) to point to it (and remove the old contributor docs) when we're happy with this content.

## To do

- [x] Setup
- [x] Adding components
- [x] Releasing

### In separate PRs

- [ ] Updating components
- [ ] Component tests
- [ ] Documentation
- [ ] Validating changes