### PR TITLE
Add ability to attach custom CSS classes to truncate items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ### New
 
+- Add ability to attach custom CSS classes to items added to `Truncate` components.
+
+    _Cameron Dutro_
+
 - Add `Primer::Alpha::Tooltip` component
 
     _Kate Higa_, _Kristján Oddsson_

--- a/app/components/primer/beta/truncate.rb
+++ b/app/components/primer/beta/truncate.rb
@@ -92,6 +92,7 @@ module Primer
           @system_arguments[:tag] = system_arguments[:tag] || :span
           @system_arguments[:classes] = class_names(
             "Truncate-text",
+            system_arguments[:classes],
             "Truncate-text--primary": priority,
             "Truncate-text--expandable": expandable
           )

--- a/test/components/beta/truncate_test.rb
+++ b/test/components/beta/truncate_test.rb
@@ -33,6 +33,14 @@ class PrimerBetaTruncateTest < Minitest::Test
     assert_selector(".Truncate > .Truncate-text", text: "content")
   end
 
+  def test_truncate_with_custom_item_classes
+    render_inline(Primer::Beta::Truncate.new) do |component|
+      component.item(classes: 'foo') { "content" }
+    end
+
+    assert_selector(".Truncate .Truncate-text.foo", text: "content")
+  end
+
   def test_truncate_with_priority
     render_inline(Primer::Beta::Truncate.new) do |component|
       component.item { "content" }

--- a/test/components/beta/truncate_test.rb
+++ b/test/components/beta/truncate_test.rb
@@ -35,7 +35,7 @@ class PrimerBetaTruncateTest < Minitest::Test
 
   def test_truncate_with_custom_item_classes
     render_inline(Primer::Beta::Truncate.new) do |component|
-      component.item(classes: 'foo') { "content" }
+      component.item(classes: "foo") { "content" }
     end
 
     assert_selector(".Truncate .Truncate-text.foo", text: "content")


### PR DESCRIPTION
Currently, it's not possible to add custom CSS classes to items added to a `Truncate` component.