### PR TITLE
Remove trailing newlines from the output of LinkComponent

### DIFF
--- a/.changeset/sour-berries-lick.md
+++ b/.changeset/sour-berries-lick.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove trailing newlines from the output of LinkComponent

--- a/app/components/primer/link_component.erb
+++ b/app/components/primer/link_component.erb
@@ -1,1 +1,0 @@
-<%= render Primer::BaseComponent.new(**@system_arguments) do -%><%= content -%><%= tooltip -%><% end %>

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -85,7 +85,7 @@ module Primer
 
     def call
       render(Primer::BaseComponent.new(**@system_arguments)) do
-        "#{content}#{tooltip}"
+        content.to_s + tooltip.to_s
       end
     end
   end

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -82,5 +82,11 @@ module Primer
     def before_render
       raise ArgumentError, "href is required when using <a> tag" if @system_arguments[:tag] == :a && @system_arguments[:href].nil? && !Rails.env.production?
     end
+
+    def call
+      render(Primer::BaseComponent.new(**@system_arguments)) do
+        "#{content}#{tooltip}"
+      end
+    end
   end
 end

--- a/test/components/link_component_test.rb
+++ b/test/components/link_component_test.rb
@@ -18,6 +18,12 @@ class PrimerLinkComponentTest < Minitest::Test
     assert_text(/^content$/)
   end
 
+  def test_renders_without_trailing_newline
+    render_inline(Primer::LinkComponent.new(href: "http://joe-jonas-shirtless.com")) { "content" }
+
+    refute @rendered_content.end_with?("\n")
+  end
+
   def test_renders_as_a_link
     render_inline(Primer::LinkComponent.new(href: "http://google.com")) { "content" }
 


### PR DESCRIPTION
The `LinkComponent` appends a trailing newline, which can appear as unwanted whitespace between the link and any text that follows it. The problem is that the link_component.erb file contains a trailing newline, and ERB faithfully reproduces it in the rendered output. This PR replaces the template with a `call` method.