### PR TITLE
Fix missing `@primer/components` dependency

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,7 @@
     "@primer/css": "^19.5.0",
     "@primer/gatsby-theme-doctocat": "^3.2.1",
     "@primer/primitives": "^6.0.0",
+    "@primer/react": "^34.7.0",
     "gatsby": "^2.24.63",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/docs/src/@primer/gatsby-theme-doctocat/components/theme-switcher.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/theme-switcher.js
@@ -1,10 +1,10 @@
 import React from 'react'
-import {Box, DropdownMenu, DropdownButton, ThemeProvider} from '@primer/components'
+import { Box, DropdownMenu, DropdownButton, ThemeProvider } from '@primer/react'
 import primitives from '@primer/primitives'
 
 const THEMES = Object.keys(primitives.colors)
 
-function ThemeSwitcher({children}) {
+function ThemeSwitcher({ children }) {
   const items = React.useMemo(
     () => THEMES.map((theme) => ({
       text: theme,
@@ -17,18 +17,18 @@ function ThemeSwitcher({children}) {
   return (
     <div className="Box" data-color-mode="light" data-dark-theme={colorMode.text} data-light-theme={colorMode.text}>
       <Box pt={2} px={2} justifyContent="flex-end" display="flex">
-      <ThemeProvider dayScheme={colorMode.text}>
-        <DropdownMenu
-          renderAnchor={({children, ...anchorProps}) => (
-            <DropdownButton variant="small" {...anchorProps}>
-              {children}
-            </DropdownButton>
-          )}
-          items={items}
-          selectedItem={colorMode}
-          onChange={setColorMode}
-        />
-      </ThemeProvider>
+        <ThemeProvider dayScheme={colorMode.text}>
+          <DropdownMenu
+            renderAnchor={({ children, ...anchorProps }) => (
+              <DropdownButton variant="small" {...anchorProps}>
+                {children}
+              </DropdownButton>
+            )}
+            items={items}
+            selectedItem={colorMode}
+            onChange={setColorMode}
+          />
+        </ThemeProvider>
       </Box>
       <div className="frame-example p-3">{children}</div>
     </div>

--- a/docs/src/component-statuses.js
+++ b/docs/src/component-statuses.js
@@ -1,7 +1,7 @@
-import {Link} from '@primer/components'
+import { Link } from '@primer/react'
 import StatusLabel from '@primer/gatsby-theme-doctocat/src/components/status-label'
 import Table from '@primer/gatsby-theme-doctocat/src/components/table'
-import {graphql, Link as GatsbyLink, useStaticQuery} from 'gatsby'
+import { graphql, Link as GatsbyLink, useStaticQuery } from 'gatsby'
 import React from 'react'
 
 export function ComponentStatuses() {
@@ -48,7 +48,7 @@ export function ComponentStatuses() {
         </tr>
       </thead>
       <tbody>
-        {components.map(({slug, description, title, status}) => (
+        {components.map(({ slug, description, title, status }) => (
           <tr key={slug}>
             <td valign="top">
               <Link as={GatsbyLink} to={`/${slug}`}>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1680,6 +1680,30 @@
     history "5.0.0"
     styled-system "5.1.5"
 
+"@primer/react@^34.7.0":
+  version "34.7.0"
+  resolved "https://registry.yarnpkg.com/@primer/react/-/react-34.7.0.tgz#b06b6ad24f54366c3a722c14ad54160378176055"
+  integrity sha512-sYS/cezy7PcbI+ZAn30Euls/FVF6/RifEtmlzv6wUHvisTJZQDWxDhWA5A2M+T+1z29ymOpFVagHPKNPAd7R+g==
+  dependencies:
+    "@primer/behaviors" "1.1.0"
+    "@primer/octicons-react" "16.1.1"
+    "@primer/primitives" "7.1.1"
+    "@radix-ui/react-polymorphic" "0.0.14"
+    "@react-aria/ssr" "3.1.0"
+    "@styled-system/css" "5.1.5"
+    "@styled-system/props" "5.1.5"
+    "@styled-system/theme-get" "5.1.2"
+    "@types/styled-components" "5.1.11"
+    "@types/styled-system" "5.1.12"
+    "@types/styled-system__css" "5.0.16"
+    "@types/styled-system__theme-get" "5.0.1"
+    classnames "2.3.1"
+    color2k "1.2.4"
+    deepmerge "4.2.2"
+    focus-visible "5.2.0"
+    history "5.0.0"
+    styled-system "5.1.5"
+
 "@radix-ui/react-polymorphic@0.0.14":
   version "0.0.14"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-polymorphic/-/react-polymorphic-0.0.14.tgz#fc6cefee6686db8c5a7ff14c8c1b9b5abdee325b"


### PR DESCRIPTION
Replaced with `@primer/react` as `@primer/components` has been renamed.

Fixes https://github.com/primer/view_components/issues/1049