### PR TITLE
Add erblint-github dependency

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,6 +7,28 @@ linters:
     enabled: true
   LabelComponentMigrationCounter:
     enabled: true
+  GitHub::Accessibility::AvoidBothDisabledAndAriaDisabled:
+    enabled: true
+  GitHub::Accessibility::AvoidGenericLinkTextCounter:
+    enabled: true
+  GitHub::Accessibility::DisabledAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::IframeHasTitle:
+    enabled: true
+  GitHub::Accessibility::ImageHasAlt:
+    enabled: true
+  GitHub::Accessibility::LinkHasHrefCounter:
+    enabled: true
+  GitHub::Accessibility::NoAriaLabelMisuseCounter:
+    enabled: true
+  GitHub::Accessibility::NoPositiveTabIndex:
+    enabled: true
+  GitHub::Accessibility::NoRedundantImageAlt:
+    enabled: true
+  GitHub::Accessibility::NoTitleAttributeCounter:
+    enabled: true
+  GitHub::Accessibility::SvgHasAccessibleTextCounter:
+    enabled: true
   Rubocop:
     enabled: true
     rubocop_config:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       rainbow
       rubocop
       smart_properties
+    erblint-github (0.1.0)
     erubi (1.10.0)
     ferrum (0.11)
       addressable (~> 2.5)
@@ -248,6 +249,7 @@ DEPENDENCIES
   capybara (~> 3)
   cuprite (= 0.13)
   erb_lint
+  erblint-github (= 0.1.0)
   listen (~> 3.0)
   matrix (~> 0.4.2)
   minitest (~> 5.0)

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "capybara", "~> 3"
   spec.add_development_dependency "cuprite", "= 0.13"
   spec.add_development_dependency "erb_lint"
+  spec.add_development_dependency "erblint-github", "0.1.0"
   spec.add_development_dependency "listen", "~> 3.0"
   spec.add_development_dependency "matrix", "~> 0.4.2"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
This PR adds [erblint-github](https://github.com/github/erblint-github) as a development dependency. This contains several accessibility-focused rules for ERB.