### PR TITLE
Renaming with_preview testing to visit_preview

### DIFF
--- a/templates/system_test.rb.tt
+++ b/templates/system_test.rb.tt
@@ -4,7 +4,7 @@ require "application_system_test_case"
 
 class Integration<%= module_name %><%= class_name %>Test < ApplicationSystemTestCase
   def test_renders_component
-    with_preview(:default)
+    visit_preview(:default)
 
     assert_selector(".<%= custom_element_name %>")
   end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -20,7 +20,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   AXE_RULES_TO_SKIP = [:region, :"color-contrast"].freeze
   AXE_WITHIN_SELECTOR = "body"
 
-  def with_preview(preview_name)
+  def visit_preview(preview_name)
     component_name = self.class.name.gsub("Test", "").gsub("Integration", "")
     match = /^(Alpha|Beta)([A-Z])/.match(component_name)
     status = match ? match[1] : ""

--- a/test/system/alpha/auto_complete_component_test.rb
+++ b/test/system/alpha/auto_complete_component_test.rb
@@ -5,7 +5,7 @@ require "application_system_test_case"
 module Alpha
   class IntegrationAutoCompleteTest < ApplicationSystemTestCase
     def test_renders_component
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_selector("auto-complete[for=\"test-id\"][src=\"/auto_complete?version=alpha\"]") do
         assert_selector("input.form-control")
@@ -15,7 +15,7 @@ module Alpha
     end
 
     def test_search_items
-      with_preview(:default)
+      visit_preview(:default)
       assert_selector("input.form-control")
 
       fill_in "input-id", with: "a"
@@ -26,19 +26,19 @@ module Alpha
     end
 
     def test_renders_non_visible_label
-      with_preview(:with_non_visible_label)
+      visit_preview(:with_non_visible_label)
 
       assert_selector("label[for=\"input-id-1\"]", text: "Select a fruit", visible: false)
     end
 
     def test_renders_clear_button
-      with_preview(:with_clear_button)
+      visit_preview(:with_clear_button)
 
       assert_selector("#input-id-4-clear")
     end
 
     def test_renders_icon
-      with_preview(:with_icon)
+      visit_preview(:with_icon)
 
       assert_selector("svg.octicon.octicon-search")
     end

--- a/test/system/alpha/tab_panels_test.rb
+++ b/test/system/alpha/tab_panels_test.rb
@@ -42,13 +42,13 @@ module Alpha
     end
 
     def test_renders_component
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_tab_panels_rendered
     end
 
     def test_changes_tabs_on_click
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_tab_panels_rendered
 

--- a/test/system/alpha/tooltip_test.rb
+++ b/test/system/alpha/tooltip_test.rb
@@ -5,7 +5,7 @@ require "application_system_test_case"
 module Alpha
   class IntegrationTooltipTest < ApplicationSystemTestCase
     def test_renders
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_selector("button[id='button-with-tooltip']")
       assert_selector("tool-tip[for='button-with-tooltip'][data-view-component][role='tooltip']", visible: false, text: "Tooltip text")

--- a/test/system/alpha/underline_panels_test.rb
+++ b/test/system/alpha/underline_panels_test.rb
@@ -42,13 +42,13 @@ module Alpha
     end
 
     def test_renders_component
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_underline_panels_rendered
     end
 
     def test_changes_tabs_on_click
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_underline_panels_rendered
 

--- a/test/system/beta/auto_complete_component_test.rb
+++ b/test/system/beta/auto_complete_component_test.rb
@@ -5,7 +5,7 @@ require "application_system_test_case"
 module Beta
   class IntegrationAutoCompleteTest < ApplicationSystemTestCase
     def test_renders_component
-      with_preview(:default)
+      visit_preview(:default)
 
       assert_selector("auto-complete[for=\"test-id\"][src=\"/auto_complete\"]") do
         assert_selector("input.FormControl-input")
@@ -15,7 +15,7 @@ module Beta
     end
 
     def test_search_items
-      with_preview(:default)
+      visit_preview(:default)
       assert_selector("input.FormControl-input")
 
       fill_in "input-id", with: "a"
@@ -26,19 +26,19 @@ module Beta
     end
 
     def test_renders_non_visible_label
-      with_preview(:with_non_visible_label)
+      visit_preview(:with_non_visible_label)
 
       assert_selector("label[for=\"input-id\"]", text: "Select a fruit", visible: false)
     end
 
     def test_renders_clear_button
-      with_preview(:show_clear_button)
+      visit_preview(:show_clear_button)
 
       assert_selector("#input-id-clear")
     end
 
     def test_renders_icon
-      with_preview(:with_icon)
+      visit_preview(:with_icon)
 
       assert_selector("svg.FormControl-input-leadingVisual")
     end

--- a/test/system/counter_component_test.rb
+++ b/test/system/counter_component_test.rb
@@ -4,7 +4,7 @@ require "application_system_test_case"
 
 class IntegrationCounterComponentTest < ApplicationSystemTestCase
   def test_integration
-    with_preview(:default)
+    visit_preview(:default)
 
     assert_selector(".Counter", text: "1,000")
   end

--- a/test/system/local_time_component_test.rb
+++ b/test/system/local_time_component_test.rb
@@ -4,19 +4,19 @@ require "application_system_test_case"
 
 class IntegrationLocalTimeComponentTest < ApplicationSystemTestCase
   def test_default
-    with_preview(:default)
+    visit_preview(:default)
 
     assert_selector("local-time[data-view-component]", text: "Wed Apr 2, 2014 8:30:00 AM GMT+8")
   end
 
   def test_with_all_the_options
-    with_preview(:with_all_the_options)
+    visit_preview(:with_all_the_options)
 
     assert_selector("local-time[data-view-component]", text: "Wednesday June 01, 16 09:05:07 PM Taipei Standard Time")
   end
 
   def test_with_contents
-    with_preview(:with_contents)
+    visit_preview(:with_contents)
 
     assert_selector("local-time[data-view-component]", text: "Wed Apr 2, 2014 8:30:00 AM GMT+8")
   end

--- a/test/system/time_ago_component_test.rb
+++ b/test/system/time_ago_component_test.rb
@@ -4,13 +4,13 @@ require "application_system_test_case"
 
 class IntegrationTimeAgoComponentTest < ApplicationSystemTestCase
   def test_render
-    with_preview(:default)
+    visit_preview(:default)
 
     assert_selector("time-ago[data-view-component]", text: "now")
   end
 
   def test_render_micro
-    with_preview(:micro)
+    visit_preview(:micro)
 
     assert_selector("time-ago[data-view-component]", text: "1m")
   end


### PR DESCRIPTION
This renames the `with_preview` testing helper to `visit_preview` to better reflect the fact it's visiting a browser instance. 

We're doing this because it's thought that this might be the final name of the helper when it's upstreamed.