### PR TITLE
Bump to @primer/css version 19.7.1

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "@primer/css": "^19.7.0",
+    "@primer/css": "^19.7.1",
     "@rails/actioncable": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "prettier": "^2.4.1",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1377,10 +1377,10 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.2.tgz#adea7b6953cbb34651766b0548468e743c6a2353"
   integrity sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q==
 
-"@primer/css@^19.7.0":
-  version "19.7.0"
-  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.0.tgz#f1cfe25c366bda5adc1fb5fda797db0d8e4026c2"
-  integrity sha512-+VRm7taPN8vdxSyHibmE9UB4XCVmANcO5ikuk5biSVwatBYBEhd852ZbgGRfip2gN+3BxDu4QFlVsTphm9ZpUA==
+"@primer/css@^19.7.1":
+  version "19.7.1"
+  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.1.tgz#36f8f185a36df57b300d0ec0db731b9a52b4ed0b"
+  integrity sha512-g3ffaBiyVs0hUqlN89YnLA0rs5zc8PtTbs+w7CSb45M/xAz0+grD6Yo81ECGpfxhAn1AuRIfcX79CPnogbpDgw==
   dependencies:
     "@primer/primitives" "^7.5.1"
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "now-build": "exit 0"
   },
   "dependencies": {
-    "@primer/css": "^19.7.0",
+    "@primer/css": "^19.7.1",
     "@primer/gatsby-theme-doctocat": "^3.2.1",
     "@primer/primitives": "^6.0.0",
     "@primer/react": "^34.7.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1572,10 +1572,10 @@
   resolved "https://registry.yarnpkg.com/@primer/component-metadata/-/component-metadata-0.4.0.tgz#44b7d7b1285bea41c2a88621fd17f2c777a4c5e9"
   integrity sha512-yppmDSSDrN2CHwjq3h+RWhfpjehFQAx21JcEipYyNTp0f/kC+iazFVNCKZE6DOavAxv003ti7QIrp+QkPT9tpg==
 
-"@primer/css@^19.7.0":
-  version "19.7.0"
-  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.0.tgz#f1cfe25c366bda5adc1fb5fda797db0d8e4026c2"
-  integrity sha512-+VRm7taPN8vdxSyHibmE9UB4XCVmANcO5ikuk5biSVwatBYBEhd852ZbgGRfip2gN+3BxDu4QFlVsTphm9ZpUA==
+"@primer/css@^19.7.1":
+  version "19.7.1"
+  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.1.tgz#36f8f185a36df57b300d0ec0db731b9a52b4ed0b"
+  integrity sha512-g3ffaBiyVs0hUqlN89YnLA0rs5zc8PtTbs+w7CSb45M/xAz0+grD6Yo81ECGpfxhAn1AuRIfcX79CPnogbpDgw==
   dependencies:
     "@primer/primitives" "^7.5.1"
 

--- a/lib/primer/classify/utilities.yml
+++ b/lib/primer/classify/utilities.yml
@@ -1417,6 +1417,12 @@
   - hide-lg
   :xl:
   - hide-xl
+  :whenNarrow:
+  - hide-whenNarrow
+  :whenRegular:
+  - hide-whenRegular
+  :whenWide:
+  - hide-whenWide
 :container:
   :sm:
   - container-sm

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@github/prettier-config": "0.0.4",
-    "@primer/css": "^19.0.0",
+    "@primer/css": "^19.7.1",
     "@primer/primitives": "^7.1.0",
     "@rollup/plugin-node-resolve": "^11.2.0",
     "@rollup/plugin-typescript": "^8.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,10 +107,10 @@
   resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.1.0.tgz#d5624195b893a1b8c72f904fbbfec2f97b234243"
   integrity sha512-Ej2OUc3ZIFaR7WwIUqESO1DTzmpb7wc8xbTVRT9s52jZQDjN7g5iljoK3ocYZm+BIAcKn3MvcwB42hEk4Ga4xQ==
 
-"@primer/css@^19.0.0":
-  version "19.7.0"
-  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.0.tgz#f1cfe25c366bda5adc1fb5fda797db0d8e4026c2"
-  integrity sha512-+VRm7taPN8vdxSyHibmE9UB4XCVmANcO5ikuk5biSVwatBYBEhd852ZbgGRfip2gN+3BxDu4QFlVsTphm9ZpUA==
+"@primer/css@^19.7.1":
+  version "19.7.1"
+  resolved "https://registry.yarnpkg.com/@primer/css/-/css-19.7.1.tgz#36f8f185a36df57b300d0ec0db731b9a52b4ed0b"
+  integrity sha512-g3ffaBiyVs0hUqlN89YnLA0rs5zc8PtTbs+w7CSb45M/xAz0+grD6Yo81ECGpfxhAn1AuRIfcX79CPnogbpDgw==
   dependencies:
     "@primer/primitives" "^7.5.1"
 


### PR DESCRIPTION
cc: @lindseywild 

This PR bumps to the latest `@primer/css` version [19.7.1](https://github.com/primer/css/releases/tag/v19.7.1) which includes  changes CSS changes we would like for `Autocomplete`.

Ideally we can get this merged in before we bump PVC @hectahertz. 