### PR TITLE
Add `role` to system args docs

### DIFF
--- a/.changeset/chatty-otters-shake.md
+++ b/.changeset/chatty-otters-shake.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Add `role` to system args docs.

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -39,6 +39,7 @@ System arguments include most HTML attributes. For example:
 | `style` | `String` | Inline styles. |
 | `title` | `String` | The `title` attribute. |
 | `width` | `Integer` | Width. |
+| `role`  | `String`  | Roles from the ARIA spec. [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles). |
 
 ## Animation
 


### PR DESCRIPTION
Role was not included in the system args docs. @joelhawksley confirmed that it does indeed function as a system arg, so this adds it to the docs.

I figured a link to MDN would be better than enumerating all the roles. WDYT?