### PR TITLE
Update IconButton and Button tooltips to be sibling instead of child

### DIFF
--- a/.changeset/honest-pants-matter.md
+++ b/.changeset/honest-pants-matter.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update IconButton and Button tooltips to be sibling instead of child

--- a/app/components/primer/button_component.html.erb
+++ b/app/components/primer/button_component.html.erb
@@ -1,5 +1,5 @@
 <% if tooltip.present? %>
-  <%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+  <%= render Primer::BaseComponent.new(tag: :div, position: :relative, display: :inline_block) do %>
     <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
       <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", ml: 2, mr: -1) if @dropdown %>
     <% end -%>

--- a/app/components/primer/button_component.html.erb
+++ b/app/components/primer/button_component.html.erb
@@ -1,4 +1,12 @@
-<%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
-  <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", ml: 2, mr: -1) if @dropdown %>
-  <%= tooltip %>
-<% end -%>
+<% if tooltip.present? %>
+  <%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+    <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
+      <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", ml: 2, mr: -1) if @dropdown %>
+    <% end -%>
+    <%= tooltip %>
+  <% end -%>
+<% else %>
+  <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
+    <%= leading_visual %><%= trimmed_content %><%= trailing_visual %><%= primer_octicon("triangle-down", ml: 2, mr: -1) if @dropdown %>
+  <% end -%>
+<% end %>

--- a/app/components/primer/icon_button.erb
+++ b/app/components/primer/icon_button.erb
@@ -1,4 +1,0 @@
-<%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
-  <%= render Primer::OcticonComponent.new(icon: @icon) %>
-  <%= render Primer::Alpha::Tooltip.new(**@tooltip_arguments) %>
-<% end -%>

--- a/app/components/primer/icon_button.html.erb
+++ b/app/components/primer/icon_button.html.erb
@@ -1,0 +1,6 @@
+<%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+  <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
+    <%= render Primer::OcticonComponent.new(icon: @icon) %>
+  <% end -%>
+  <%= render Primer::Alpha::Tooltip.new(**@tooltip_arguments) %>
+<% end %>

--- a/app/components/primer/icon_button.html.erb
+++ b/app/components/primer/icon_button.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+<%= render Primer::BaseComponent.new(tag: :div, position: :relative, display: :inline_block) do %>
   <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
     <%= render Primer::OcticonComponent.new(icon: @icon) %>
   <% end -%>


### PR DESCRIPTION
This work does the same thing @khiga8 did in https://github.com/primer/view_components/pull/1260 for similar reasons that the Tooltip content shouldn't exist inside the button.