### PR TITLE
Update README.md

### DIFF
--- a/.changeset/loud-carrots-hear.md
+++ b/.changeset/loud-carrots-hear.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update README.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="300px" alt="" src="/static/assets/view-components.svg">
+  <img width="300px" alt="Primer ViewComponents Logo" src="/static/assets/view-components.svg">
 </p>
 
 <h1 align="center">Primer ViewComponents</h1>


### PR DESCRIPTION
Currently, all images on GitHub are rendered as a link so we cannot mark an image as decorative.
An image marked as decorative will render as an unlabeled link which may confuse screen reader users.
