### PR TITLE
Trigger workflows on commit created by docs-build action

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:


### PR DESCRIPTION
Events triggered with the default token won't create a new workflow run,
but using the shared Primer token will trigger them.

We want to trigger all workflows when a commit is made for updating
the docs because otherwise it can leave PRs in a permanent waiting
state with required checks not being run. It also can disguise
a PR with failing checks.

Closes https://github.com/github/primer/issues/582

## Before merge

- [x] Remove last 2 commits