### PR TITLE
Fix for flash_preview rename

### DIFF
--- a/test/components/previews/beta/flash_preview.rb
+++ b/test/components/previews/beta/flash_preview.rb
@@ -2,7 +2,7 @@
 
 module Beta
   # @label FlashComponent
-  class FlashComponentPreview < ViewComponent::Preview
+  class FlashPreview < ViewComponent::Preview
     # @label Playground
     #
     # @param full toggle


### PR DESCRIPTION
<img width="450" alt="Screen Shot 2022-07-25 at 4 41 02 PM" src="https://user-images.githubusercontent.com/54012/180892725-1e503c46-86b0-4a8a-9eee-b41a73c97b51.png">

Noticed that the FlashPreview didn't get renamed when the file was renamed.