### PR TITLE
updating links in the contributing docs to point to correct locations

### DIFF
--- a/.changeset/twenty-chairs-hammer.md
+++ b/.changeset/twenty-chairs-hammer.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+updating links in the contributing docs to point to correct locations

--- a/contributor-docs/README.md
+++ b/contributor-docs/README.md
@@ -4,18 +4,18 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 
 If you have any substantial changes that you would like to make, please [open an issue](issues/new) to start a discussion.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.txt).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](https://github.com/primer/view_components/blob/main/LICENSE.txt).
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/primer/view_components/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ## Submitting a pull request
 
 1. Read through the docs in this folder for information on setup and our development practices
-1. [Fork](fork) and clone the repository
+1. [Fork](https://github.com/primer/fork) and clone the repository
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass
 1. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading
-1. Push to your fork and [submit a pull request](compare)
+1. Push to your fork and [submit a pull request](https://github.com/primer/compare)
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged, after merging it will be included in the next release
 
 ### PR tips
@@ -24,5 +24,5 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 * Write a descriptive pull request message
 * Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent on one other consider submitting them as separate pull requests
-* Write comprehensive [documentation](./contributor-docs/documentation.md) and make sure the generated documentation is committed
-* Write thorough [tests](./contributor-docs/component-tests.md)
+* Write comprehensive [documentation](/contributor-docs/documentation.md) and make sure the generated documentation is committed
+* Write thorough [tests](/contributor-docs/component-tests.md)

--- a/contributor-docs/README.md
+++ b/contributor-docs/README.md
@@ -11,7 +11,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 ## Submitting a pull request
 
 1. Read through the docs in this folder for information on setup and our development practices
-1. [Fork](https://github.com/primer/fork) and clone the repository
+1. [Fork](https://github.com/primer/view_components/fork) and clone the repository
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass
 1. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading

--- a/contributor-docs/README.md
+++ b/contributor-docs/README.md
@@ -24,5 +24,5 @@ Here are a few things you can do that will increase the likelihood of your pull 
 
 * Write a descriptive pull request message
 * Keep your change as focused as possible; if there are multiple changes you would like to make that are not dependent on one other consider submitting them as separate pull requests
-* Write comprehensive [documentation](/contributor-docs/documentation.md) and make sure the generated documentation is committed
-* Write thorough [tests](/contributor-docs/component-tests.md)
+* Write comprehensive [documentation](https://primer.style/view-components/contributing#writing-documentation) and make sure the generated documentation is committed
+* Write thorough [tests](https://primer.style/view-components/contributing#testing)

--- a/contributor-docs/README.md
+++ b/contributor-docs/README.md
@@ -15,7 +15,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass
 1. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading
-1. Push to your fork and [submit a pull request](https://github.com/primer/compare)
+1. Push to your fork and [submit a pull request](https://github.com/primer/view_components/compare)
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged, after merging it will be included in the next release
 
 ### PR tips

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -6,9 +6,9 @@ Hi there! We're thrilled that you'd like to contribute to this project. Your hel
 
 If you have any substantial changes that you would like to make, please [open an issue](http://github.com/primer/view_components/issues/new) first to discuss them with us.
 
-Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE.txt).
+Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](https://github.com/primer/view_components/blob/main/LICENSE.txt).
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/primer/view_components/blob/main/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.
 
 ## Adding a new component
 


### PR DESCRIPTION
## problem

while reading through [the contributing docs](https://primer.style/view-components/contributing), i noticed the links to the project license and code of conduct were broken. they're pointing to files in places that they don't exist

i also noticed there's another copy of some contributing docs in the [contributor-docs/README.md](/contributor-docs/README.md) file, which had bad links for the same files, bad links to `fork` and `compare`, and bad links for the `documentation` and `testing` bits

## solution

this PR adjusts the links in both of the contributing docs mentioned above, setting all the currently broken links to the full url of the document or repo page instead of relying on the interpolation of links at build / run time.