### PR TITLE
Use Rubocop cops in .erb files

### DIFF
--- a/.changeset/breezy-kids-play.md
+++ b/.changeset/breezy-kids-play.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use Rubocop cops to lint .erb files

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,6 +12,10 @@ linters:
     rubocop_config:
       inherit_from:
         - lib/rubocop/config/default.yml
+      inherit_gem:
+        rubocop-github:
+          - config/default_edge.yml
+          - config/rails_edge.yml
       Primer/DeprecatedComponents:
         Enabled: true
         Exclude:

--- a/app/components/primer/blankslate_component.html.erb
+++ b/app/components/primer/blankslate_component.html.erb
@@ -5,7 +5,7 @@
   <% elsif @icon.present? %>
     <%= primer_octicon @icon, size: @icon_size, classes: "blankslate-icon" %>
   <% elsif @image_src.present? && @image_alt.present? %>
-    <%= image_tag "#{@image_src}", class: "mb-3", size: "56x56", alt: "#{@image_alt}" %>
+    <%= image_tag @image_src.to_s, class: "mb-3", size: "56x56", alt: @image_alt.to_s %>
   <% end %>
 
   <% if @title.present? %>
@@ -24,7 +24,7 @@
 
   <% if @link_text.present? && @link_url.present? %>
     <p>
-      <%= link_to "#{@link_url}" do %><%= @link_text %><% end %>
+      <%= link_to @link_url.to_s do %><%= @link_text %><% end %>
     </p>
   <% end %>
 <% end %>

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -1,9 +1,33 @@
 require:
   - rubocop/cop/primer
+  - rubocop-rails
 
-AllCops:
-  DisabledByDefault: true
+####### RUBOCOP'S DEFAULTS #######
+# we don't want these in .erb files
+Style/FrozenStringLiteralComment:
+  Enabled: false
 
+# lots of false-positives in .erb files
+Layout/InitialIndentation:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# lots of false-positives - this cop is meant for Ruby code, not .erb
+Layout/TrailingEmptyLines:
+  Enabled: false
+
+# it's often not desirable to add unnecessary newlines into .erb files, as
+# they will appear in the rendered HTML
+Layout/LineLength:
+  Enabled: false
+
+# calling .html_safe in templates is ok
+Rails/OutputSafety:
+  Enabled: false
+
+####### PRIMER COPS #######
 Primer/SystemArgumentInsteadOfClass:
   Enabled: true
 


### PR DESCRIPTION
I noticed we don't use any Rubocop cops for .erb files. We probably should?