### PR TITLE
Replace YAML load with YAML safe load with allowed classes list

### DIFF
--- a/.changeset/stale-pumpkins-flash.md
+++ b/.changeset/stale-pumpkins-flash.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Replace YAML load with YAML safe load with allowed classes list

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -7,15 +7,12 @@ module Primer
   class Classify
     # Handler for PrimerCSS utility classes loaded from utilities.rake
     class Utilities
-      # Load the utilities.yml file.
-      # Disabling because we want to load symbols, strings, and integers from the .yml file
-      # rubocop:disable Security/YAMLLoad
-      UTILITIES = YAML.load(
+      UTILITIES = YAML.safe_load(
         File.read(
           File.join(File.dirname(__FILE__), "./utilities.yml")
-        )
+        ),
+        permitted_classes: [Symbol]
       ).freeze
-      # rubocop:enable Security/YAMLLoad
 
       BREAKPOINTS = ["", "-sm", "-md", "-lg", "-xl"].freeze
 


### PR DESCRIPTION
See: https://github.com/primer/view_components/pull/863 (I copied and pasted it so I could add a changeset)

In Psych 4+ YAML.load will default to YAML.safe_load. it is worth using it here since it works with a small list of specified classes even though it is a static list that we supply ourselves