### PR TITLE
Release v0.0.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+## 0.0.69
+
 ### New
 
 - Add `Primer::Alpha::Tooltip` component

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    primer_view_components (0.0.68)
+    primer_view_components (0.0.69)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 17.0.0)

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -20,7 +20,7 @@ GIT
 PATH
   remote: ..
   specs:
-    primer_view_components (0.0.68)
+    primer_view_components (0.0.69)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 17.0.0)

--- a/lib/primer/view_components/version.rb
+++ b/lib/primer/view_components/version.rb
@@ -5,7 +5,7 @@ module Primer
     module VERSION
       MAJOR = 0
       MINOR = 0
-      PATCH = 68
+      PATCH = 69
 
       STRING = [MAJOR, MINOR, PATCH].join(".")
     end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/view-components",
-  "version": "0.0.68",
+  "version": "0.0.69",
   "description": "ViewComponents for the Primer Design System",
   "main": "app/assets/javascripts/primer_view_components.js",
   "module": "app/components/primer/primer.js",


### PR DESCRIPTION
## 0.0.69

### New

- Add `Primer::Alpha::Tooltip` component

    _Kate Higa_, _Kristján Oddsson_

### Breaking Changes

- Module for [script/update-statuses-project.rb](script/update-statuses-project.rb) changed to `GitHub`

    _Josh Soref_

### Misc

- Spelling fixes

    _Josh Soref_

- Bump view_component in Gemfile.lock files

    _Cameron Dutro_

- Remove markdown file mistakenly checked in.

  _Kate Higa_

- Upgrade octicons to >= 17.0.0

  _Jon Rohan_

### Bug Fixes

- Fix missing @primer/components dependency.

    _Hector Garcia_