### PR TITLE
Fix Changelog required check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,15 @@
 name: CHANGELOG
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
 
 jobs:
   changed_files:
@@ -20,6 +29,7 @@ jobs:
         run: |
           echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
   check_for_changes:
+    if: ${{ !contains(github.event.pull_request.labels.*.name , 'skip changelog') }}
     runs-on: ubuntu-latest
     # require the first job to have ran
     needs: changed_files
@@ -27,6 +37,6 @@ jobs:
       - name: echo changed files
         run: |
           if [[ ! "${{needs.changed_files.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
-            echo "::error file=CHANGELOG.md,line=1,col=1::Please make sure that you add a CHANGELOG entry to describe the changes in this pull request."
+            echo "::error file=CHANGELOG.md,line=1,col=1::Please add a CHANGELOG entry to describe the changes in this pull request or if the changes don’t effect the library output add a ‘skip changelog’ label to the PR."
             exit 1
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,11 +24,11 @@ jobs:
   check_for_changes:
     runs-on: ubuntu-latest
     # require the first job to have ran
-    needs: changedfiles
+    needs: changed_files
     steps:
       - name: echo changed files
         run: |
-          if [[ ! "${{needs.changedfiles.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
+          if [[ ! "${{needs.changed_files.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
             echo "::error file=CHANGELOG.md,line=1,col=1::Please make sure that you add a CHANGELOG entry to describe the changes in this pull request."
             exit 1
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,4 @@
-name: CHANGELOG
+name: Changelog
 
 on:
   pull_request:
@@ -12,31 +12,20 @@ on:
       - unlabeled
 
 jobs:
-  changed_files:
+  check_changelog:
+    if: ${{ !contains(github.event.pull_request.labels.*.name , 'skip changelog') }}
+    name: Require changes
     runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      markdown: ${{ steps.changes.outputs.markdown }}
     steps:
       # Make sure we have some code to diff.
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get changed files
-        id: changes
-        # Set outputs using the command.
+      - name: Check changed files
         run: |
-          echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
-  check_for_changes:
-    if: ${{ !contains(github.event.pull_request.labels.*.name , 'skip changelog') }}
-    runs-on: ubuntu-latest
-    # require the first job to have ran
-    needs: changed_files
-    steps:
-      - name: echo changed files
-        run: |
-          if [[ ! "${{needs.changed_files.outputs.markdown}}" == *"CHANGELOG.md"* ]]; then
-            echo "::error file=CHANGELOG.md,line=1,col=1::Please add a CHANGELOG entry to describe the changes in this pull request or if the changes don’t effect the library output add a ‘skip changelog’ label to the PR."
+          changed_md_files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)
+          if [[ ! "$changed_md_files" == *"CHANGELOG.md"* ]]; then
+            echo "::error file=CHANGELOG.md,line=1,col=1::Please add a Changelog entry to describe the changes in this pull request or if the changes don’t effect the library output add a ‘skip changelog’ label to the PR."
             exit 1
           fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
-      all: ${{ steps.changes.outputs.all}}
       markdown: ${{ steps.changes.outputs.markdown }}
     steps:
       # Make sure we have some code to diff.
@@ -19,7 +18,6 @@ jobs:
         id: changes
         # Set outputs using the command.
         run: |
-          echo "::set-output name=all::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | xargs)"
           echo "::set-output name=markdown::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep .md$ | xargs)"
   check_for_changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
@owenniblock alerted me that he was getting emails about invalid workflows. The error message can be found [in this run](https://github.com/primer/view_components/actions/runs/1667154685):

> The workflow is not valid. .github/workflows/changelog.yml (Line: 27, Col: 12): Job 'check_for_changes' depends on unknown job 'changedfiles'.

This is because of a typo introduced in https://github.com/primer/view_components/pull/766. The feature was first added in https://github.com/primer/view_components/pull/565.

The original intention of the lint was to require Changelog entries for every PR but there are lots of changes (e.g. this one) that don't effect the library itself where we'd want to skip this check. In the vein of https://github.com/primer/react and their `skip changeset` PR label, this uses a `skip changelog` PR label to bypass the check.

## Testing

- [x] No changelog changes and no labels = fail
- [x] No changelog changes and `skip changelog` label = skipped
- [x] Changelog change and no labels = pass
- [x] Changelog change and `skip changelog` label = skip