### PR TITLE
component generator: correcting template and thor tasks to account for component status

### DIFF
--- a/.changeset/good-needles-fix.md
+++ b/.changeset/good-needles-fix.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+component generator: correcting template and thor tasks to account for component status

--- a/component_generator.thor
+++ b/component_generator.thor
@@ -57,7 +57,7 @@ class ComponentGenerator < Thor::Group
     insert_into_file(
       "docs/src/@primer/gatsby-theme-doctocat/nav.yml",
       component_nav,
-      after: "url: \"/components\"\n  children:\n"
+      after: "- title: Components\n  children:\n"
     )
   end
 
@@ -78,7 +78,7 @@ class ComponentGenerator < Thor::Group
   def component_nav
     <<-HEREDOC
   - title: #{class_name} - Fix my order in docs/src/@primer/gatsby-theme-doctocat/nav.yml
-    url: /components/#{status_path}#{short_name}
+    url: "/components/#{status_path}#{short_name}"
     HEREDOC
   end
 

--- a/templates/component.tt
+++ b/templates/component.tt
@@ -6,11 +6,11 @@ module Primer
     # Add additional usage considerations or best practices that may aid the user to use the component correctly.
     # @accessibility Add any accessibility considerations
     class <%= class_name %> < Primer::Component
-      status :alpha
+      status :<%= status %>
 
       # @example Example goes here
       #
-      #   <%%= render(Primer::<%= class_name %>.new) { "Example" } %>
+      #   <%%= render(Primer::<%= status_module %><%= class_name %>.new) { "Example" } %>
       #
       # @param system_arguments [Hash] <%%= link_to_system_arguments_docs %>
       def initialize(**system_arguments)


### PR DESCRIPTION
## the problem

while exploring the view components code and learning how it works, how to build components, etc, i ran into some issues with the `component_generator` thor command:

* the component status was not set correctly by the `component.tt` template. it was hard coded to `:alpha`
* the component namespace was not set correctly in the `component.tt` yard doc example. status based namespace was missing
* the gatsby `nav.yml` file was not updated to include the newly generate component. errors out saying supplied flag value not found

these issues resulted in failure to build or run the view components web app, due to the incorrect or missing status.

## the fixes

this PR corrects the issues above with these changes:

* update `component.tt` template to ensure the correct status is used for both alpha and beta states
* update the module/namespace used in the `@Example` generated by the `component.tt` template
* corrects the `component_generator.thor` file to correct the `after:` setting for inserting the new component into the `nav.yml` file

with these changes, i am able to generate a new component with the correct status and namespace, having it update the `nav.yml` file correctly:

## example output

generate component with no flags:

```shell
❯ bundle exec thor component_generator sample_thing

      create  app/components/primer/alpha/sample_thing.rb
      create  app/components/primer/alpha/sample_thing.html.erb
      create  test/components/primer/alpha/sample_thing_test.rb
      create  test/components/previews/alpha/sample_thing_preview.rb
      insert  lib/tasks/docs.rake
      insert  test/components/component_test.rb
      insert  docs/src/@primer/gatsby-theme-doctocat/nav.yml
```

generate component with status flag:

```shell
❯ bundle exec thor component_generator sample_thing --status beta

      create  app/components/primer/beta/sample_thing.rb
      create  app/components/primer/beta/sample_thing.html.erb
      create  test/components/primer/beta/sample_thing_test.rb
      create  test/components/previews/beta/sample_thing_preview.rb
      insert  lib/tasks/docs.rake
      insert  test/components/component_test.rb
      insert  docs/src/@primer/gatsby-theme-doctocat/nav.yml
```

generate component with status flag and js flag

```shell
❯ bundle exec thor component_generator sample_thing --status beta --js

      create  app/components/primer/beta/sample_thing.rb
      create  app/components/primer/beta/sample_thing.html.erb
      create  test/components/primer/beta/sample_thing_test.rb
      create  test/system/beta/sample_thing_test.rb
      create  demo/test/components/previews/primer/beta/sample_thing_preview.rb
      create  test/components/previews/beta/sample_thing_preview.rb
      insert  lib/tasks/docs.rake
      insert  lib/tasks/docs.rake
      insert  test/components/component_test.rb
      insert  docs/src/@primer/gatsby-theme-doctocat/nav.yml
      create  app/components/primer/beta/sample_thing.ts
      append  app/components/primer/primer.ts

         run  yarn add js from "."
yarn add v1.22.19
[1/4] 🔍  Resolving packages...
...
```

## screenshots

screenshot showing sample thing component in localhost:5400, generated with `--status beta --js` flags. shows the correct status, the correct message in the sidebar telling the developer to edit the nav file, and the correct namespace with running example in the page

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/75190/181282085-06a10e5f-5b09-4396-89d8-2a0029e52894.png">