### PR TITLE
fix storybook deployment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
           key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
 
       - name: Install dependencies
-        run: yarn
+        run: yarn && cd docs && yarn && cd ..
 
       - name: Generate static files
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: yarn
+        run: yarn && cd docs && yarn && cd ..
 
       - name: Generate static files
         run: |
@@ -64,7 +64,7 @@ jobs:
         run: yarn build:docs
 
       - name: Archive build output
-        run: 'tar --dereference --directory ${{ inputs.output_dir }} -cvf artifact.tar .'
+        run: 'tar --dereference --directory docs/public -cvf artifact.tar .'
 
       - name: Upload artifact
         uses: actions/upload-artifact@main

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build:docs": "cd docs && yarn gatsby build --prefix-paths",
     "build:docs:preview": "cd docs && yarn gatsby build",
-    "postinstall": "cd docs && yarn",
     "prepare": "tsc && rollup -c",
     "lint": "eslint 'app/components/**/*.ts' demo/.storybook",
     "lint:fix": "eslint 'app/components/**/*.ts' demo/.storybook --fix"


### PR DESCRIPTION
The `postinstall` script is breaking the Storybook deployment script on `main` from here: https://github.com/primer/view_components/blob/main/Procfile#L3

![Screenshot 2022-04-20 at 17 57 30](https://user-images.githubusercontent.com/13340707/164283910-6b7bae5e-2021-42c8-b7ff-0eb0bb70f7d3.png)

This PR removes the `postinstall` in favour of doing it manually in the workflows that require this. Also fixes a missing variable in the production deployment workflow.

