### PR TITLE
Fix Dependabot CI checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,12 +9,18 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "skip changelog"
     allow:
       - dependency-name: "@primer/css"
   - package-ecosystem: "npm"
     directory: "/docs"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "skip changelog"
     allow:
       - dependency-name: "@primer/gatsby-theme-doctocat"
       - dependency-name: "@primer/css"
@@ -22,5 +28,8 @@ updates:
     directory: "/demo"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "skip changelog"
     allow:
       - dependency-name: "@primer/css"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-docs:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: Build Docs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Dependabot PRs are currently failing the CI checks for docs-build and required changelog. Details in the commit messages about the solutions.

I've tried to test these changes on https://github.com/primer/view_components/pull/978 but Dependabot's too clever to rebase when there are human-authored commits on the branch, so there's no way to test these changes 🤷 I think they're low-risk, happy to attempt a different fix if they don't work

After merge:
- [ ] Comment `@dependabot rebase` in #976 #977 #978 #979 and add `skip changelog` labels