### PR TITLE
Make all subdirs of docs/static in prepare script

### DIFF
--- a/.changeset/short-foxes-explain.md
+++ b/.changeset/short-foxes-explain.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Make all subdirs of docs/static in prepare script

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "build:docs": "cd docs && yarn gatsby build --prefix-paths",
     "build:docs:preview": "cd docs && yarn gatsby build",
-    "prepare": "rm -rf docs/static && mkdir docs/static && tsc && rollup -c && cp app/assets/javascripts/primer_view_components.js docs/static/primer_view_components.js",
+    "prepare": "rm -rf docs/static && mkdir -p docs/static && tsc && rollup -c && cp app/assets/javascripts/primer_view_components.js docs/static/primer_view_components.js",
     "lint": "eslint 'app/components/**/*.ts' demo/.storybook",
     "lint:fix": "eslint 'app/components/**/*.ts' demo/.storybook --fix",
     "changeset:version": "changeset version && script/version"


### PR DESCRIPTION
I think this is causing the storybook deploy issue evidenced [here](https://github.com/primer/view_components/runs/7621342012?check_suite_focus=true).