### PR TITLE
Force production docs to deploy on each push to main

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,11 +3,6 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - 'app/**'
-      - 'docs/**'
-      - '.github/workflows/deploy*.yml'
-      - 'package.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
https://primer.github.io/view_components/ is not showing the expected production deployment.

This is because GitHub Pages resets the production environment on each push to `main`, which happens outside of our control

This PR will fix this by ensuring that _all_ pushes to `main` branch deploy the docs, by removing the the file/folder pattern matching. The production workflow will trigger the production deployment all the time.