### PR TITLE
Add missing alt attribute to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### Misc
 
+- Updates README with missing `alt` attribute on image
+
+  _Kate Higa_
+
 - Updates contributing docs
 
   _Lindsey Wild_

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="300px" src="/static/assets/view-components.svg">
+  <img width="300px" alt="" src="/static/assets/view-components.svg">
 </p>
 
 <h1 align="center">Primer ViewComponents</h1>


### PR DESCRIPTION
### Context

As I was browsing around with [github-a11y chrome extension](https://github.com/khiga8/github-a11y,) I noticed we're missing `alt` attribute for this README image. I believe this is a decorative image so I'm setting the `alt` to empty.

Related:

- [erblint-github/blob/main/docs/rules/accessibility/image-has-alt.md](https://github.com/github/erblint-github/blob/main/docs/rules/accessibility/image-has-alt.md)
- https://webaim.org/techniques/alttext/