### PR TITLE
Improve last example on the PopoverComponent docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     _Hector Garcia_
 
+- Improve last example on the PopoverComponent docs
+
+    _Hector Garcia_
+
 ## 0.0.68
 
 ### Updates

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -88,20 +88,16 @@ module Primer
     #     <% end %>
     #   <% end %>
     #
-    # @example With HTML body
+    # @example With multiple elements in the body
     #   <%= render Primer::PopoverComponent.new do |component| %>
     #     <% component.heading do %>
     #       Activity feed
     #     <% end %>
     #     <% component.body(caret: :left) do %>
-    #       <p> This is the Popover body.</p>
-    #       <div>
-    #         This is using HTML.
-    #         <ul>
-    #           <li>Thing #1</li>
-    #           <li>Thing #2</li>
-    #         </ul>
-    #       </div>
+    #       <p>This is the Popover body.</p>
+    #       <%= render Primer::ButtonComponent.new(type: :submit) do %>
+    #         Got it!
+    #       <% end %>
     #     <% end %>
     #   <% end %>
     #


### PR DESCRIPTION
### What are you trying to accomplish?

Makes the last example of the PopoverComponent docs closer to the Primer CSS docs. This is part of the efforts to increase consistency between Primer PVC and Primer CSS.

#### Before

![before](https://user-images.githubusercontent.com/24622853/153235893-cdf3d8c5-a93f-489c-906d-afcd34482280.png)

#### After

![after](https://user-images.githubusercontent.com/24622853/153235946-6a94fa75-e6aa-4027-874d-0592da3984f8.png)

### Are additional changes needed?

- [X] No, this PR should be ok to ship as is. 🚢 



