### PR TITLE
Silence polymorphic slots warning

### DIFF
--- a/.changeset/wet-tomatoes-change.md
+++ b/.changeset/wet-tomatoes-change.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Silence polymorphic slots warning message

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -6,7 +6,7 @@ module Primer
   # @private
   class Component < ViewComponent::Base
     include ViewComponent::SlotableV2 unless ViewComponent::Base < ViewComponent::SlotableV2
-    include ViewComponent::PolymorphicSlots
+    include ViewComponent::PolymorphicSlots unless ViewComponent::Base < ViewComponent::PolymorphicSlots
     include ClassNameHelper
     include FetchOrFallbackHelper
     include TestSelectorHelper


### PR DESCRIPTION
Recent versions of view_component now include `ViewComponent::PolymorphicSlots` in `ViewComponent::Base` by default. Including it a second time prints a warning. This PR gets rid of the warning.