### PR TITLE
Hide deprecated tooltip component from docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Misc
+
+- Hide deprecated tooltip component page.
+
+  _Kate Higa_
+
 ## 0.0.68
 
 ### Updates

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -103,8 +103,6 @@
     url: "/components/timeago"
   - title: TimelineItem
     url: "/components/timelineitem"
-  - title: Tooltip
-    url: "/components/tooltip"
   - title: Truncate
     url: "/components/beta/truncate"
   - title: UnderlineNav


### PR DESCRIPTION
This PR hides deprecated tooltip component page from docs.