### PR TITLE
Add performance improvement to `DeprecatedComponents` linter

### DIFF
--- a/lib/rubocop/cop/primer/deprecated_components.rb
+++ b/lib/rubocop/cop/primer/deprecated_components.rb
@@ -65,14 +65,14 @@ module RuboCop
         end
 
         def deprecated_components
-          deprecated_components = statuses_json.select { |_, value| value == "deprecated" }.keys
-          deprecated_components.each do |deprecated|
-            unless COMPONENT_TO_USE_INSTEAD.key?(deprecated)
-              raise "Please provide a component that should be used in place of #{deprecated} in COMPONENT_TO_USE_INSTEAD. "\
-                    "If there is no alternative, set the value to nil."
+          @deprecated_components ||= statuses_json.select { |_, value| value == "deprecated" }.keys.tap do |deprecated_components|
+            deprecated_components.each do |deprecated|
+              unless COMPONENT_TO_USE_INSTEAD.key?(deprecated)
+                raise "Please provide a component that should be used in place of #{deprecated} in COMPONENT_TO_USE_INSTEAD. "\
+                      "If there is no alternative, set the value to nil."
+              end
             end
           end
-          deprecated_components
         end
       end
     end


### PR DESCRIPTION
@camertron had a performance improvement suggestion in https://github.com/primer/view_components/pull/1108 but I had auto-merge set.

This adds the review suggestion which is to use memoization in the `deprecated_components` method for performance improvements.