### PR TITLE
Fix post-create-command

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -7,8 +7,4 @@ script_folder="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 workspaces_folder="$(cd "${script_folder}/.." && pwd)"
 
 cd "${workspaces_folder}"
-if [ ! -d "$1" ]; then
-    git clone "https://github.com/primer/css"
-else
-    echo "Already cloned $1"
-fi
+git clone "https://github.com/primer/css"


### PR DESCRIPTION
Fixes an issue with https://github.com/primer/view_components/pull/1089 where we were checking for a parameter that doesn't exist; this code was a leftover from a function we removed.

This has now been tested by running the script manually on a Codespace.