### PR TITLE
Update devcontainer.json

### DIFF
--- a/.changeset/smart-dolphins-deny.md
+++ b/.changeset/smart-dolphins-deny.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update devcontainer.json with ERB lint extension

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
   "extensions": [
     "castwide.solargraph",
     "kaiwood.endwise",
+    "manuelpuyol.erb-linter",
     "misogi.ruby-rubocop",
     "rebornix.ruby",
     "wingrunr21.vscode-ruby",


### PR DESCRIPTION
Manuel's ERB lint extension should be auto-installed in a brand new PVC codespace so developers get immediate linter feedback.