### PR TITLE
Adding test/components/previews folder to app config

### DIFF
--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.primer_view_components.silence_deprecations = true
   config.primer_view_components.raise_on_invalid_options = false
+
+  config.view_component.preview_paths << Rails.root.join("../test/components/previews")
 end


### PR DESCRIPTION
Adding this preview_paths here allows us to use `render_preview` in component tests.