### PR TITLE
`ClipboardCopy` only needs `aria-label` when empty

### DIFF
--- a/.changeset/good-coats-shout.md
+++ b/.changeset/good-coats-shout.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Stop requiring aria-label on ClipboardCopy with other content.

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -12,7 +12,7 @@ module Primer
     #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) %>
     #
     # @example With text instead of icons
-    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy", "aria-label": "Copy text to the system clipboard")) do %>
+    #   <%= render(Primer::ClipboardCopy.new(value: "Text to copy")) do %>
     #     Click to copy!
     #   <% end %>
     #
@@ -34,10 +34,16 @@ module Primer
       @system_arguments[:value] = value if value.present?
     end
 
+    # :nodoc:
+    def render_in(*args, &block)
+      validate_aria_label unless block_given?
+
+      super
+    end
+
     private
 
     def validate!
-      validate_aria_label
       raise ArgumentError, "Must provide either `value` or `for`" if @value.nil? && @system_arguments[:for].nil?
     end
   end

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -35,10 +35,8 @@ module Primer
     end
 
     # :nodoc:
-    def render_in(*args, &block)
-      validate_aria_label unless block_given?
-
-      super
+    def before_render
+      validate_aria_label if content.blank?
     end
 
     private

--- a/test/components/clipboard_copy_test.rb
+++ b/test/components/clipboard_copy_test.rb
@@ -17,6 +17,7 @@ class PrimerClipboardCopyTest < Minitest::Test
   def test_requires_aria_label_when_empty
     assert_raises(ArgumentError) do
       render_inline Primer::ClipboardCopy.new(value: "my-branch-name") do
+        nil
       end
     end
   end

--- a/test/components/clipboard_copy_test.rb
+++ b/test/components/clipboard_copy_test.rb
@@ -14,8 +14,14 @@ class PrimerClipboardCopyTest < Minitest::Test
     end
   end
 
+  def test_requires_aria_label_when_empty
+    assert_raises(ArgumentError) do
+      render_inline Primer::ClipboardCopy.new(value: "my-branch-name")
+    end
+  end
+
   def test_renders_with_text_contents
-    render_inline Primer::ClipboardCopy.new(value: "my-branch-name", "aria-label": "Copy branch name to clipboard") do
+    render_inline Primer::ClipboardCopy.new(value: "my-branch-name") do
       "Click to copy!"
     end
 

--- a/test/components/clipboard_copy_test.rb
+++ b/test/components/clipboard_copy_test.rb
@@ -16,7 +16,8 @@ class PrimerClipboardCopyTest < Minitest::Test
 
   def test_requires_aria_label_when_empty
     assert_raises(ArgumentError) do
-      render_inline Primer::ClipboardCopy.new(value: "my-branch-name")
+      render_inline Primer::ClipboardCopy.new(value: "my-branch-name") do
+      end
     end
   end
 


### PR DESCRIPTION
We were requiring `aria-label` on `ClipboardCopy` in all cases, but when the component already contains suitable text this is not recommended.

This changes when we validate the presence of `aria-label`. At instantiation time the component doesn't know if it will be rendered with a block, so we check at render time instead.

Fixes #1081