### PR TITLE
Adding listen path for the app/components folder

### DIFF
--- a/.changeset/little-spies-nail.md
+++ b/.changeset/little-spies-nail.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Adding listen path for the app/components folder

--- a/lookbook/config/environments/development.rb
+++ b/lookbook/config/environments/development.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   config.view_component.preview_paths << Rails.root.join("../test/components/previews")
+  config.lookbook.listen_paths << Rails.root.join("../app/components")
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
This adds config to the lookbook development environment to watch for changes in the root `../app/components` folder. This is helpful when developing components because it will reload the page when making changes to the component.