### PR TITLE
LiveReload lookbook when primer_view_components.js

### DIFF
--- a/lookbook/Procfile.dev
+++ b/lookbook/Procfile.dev
@@ -1,2 +1,4 @@
 web: bin/rails server -p 3000
 css: yarn build:css --watch
+ts: yarn build:ts --watch
+rollup: yarn build:rollup --watch

--- a/lookbook/app/views/layouts/application.html.erb
+++ b/lookbook/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-    <%= javascript_include_tag "primer_view_components", type: "module" %>
+    <%= javascript_include_tag "primer_view_components", type: "module", "data-turbo-track": "reload" %>
     <% if Rails.env.development? %>
       <%= javascript_include_tag "hotwire-livereload", defer: true %>
     <% end %>

--- a/lookbook/config/environments/development.rb
+++ b/lookbook/config/environments/development.rb
@@ -20,6 +20,8 @@ Rails.application.configure do
   config.server_timing = true
 
   config.hotwire_livereload.listen_paths << "/workspaces/css/src/"
+  config.hotwire_livereload.listen_paths << Rails.root.join("../app/assets/javascripts")
+  config.hotwire_livereload.force_reload_paths << Rails.root.join("../app/assets/javascripts")
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.

--- a/lookbook/package.json
+++ b/lookbook/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "scripts": {
     "dev": "bin/dev",
-    "build:css": "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css"
+    "build:css": "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css",
+    "build:ts": "yarn --cwd ../ run tsc",
+    "build:rollup": "yarn --cwd ../ run rollup -c"
   },
   "dependencies": {
     "@koddsson/postcss-sass": "^5.0.1",


### PR DESCRIPTION
I wanted to have lookbook watch for `*.ts` changes in `app/components` and reload when changes are made. This adds config to watch the compiled version for changes `app/assets/javascripts` and hard reload when that happens.

1. Procfile ts watches and compiles *.ts files
2. Procfile rollup watches compiled *.js files and builds final js
3. Hotwire watches final js file and reloads