### PR TITLE
Fix path of generated system test previews

### DIFF
--- a/component_generator.thor
+++ b/component_generator.thor
@@ -37,7 +37,7 @@ class ComponentGenerator < Thor::Group
 
   def create_system_test
     template("templates/system_test.rb.tt", "test/system/#{status_path}#{underscore_name}_test.rb") if js_package_name
-    template("templates/#{status_template_path}system_test_preview.rb.tt", "test/components/previews/primer/#{status_path}#{underscore_name}_preview.rb") if js_package_name
+    template("templates/#{status_template_path}system_test_preview.rb.tt", "demo/test/components/previews/primer/#{status_path}#{underscore_name}_preview.rb") if js_package_name
   end
 
   def create_stories


### PR DESCRIPTION
[I noticed this while writing docs](https://github.com/primer/view_components/pull/946#discussion_r773293295), this matches [the folder structure of other system test preview files](https://github.com/primer/view_components/tree/v0.0.66/demo/test/components/previews/primer).