### PR TITLE
Use GitHub action for Vercel deployments: test

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -66,6 +66,7 @@ jobs:
           github-comment: false
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID_SHARED }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: docs
 
       - name: Update deployment status (success)
         if: success()

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-docs:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ false && github.actor != 'dependabot[bot]' }}
     name: Build Docs
     runs-on: ubuntu-latest
     steps:

--- a/app/components/primer/beta/blankslate.rb
+++ b/app/components/primer/beta/blankslate.rb
@@ -2,7 +2,7 @@
 
 module Primer
   module Beta
-    # Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there.
+    # Use `Blankslate` when there is a lack of content within a page or section. Use as placeholder to tell users why something isn't there!!!!!
     #
     # @accessibility
     #   - The blankslate uses a semantic heading that must be set at the appropriate level based on the hierarchy of the page.

--- a/docs/.vercelignore
+++ b/docs/.vercelignore
@@ -1,7 +1,5 @@
 # Ignore everything apart from files in docs root and Gatsby build
-/*
-!docs
-docs/content/
-docs/node_modules/
-docs/src/
-docs/.cache/
+content/
+node_modules/
+src/
+.cache/

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -1,5 +1,5 @@
 ---
-- title: Getting started
+- title: Getting started!!!!!
   url: "/"
   children:
   - title: Contributing


### PR DESCRIPTION
Proving that #989 actually builds the docs site from the source and doesn't rely on existing content in the file system.

Screenshots from the preview app:
<img width="297" alt="Updated nav" src="https://user-images.githubusercontent.com/1901935/151347073-1a42845c-0bed-49fc-b1df-a87de0124d24.png">
<img width="345" alt="Updated content" src="https://user-images.githubusercontent.com/1901935/151347106-1cca40e3-be3d-4d88-b4ef-795b9219784c.png">