### PR TITLE
docs: updates action menu docs, fixes yarn.lock

### DIFF
--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -2,12 +2,14 @@
 
 module Primer
   module Alpha
-    # The ActionMenu should be used when a user can select a single option triggering an action from a list of items. Primer will automatically nest an `Item` within a presentational `<li>` tag. The functionality should live on element with `role="menuitem"`.
+    # The ActionMenu should be used when a user can select a single option triggering an action from a list of items. Primer will automatically nest an `Item` within a presentational `<li>` tag.
     #
-    #  The only allowed elements for the `Item` components are `:a`, `:button` and `:clipboard-copy`. We can add to this list if we need more allowed items. To add functionality, use a `.js` class that creates the functionality.
+    # The only allowed elements for the `Item` components are: `:a`, `:button`, and `:clipboard-copy`. If one isn't selected, a fallback `:span` will be used. To add functionality, use a `.js` class to create the functionality, or an `onclick` handler.
     #
     # @accessibility
-    #  When an item has `role="menuitem"`, all other semantics inside of that element are ignored. The action for the menu item needs to be on that element for correct functionality.
+    #   The action for the menu item needs to be on the element with `role="menuitem"`. Semantics are removed for everything nested inside of it. When a menu item is selected, the menu will close immediately.
+    #
+    #   Additional information around the keyboard functionality and implementation can be found on the [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/#menu).
     class ActionMenu < Primer::Component
       # Button to activate the menu. This may be a <%= link_to_component(Primer::ButtonComponent) %> or <%= link_to_component(Primer::IconButton) %>.
       #

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,11 +104,7 @@
 
 "@primer/behaviors@^1.1.2":
   version "1.1.2"
-<<<<<<< HEAD
-  resolved "https://registry.yarnpkg.com/@primer/behaviors/-/behaviors-1.1.2.tgz#bd572fa89c88820c10d173bc2cd43339328d0b60"
-=======
   resolved "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.1.2.tgz"
->>>>>>> 73299c73 (Hooking up `getAnchoredPosition` to position menu (#1131))
   integrity sha512-gMlUDRc2boyme1th2Sr0tVeH6VyWjFGwuraHj08HDlkfulJ7a6VT0YU0wtSnK1FtC45ZsTXNWOSiLwXWYmLR9g==
 
 "@primer/css@^19.7.1":


### PR DESCRIPTION
Closes https://github.com/github/accessibility/issues/826.

Updates docs for the ActionMenu component. Since this will be moved to dotcom, I did not spend a lot of time on other areas of Primer that may need documentation or storybook examples.

Also fixes a merge conflict in the `yarn.lock` file.