### PR TITLE
Fixes component-generator output when js packages added

### DIFF
--- a/component_generator.thor
+++ b/component_generator.thor
@@ -66,7 +66,7 @@ class ComponentGenerator < Thor::Group
   end
 
   def import_in_primer_ts
-    append_to_file("app/components/primer/primer.ts", "import './#{status_path}#{underscore_name}'") if js_package_name
+    append_to_file("app/components/primer/primer.ts", "import './#{status_path}#{underscore_name}'\n") if js_package_name
   end
 
   def install_js_package

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    primer_view_components (0.0.64)
+    primer_view_components (0.0.66)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (~> 15)

--- a/static/constants.json
+++ b/static/constants.json
@@ -354,8 +354,7 @@
     }
   },
   "Primer::Dropdown": {
-    "Menu": "Primer::Dropdown::Menu",
-    "MenuTest": "Primer::Dropdown::MenuTest"
+    "Menu": "Primer::Dropdown::Menu"
   },
   "Primer::Dropdown::Menu": {
     "AS_DEFAULT": "default",

--- a/static/constants.json
+++ b/static/constants.json
@@ -354,7 +354,8 @@
     }
   },
   "Primer::Dropdown": {
-    "Menu": "Primer::Dropdown::Menu"
+    "Menu": "Primer::Dropdown::Menu",
+    "MenuTest": "Primer::Dropdown::MenuTest"
   },
   "Primer::Dropdown::Menu": {
     "AS_DEFAULT": "default",

--- a/templates/stable/system_test_preview.rb.tt
+++ b/templates/stable/system_test_preview.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Primer
   class <%= class_name %>Preview < ViewComponent::Preview
     def default

--- a/templates/system_test.rb.tt
+++ b/templates/system_test.rb.tt
@@ -6,6 +6,6 @@ class Integration<%= module_name %><%= class_name %>Test < ApplicationSystemTest
   def test_renders_component
     with_preview(:default)
 
-    assert_selector("<%= custom_element_name %>")
+    assert_selector(".<%= custom_element_name %>")
   end
 end

--- a/templates/system_test_preview.rb.tt
+++ b/templates/system_test_preview.rb.tt
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Primer
   module <%= module_name %>
     class <%= class_name %>Preview < ViewComponent::Preview

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -21,9 +21,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   AXE_WITHIN_SELECTOR = "body"
 
   def with_preview(preview_name)
-    component_uri = self.class.name.gsub("Test", "").gsub("Integration", "").underscore
+    component_name = self.class.name.gsub("Test", "").gsub("Integration", "")
+    status = ""
+    status = "beta/" if component_name.include?("Beta")
+    status = "alpha/" if component_name.include?("Alpha")
+    component_uri = component_name.gsub("Alpha", "").gsub("Beta", "").underscore
 
-    visit("/rails/view_components/primer/#{component_uri}/#{preview_name}")
+    visit("/rails/view_components/primer/#{status}#{component_uri}/#{preview_name}")
 
     assert_accessible(page)
   end


### PR DESCRIPTION
# Motivation

While working on a draft to add a dialog component, I discovered some flaws in the `component_generator.thor` script.

I validated these fixed in my branch which you can see on [my draft PR](https://github.com/primer/view_components/pull/949) but I wanted to pull those changes out since there is other separate component work planned by accessibility in the coming weeks.

# Notes

It may be useful for us to separate the logic triggered by `--js some-npm-package` - I can see further instances where we would want to take an existing component and add a JavaScript package to it (for example stripping out behaviours and moving them to https://github.com/primer/behaviors.

The biggest change is to the `test/application_system_test_case.rb` file - this test was not accessing the `status` directories that were being created. Another approach to this could be to avoid using `alpha` or `beta` entirely in this process but this felt like the approach that was intended by the code that was already there.

I have left in the changes:
https://github.com/primer/view_components/compare/fix-component-generator?expand=1#diff-c3ad7f6264098b2f742d9566b61dbe9da505daf112c9e318989dc723e4e02e02
and
https://github.com/primer/view_components/compare/fix-component-generator?expand=1#diff-0395af05f34bf8d74de71be36172e81ffb9bd74cbcaddf502dd49fe91035944d

Although they don't have bearing on this PR these changes occurred while running tests locally. Please let me know if you'd like me to revert those changes on this PR.

cc @pouretrebelle as I noticed that she already fixed one of these issues yesterday: https://github.com/primer/view_components/pull/963