### PR TITLE
bugfix: ensure that no whitespace is added inside LinkComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Bug Fixes
+
+- Ensure that no whitespace is added inside LinkComponent.
+
+  _Sam Morrow_
+
 ## 0.0.71
 
 ### Updates

--- a/app/components/primer/link_component.erb
+++ b/app/components/primer/link_component.erb
@@ -1,4 +1,1 @@
-<%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <%= content %>
-  <%= tooltip %>
-<% end %>
+<%= render Primer::BaseComponent.new(**@system_arguments) do -%><%= content -%><%= tooltip -%><% end %>

--- a/test/components/link_component_test.rb
+++ b/test/components/link_component_test.rb
@@ -12,6 +12,12 @@ class PrimerLinkComponentTest < Minitest::Test
     refute_selector(".Link--muted")
   end
 
+  def test_renders_no_additional_whitespace
+    render_inline(Primer::LinkComponent.new(href: "http://joe-jonas-shirtless.com")) { "content" }
+
+    assert_text(/^content$/)
+  end
+
   def test_renders_as_a_link
     render_inline(Primer::LinkComponent.new(href: "http://google.com")) { "content" }
 


### PR DESCRIPTION
Closes https://github.com/primer/view_components/issues/1106

Ensure that there is a test to catch extra whitespace, and change the `.erb` file so that it adds no whitespace.