### PR TITLE
Run bundle in demo directory during release script

### DIFF
--- a/script/release
+++ b/script/release
@@ -67,9 +67,7 @@ class ReleaseCLI < Thor::Group
 
   def update_gemfiles
     run("bundle")
-    run("pushd demo")
-    run("bundle")
-    run("popd")
+    run("cd demo && bundle")
   end
 
   def update_npm


### PR DESCRIPTION
Follow-up from #925, this functionality was broken because the cwd is reset between `run`s. I've experienced this a few times locally and it was also flagged in #964.

Can be tested locally by commenting out all the other steps in the file and running `script/release` - this will update the version in Gemfile.lock to 0.0.66.