### PR TITLE
Always set `:absolute` position on Primer::Alpha::Tooltip

### DIFF
--- a/.changeset/honest-vans-fold.md
+++ b/.changeset/honest-vans-fold.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Always set `:absolute` position on Primer::Alpha::Tooltip

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -91,6 +91,7 @@ module Primer
         @system_arguments[:tag] = :"tool-tip"
         @system_arguments[:style] = join_style_arguments(@system_arguments[:style], "visibility: hidden")
         @system_arguments[:for] = for_id
+        @system_arguments[:position] = :absolute
         @system_arguments[:"data-direction"] = fetch_or_fallback(DIRECTION_OPTIONS, direction, DIRECTION_DEFAULT).to_s
         @system_arguments[:"data-type"] = fetch_or_fallback(TYPE_OPTIONS, type, TYPE_FALLBACK).to_s
       end

--- a/static/classes.yml
+++ b/static/classes.yml
@@ -212,6 +212,7 @@
 - ".p-3"
 - ".p-4"
 - ".p-5"
+- ".position-absolute"
 - ".position-relative"
 - ".pr-2"
 - ".pt-5"

--- a/test/components/alpha/tooltip_test.rb
+++ b/test/components/alpha/tooltip_test.rb
@@ -29,4 +29,9 @@ class PrimerAlphaTooltipTest < Minitest::Test
       render_inline(Primer::Alpha::Tooltip.new(type: :description, for_id: "someButton", text: not_text, visible: false))
     end
   end
+
+  def test_tooltip_is_position_absolute
+    render_inline(Primer::Alpha::Tooltip.new(type: :description, for_id: "someButton", text: "Tooltip"))
+    assert_selector("tool-tip.position-absolute", visible: false)
+  end
 end


### PR DESCRIPTION
I was working on `SegmentedController` and noticed a small size jump with the components. It turns out because there's a moment before the Javascript is loaded in that the Tooltip is hidden, but is taking up dom space. It isn't noticeable in our previews because we're only rendering one of the items that have a tooltip, but I disabled JS for the screenshot below and put a second button in line.

<img width="291" alt="image" src="https://user-images.githubusercontent.com/54012/183222418-cff061c3-48fa-450c-80c7-13d10b16abec.png">

I think we should have a hardcoded `position: absolute;` css that will keep the element out of the flow even when JS fails to load. I opted for adding the system argument, but I'm open to other ways.