### PR TITLE
Fix local development.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     _Hector Garcia_
 
+### Bug Fixes
+
+- Fix live reloading during local docs development.
+
+    _Cameron Dutro_
+
 ## 0.0.68
 
 ### Updates

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -115,7 +115,7 @@ namespace :docs do
       data = docs_metadata(component)
 
       path = Pathname.new(data[:path])
-      path.dirname.mkdir unless path.dirname.exist?
+      path.dirname.mkpath unless path.dirname.exist?
       File.open(path, "w") do |f|
         f.puts("---")
         f.puts("title: #{data[:title]}")

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -106,9 +106,8 @@ namespace :docs do
     errors = []
 
     # Deletes docs before regenerating them, guaranteeing that we don't keep stale docs.
-    components_content_dir = File.join(*%w[docs content components])
-    FileUtils.rm_rf(File.join(components_content_dir))
-    FileUtils.mkdir(components_content_dir)
+    components_content_glob = File.join(*%w[docs content components ** *.md])
+    FileUtils.rm_rf(components_content_glob)
 
     components.sort_by(&:name).each do |component|
       documentation = registry.get(component.name)


### PR DESCRIPTION
An issue reported in Slack uncovered that making changes to a component's Ruby files while the doctocat server was running would cause Gatsby to raise an error saying no resources could be found for the corresponding path. After a bit of research I discovered that a [recent change](https://github.com/primer/view_components/pull/996/files#diff-c214978886585f469c549fe44e7c4681eaae0e8be954e7ce91aef993bda0ddc3R109) to docs.rake, specifically the `build` task, removed the entire docs/content/components directory whereas the previous version of the code had only removed the .md files. I started the `docs:livereload` task in one terminal window and `gatsby develop` in another, and watched the output scroll by after making a change to the Yard comments in one of our component Ruby files (autocomplete.rb). Interestingly, the docs were regenerated successfully, but all Gatsby seemed to see was that a bunch of files had been deleted. I expected to see a bunch of "file created" messages, but there were none. Very curious! My hypothesis was that, once the docs/content/components directory was deleted, Gatsby "forgot" about it and could no longer monitor it for changes. I tried changing back to only removing app/content/components/**/*.md and voila, it worked!