### PR TITLE
Fix post-create-command.sh css folder

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -4,7 +4,7 @@ sudo cp --force .devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-cont
 script/setup
 
 script_folder="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
-workspaces_folder="$(cd "${script_folder}/.." && pwd)"
+workspaces_folder="$(cd "${script_folder}/../.." && pwd)"
 
 cd "${workspaces_folder}"
 git clone "https://github.com/primer/css"


### PR DESCRIPTION
Fixes an issue with https://github.com/primer/view_components/pull/1089 where it clones `primer/css` in `workspaces/view_components/css` instead of `workspaces/css`.

This is due to the location of the `post-create-command.sh` file, which is not at the root of the project. The code we used as an example was not accounting for this.

This has now been tested by running the script manually on a Codespace.