### PR TITLE
Add `eslint-plugin-custom-elements`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "node": true
   },
   "extends": [
-    "eslint:recommended"
+    "eslint:recommended",
+    "plugin:custom-elements/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   ],
   "scripts": {
     "prepare": "tsc && rollup -c",
-    "lint": "eslint app/components demo/.storybook",
-    "lint:fix": "eslint app/components demo/.storybook --fix"
+    "lint": "eslint 'app/components/**/*.ts' demo/.storybook",
+    "lint:fix": "eslint 'app/components/**/*.ts' demo/.storybook --fix"
   },
   "dependencies": {
     "@github/auto-complete-element": "^3.1.0",
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "eslint": "^7.20.0",
+    "eslint-plugin-custom-elements": "^0.0.6",
     "eslint-plugin-github": "^4.1.1",
     "eslint-plugin-prettier": "^3.3.1",
     "mocha": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -653,6 +653,11 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-custom-elements@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-custom-elements/-/eslint-plugin-custom-elements-0.0.6.tgz#2e0f5018af7ac8348f591cec9b5e80d08996f235"
+  integrity sha512-JwPHRSOUe7y8dpC5hg90ySHejsfnQ3yqprv0902VMZ3j8FRZDudj+yzxqqkRDhZTNFUxP3r+0TWuveZhLgJONg==
+
 eslint-plugin-eslint-comments@>=3.0.1:
   version "3.2.0"
   resolved "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz"


### PR DESCRIPTION
## What

This PR adds [eslint-plugin-custom-elements](https://github.com/github/eslint-plugin-custom-elements) and updates our `npm run lint` script to only run eslint on `.ts` files because the `.js` files are auto-generated.

## Why

We've started housing some custom elements in PVC and should probably align with how we build custom elements at GitHub.