### PR TITLE
bump view_component to 2.56.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,7 +206,7 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
-    view_component (2.49.1)
+    view_component (2.56.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     view_component_storybook (0.8.0)

--- a/test/components/primer/alpha/layout_test.rb
+++ b/test/components/primer/alpha/layout_test.rb
@@ -113,7 +113,7 @@ class PrimerAlphaLayoutTest < Minitest::Test
       c.sidebar { "Sidebar" }
     end
 
-    assert_match(/Layout-sidebar.*Layout-main/m, @rendered_component)
+    assert_match(/Layout-sidebar.*Layout-main/m, page.native.serialize)
   end
 
   def test_main_first_in_html
@@ -122,7 +122,7 @@ class PrimerAlphaLayoutTest < Minitest::Test
       c.sidebar { "Sidebar" }
     end
 
-    assert_match(/Layout-main.*Layout-sidebar/m, @rendered_component)
+    assert_match(/Layout-main.*Layout-sidebar/m, page.native.serialize)
   end
 
   def test_renders_main_slot_as_different_elements


### PR DESCRIPTION
This PR bumps our dependency on `view_component` to 2.56.0 and removes our dependency on the now-changed private `@rendered_component` API ❤️ 