### PR TITLE
Codespaces need more memory

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -58,5 +58,8 @@
         }
       }
     ]
+  },
+  "hostRequirements": {
+    "memory": "8gb"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ The category for changes related to documentation, testing and tooling. Also, fo
 
 - Fix alphabetization of components in docs.
 
+  _David Wilson_
+
+- Give codespaces more memory (4gb is not sufficient).
+
+  _Lindsey Wild_
+  _Cameron Dutro_
+
 ### Bug Fixes
 
 - Ensure that no whitespace is added inside LinkComponent.


### PR DESCRIPTION
@lindseywild and I paired today trying to figure out why running `script/dev` kept erroring out. We tried running each individual line in the Procfile but the error never happened, so in a last ditch attempt I Googled the error message "command failed with exit code 137". Turns out it's a well-known error emitted by Yarn (or maybe Node?) and means the system ran out of memory. We tried upgrading Lindsey's codespace to 8gb ram and voila! No more errors 😄 🎉 