### PR TITLE
Fix `ButtonComponent` example indentation

### DIFF
--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -117,10 +117,10 @@ module Primer
     #   @description
     #     Use tooltips sparingly and as a last resort. Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
     #   @code
-    #   <%= render(Primer::ButtonComponent.new(id: "button-with-tooltip")) do |c| %>
-    #     <% c.tooltip(text: "Tooltip text") %>
-    #     Button
-    #   <% end %>
+    #     <%= render(Primer::ButtonComponent.new(id: "button-with-tooltip")) do |c| %>
+    #       <% c.tooltip(text: "Tooltip text") %>
+    #       Button
+    #     <% end %>
     #
     # @param scheme [Symbol] <%= one_of(Primer::ButtonComponent::SCHEME_OPTIONS) %>
     # @param variant [Symbol] DEPRECATED. <%= one_of(Primer::ButtonComponent::SIZE_OPTIONS) %>


### PR DESCRIPTION
### What are you trying to accomplish?

The code block of the `ButtonComponent` example with a tooltip was not indented properly as it was missing one level of indentation.

#### Before
<img width="670" alt="Screen Shot 2022-03-23 at 14 18 17" src="https://user-images.githubusercontent.com/24622853/159708437-36d8cd7d-c9b6-44b3-8fc8-6bc5f0a39843.png">


#### After
<img width="670" alt="Screen Shot 2022-03-23 at 14 18 19" src="https://user-images.githubusercontent.com/24622853/159708459-f373ef12-e078-4a18-bbb5-c1055bf61327.png">

