### PR TITLE
Add a linter for calls to `super` in templates

### DIFF
--- a/.changeset/popular-vans-sleep.md
+++ b/.changeset/popular-vans-sleep.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Add a linter for calls to super in templates

--- a/.changeset/popular-vans-sleep.md
+++ b/.changeset/popular-vans-sleep.md
@@ -1,5 +1,5 @@
 ---
-'@primer/view-components': minor
+'@primer/view-components': patch
 ---
 
 Add a linter for calls to super in templates

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,8 +116,6 @@ GEM
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
     octicons (17.1.0)
     parallel (1.21.0)
     parser (3.0.2.0)

--- a/lib/primer/view_components/linters/super_in_component_templates.rb
+++ b/lib/primer/view_components/linters/super_in_component_templates.rb
@@ -14,6 +14,8 @@ module ERBLint
           indicator_node, _, code_node = *erb_node
           code = code_node.children.first
           ast = erb_ast(code)
+          next unless ast
+
           super_call_nodes = find_super_call_nodes(ast)
           next if super_call_nodes.empty?
 

--- a/lib/primer/view_components/linters/super_in_component_templates.rb
+++ b/lib/primer/view_components/linters/super_in_component_templates.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "helpers/rubocop_helpers"
+
+module ERBLint
+  module Linters
+    # Replaces calls to `super` with calls to `render_parent`.
+    class SuperInComponentTemplates < Linter
+      include ERBLint::LinterRegistry
+      include Helpers::RubocopHelpers
+
+      def run(processed_source)
+        processed_source.ast.descendants(:erb).each do |erb_node|
+          indicator_node, _, code_node = *erb_node
+          code = code_node.children.first
+          ast = erb_ast(code)
+          super_call_nodes = find_super_call_nodes(ast)
+          next if super_call_nodes.empty?
+
+          indicator, = *indicator_node
+          indicator ||= ""
+
+          # +2 to account for the leading "<%" characters
+          code_start_pos = erb_node.location.begin_pos + indicator.size + 2
+
+          super_call_nodes.each do |super_call_node|
+            orig_loc = code_node.location
+            super_call_loc = super_call_node.location.expression
+
+            new_loc = orig_loc.with(
+              begin_pos: super_call_loc.begin_pos + code_start_pos,
+              end_pos: super_call_loc.end_pos + code_start_pos
+            )
+
+            add_offense(
+              new_loc,
+              "Avoid calling `super` in component templates. Call `render_parent` instead",
+              "render_parent"
+            )
+          end
+        end
+      end
+
+      def autocorrect(_, offense)
+        return unless offense.context
+
+        lambda do |corrector|
+          corrector.replace(offense.source_range, offense.context)
+        end
+      end
+
+      private
+
+      def find_super_call_nodes(ast)
+        return [ast] if ast.type == :zsuper
+
+        ast.each_child_node.flat_map do |child_ast|
+          find_super_call_nodes(child_ast)
+        end
+      end
+    end
+  end
+end

--- a/test/linters/super_in_component_templates_test.rb
+++ b/test/linters/super_in_component_templates_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class SuperInComponentTemplatesTest < LinterTestCase
+  def test_identifies_super_calls
+    @file = "<div><% super %></div>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_identifies_echoed_super_calls
+    @file = "<div><%= super %></div>"
+    @linter.run(processed_source)
+
+    refute_empty @linter.offenses
+  end
+
+  def test_replaces_super_with_render_parent
+    @file = <<~ERB
+      <div>
+        <% super %>
+      </div>
+    ERB
+
+    expected = <<~ERB
+      <div>
+        <% render_parent %>
+      </div>
+    ERB
+
+    assert_equal expected, corrected_content
+  end
+
+  def test_replaces_echoed_super_with_render_parent
+    @file = <<~ERB
+      <div>
+        <%= super %>
+      </div>
+    ERB
+
+    expected = <<~ERB
+      <div>
+        <%= render_parent %>
+      </div>
+    ERB
+
+    assert_equal expected, corrected_content
+  end
+
+  private
+
+  def linter_class
+    ERBLint::Linters::SuperInComponentTemplates
+  end
+end

--- a/test/linters/super_in_component_templates_test.rb
+++ b/test/linters/super_in_component_templates_test.rb
@@ -49,6 +49,22 @@ class SuperInComponentTemplatesTest < LinterTestCase
     assert_equal expected, corrected_content
   end
 
+  def test_replaces_super_when_nested
+    @file = <<~ERB
+      <div>
+        <% 3.times { |_i| super } %>
+      </div>
+    ERB
+
+    expected = <<~ERB
+      <div>
+        <% 3.times { |_i| render_parent } %>
+      </div>
+    ERB
+
+    assert_equal expected, corrected_content
+  end
+
   private
 
   def linter_class


### PR DESCRIPTION
A [recent issue](https://github.com/github/platform-ux/issues/825) was brought to our attention wherein slash commands were being double rendered in dotcom. We tracked the issue down to calling `super` inside a component's template. The code in question was emitting the result of the `super` call, eg:

```erb
<%= super %>
```

Removing the `=` indicator fixes the issue. To remove further confusion, [I wrote a helper method](https://github.com/github/view_component/pull/1353) called `render_parent` that functions as a call to `super` and returns `nil` (to avoid double rendering).

This PR adds a linter to automatically replace `super` calls with `render_parent`.