### PR TITLE
Add `Tooltip` support to `Link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
     _Hector Garcia_
 
+- Add `Tooltip` support to `Link`.
+
+    _Hector Garcia_
+
 ### Bug Fixes
 
 - Ensure tooltip arrow position and tooltip width is correct.

--- a/app/components/primer/link_component.erb
+++ b/app/components/primer/link_component.erb
@@ -1,0 +1,3 @@
+<%= render Primer::BaseComponent.new(**@system_arguments) do %>
+  <%= content %>
+<% end %>

--- a/app/components/primer/link_component.erb
+++ b/app/components/primer/link_component.erb
@@ -1,3 +1,4 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <%= content %>
+  <%= tooltip %>
 <% end %>

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -15,6 +15,23 @@ module Primer
     DEFAULT_TAG = :a
     TAG_OPTIONS = [DEFAULT_TAG, :span].freeze
 
+    # `Tooltip` that appears on mouse hover or keyboard focus over the link. Use tooltips sparingly and as a last resort.
+    # **Important:** This tooltip defaults to `type: :description`. In a few scenarios, `type: :label` may be more appropriate.
+    # Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
+    #
+    # @param type [Symbol] (:description) <%= one_of(Primer::Alpha::Tooltip::TYPE_OPTIONS) %>
+    # @param system_arguments [Hash] Same arguments as <%= link_to_component(Primer::Alpha::Tooltip) %>.
+    renders_one :tooltip, lambda { |**system_arguments|
+      raise ArgumentError, "Links with a tooltip must have a unique `id` set on the `LinkComponent`." if @id.blank? && !Rails.env.production?
+
+      @system_arguments = system_arguments
+
+      @system_arguments[:for_id] = @id
+      @system_arguments[:type] ||= :description
+
+      Primer::Alpha::Tooltip.new(**@system_arguments)
+    }
+
     # @example Default
     #   <%= render(Primer::LinkComponent.new(href: "#")) { "Link" } %>
     #
@@ -31,6 +48,15 @@ module Primer
     # @example Span as link
     #   <%= render(Primer::LinkComponent.new(tag: :span)) { "Span as a link" } %>
     #
+    # @example With tooltip
+    #   @description
+    #     Use tooltips sparingly and as a last resort. Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
+    #   @code
+    #     <%= render(Primer::LinkComponent.new(href: "#", id: "link-with-tooltip")) do |c| %>
+    #       <% c.tooltip(text: "Tooltip text") %>
+    #       Link
+    #     <% end %>
+    #
     # @param tag [String]  <%= one_of(Primer::LinkComponent::TAG_OPTIONS) %>
     # @param href [String] URL to be used for the Link. Required if tag is `:a`. If the requirements are not met an error will be raised in non production environments. In production, an empty link element will be rendered.
     # @param scheme [Symbol] <%= one_of(Primer::LinkComponent::SCHEME_MAPPINGS.keys) %>
@@ -39,6 +65,9 @@ module Primer
     # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
     def initialize(href: nil, tag: DEFAULT_TAG, scheme: DEFAULT_SCHEME, muted: false, underline: true, **system_arguments)
       @system_arguments = system_arguments
+
+      @id = @system_arguments[:id]
+
       @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
       @system_arguments[:href] = href
       @system_arguments[:classes] = class_names(

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -50,10 +50,6 @@ module Primer
       )
     end
 
-    def call
-      render(Primer::BaseComponent.new(**@system_arguments)) { content }
-    end
-
     def before_render
       raise ArgumentError, "href is required when using <a> tag" if @system_arguments[:tag] == :a && @system_arguments[:href].nil? && !Rails.env.production?
     end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -97,7 +97,8 @@ namespace :docs do
       Primer::Alpha::UnderlinePanels,
       Primer::Alpha::TabPanels,
       Primer::Alpha::Tooltip,
-      Primer::ButtonComponent
+      Primer::ButtonComponent,
+      Primer::LinkComponent
     ]
 
     all_components = Primer::Component.descendants - [Primer::BaseComponent]

--- a/stories/primer/link_component_stories.rb
+++ b/stories/primer/link_component_stories.rb
@@ -16,4 +16,20 @@ class Primer::LinkComponentStories < ViewComponent::Storybook::Stories
       "This is a link!"
     end
   end
+
+  story(:with_tooltip) do
+    controls do
+      href "https://github.com/"
+      muted false
+      underline true
+      text(:id, "link-with-tooltip")
+      select(:scheme, Primer::LinkComponent::SCHEME_MAPPINGS.keys, Primer::LinkComponent::DEFAULT_SCHEME)
+      select(:tag, Primer::LinkComponent::TAG_OPTIONS, Primer::LinkComponent::DEFAULT_TAG)
+    end
+
+    content do |c|
+      c.tooltip(text: "Tooltip text")
+      "This is a link!"
+    end
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

The API of `Link` should be updated so `Tooltip` can be rendered via the component arguments.

- Closes https://github.com/github/primer/issues/781
- See the Accessibility story issue https://github.com/github/accessibility/issues/802

### What approach did you choose and why?

We decided to use a slot to render the `Tooltip` as it allows for explicit control of the defaults, which we want to ensure proper integration and an accessible outcome. We will follow the same pattern for the rest of the components that integrate `Tooltip`.

For example, we set `type: :description` as the default, as all links will have a label already.

Very similar to:
- https://github.com/primer/view_components/pull/1058

### Docs

![Screen Shot 2022-03-22 at 18 12 07](https://user-images.githubusercontent.com/24622853/159537141-c51ec86c-daad-45c5-ad0f-de1dc21cda81.png)

![Screen Shot 2022-03-22 at 18 10 26](https://user-images.githubusercontent.com/24622853/159536891-c28b6529-5f0c-4239-86ad-39e56361e322.png)

![Screen Shot 2022-03-22 at 18 11 33](https://user-images.githubusercontent.com/24622853/159537047-56a1041d-76a8-4c38-88ed-0f6ad7868d64.png)

