### PR TITLE
Use GitHub actions for Vercel deployments

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,6 +15,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: yarn
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
+
+      - name: Generate static files
+        run: |
+          gem install bundler:2.2.9
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+          bundle exec rake utilities:build
+          bundle exec rake docs:build
+          bundle exec rake static:dump
+        env:
+          SKIP_STORYBOOK_PRELOAD: 1
+
       - uses: chrnorm/deployment-action@v1.2.0
         name: Create GitHub deployment
         id: deployment

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,50 @@
+name: Deploy
+on:
+  push:
+    branches-ignore:
+      - 'main'
+    paths:
+      - 'app/**'
+      - 'docs/**'
+      - '.github/workflows/deploy*.yml'
+      - 'package.json'
+jobs:
+  deploy-preview:
+    if: ${{ github.repository == 'primer/view_components' }}
+    name: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: chrnorm/deployment-action@v1.2.0
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: Preview
+
+      - name: Vercel Action
+        uses: amondnet/vercel-action@v20
+        id: vercel-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN_SHARED }}
+          github-comment: false
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID_SHARED }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment_url: ${{ steps.vercel-action.outputs.preview-url }}
+          state: "success"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: "failure"
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,7 +11,6 @@ on:
       - '.vercelignore'
 jobs:
   deploy-preview:
-    if: ${{ github.repository == 'primer/view_components' }}
     name: Preview
     runs-on: ubuntu-latest
     steps:
@@ -23,9 +22,6 @@ jobs:
           environment: Preview
 
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            docs/yarn.lock
+
       - run: yarn
       - uses: actions/cache@v2
         with:
@@ -41,6 +46,12 @@ jobs:
           bundle exec rake static:dump
         env:
           SKIP_STORYBOOK_PRELOAD: 1
+
+      - name: Build docs
+        run: |
+          cd docs
+          yarn
+          yarn build
 
       - uses: chrnorm/deployment-action@v1.2.0
         name: Create GitHub deployment

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,6 +15,13 @@ jobs:
     name: Preview
     runs-on: ubuntu-latest
     steps:
+      - uses: chrnorm/deployment-action@v1.2.0
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: Preview
+
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -53,13 +60,6 @@ jobs:
           cd docs
           yarn
           yarn build
-
-      - uses: chrnorm/deployment-action@v1.2.0
-        name: Create GitHub deployment
-        id: deployment
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: Preview
 
       - name: Vercel Action
         uses: amondnet/vercel-action@v20

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'
       - '.github/workflows/deploy*.yml'
       - 'package.json'
+      - '.vercelignore'
 jobs:
   deploy-preview:
     if: ${{ github.repository == 'primer/view_components' }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -22,10 +22,10 @@ jobs:
           environment: Preview
 
       - uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7.x
+      # - name: Setup Ruby
+      #   uses: actions/setup-ruby@v1
+      #   with:
+      #     ruby-version: 2.7.x
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -34,22 +34,22 @@ jobs:
             yarn.lock
             docs/yarn.lock
 
-      - run: yarn
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
+      # - run: yarn
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: vendor/bundle
+      #     key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
 
-      - name: Generate static files
-        run: |
-          gem install bundler:2.2.9
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-          bundle exec rake utilities:build
-          bundle exec rake docs:build
-          bundle exec rake static:dump
-        env:
-          SKIP_STORYBOOK_PRELOAD: 1
+      # - name: Generate static files
+      #   run: |
+      #     gem install bundler:2.2.9
+      #     bundle config path vendor/bundle
+      #     bundle install --jobs 4 --retry 3
+      #     bundle exec rake utilities:build
+      #     bundle exec rake docs:build
+      #     bundle exec rake static:dump
+      #   env:
+      #     SKIP_STORYBOOK_PRELOAD: 1
 
       - name: Build docs
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,62 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'app/**'
+      - 'docs/**'
+      - '.github/workflows/deploy*.yml'
+      - 'package.json'
+      - '.vercelignore'
+jobs:
+  deploy:
+    name: Production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.x
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            docs/yarn.lock
+
+      - run: yarn
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
+
+      - name: Generate static files
+        run: |
+          gem install bundler:2.2.9
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+          bundle exec rake utilities:build
+          bundle exec rake docs:build
+          bundle exec rake static:dump
+        env:
+          SKIP_STORYBOOK_PRELOAD: 1
+
+      - name: Build docs
+        run: |
+          cd docs
+          yarn
+          yarn build
+
+      - name: Vercel Action
+        uses: amondnet/vercel-action@v20
+        id: vercel-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN_SHARED }}
+          vercel-args: '--prod'
+          github-comment: false
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID_SHARED }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7.x
+      # - name: Setup Ruby
+      #   uses: actions/setup-ruby@v1
+      #   with:
+      #     ruby-version: 2.7.x
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -27,22 +27,22 @@ jobs:
             yarn.lock
             docs/yarn.lock
 
-      - run: yarn
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
+      # - run: yarn
+      # - uses: actions/cache@v2
+      #   with:
+      #     path: vendor/bundle
+      #     key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
 
-      - name: Generate static files
-        run: |
-          gem install bundler:2.2.9
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
-          bundle exec rake utilities:build
-          bundle exec rake docs:build
-          bundle exec rake static:dump
-        env:
-          SKIP_STORYBOOK_PRELOAD: 1
+      # - name: Generate static files
+      #   run: |
+      #     gem install bundler:2.2.9
+      #     bundle config path vendor/bundle
+      #     bundle install --jobs 4 --retry 3
+      #     bundle exec rake utilities:build
+      #     bundle exec rake docs:build
+      #     bundle exec rake static:dump
+      #   env:
+      #     SKIP_STORYBOOK_PRELOAD: 1
 
       - name: Build docs
         run: |

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+# Ignore everything apart from files in docs root and Gatsby build
+/*
+!docs
+docs/content/
+docs/node_modules/
+docs/src/
+docs/.cache/

--- a/docs/now.json
+++ b/docs/now.json
@@ -9,5 +9,8 @@
     }
   ],
   "rewrites": [{"source": "/view-components(/.*)?", "destination": "/$1"}],
-  "redirects": [{"source": "/", "destination": "/view-components"}]
+  "redirects": [{"source": "/", "destination": "/view-components"}],
+  "github": {
+    "enabled": false
+  }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "build": "gatsby build --prefix-paths",
-    "now-build": "yarn run build"
+    "now-build": "exit 0"
   },
   "dependencies": {
     "@primer/css": "^19.2.0",

--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,10 +1,8 @@
 {
-  "version": 2,
-  "name": "primer-viewcomponents",
   "builds": [
     {
       "src": "package.json",
-      "use": "@now/static-build",
+      "use": "@vercel/static-build",
       "config": {"distDir": "public"}
     }
   ],


### PR DESCRIPTION
## Description

This is a stepping stone to #982.

To be able to git-ignore generated content we need a way to build this content for deployment. Currently Vercel builds the Gatsby site but it expects all the YARD-generated markdown to already be in the file system.

By using a GitHub Action we can set up Ruby to run the static file generation and pass that content to Vercel for the build. In the spirit of doing all the building on our end, I also moved the Gatsby build from Vercel to the action, so Vercel just has to deploy the static files. I managed to get Vercel to stop running the build on their side (8b077a8ae12383a6d460af7fecddb50604be2c7b) but couldn't get it to stop installing the dependencies, so the total build time on Vercel is ~30secs. I think [we can follow these instructions](https://vercel.com/docs/concepts/deployments/build-step#build-command) to remove the installation completely, but this can only be done from the UI settings so should only be done once this is merged and all PRs are up to date (to avoid breaking existing PR preview apps). Since this is all static now we could use a different service for deployment (GH pages?) but that's a conversation for another day.

> Frustration sidenote - [Vercel's move to zero config](https://vercel.com/blog/zero-config) has discouraged people from using `vercel.json` files and doing all the config in the UI which makes it really difficult to make these sort of setup changes, and they've also removed all the docs related to `vercel.json` which is a big kick in the teeth when they're not even deprecated. Also there's no documentation on how the ['root directory'](https://vercel.com/docs/concepts/deployments/build-step#root-directory) changes things when you're using `.vercelignore` (without this we were uploading thousands of files for the deployment which would crash); by trial and error I found that `.vercelignore` _must_ be in the actual root but `vercel.json` _must_ be in the 'root directory' 🙃
>> Ideally we'd set the ['working directory'](https://github.com/amondnet/vercel-action#inputs) of the action to docs (then the `.vercelignore` can be in docs and not have to do the allowlist/blocklist thing it's currently doing) and the 'root directory' to `.` but we can't because ofc that's controlled in the Vercel settings UI and I can't figure out how to override it in `vercel.json` 🙃🙃 so we're stuck with this unless we make a separate Vercel project for the shift.

## Visible changes

| Before | After |
|--------|--------|
| <img width="938" alt="" src="https://user-images.githubusercontent.com/1901935/151347421-7bcda28c-4764-4603-8bf5-a185c4f9f5ad.png"> | <img width="873" alt="" src="https://user-images.githubusercontent.com/1901935/151347489-65416ac4-1091-4226-81a2-f9214472f374.png"> | 
| Vercel comments on your PR with the Preview link | GitHub Actions adds a timeline item with the Preview link |

The new way takes ~3m40 from action initiation to complete deployment, as I said above we should be able to shave off 30s from that after merge. The old way took ~2m20s to deploy on Vercel so we are losing a bit of time, but I'm unsure whether the Vercel integration gets triggered as quickly as the GitHub action does so the time difference could be negligible.

## Validation

I checked in #994 (branched off after ba407fe) that the workflow was actually building and deploying from source by turning off the docs-build action and changing the source. The path to #982 is clear!

## Possible issues

I have pretty high confidence in the deploy-production workflow because [it does the same thing as @primer/css](https://github.com/primer/css/blob/main/.github/workflows/deploy_production.yml) but if it doesn't deploy correctly when this is merged it either won't deploy at all (which we can fix) or if deploys a broken one we can promote a previous deployment to production in the Vercel UI (which happens instantly) and then fix it.

## Follow-up

In a few weeks to make sure all working PRs are up to date with this:

- [ ] Remove build command from [settings](https://vercel.com/primer/view-components/settings)
- [ ] Remove `now-build` script hack from `docs/package.json`