### PR TITLE
[WIP] feat: adds accessibility updates to autocomplete element

### DIFF
--- a/app/components/primer/beta/auto_complete.rb
+++ b/app/components/primer/beta/auto_complete.rb
@@ -5,13 +5,16 @@ module Primer
     # Use `AutoComplete` to provide a user with a list of selectable suggestions that appear when they type into the
     # input field. This list is populated by server search results.
     # @accessibility
-    #   Always set an accessible label to help the user interact with the component.
+    #   * Always set an accessible label to help the user interact with the component.
     #
-    #   * Set the `label` slot to render a visible label. Alternatively, associate an existing visible text element
+    #     * Set the `label` slot to render a visible label. Alternatively, associate an existing visible text element
     #   as a label by setting `aria-labelledby`.
-    #   * If you must use a non-visible label, set `:"aria-label"` on `AutoComplete` and Primer
+    #     * If you must use a non-visible label, set `:"aria-label"` on `AutoComplete` and Primer
     #   will apply it to the correct elements. However, please note that a visible label should almost
     #   always be used unless there is compelling reason not to. A placeholder is not a label.
+    #
+    #   * Provide a `div` element with an `id` of `<list_id>-feedback` and class of `sr-only` (`list_id` should match `list_id` passed in to the initial component) to provide feedback to screen reader users about the available autoselect options.
+    #   * Provide a `button` element with an `id` of `<input_id>-clear` to return the user's focus to the input and announce that the input has been cleared
     class AutoComplete < Primer::Component
       status :beta
 
@@ -69,19 +72,28 @@ module Primer
       #     <% c.input(type: :text) %>
       #   <% end %>
       #
+      # @example With `data-autoselect`
+      #   @description
+      #     If `data-autoselect` is `true`, pressing the "Enter" key will select the first option available.
+      #   @code
+      #     <%= render(Primer::Beta::AutoComplete.new("data-autoselect": true, src: "/auto_complete", input_id: "fruits-input-2", list_id: "fruits-popup-2", position: :relative)) do |c| %>
+      #       <% c.label(classes:"").with_content("Fruits") %>
+      #       <% c.input(type: :text) %>
+      #     <% end %>
+      #
       # @example With `aria-label`
-      #   <%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", input_id: "fruits-input-2", list_id: "fruits-popup-2", position: :relative)) do |c| %>
+      #   <%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", input_id: "fruits-input-3", list_id: "fruits-popup-3", position: :relative)) do |c| %>
       #     <% c.input(type: :text) %>
       #   <% end %>
       #
       # @example With `aria-labelledby`
       #   <%= render(Primer::HeadingComponent.new(tag: :h2, id: "search-1")) { "Search" } %>
-      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-3", list_id: "fruits-popup-3", position: :relative)) do |c| %>
+      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-4", list_id: "fruits-popup-4", position: :relative)) do |c| %>
       #     <% c.input("aria-labelledby": "search-1") %>
       #   <% end %>
       #
       # @example With custom classes for the results
-      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-4", list_id: "fruits-popup-4", position: :relative)) do |c| %>
+      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-5", list_id: "fruits-popup-5", position: :relative)) do |c| %>
       #     <% c.label(classes:"").with_content("Fruits") %>
       #     <% c.input(type: :text) %>
       #     <% c.results(classes: "custom-class") do %>
@@ -95,9 +107,21 @@ module Primer
       #   <% end %>
       #
       # @example With Icon
-      #   <%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", list_id: "fruits-popup-5", input_id: "fruits-input-5", position: :relative)) do |c| %>
+      #   <%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", list_id: "fruits-popup-6", input_id: "fruits-input-6", position: :relative)) do |c| %>
       #     <% c.input(type: :text) %>
       #     <% c.icon(icon: :search) %>
+      #   <% end %>
+      #
+      # @example With Screen Reader Feedback Element - TODO IN COMMENTS
+      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-7", list_id: "fruits-popup-7", position: :relative)) do |c| %>
+      #     <% c.label(classes:"").with_content("Fruits") %>
+      #     <% c.input(type: :text) %>
+      #   <% end %>
+      #
+      # @example With Custom Clear Button - TODO IN COMMENTS
+      #   <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-8", list_id: "fruits-popup-8", position: :relative)) do |c| %>
+      #     <% c.label(classes:"").with_content("Fruits") %>
+      #     <% c.input(type: :text) %>
       #   <% end %>
       #
       # @param src [String] The route to query.

--- a/docs/content/components/beta/autocomplete.md
+++ b/docs/content/components/beta/autocomplete.md
@@ -27,6 +27,7 @@ will apply it to the correct elements. However, please note that a visible label
 always be used unless there is compelling reason not to. A placeholder is not a label.
 
 * Provide a `div` element with an `id` of `<list_id>-feedback` and class of `sr-only` (`list_id` should match `list_id` passed in to the initial component) to provide feedback to screen reader users about the available autoselect options.
+* Provide a `button` element with an `id` of `<input_id>-clear` to return the user's focus to the input and announce that the input has been cleared
 
 ## Arguments
 
@@ -145,12 +146,23 @@ If `data-autoselect` is `true`, pressing the "Enter" key will select the first o
 <% end %>
 ```
 
-### With Screen Reader Feedback Element
+### With Screen Reader Feedback Element - TODO IN COMMENTS
 
 <Example src="<label for='fruits-input-7' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-7' data-view-component='true' class='position-relative'>  <input id='fruits-input-7' name='fruits-input-7' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-7' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-7", list_id: "fruits-popup-7", position: :relative)) do |c| %>
+  <% c.label(classes:"").with_content("Fruits") %>
+  <% c.input(type: :text) %>
+<% end %>
+```
+
+### With Custom Clear Button - TODO IN COMMENTS
+
+<Example src="<label for='fruits-input-8' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-8' data-view-component='true' class='position-relative'>  <input id='fruits-input-8' name='fruits-input-8' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-8' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+
+```erb
+<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-8", list_id: "fruits-popup-8", position: :relative)) do |c| %>
   <% c.label(classes:"").with_content("Fruits") %>
   <% c.input(type: :text) %>
 <% end %>

--- a/docs/content/components/beta/autocomplete.md
+++ b/docs/content/components/beta/autocomplete.md
@@ -18,13 +18,15 @@ input field. This list is populated by server search results.
 
 ## Accessibility
 
-Always set an accessible label to help the user interact with the component.
+* Always set an accessible label to help the user interact with the component.
 
-* Set the `label` slot to render a visible label. Alternatively, associate an existing visible text element
+  * Set the `label` slot to render a visible label. Alternatively, associate an existing visible text element
 as a label by setting `aria-labelledby`.
-* If you must use a non-visible label, set `:"aria-label"` on `AutoComplete` and Primer
+  * If you must use a non-visible label, set `:"aria-label"` on `AutoComplete` and Primer
 will apply it to the correct elements. However, please note that a visible label should almost
 always be used unless there is compelling reason not to. A placeholder is not a label.
+
+* Provide a `div` element with an `id` of `<list_id>-feedback` and class of `sr-only` (`list_id` should match `list_id` passed in to the initial component) to provide feedback to screen reader users about the available autoselect options.
 
 ## Arguments
 
@@ -79,33 +81,46 @@ Customizable results list.
 <% end %>
 ```
 
-### With `aria-label`
+### With `data-autoselect`
 
-<Example src="<auto-complete src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-2' name='fruits-input-2' aria-label='Fruits' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-2' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+If `data-autoselect` is `true`, pressing the "Enter" key will select the first option available.
+
+<Example src="<label for='fruits-input-2' data-view-component='true'>Fruits</label><auto-complete data-autoselect='true' src='/auto_complete' for='fruits-popup-2' data-view-component='true' class='position-relative'>  <input id='fruits-input-2' name='fruits-input-2' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-2' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
-<%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", input_id: "fruits-input-2", list_id: "fruits-popup-2", position: :relative)) do |c| %>
+<%= render(Primer::Beta::AutoComplete.new("data-autoselect": true, src: "/auto_complete", input_id: "fruits-input-2", list_id: "fruits-popup-2", position: :relative)) do |c| %>
+  <% c.label(classes:"").with_content("Fruits") %>
+  <% c.input(type: :text) %>
+<% end %>
+```
+
+### With `aria-label`
+
+<Example src="<auto-complete src='/auto_complete' for='fruits-popup-3' data-view-component='true' class='position-relative'>  <input id='fruits-input-3' name='fruits-input-3' aria-label='Fruits' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-3' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+
+```erb
+<%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", input_id: "fruits-input-3", list_id: "fruits-popup-3", position: :relative)) do |c| %>
   <% c.input(type: :text) %>
 <% end %>
 ```
 
 ### With `aria-labelledby`
 
-<Example src="<h2 id='search-1' data-view-component='true'>Search</h2><auto-complete src='/auto_complete' for='fruits-popup-3' data-view-component='true' class='position-relative'>  <input id='fruits-input-3' name='fruits-input-3' aria-labelledby='search-1' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-3' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<h2 id='search-1' data-view-component='true'>Search</h2><auto-complete src='/auto_complete' for='fruits-popup-4' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' name='fruits-input-4' aria-labelledby='search-1' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-4' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
 <%= render(Primer::HeadingComponent.new(tag: :h2, id: "search-1")) { "Search" } %>
-<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-3", list_id: "fruits-popup-3", position: :relative)) do |c| %>
+<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-4", list_id: "fruits-popup-4", position: :relative)) do |c| %>
   <% c.input("aria-labelledby": "search-1") %>
 <% end %>
 ```
 
 ### With custom classes for the results
 
-<Example src="<label for='fruits-input-4' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-4' data-view-component='true' class='position-relative'>  <input id='fruits-input-4' name='fruits-input-4' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-4' data-view-component='true' class='autocomplete-results custom-class'>    <li role='option' data-autocomplete-value='apple' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Apple</li>    <li role='option' data-autocomplete-value='orange' data-view-component='true' class='autocomplete-item'>      Orange</li></ul></auto-complete>" />
+<Example src="<label for='fruits-input-5' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-5' data-view-component='true' class='position-relative'>  <input id='fruits-input-5' name='fruits-input-5' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-5' data-view-component='true' class='autocomplete-results custom-class'>    <li role='option' data-autocomplete-value='apple' aria-selected='true' data-view-component='true' class='autocomplete-item'>      Apple</li>    <li role='option' data-autocomplete-value='orange' data-view-component='true' class='autocomplete-item'>      Orange</li></ul></auto-complete>" />
 
 ```erb
-<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-4", list_id: "fruits-popup-4", position: :relative)) do |c| %>
+<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-5", list_id: "fruits-popup-5", position: :relative)) do |c| %>
   <% c.label(classes:"").with_content("Fruits") %>
   <% c.input(type: :text) %>
   <% c.results(classes: "custom-class") do %>
@@ -121,11 +136,22 @@ Customizable results list.
 
 ### With Icon
 
-<Example src="<auto-complete src='/auto_complete' for='fruits-popup-5' data-view-component='true' class='position-relative'>    <label for='fruits-input-5'>        <span class='sr-only'>Fruits</span>      <svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-search'>    <path fill-rule='evenodd' d='M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z'></path></svg>    </label>  <input id='fruits-input-5' name='fruits-input-5' aria-label='Fruits' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-5' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+<Example src="<auto-complete src='/auto_complete' for='fruits-popup-6' data-view-component='true' class='position-relative'>    <label for='fruits-input-6'>        <span class='sr-only'>Fruits</span>      <svg aria-hidden='true' height='16' viewBox='0 0 16 16' version='1.1' width='16' data-view-component='true' class='octicon octicon-search'>    <path fill-rule='evenodd' d='M11.5 7a4.499 4.499 0 11-8.998 0A4.499 4.499 0 0111.5 7zm-.82 4.74a6 6 0 111.06-1.06l3.04 3.04a.75.75 0 11-1.06 1.06l-3.04-3.04z'></path></svg>    </label>  <input id='fruits-input-6' name='fruits-input-6' aria-label='Fruits' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-6' aria-label='Fruits' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
 
 ```erb
-<%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", list_id: "fruits-popup-5", input_id: "fruits-input-5", position: :relative)) do |c| %>
+<%= render(Primer::Beta::AutoComplete.new("aria-label": "Fruits", src: "/auto_complete", list_id: "fruits-popup-6", input_id: "fruits-input-6", position: :relative)) do |c| %>
   <% c.input(type: :text) %>
   <% c.icon(icon: :search) %>
+<% end %>
+```
+
+### With Screen Reader Feedback Element
+
+<Example src="<label for='fruits-input-7' data-view-component='true'>Fruits</label><auto-complete src='/auto_complete' for='fruits-popup-7' data-view-component='true' class='position-relative'>  <input id='fruits-input-7' name='fruits-input-7' type='text' data-view-component='true' class='form-control' />  <ul id='fruits-popup-7' data-view-component='true' class='autocomplete-results'></ul></auto-complete>" />
+
+```erb
+<%= render(Primer::Beta::AutoComplete.new(src: "/auto_complete", input_id: "fruits-input-7", list_id: "fruits-popup-7", position: :relative)) do |c| %>
+  <% c.label(classes:"").with_content("Fruits") %>
+  <% c.input(type: :text) %>
 <% end %>
 ```


### PR DESCRIPTION
Fixes https://github.com/github/accessibility/issues/385.

## Description
This work adds documentation about accessibility enhancements that were made for the [autocomplete element](https://github.com/github/auto-complete-element). Note: This cannot be merged until the latest auto-complete package is in Primer View Components.

## TODO:
There are a few incomplete examples that may need to wait until the latest auto-complete element package is published and consumed. Updates needed have been made as inline comments.