### PR TITLE
Fix alphabetization of components in navigation of doc site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 ## main
 
 ### Misc
+
 - Fix alphabetization of components in docs.
 
 ## 0.0.71

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Misc
+- Fix alphabetization of components in docs.
+
 ## 0.0.71
 
 ### Updates

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -59,12 +59,12 @@
     url: "/components/heading"
   - title: HiddenTextExpander
     url: "/components/hiddentextexpander"
+  - title: IconButton
+    url: "/components/iconbutton"
   - title: Image
     url: "/components/image"
   - title: ImageCrop
     url: "/components/imagecrop"
-  - title: IconButton
-    url: "/components/iconbutton"
   - title: Label
     url: "/components/label"
   - title: Layout
@@ -73,10 +73,10 @@
     url: "/components/link"
   - title: LocalTime
     url: "/components/localtime"
-  - title: Menu
-    url: "/components/menu"
   - title: Markdown
     url: "/components/markdown"
+  - title: Menu
+    url: "/components/menu"
   - title: Octicon
     url: "/components/octicon"
   - title: OcticonSymbols


### PR DESCRIPTION
Fix alphabetization of components in docs nav.
<img width="223" alt="image" src="https://user-images.githubusercontent.com/15931013/162036597-db29366d-a532-41ea-a815-2ccafa16a036.png">
(IconButton should be a little higher up)