### PR TITLE
Fix sequence of content in Subhead

### DIFF
--- a/app/components/primer/subhead_component.html.erb
+++ b/app/components/primer/subhead_component.html.erb
@@ -1,5 +1,5 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <%= heading %>
-  <%= actions %>
   <%= description %>
+  <%= actions %>
 <% end %>


### PR DESCRIPTION
### What are you trying to accomplish?

When a heading, description, and action are rendered in the Subhead component, the content now follows logical order on screen readers.

- Fixes https://github.com/github/primer/issues/644
- Originally reported on [the subhead accessibility audit](https://github.com/github/primer/issues/358#issuecomment-996908226).

#### Before
![Before](https://user-images.githubusercontent.com/24622853/155348437-f709ef70-7903-4a43-b1f7-ed7ef0f527b8.png)
Accessibility tree
![Before, accessibility tree](https://user-images.githubusercontent.com/24622853/155348495-bc307a6a-ebc5-4de7-84e7-a767836d0649.png)


#### After

![After](https://user-images.githubusercontent.com/24622853/155348796-0ebcd4b1-de4e-4030-90f1-40ce0fe09048.png)
Accessibility tree
![After, accessibility tree](https://user-images.githubusercontent.com/24622853/155348918-93ffe2ef-e27f-4cf5-9e39-7788407776a7.png)

### What approach did you choose and why?

I decided to reorder the elements on the DOM and use the [flexbox order property](https://www.w3.org/TR/css-flexbox-1/#order-accessibility) so elements are still rendered in the same way.

See [the primer/css pull request](https://github.com/primer/css/pull/1950) for more details.

<!-- ### What should reviewers focus on? -->

<!-- Let reviewers know if there is anything that needs special attention. You can also describe any alternatives that you explored. -->

### Are additional changes needed?

<!-- Please add a ⚠️ note here if this PR depends on additional changes. For example an update from Primer Primitives. Or additional changes when shipping to "dotcom". This will make sure we don't forget to include them. -->

- [ ] Depends on https://github.com/primer/css/pull/1950
