### PR TITLE
Ensure gh CLI tool is installed when running script/publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### New
+
+- Check for the `gh` CLI tool in release scripts.
+
+    _Cameron Dutro_
+
 ## 0.0.69
 
 ### New

--- a/script/publish
+++ b/script/publish
@@ -12,6 +12,16 @@ require_relative "../lib/primer/view_components/version"
 class PublishCLI < Thor::Group
   include Thor::Actions
 
+  def exit_on_failure?
+    false
+  end
+
+  def tools_are_installed
+    unless run("which gh")
+      raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing."
+    end
+  end
+
   def release_gem
     run("bundle exec rake release")
   end

--- a/script/publish
+++ b/script/publish
@@ -17,9 +17,7 @@ class PublishCLI < Thor::Group
   end
 
   def tools_are_installed
-    unless run("which gh")
-      raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing."
-    end
+    raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing." unless run("which gh")
   end
 
   def release_gem

--- a/script/release
+++ b/script/release
@@ -22,6 +22,12 @@ class ReleaseCLI < Thor::Group
     false
   end
 
+  def tools_are_installed
+    unless run("which gh")
+      raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing."
+    end
+  end
+
   def working_tree_is_clean
     tree_status = run("git status --porcelain", capture: true).strip
     raise "Tree is not clean" unless tree_status.empty?

--- a/script/release
+++ b/script/release
@@ -23,9 +23,7 @@ class ReleaseCLI < Thor::Group
   end
 
   def tools_are_installed
-    unless run("which gh")
-      raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing."
-    end
+    raise "The gh CLI tool couldn't be found on your PATH. Please install it and run `gh auth login` before continuing." unless run("which gh")
   end
 
   def working_tree_is_clean


### PR DESCRIPTION
The script/publish script will fail if the gh CLI tool isn't installed.