### PR TITLE
Refactors selectors to args logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 ### Updates
 
 * Optimize logic for converting class names into args
+
     *Josh Klina*
 
 ### Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Updates
+
+* Optimize logic for converting class names into args
+    *Josh Klina*
+
 ### Deprecations
 
 * Deprecate `variant` in favor of `size` in `ButtonComponent` and `ButtonGroup`.

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -19,20 +19,6 @@ module Primer
 
       BREAKPOINTS = ["", "-sm", "-md", "-lg", "-xl"].freeze
 
-      # Replacements for some classnames that end up being a different argument key
-      REPLACEMENT_KEYS = {
-        "^anim" => "animation",
-        "^v-align" => "vertical_align",
-        "^d" => "display",
-        "^wb" => "word_break",
-        "^v" => "visibility",
-        "^width" => "w",
-        "^height" => "h",
-        "^color-bg" => "bg",
-        "^color-border" => "border_color",
-        "^color-fg" => "color"
-      }.freeze
-
       SUPPORTED_KEY_CACHE = Hash.new { |h, k| h[k] = !UTILITIES[k].nil? }
       BREAKPOINT_INDEX_CACHE = Hash.new { |h, k| h[k] = BREAKPOINTS.index(k) }
 
@@ -173,31 +159,14 @@ module Primer
         private
 
         def find_selector(selector)
-          key = infer_selector_key(selector)
-          value_hash = UTILITIES[key]
-
-          return nil if value_hash.blank?
-
-          # Each value hash will also contain an array of classnames for breakpoints
-          # Key argument `0`, classes `[ "mr-0", "mr-sm-0", "mr-md-0", "mr-lg-0", "mr-xl-0" ]`
-          value_hash.each do |key_argument, classnames|
-            # Skip each value hash until we get one with the selector
-            next unless classnames.include?(selector)
-
-            # Return [:mr, 0, 1]
-            # has index of classname, so we can match it up with responsive array `mr: [nil, 0]`
-            return [key, key_argument, classnames.index(selector)]
+          @selector_cache ||= UTILITIES.each_with_object({}) do |(keyword, argument_w_selectors), dict|
+            argument_w_selectors.each do |argument, selectors|
+              selectors.each_with_index do |css_selector, index|
+                dict[css_selector] = [keyword, argument, index]
+              end
+            end
           end
-
-          nil
-        end
-
-        def infer_selector_key(selector)
-          REPLACEMENT_KEYS.each do |k, v|
-            return v.to_sym if selector.match?(Regexp.new(k))
-          end
-
-          selector.split("-").first.to_sym
+          @selector_cache[selector]
         end
       end
     end

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -159,6 +159,7 @@ module Primer
         private
 
         def find_selector(selector)
+          # Build hash indexed on the selector for fast lookup.
           @selector_cache ||= UTILITIES.each_with_object({}) do |(keyword, argument_w_selectors), dict|
             argument_w_selectors.each do |argument, selectors|
               selectors.each_with_index do |css_selector, index|

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -5,7 +5,6 @@ namespace :utilities do
     require "yaml"
     require "json"
     require File.expand_path("./../../demo/config/environment.rb", __dir__)
-    require "primer/classify/utilities"
 
     # Keys that are looked for to be included in the utilities.yml file
     # rubocop:disable Lint/ConstantDefinitionInBlock
@@ -28,6 +27,20 @@ namespace :utilities do
       /^width\b/,
       /^v\b/
     ].freeze
+
+    # Replacements for some classnames that end up being a different argument key
+    REPLACEMENT_KEYS = {
+      "^anim" => "animation",
+      "^v-align" => "vertical_align",
+      "^d" => "display",
+      "^wb" => "word_break",
+      "^v" => "visibility",
+      "^width" => "w",
+      "^height" => "h",
+      "^color-bg" => "bg",
+      "^color-border" => "border_color",
+      "^color-fg" => "color"
+    }.freeze
 
     BREAKPOINTS = [nil, "sm", "md", "lg", "xl"].freeze
     # rubocop:enable Lint/ConstantDefinitionInBlock
@@ -67,7 +80,7 @@ namespace :utilities do
       key = ""
 
       # Look for a replacement key
-      Primer::Classify::Utilities::REPLACEMENT_KEYS.each do |k, v|
+      REPLACEMENT_KEYS.each do |k, v|
         next unless classname.match?(Regexp.new(k))
 
         key = v

--- a/test/linters/argument_mappers/base_test.rb
+++ b/test/linters/argument_mappers/base_test.rb
@@ -30,12 +30,12 @@ class ArgumentMappersBaseTest < LinterTestCase
   end
 
   def test_raises_if_a_class_cannot_be_converted
-    @file = '<div class="mr-1 p-3 d-none d-md-block anim-fade-in text-center"></div>'
+    @file = '<div class="mr-1 p-3 d-none d-md-block anim-fade-in text-fuzzy-waffle"></div>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Base.new(tags.first).to_s
     end
 
-    assert_equal("Cannot convert class text-center", err.message)
+    assert_equal("Cannot convert class text-fuzzy-waffle", err.message)
   end
 
   def test_returns_aria_arguments_as_string_symbols

--- a/test/linters/argument_mappers/button_test.rb
+++ b/test/linters/argument_mappers/button_test.rb
@@ -87,12 +87,12 @@ class ArgumentMappersButtonTest < LinterTestCase
   end
 
   def test_raises_if_cannot_map_class
-    @file = '<button class="text-center">Button</button>'
+    @file = '<button class="text-fuzzy-waffle">Button</button>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Button.new(tags.first).to_args
     end
 
-    assert_equal "Cannot convert class text-center", err.message
+    assert_equal "Cannot convert class text-fuzzy-waffle", err.message
   end
 
   def test_raises_if_cannot_map_attribute

--- a/test/linters/argument_mappers/flash_test.rb
+++ b/test/linters/argument_mappers/flash_test.rb
@@ -29,12 +29,12 @@ class ArgumentMappersFlashTest < LinterTestCase
   end
 
   def test_raises_if_cannot_map_class
-    @file = '<div class="text-center">flash</div>'
+    @file = '<div class="text-fuzzy-waffle">flash</div>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Flash.new(tags.first).to_args
     end
 
-    assert_equal "Cannot convert class text-center", err.message
+    assert_equal "Cannot convert class text-fuzzy-waffle", err.message
   end
 
   def test_complex_case

--- a/test/linters/argument_mappers/label_test.rb
+++ b/test/linters/argument_mappers/label_test.rb
@@ -52,12 +52,12 @@ class ArgumentMappersLabelTest < LinterTestCase
   end
 
   def test_raises_if_cannot_map_class
-    @file = '<span class="text-center">Label</span>'
+    @file = '<span class="text-fuzzy-waffle">Label</span>'
     err = assert_raises ERBLint::Linters::ArgumentMappers::ConversionError do
       ERBLint::Linters::ArgumentMappers::Label.new(tags.first).to_args
     end
 
-    assert_equal "Cannot convert class text-center", err.message
+    assert_equal "Cannot convert class text-fuzzy-waffle", err.message
   end
 
   def test_complex_case

--- a/test/linters/support/autocorrectable_linter_shared_tests.rb
+++ b/test/linters/support/autocorrectable_linter_shared_tests.rb
@@ -66,7 +66,7 @@ module Primer
 
     def test_ignores_if_cannot_convert_class
       @file = <<~HTML
-        <#{default_tag} class="#{default_class} text-center" #{required_attributes}>
+        <#{default_tag} class="#{default_class} text-fuzzy-waffle" #{required_attributes}>
           #{default_content}
         </#{default_tag}>
       HTML

--- a/test/rubocop/primer_octicon_test.rb
+++ b/test/rubocop/primer_octicon_test.rb
@@ -188,7 +188,7 @@ class RubocopPrimerOcticonTest < CopTest
 
   def test_octicon_with_class_that_cant_be_converted
     investigate(cop, <<-'RUBY')
-      octicon(:icon, class: "mr-1 text-center")
+      octicon(:icon, class: "mr-1 text-fuzzy-waffle")
     RUBY
 
     assert_empty cop.offenses


### PR DESCRIPTION
Now that all selectors are stored in utilities.yml, we can build a hash with selectors as keys and the arguments and positions as values. This will allow us to remove some specialized mapping rules and clean things up overall.

This also has the nice advantage of being about 25x faster:

```ruby
Benchmark.ips do |x|
  x.report do
    Primer::Classify::Utilities.classes_to_args("mr-1 mr-sm-2 baz bin")
  end
end
```

```
Before:

Warming up --------------------------------------
                         1.266k i/100ms
Calculating -------------------------------------
                         12.570k (± 9.2%) i/s -     63.300k in   5.085757s

After:

Warming up --------------------------------------
                        30.697k i/100ms
Calculating -------------------------------------
                        305.832k (± 5.1%) i/s -      1.535M in   5.033715s
```

I did a memory estimate using `ObjectSpace.memsize_of` and its reporting this hash uses `57440 bytes`, though I don't believe this is used in production. 