### PR TITLE
Introduce `DeprecatedComponents` rubocop rule to automatically lint against deprecated component

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,3 +12,7 @@ linters:
     rubocop_config:
       inherit_from:
         - lib/rubocop/config/default.yml
+      Primer/DeprecatedComponents:
+        Enabled: true
+        Exclude:
+          - app/components/primer/layout_component.html.erb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,3 +76,6 @@ Primer/ComponentNameMigration:
   Enabled: true
   Exclude:
     - "test/**/*"
+
+Primer/DeprecatedComponents:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+- Introduce `DeprecatedComponents` rubocop rule.
+
+    _Kate Higa_
+
+## 0.0.69
+
 ### New
 
 - Add `Tooltip` support to `Button`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ The category for changes related to documentation, testing and tooling. Also, fo
 -->
 
 ## main
-
 - Introduce `DeprecatedComponents` rubocop rule.
 
     _Kate Higa_
@@ -37,7 +36,6 @@ The category for changes related to documentation, testing and tooling. Also, fo
 ## 0.0.69
 
 ### Misc
-
 - Fix alphabetization of components in docs.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,11 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 ## main
 
+### Misc
+
 - Introduce `DeprecatedComponents` rubocop rule.
 
     _Kate Higa_
-
-## 0.0.69
-
-### Misc
 
 - Fix alphabetization of components in docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 -->
 
 ## main
+
 - Introduce `DeprecatedComponents` rubocop rule.
 
     _Kate Higa_
@@ -36,6 +37,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
 ## 0.0.69
 
 ### Misc
+
 - Fix alphabetization of components in docs.
 
 ### Bug Fixes
@@ -53,6 +55,7 @@ The category for changes related to documentation, testing and tooling. Also, fo
     _Lukas Spieß_
 
 ## 0.0.70
+
 ### New
 
 - Add `Tooltip` support to `Button`.

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -15,3 +15,6 @@ Primer/PrimerOcticon:
 
 Primer/DeprecatedArguments:
   Enabled: true
+
+Primer/DeprecatedComponents:
+  Enabled: true

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -9,7 +9,7 @@ module RuboCop
     module Primer
       # This cop ensures that components marked as "deprecated" in `static/statuses.json` are not used.
       class DeprecatedComponents < BaseCop
-        # Converts a string to a pattern accepted by rubocop-ast
+        # Converts a string to acceptable rubocop-ast pattern syntax
         def pattern(component)
           Parser::CurrentRuby.parse(component)
             .to_s
@@ -17,10 +17,6 @@ module RuboCop
             .gsub("\n", "")
             .gsub("  ", " ")
         end
-
-        # def_node_matcher :legacy_component?, <<~PATTERN
-        #   (send %pattern :new ...)
-        # PATTERN
 
         # If there is no alternative, set the value to nil.
         ALTERNATIVE_COMPONENTS = {
@@ -33,21 +29,16 @@ module RuboCop
 
         def on_send(node)
           load_deprecated_components
-          # @deprecated_components
-          # ["Primer::Tooltip"].each do |component|
-          #   # add_offense(node, message: message(component)) 
-          #   binding.irb if legacy_component?(node, pattern: pattern(component))
-          # end
-          ["Primer::Tooltip"].each do |component|
+          @deprecated_components.each do |component|
             pattern = "(send #{pattern(component)} :new ...)"
-            if NodePattern.new(pattern).match(node)
+            add_offense(node, message: message(component))  if NodePattern.new(pattern).match(node)
           end
         end
 
         def message(component)
           message = "#{component} has been deprecated and should not be used."
           if ALTERNATIVE_COMPONENTS.fetch(component).present?
-            message += " Please try #{ALTERNATIVE_COMPONENTS[component]} instead." 
+            message += " Please use #{ALTERNATIVE_COMPONENTS[component]} instead." 
           end
           message
         end
@@ -61,7 +52,7 @@ module RuboCop
           @deprecated_components = json.select { |_, value| value == "deprecated" }.keys
           @deprecated_components.each do |deprecated|
             unless ALTERNATIVE_COMPONENTS.keys.include?(deprecated)
-              raise "Please provide an alternative component for #{deprecated} in ALTERNATIVE_COMPONENTS. If none exist, set the value to nil."
+              raise "Please add an alternative component for #{deprecated} to ALTERNATIVE_COMPONENTS. If none exist, set the value to nil."
             end
           end
         end

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -14,7 +14,7 @@ module RuboCop
           "Primer::LayoutComponent" => "Primer::Alpha::Layout",
           "Primer::Tooltip" => "Primer::Alpha::Tooltip",
           "Primer::BlankslateComponent" => "Primer::Beta::Blankslate"
-        }
+        }.freeze
 
         def on_send(node)
           load_deprecated_components
@@ -23,12 +23,9 @@ module RuboCop
           add_offense(node, message: message(component))
         end
 
-
         def message(component)
           message = "#{component} has been deprecated."
-          if ALTERNATIVE_COMPONENTS.key?(component)
-            message += "Please try #{ALTERNATIVE_COMPONENTS[component]} instead."
-          end
+          message += "Please try #{ALTERNATIVE_COMPONENTS[component]} instead." if ALTERNATIVE_COMPONENTS.key?(component)
 
           message
         end
@@ -39,7 +36,7 @@ module RuboCop
               File.join(File.dirname(__FILE__), "../../../../static/statuses.json")
             )
           ).freeze
-          @deprecated_components = json.select {|key, value| value == 'deprecated'}.keys
+          @deprecated_components = json.select { |_key, value| value == "deprecated" }.keys
         end
       end
     end

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -2,22 +2,25 @@
 
 require "rubocop"
 require "json"
-require 'parser/current'
+require "parser/current"
 
 module RuboCop
   module Cop
     module Primer
       # This cop ensures that components marked as "deprecated" in `static/statuses.json` are not used.
+      #
+      # bad
+      # Primer::BlankslateComponent.new(:foo)
+      #
+      # good
+      # Primer::Beta::Blankslate.new(:foo)
+      #
+      # bad
+      # Primer::Tooltip.new(:foo)
+      #
+      # good
+      # Primer::Alpha::Tooltip.new(:foo)
       class DeprecatedComponents < BaseCop
-        # Converts a string to acceptable rubocop-ast pattern syntax
-        def pattern(component)
-          Parser::CurrentRuby.parse(component)
-            .to_s
-            .gsub('nil', 'nil?')
-            .gsub("\n", "")
-            .gsub("  ", " ")
-        end
-
         # If there is no alternative, set the value to nil.
         ALTERNATIVE_COMPONENTS = {
           "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
@@ -28,33 +31,40 @@ module RuboCop
         }.freeze
 
         def on_send(node)
-          load_deprecated_components
-          @deprecated_components.each do |component|
+          deprecated_components.each do |component|
             pattern = "(send #{pattern(component)} :new ...)"
-            add_offense(node, message: message(component))  if NodePattern.new(pattern).match(node)
+            add_offense(node, message: message(component)) if NodePattern.new(pattern).match(node)
           end
+        end
+
+        private
+
+        # Converts a string to acceptable rubocop-ast pattern syntax
+        def pattern(component)
+          Parser::CurrentRuby.parse(component)
+                             .to_s
+                             .gsub("nil", "nil?")
+                             .delete("\n")
+                             .gsub("  ", " ")
         end
 
         def message(component)
           message = "#{component} has been deprecated and should not be used."
-          if ALTERNATIVE_COMPONENTS.fetch(component).present?
-            message += " Please use #{ALTERNATIVE_COMPONENTS[component]} instead." 
-          end
+          message += " Please use #{ALTERNATIVE_COMPONENTS[component]} instead." if ALTERNATIVE_COMPONENTS.fetch(component).present?
           message
         end
 
-        def load_deprecated_components
+        def deprecated_components
           json = JSON.parse(
             File.read(
               File.join(File.dirname(__FILE__), "../../../../static/statuses.json")
             )
           ).freeze
-          @deprecated_components = json.select { |_, value| value == "deprecated" }.keys
-          @deprecated_components.each do |deprecated|
-            unless ALTERNATIVE_COMPONENTS.keys.include?(deprecated)
-              raise "Please add an alternative component for #{deprecated} to ALTERNATIVE_COMPONENTS. If none exist, set the value to nil."
-            end
+          deprecated_components = json.select { |_, value| value == "deprecated" }.keys
+          deprecated_components.each do |deprecated|
+            raise "Please add an alternative component for #{deprecated} to ALTERNATIVE_COMPONENTS. If none exist, set the value to nil." unless ALTERNATIVE_COMPONENTS.key?(deprecated)
           end
+          deprecated_components
         end
       end
     end

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -65,8 +65,8 @@ module RuboCop
           deprecated_components = json.select { |_, value| value == "deprecated" }.keys
           deprecated_components.each do |deprecated|
             unless COMPONENT_TO_USE_INSTEAD.key?(deprecated)
-              raise "Please provide a component that should be used in place of #{deprecated} in COMPONENT_TO_USE_INSTEAD. " +
-              "If there is no alternative, set the value to nil."
+              raise "Please provide a component that should be used in place of #{deprecated} in COMPONENT_TO_USE_INSTEAD. "\
+                    "If there is no alternative, set the value to nil."
             end
           end
           deprecated_components

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -2,31 +2,53 @@
 
 require "rubocop"
 require "json"
+require 'parser/current'
 
 module RuboCop
   module Cop
     module Primer
-      # This cop ensures that components with deprecated status are not used.
-      # When an alternative component is available, it should be added to the ALTERNATIVE_COMPONENTS
-      # so that it can be suggested.
+      # This cop ensures that components marked as "deprecated" in `static/statuses.json` are not used.
       class DeprecatedComponents < BaseCop
+        # Converts a string to a pattern accepted by rubocop-ast
+        def pattern(component)
+          Parser::CurrentRuby.parse(component)
+            .to_s
+            .gsub('nil', 'nil?')
+            .gsub("\n", "")
+            .gsub("  ", " ")
+        end
+
+        # def_node_matcher :legacy_component?, <<~PATTERN
+        #   (send %pattern :new ...)
+        # PATTERN
+
+        # If there is no alternative, set the value to nil.
         ALTERNATIVE_COMPONENTS = {
-          "Primer::LayoutComponent" => "Primer::Alpha::Layout",
+          "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
+          "Primer::DropdownMenuComponent" => nil,
           "Primer::Tooltip" => "Primer::Alpha::Tooltip",
-          "Primer::BlankslateComponent" => "Primer::Beta::Blankslate"
+          "Primer::FlexComponent" => nil,
+          "Primer::FlexItemComponent" => nil
         }.freeze
 
         def on_send(node)
           load_deprecated_components
-          # Todo - find match with `@deprecated_components``
-          # save match to `component` variable
-          add_offense(node, message: message(component))
+          # @deprecated_components
+          # ["Primer::Tooltip"].each do |component|
+          #   # add_offense(node, message: message(component)) 
+          #   binding.irb if legacy_component?(node, pattern: pattern(component))
+          # end
+          ["Primer::Tooltip"].each do |component|
+            pattern = "(send #{pattern(component)} :new ...)"
+            if NodePattern.new(pattern).match(node)
+          end
         end
 
         def message(component)
-          message = "#{component} has been deprecated."
-          message += "Please try #{ALTERNATIVE_COMPONENTS[component]} instead." if ALTERNATIVE_COMPONENTS.key?(component)
-
+          message = "#{component} has been deprecated and should not be used."
+          if ALTERNATIVE_COMPONENTS.fetch(component).present?
+            message += " Please try #{ALTERNATIVE_COMPONENTS[component]} instead." 
+          end
           message
         end
 
@@ -36,7 +58,12 @@ module RuboCop
               File.join(File.dirname(__FILE__), "../../../../static/statuses.json")
             )
           ).freeze
-          @deprecated_components = json.select { |_key, value| value == "deprecated" }.keys
+          @deprecated_components = json.select { |_, value| value == "deprecated" }.keys
+          @deprecated_components.each do |deprecated|
+            unless ALTERNATIVE_COMPONENTS.keys.include?(deprecated)
+              raise "Please provide an alternative component for #{deprecated} in ALTERNATIVE_COMPONENTS. If none exist, set the value to nil."
+            end
+          end
         end
       end
     end

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -56,13 +56,16 @@ module RuboCop
           message
         end
 
-        def deprecated_components
-          json = JSON.parse(
+        def statuses_json
+          JSON.parse(
             File.read(
               File.join(File.dirname(__FILE__), "../../../../static/statuses.json")
             )
           ).freeze
-          deprecated_components = json.select { |_, value| value == "deprecated" }.keys
+        end
+
+        def deprecated_components
+          deprecated_components = statuses_json.select { |_, value| value == "deprecated" }.keys
           deprecated_components.each do |deprecated|
             unless COMPONENT_TO_USE_INSTEAD.key?(deprecated)
               raise "Please provide a component that should be used in place of #{deprecated} in COMPONENT_TO_USE_INSTEAD. "\

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -31,6 +31,8 @@ module RuboCop
         }.freeze
 
         def on_send(node)
+          return unless node.source.include?("Primer::")
+
           deprecated_components.each do |component|
             pattern = "(send #{pattern(component)} :new ...)"
             add_offense(node, message: message(component)) if NodePattern.new(pattern).match(node)

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rubocop"
+require "json"
+
+module RuboCop
+  module Cop
+    module Primer
+      # This cop ensures that components with deprecated status are not used.
+      # When an alternative is available, it should be added to the ALTERNATIVE_COMPONENTS map.
+      class DeprecatedComponents < BaseCop
+        def_node_matcher :legacy_component?, <<~PATTERN
+          (send (const (const nil? :Primer) :LayoutComponent) :new ...)
+        PATTERN
+
+        ALTERNATIVE_COMPONENTS = {
+          "Primer::LayoutComponent" => "Primer::Alpha::Layout",
+          "Primer::Tooltip" => "Primer::Alpha::Tooltip",
+          "Primer::BlankslateComponent" => "Primer::Beta::Blankslate"
+        }
+
+        def on_send(node)
+          load_deprecated_components
+          return unless legacy_component?(node)
+
+          add_offense(node, message: message(component))
+        end
+
+
+        def message(component)
+          message = "#{component} has been deprecated."
+          if ALTERNATIVE_COMPONENTS.key?(component)
+            message += "Please try #{ALTERNATIVE_COMPONENTS[component]} instead."
+          end
+
+          message
+        end
+
+        def load_deprecated_components
+          json = JSON.parse(
+            File.read(
+              File.join(File.dirname(__FILE__), "../../../static/statuses.json")
+            )
+          ).freeze
+          json.select {|key, value| value == 'deprecated'}
+          @deprecated_components = json.fetch_keys
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -7,12 +7,9 @@ module RuboCop
   module Cop
     module Primer
       # This cop ensures that components with deprecated status are not used.
-      # When an alternative is available, it should be added to the ALTERNATIVE_COMPONENTS map.
+      # When an alternative component is available, it should be added to the ALTERNATIVE_COMPONENTS
+      # so that it can be suggested.
       class DeprecatedComponents < BaseCop
-        def_node_matcher :legacy_component?, <<~PATTERN
-          (send (const (const nil? :Primer) :LayoutComponent) :new ...)
-        PATTERN
-
         ALTERNATIVE_COMPONENTS = {
           "Primer::LayoutComponent" => "Primer::Alpha::Layout",
           "Primer::Tooltip" => "Primer::Alpha::Tooltip",
@@ -21,8 +18,8 @@ module RuboCop
 
         def on_send(node)
           load_deprecated_components
-          return unless legacy_component?(node)
-
+          # Todo - find match with `@deprecated_components``
+          # save match to `component` variable
           add_offense(node, message: message(component))
         end
 
@@ -39,11 +36,10 @@ module RuboCop
         def load_deprecated_components
           json = JSON.parse(
             File.read(
-              File.join(File.dirname(__FILE__), "../../../static/statuses.json")
+              File.join(File.dirname(__FILE__), "../../../../static/statuses.json")
             )
           ).freeze
-          json.select {|key, value| value == 'deprecated'}
-          @deprecated_components = json.fetch_keys
+          @deprecated_components = json.select {|key, value| value == 'deprecated'}.keys
         end
       end
     end

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "cop_test"
+
+class RubocopDeprecatedComponentsTest < CopTest
+  def cop_class
+    RuboCop::Cop::Primer::DeprecatedComponents
+  end
+
+  def test_raises_offense_if_calling_legacy_component
+    investigate(cop, <<-RUBY)
+      Primer::Tooltip.new
+      Primer::BlankslateComponent.new
+      Primer::LayoutComponent.new
+    RUBY
+
+    assert_equal 3, cop.offenses.count
+  end
+
+  def test_raises_offense_if_calling_legacy_component_with_args
+    investigate(cop, <<-RUBY)
+      Primer::LayoutComponent.new(:foo)
+    RUBY
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_raises_offense_if_calling_legacy_component_in_render
+    investigate(cop, <<-RUBY)
+      render(Primer::Tooltip.new)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_raises_offense_if_calling_legacy_component_in_render_with_args
+    investigate(cop, <<-RUBY)
+      render(Primer::LayoutComponent.new(foo: "bar"))
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_suggests_alternative_component_if_available
+    investigate(cop, <<-RUBY)
+      render(Primer::LayoutComponent.new(foo: "bar"))
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Please try Primer::Alpha::Layout instead.", cop.offenses.first.message
+  end
+end

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -7,22 +7,22 @@ class RubocopDeprecatedComponentsTest < CopTest
     RuboCop::Cop::Primer::DeprecatedComponents
   end
 
-  # def test_raises_offense_if_calling_legacy_component
-  #   investigate(cop, <<-RUBY)
-  #     Primer::Tooltip.new
-  #     Primer::BlankslateComponent.new
-  #     Primer::FlexComponent.new
-  #   RUBY
+  def test_raises_offense_if_calling_legacy_component
+    investigate(cop, <<-RUBY)
+      Primer::Tooltip.new
+      Primer::BlankslateComponent.new
+      Primer::FlexComponent.new
+    RUBY
 
-  #   assert_equal 3, cop.offenses.count
-  # end
+    assert_equal 3, cop.offenses.count
+  end
 
-  # def test_raises_offense_if_calling_legacy_component_with_args
-  #   investigate(cop, <<-RUBY)
-  #     Primer::FlexComponent.new(:foo)
-  #   RUBY
-  #   assert_equal 1, cop.offenses.count
-  # end
+  def test_raises_offense_if_calling_legacy_component_with_args
+    investigate(cop, <<-RUBY)
+      Primer::FlexComponent.new(:foo)
+    RUBY
+    assert_equal 1, cop.offenses.count
+  end
 
   def test_raises_offense_if_calling_legacy_component_in_render
     investigate(cop, <<-RUBY)
@@ -32,21 +32,20 @@ class RubocopDeprecatedComponentsTest < CopTest
     assert_equal 1, cop.offenses.count
   end
 
-  # def test_raises_offense_if_calling_legacy_component_in_render_with_args
-  #   investigate(cop, <<-RUBY)
-  #     render(Primer::FlexComponent.new(foo: "bar"))
-  #   RUBY
+  def test_raises_offense_if_calling_legacy_component_in_render_with_args
+    investigate(cop, <<-RUBY)
+      render(Primer::FlexComponent.new(foo: "bar"))
+    RUBY
 
-  #   assert_equal 1, cop.offenses.count
-  # end
+    assert_equal 1, cop.offenses.count
+  end
 
-  # def test_suggests_alternative_component_if_available
-  #   investigate(cop, <<-RUBY)
-  #     render(Primer::Tooltip.new(foo: "bar"))
-  #   RUBY
+  def test_suggests_alternative_component_if_available
+    investigate(cop, <<-RUBY)
+      render(Primer::Tooltip.new(foo: "bar"))
+    RUBY
 
-  #   binding.irb
-  #   assert_equal 1, cop.offenses.count
-  #   assert_equal "Please try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
-  # end
+    assert_equal 1, cop.offenses.count
+    assert_equal "Primer::Tooltip has been deprecated and should not be used. Please use Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+  end
 end

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -62,6 +62,6 @@ class RubocopDeprecatedComponentsTest < CopTest
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "Primer::Tooltip has been deprecated and should not be used. Please use Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+    assert_equal "Primer::Tooltip has been deprecated and should not be used. Try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
   end
 end

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -7,61 +7,70 @@ class RubocopDeprecatedComponentsTest < CopTest
     RuboCop::Cop::Primer::DeprecatedComponents
   end
 
-  def test_does_not_raise_offense_for_non_primer_node
-    investigate(cop, <<-RUBY)
-      text = FakeComponent.new
-    RUBY
+  # def test_does_not_raise_offense_for_non_primer_node
+  #   investigate(cop, <<-RUBY)
+  #     text = FakeComponent.new
+  #   RUBY
 
-    assert_equal 0, cop.offenses.count
-  end
+  #   assert_equal 0, cop.offenses.count
+  # end
 
-  def test_does_not_raise_offense_if_non_legacy_component_is_used
-    investigate(cop, <<-RUBY)
-      Primer::ClipboardCopy.new
-    RUBY
+  # def test_does_not_raise_offense_if_non_legacy_component_is_used
+  #   investigate(cop, <<-RUBY)
+  #     Primer::ClipboardCopy.new
+  #   RUBY
 
-    assert_equal 0, cop.offenses.count
-  end
+  #   assert_equal 0, cop.offenses.count
+  # end
 
-  def test_raises_offense_if_calling_legacy_component
-    investigate(cop, <<-RUBY)
-      Primer::Tooltip.new
-      Primer::BlankslateComponent.new
-      Primer::FlexComponent.new
-    RUBY
+  # def test_raises_offense_if_calling_legacy_component
+  #   investigate(cop, <<-RUBY)
+  #     Primer::Tooltip.new
+  #     Primer::BlankslateComponent.new
+  #     Primer::FlexComponent.new
+  #   RUBY
 
-    assert_equal 3, cop.offenses.count
-  end
+  #   assert_equal 3, cop.offenses.count
+  # end
 
-  def test_raises_offense_if_calling_legacy_component_with_args
-    investigate(cop, <<-RUBY)
-      Primer::FlexComponent.new(:foo)
-    RUBY
-    assert_equal 1, cop.offenses.count
-  end
+  # def test_raises_offense_if_calling_legacy_component_with_args
+  #   investigate(cop, <<-RUBY)
+  #     Primer::FlexComponent.new(:foo)
+  #   RUBY
+  #   assert_equal 1, cop.offenses.count
+  # end
 
-  def test_raises_offense_if_calling_legacy_component_in_render
-    investigate(cop, <<-RUBY)
-      render(Primer::Tooltip.new)
-    RUBY
+  # def test_raises_offense_if_calling_legacy_component_in_render
+  #   investigate(cop, <<-RUBY)
+  #     render(Primer::Tooltip.new)
+  #   RUBY
 
-    assert_equal 1, cop.offenses.count
-  end
+  #   assert_equal 1, cop.offenses.count
+  # end
 
-  def test_raises_offense_if_calling_legacy_component_in_render_with_args
-    investigate(cop, <<-RUBY)
-      render(Primer::FlexComponent.new(foo: "bar"))
-    RUBY
+  # def test_raises_offense_if_calling_legacy_component_in_render_with_args
+  #   investigate(cop, <<-RUBY)
+  #     render(Primer::FlexComponent.new(foo: "bar"))
+  #   RUBY
 
-    assert_equal 1, cop.offenses.count
-  end
+  #   assert_equal 1, cop.offenses.count
+  # end
 
-  def test_suggests_alternative_component_if_available
-    investigate(cop, <<-RUBY)
-      render(Primer::Tooltip.new(foo: "bar"))
-    RUBY
+  # def test_suggests_alternative_component_if_available
+  #   investigate(cop, <<-RUBY)
+  #     render(Primer::Tooltip.new(foo: "bar"))
+  #   RUBY
 
-    assert_equal 1, cop.offenses.count
-    assert_equal "Primer::Tooltip has been deprecated and should not be used. Try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+  #   assert_equal 1, cop.offenses.count
+  #   assert_equal "Primer::Tooltip has been deprecated and should not be used. Try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+  # end
+
+  def test_raises_if_legacy_component_missing_in_alternative_components
+    RuboCop::Cop::Primer::DeprecatedComponents.any_instance.stubs(:statuses_json).returns({ "Primer::FakeComponent": "deprecated" })
+    assert_raises(RuntimeError) do
+      investigate(cop, <<-RUBY)
+        render(Primer::FakeComponent.new(foo: "bar"))
+      RUBY
+    end
   end
 end

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -7,63 +7,63 @@ class RubocopDeprecatedComponentsTest < CopTest
     RuboCop::Cop::Primer::DeprecatedComponents
   end
 
-  # def test_does_not_raise_offense_for_non_primer_node
-  #   investigate(cop, <<-RUBY)
-  #     text = FakeComponent.new
-  #   RUBY
+  def test_does_not_raise_offense_for_non_primer_node
+    investigate(cop, <<-RUBY)
+      text = FakeComponent.new
+    RUBY
 
-  #   assert_equal 0, cop.offenses.count
-  # end
+    assert_equal 0, cop.offenses.count
+  end
 
-  # def test_does_not_raise_offense_if_non_legacy_component_is_used
-  #   investigate(cop, <<-RUBY)
-  #     Primer::ClipboardCopy.new
-  #   RUBY
+  def test_does_not_raise_offense_if_non_legacy_component_is_used
+    investigate(cop, <<-RUBY)
+      Primer::ClipboardCopy.new
+    RUBY
 
-  #   assert_equal 0, cop.offenses.count
-  # end
+    assert_equal 0, cop.offenses.count
+  end
 
-  # def test_raises_offense_if_calling_legacy_component
-  #   investigate(cop, <<-RUBY)
-  #     Primer::Tooltip.new
-  #     Primer::BlankslateComponent.new
-  #     Primer::FlexComponent.new
-  #   RUBY
+  def test_raises_offense_if_calling_legacy_component
+    investigate(cop, <<-RUBY)
+      Primer::Tooltip.new
+      Primer::BlankslateComponent.new
+      Primer::FlexComponent.new
+    RUBY
 
-  #   assert_equal 3, cop.offenses.count
-  # end
+    assert_equal 3, cop.offenses.count
+  end
 
-  # def test_raises_offense_if_calling_legacy_component_with_args
-  #   investigate(cop, <<-RUBY)
-  #     Primer::FlexComponent.new(:foo)
-  #   RUBY
-  #   assert_equal 1, cop.offenses.count
-  # end
+  def test_raises_offense_if_calling_legacy_component_with_args
+    investigate(cop, <<-RUBY)
+      Primer::FlexComponent.new(:foo)
+    RUBY
+    assert_equal 1, cop.offenses.count
+  end
 
-  # def test_raises_offense_if_calling_legacy_component_in_render
-  #   investigate(cop, <<-RUBY)
-  #     render(Primer::Tooltip.new)
-  #   RUBY
+  def test_raises_offense_if_calling_legacy_component_in_render
+    investigate(cop, <<-RUBY)
+      render(Primer::Tooltip.new)
+    RUBY
 
-  #   assert_equal 1, cop.offenses.count
-  # end
+    assert_equal 1, cop.offenses.count
+  end
 
-  # def test_raises_offense_if_calling_legacy_component_in_render_with_args
-  #   investigate(cop, <<-RUBY)
-  #     render(Primer::FlexComponent.new(foo: "bar"))
-  #   RUBY
+  def test_raises_offense_if_calling_legacy_component_in_render_with_args
+    investigate(cop, <<-RUBY)
+      render(Primer::FlexComponent.new(foo: "bar"))
+    RUBY
 
-  #   assert_equal 1, cop.offenses.count
-  # end
+    assert_equal 1, cop.offenses.count
+  end
 
-  # def test_suggests_alternative_component_if_available
-  #   investigate(cop, <<-RUBY)
-  #     render(Primer::Tooltip.new(foo: "bar"))
-  #   RUBY
+  def test_suggests_alternative_component_if_available
+    investigate(cop, <<-RUBY)
+      render(Primer::Tooltip.new(foo: "bar"))
+    RUBY
 
-  #   assert_equal 1, cop.offenses.count
-  #   assert_equal "Primer::Tooltip has been deprecated and should not be used. Try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
-  # end
+    assert_equal 1, cop.offenses.count
+    assert_equal "Primer::Tooltip has been deprecated and should not be used. Try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+  end
 
   def test_raises_if_legacy_component_missing_in_alternative_components
     RuboCop::Cop::Primer::DeprecatedComponents.any_instance.stubs(:statuses_json).returns({ "Primer::FakeComponent": "deprecated" })

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -7,6 +7,22 @@ class RubocopDeprecatedComponentsTest < CopTest
     RuboCop::Cop::Primer::DeprecatedComponents
   end
 
+  def test_does_not_raise_offense_for_non_primer_node
+    investigate(cop, <<-RUBY)
+      text = FakeComponent.new
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
+  def test_does_not_raise_offense_if_non_legacy_component_is_used
+    investigate(cop, <<-RUBY)
+      Primer::ClipboardCopy.new
+    RUBY
+
+    assert_equal 0, cop.offenses.count
+  end
+
   def test_raises_offense_if_calling_legacy_component
     investigate(cop, <<-RUBY)
       Primer::Tooltip.new

--- a/test/rubocop/deprecated_components_test.rb
+++ b/test/rubocop/deprecated_components_test.rb
@@ -7,22 +7,22 @@ class RubocopDeprecatedComponentsTest < CopTest
     RuboCop::Cop::Primer::DeprecatedComponents
   end
 
-  def test_raises_offense_if_calling_legacy_component
-    investigate(cop, <<-RUBY)
-      Primer::Tooltip.new
-      Primer::BlankslateComponent.new
-      Primer::LayoutComponent.new
-    RUBY
+  # def test_raises_offense_if_calling_legacy_component
+  #   investigate(cop, <<-RUBY)
+  #     Primer::Tooltip.new
+  #     Primer::BlankslateComponent.new
+  #     Primer::FlexComponent.new
+  #   RUBY
 
-    assert_equal 3, cop.offenses.count
-  end
+  #   assert_equal 3, cop.offenses.count
+  # end
 
-  def test_raises_offense_if_calling_legacy_component_with_args
-    investigate(cop, <<-RUBY)
-      Primer::LayoutComponent.new(:foo)
-    RUBY
-    assert_equal 1, cop.offenses.count
-  end
+  # def test_raises_offense_if_calling_legacy_component_with_args
+  #   investigate(cop, <<-RUBY)
+  #     Primer::FlexComponent.new(:foo)
+  #   RUBY
+  #   assert_equal 1, cop.offenses.count
+  # end
 
   def test_raises_offense_if_calling_legacy_component_in_render
     investigate(cop, <<-RUBY)
@@ -32,20 +32,21 @@ class RubocopDeprecatedComponentsTest < CopTest
     assert_equal 1, cop.offenses.count
   end
 
-  def test_raises_offense_if_calling_legacy_component_in_render_with_args
-    investigate(cop, <<-RUBY)
-      render(Primer::LayoutComponent.new(foo: "bar"))
-    RUBY
+  # def test_raises_offense_if_calling_legacy_component_in_render_with_args
+  #   investigate(cop, <<-RUBY)
+  #     render(Primer::FlexComponent.new(foo: "bar"))
+  #   RUBY
 
-    assert_equal 1, cop.offenses.count
-  end
+  #   assert_equal 1, cop.offenses.count
+  # end
 
-  def test_suggests_alternative_component_if_available
-    investigate(cop, <<-RUBY)
-      render(Primer::LayoutComponent.new(foo: "bar"))
-    RUBY
+  # def test_suggests_alternative_component_if_available
+  #   investigate(cop, <<-RUBY)
+  #     render(Primer::Tooltip.new(foo: "bar"))
+  #   RUBY
 
-    assert_equal 1, cop.offenses.count
-    assert_equal "Please try Primer::Alpha::Layout instead.", cop.offenses.first.message
-  end
+  #   binding.irb
+  #   assert_equal 1, cop.offenses.count
+  #   assert_equal "Please try Primer::Alpha::Tooltip instead.", cop.offenses.first.message
+  # end
 end


### PR DESCRIPTION
## What

This introduces a rubocop cop called `DeprecatedComponents` to notify consumers when they are using a deprecated component.

Similar to [DeprecatedInPrimer](https://github.com/github/github/blob/master/.erb-linters/deprecated_in_primer_counter.rb) (Staff-only link), we can make use of the `statuses.json` file to dynamically determine which components have been deprecated. 

We can keep a mapping of alternative components to render, if there are any to customize the message. Even when there are no alternative components, the value should be set. That allows us to have a validation that reminds people to update the map.

## Why

I noticed that there were deprecated components being newly used in dotcom which we DON'T want.
Currently we have a few individual deprecated component linters like `lib/rubocop/cop/primer/deprecated_layout_component.rb`. Having individual linters depend on us remembering to make a linter whenever we deprecated a component which can be easy to forget. Since we have `deprecated` info available to us, let's use it!