### PR TITLE
Adjust DeprecatedArguments cop to handle boolean values

### DIFF
--- a/.changeset/breezy-dragons-rush.md
+++ b/.changeset/breezy-dragons-rush.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Adjust DeprecatedArguments cop to handle boolean values

--- a/lib/rubocop/cop/primer/deprecated_arguments.rb
+++ b/lib/rubocop/cop/primer/deprecated_arguments.rb
@@ -33,8 +33,14 @@ module RuboCop
         # }
         #
         DEPRECATED = {
-          is_label_inline: nil,
-          with_icon: nil,
+          is_label_inline: {
+            true: nil,
+            false: nil
+          },
+          with_icon: {
+            true: nil,
+            false: nil
+          },
           is_label_visible: {
             false => "visually_hide_label: true",
             true => "visually_hide_label: false"

--- a/lib/rubocop/cop/primer/deprecated_arguments.rb
+++ b/lib/rubocop/cop/primer/deprecated_arguments.rb
@@ -34,12 +34,12 @@ module RuboCop
         #
         DEPRECATED = {
           is_label_inline: {
-            true: nil,
-            false: nil
+            true => nil,
+            false => nil
           },
           with_icon: {
-            true: nil,
-            false: nil
+            true => nil,
+            false => nil
           },
           is_label_visible: {
             false => "visually_hide_label: true",

--- a/lib/rubocop/cop/primer/deprecated_arguments.rb
+++ b/lib/rubocop/cop/primer/deprecated_arguments.rb
@@ -314,14 +314,16 @@ module RuboCop
         def extract_kv_from(pair)
           key = pair.key.value
 
+          # rubocop:disable Lint/BooleanSymbol
           value = case pair.value.type
-          when :sym, :str
-            pair.value.value.to_sym
-          when :false, :true
-            pair.value.type == :true
-          else
-            return []
-          end
+                  when :sym, :str
+                    pair.value.value.to_sym
+                  when :false, :true
+                    pair.value.type == :true
+                  else
+                    return []
+                  end
+          # rubocop:enable Lint/BooleanSymbol
 
           [key, value]
         end

--- a/test/rubocop/deprecated_arguments_test.rb
+++ b/test/rubocop/deprecated_arguments_test.rb
@@ -67,4 +67,20 @@ class RubocopDeprecatedArgumentsTest < CopTest
     assert_equal 1, cop.offenses.count
     assert_equal "Primer::Beta::AutoComplete.new(visually_hide_label: true)", cop.offenses.first.corrector.rewrite.strip
   end
+
+  def test_identifies_is_label_inline
+    investigate(cop, <<-RUBY)
+      Primer::Beta::AutoComplete.new(label_text: "User", is_label_inline: true)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
+
+  def test_identifies_with_icon
+    investigate(cop, <<-RUBY)
+      Primer::Beta::AutoComplete.new(label_text: "User", with_icon: true)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+  end
 end

--- a/test/rubocop/deprecated_arguments_test.rb
+++ b/test/rubocop/deprecated_arguments_test.rb
@@ -58,4 +58,13 @@ class RubocopDeprecatedArgumentsTest < CopTest
     assert_equal 1, cop.offenses.count
     refute cop.offenses.first.correctable?
   end
+
+  def test_supports_boolean_values
+    investigate(cop, <<-RUBY)
+      Primer::Beta::AutoComplete.new(is_label_visible: false)
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Primer::Beta::AutoComplete.new(visually_hide_label: true)", cop.offenses.first.corrector.rewrite.strip
+  end
 end


### PR DESCRIPTION
The `DeprecatedArguments` cop currently only supports string and symbol values. This PR adds support for `true` and `false`.