### PR TITLE
Prevent slot from overriding component system_arguments

### DIFF
--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -65,12 +65,10 @@ module Primer
     renders_one :tooltip, lambda { |**system_arguments|
       raise ArgumentError, "Buttons with a tooltip must have a unique `id` set on the `Button`." if @id.blank? && !Rails.env.production?
 
-      @system_arguments = system_arguments
+      system_arguments[:for_id] = @id
+      system_arguments[:type] ||= :description
 
-      @system_arguments[:for_id] = @id
-      @system_arguments[:type] ||= :description
-
-      Primer::Alpha::Tooltip.new(**@system_arguments)
+      Primer::Alpha::Tooltip.new(**system_arguments)
     }
 
     # @example Schemes

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -24,12 +24,10 @@ module Primer
     renders_one :tooltip, lambda { |**system_arguments|
       raise ArgumentError, "Links with a tooltip must have a unique `id` set on the `LinkComponent`." if @id.blank? && !Rails.env.production?
 
-      @system_arguments = system_arguments
+      system_arguments[:for_id] = @id
+      system_arguments[:type] ||= :description
 
-      @system_arguments[:for_id] = @id
-      @system_arguments[:type] ||= :description
-
-      Primer::Alpha::Tooltip.new(**@system_arguments)
+      Primer::Alpha::Tooltip.new(**system_arguments)
     }
 
     # @example Default


### PR DESCRIPTION
Currently component content (`content`) is lazily evaluated. This often includes code where slots are defined, for example:

```erb
<% render Button.new do |c| %>
  <% c.label("Foo") %>
<% end %>
```

The block code won't be called until `content` is called, or slots are accessed. It's common for `content` to be evaluated mid-render, e.g.:

```erb
<%# Button.html.erb %>
<button class="<%= @system_arguments[:class] %>>
  <%= label %> <%# render label slot %>
</button>
```

In the above example, `system_arguments` is accessed before the block setting the label (`<% c.label("Foo") %>`) is executed. Imagine the `label` slot definition looking like:

```ruby
renders_one :label do |system_arguments|
  @system_arguments = system_arguments
end
```

Now, when the label is evaluated, we're actually overriding the `Button` component's system arguments! In practice this isn't noticeable most of the time due to the order of evaluation mentioned above, we're overriding *after* we've used the original value.

With [this change](https://github.com/github/view_component/pull/1407) in ViewComponents causing `content` to be evaluated before render the issue is now revealing itself as failed tests in that branch.  To be clear, the ViewComponent PR didn't introduce the bug, it just made component behavior more consistent and revealed a bug.

There's a good number of other components following this pattern that will likely need to be fixed too.