### PR TITLE
Fix view_component deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
   _Sam Morrow_
 
+### Misc
+
+- Update documentation to reflect deprecation of `require "view_component/engine"`
+
+  _Leo Correa_
+
 ## 0.0.71
 
 ### Updates

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -27,7 +27,7 @@ gem "primer_view_components"
 In `config/application.rb`, add **after the application definition**:
 
 ```ruby
-require "view_component/engine"
+require "view_component"
 require "primer/view_components/engine"
 ```
 


### PR DESCRIPTION
Requiring `view_component/engine` was deprecated in `view_component` version 2.46.0 https://github.com/github/view_component/commit/d24b26ae2697685e930d863839d7f8834b9ca4a3

Requiring `view_component` will automatically load the engine when in the correct context.

I'm also wondering if we should `require "view_component"` inside `primer/view_components/engine` so that we don't have to require `view_component` explicitly from apps using `primer/view_component/engine`?