### PR TITLE
Add an ActionList linter

### DIFF
--- a/.changeset/thick-suns-perform.md
+++ b/.changeset/thick-suns-perform.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add ActionList linter

--- a/docs/content/system-arguments.md
+++ b/docs/content/system-arguments.md
@@ -39,7 +39,6 @@ System arguments include most HTML attributes. For example:
 | `style` | `String` | Inline styles. |
 | `title` | `String` | The `title` attribute. |
 | `width` | `Integer` | Width. |
-| `role`  | `String`  | Roles from the ARIA spec. [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles). |
 
 ## Animation
 

--- a/lib/primer/view_components/linters/disallow_action_list.rb
+++ b/lib/primer/view_components/linters/disallow_action_list.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative "helpers/rubocop_helpers"
+
+module ERBLint
+  module Linters
+    # Replaces calls to `super` with calls to `render_parent`.
+    class DisallowActionList < Linter
+      PVC_PATTERNS = %w[
+        app/components/primer/*.html.erb
+        app/components/primer/**/*.html.erb
+      ].freeze
+
+      include ERBLint::LinterRegistry
+      include Helpers::RubocopHelpers
+      include TagTreeHelpers
+
+      def run(processed_source)
+        # PVCs are exempt
+        return if pvc_template?(processed_source.filename)
+
+        class_regex = /ActionList[\w-]*/
+        tags, * = build_tag_tree(processed_source)
+
+        tags.each do |tag|
+          next if tag.closing?
+
+          classes =
+            if (class_attrib = tag.attributes["class"])
+              loc = class_attrib.value_node.loc
+              loc.source_buffer.source[loc.begin_pos...loc.end_pos]
+            else
+              ""
+            end
+
+          indices = [].tap do |results|
+            classes.scan(class_regex) do
+              results << Regexp.last_match.offset(0)
+            end
+          end
+
+          next if indices.empty?
+
+          indices.each do |(start_idx, end_idx)|
+            new_loc = class_attrib.value_node.loc.with(
+              begin_pos: class_attrib.value_node.loc.begin_pos + start_idx,
+              end_pos: class_attrib.value_node.loc.begin_pos + end_idx
+            )
+
+            add_offense(
+              new_loc,
+              "ActionList classes are only designed to be used by Primer View Components and " \
+                "should be considered private."
+            )
+          end
+        end
+      end
+
+      private
+
+      def pvc_template?(filename)
+        begin
+          relative_filename = Pathname(filename).relative_path_from(Rails.root)
+        rescue ArgumentError
+          # raised if filename doesn't start with Rails.root
+          return false
+        end
+
+        PVC_PATTERNS.any? { |pattern| relative_filename.fnmatch?(pattern) }
+      end
+    end
+  end
+end

--- a/test/linter_test_case.rb
+++ b/test/linter_test_case.rb
@@ -7,6 +7,7 @@ require "linters/support/autocorrectable_linter_shared_tests"
 class LinterTestCase < Minitest::Test
   def setup
     @linter = linter_class&.new(file_loader, linter_class.config_schema.new)
+    @filename = "file.rb"
   end
 
   private
@@ -38,7 +39,7 @@ class LinterTestCase < Minitest::Test
   end
 
   def processed_source
-    ERBLint::ProcessedSource.new("file.rb", @file)
+    ERBLint::ProcessedSource.new(@filename, @file)
   end
 
   def tags

--- a/test/linters/disallow_action_list_test.rb
+++ b/test/linters/disallow_action_list_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "linter_test_case"
+
+class DisallowActionListTest < LinterTestCase
+  def test_identifies_action_list_class
+    @file = "<div class='ActionList <%= foo %>'>fooo</div>"
+    @linter.run(processed_source)
+
+    assert @linter.offenses.size == 1
+
+    offense = @linter.offenses.first
+    assert offense.source_range.begin_pos == 12
+    assert offense.source_range.end_pos == 22
+  end
+
+  def test_identifies_two_action_list_classes
+    @file = "<div class='ActionList ActionList-item'>fooo</div>"
+    @linter.run(processed_source)
+
+    assert @linter.offenses.size == 2
+
+    offense = @linter.offenses[0]
+    assert offense.source_range.begin_pos == 12
+    assert offense.source_range.end_pos == 22
+
+    offense = @linter.offenses[1]
+    assert offense.source_range.begin_pos == 23
+    assert offense.source_range.end_pos == 38
+  end
+
+  def test_identifies_action_list_class_nested
+    @file = "<div><div class='ActionList <%= foo %>'>fooo</div></div>"
+    @linter.run(processed_source)
+
+    assert @linter.offenses.size == 1
+
+    offense = @linter.offenses.first
+    assert offense.source_range.begin_pos == 17
+    assert offense.source_range.end_pos == 27
+  end
+
+  def test_does_not_identify_action_list_class_in_pvc_template
+    @file = "<div class='ActionList <%= foo %>'>fooo</div>"
+    @filename = Rails.root.join("app/components/primer/component_template.html.erb").to_s
+    @linter.run(processed_source)
+
+    assert_empty @linter.offenses
+  end
+
+  def linter_class
+    ERBLint::Linters::DisallowActionList
+  end
+end


### PR DESCRIPTION
A few times now we've seen dotcom developers (with good intentions) attempting to use `ActionList` classes outside of Primer View Components. This PR adds a linter to catch such usages.