### PR TITLE
Move tooltip to be sibling of link

### DIFF
--- a/.changeset/silly-bananas-joke.md
+++ b/.changeset/silly-bananas-joke.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move tooltip to be sibling of link

--- a/app/components/primer/link_component.html.erb
+++ b/app/components/primer/link_component.html.erb
@@ -1,0 +1,12 @@
+<% if tooltip.present? %>
+  <%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+    <%= render Primer::BaseComponent.new(**@system_arguments) do %>
+      <% content %>
+    <% end %>
+    <%= tooltip %>
+  <% end %>
+<% else %>
+  <%= render Primer::BaseComponent.new(**@system_arguments) do %>
+    <% content %>
+  <% end %>
+<% end %>

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -17,6 +17,8 @@ module Primer
 
     # `Tooltip` that appears on mouse hover or keyboard focus over the link. Use tooltips sparingly and as a last resort.
     # **Important:** This tooltip defaults to `type: :description`. In a few scenarios, `type: :label` may be more appropriate.
+    # The tooltip will appear adjacent to the anchor element. Both the tooltip and the anchor will be nested
+    # under a positioning wrapper.
     # Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
     #
     # @param type [Symbol] (:description) <%= one_of(Primer::Alpha::Tooltip::TYPE_OPTIONS) %>
@@ -42,9 +44,6 @@ module Primer
     #
     # @example Without underline
     #   <%= render(Primer::LinkComponent.new(href: "#", underline: false)) { "Link" } %>
-    #
-    # @example Span as link
-    #   <%= render(Primer::LinkComponent.new(tag: :span)) { "Span as a link" } %>
     #
     # @example With tooltip
     #   @description
@@ -79,12 +78,6 @@ module Primer
 
     def before_render
       raise ArgumentError, "href is required when using <a> tag" if @system_arguments[:tag] == :a && @system_arguments[:href].nil? && !Rails.env.production?
-    end
-
-    def call
-      render(Primer::BaseComponent.new(**@system_arguments)) do
-        content.to_s + tooltip.to_s
-      end
     end
   end
 end

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -62,7 +62,6 @@
 - ".Layout-main-centered-md"
 - ".Layout-main-centered-xl"
 - ".Layout-sidebar"
-- ".Link"
 - ".Link--muted"
 - ".Link--primary"
 - ".Link--secondary"


### PR DESCRIPTION
The `Link` component now supports rendering of tooltip through its API.

Currently the tooltip element is nested within the anchor element. However this will result in the tooltip element becoming a touch area for the link which is unexpected behavior. 

Instead the tooltip element should be rendered adjacent to the anchor.

Additionally, to ensure the tooltip (which uses absolute positioning) is positioned correctly, this PR adds a `position: 'relative` container that wraps the tooltip and the anchor element. I made this a `span` to mimic `inline` positioning of  link.