### PR TITLE
Don't render tooltip on IconButton when tag is summary

### DIFF
--- a/.changeset/poor-elephants-impress.md
+++ b/.changeset/poor-elephants-impress.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Don't render tooltip on IconButton when tag is a summary element

--- a/app/components/primer/icon_button.html.erb
+++ b/app/components/primer/icon_button.html.erb
@@ -1,6 +1,12 @@
-<%= render Primer::BaseComponent.new(tag: :div, position: :relative, display: :inline_block) do %>
+<% if render_tooltip? %>
+  <%= render Primer::BaseComponent.new(tag: :div, position: :relative, display: :inline_block) do %>
+    <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
+      <%= render Primer::OcticonComponent.new(icon: @icon) %>
+    <% end -%>
+    <%= render Primer::Alpha::Tooltip.new(**@tooltip_arguments) %>
+  <% end %>
+<% else %>
   <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
     <%= render Primer::OcticonComponent.new(icon: @icon) %>
   <% end -%>
-  <%= render Primer::Alpha::Tooltip.new(**@tooltip_arguments) %>
 <% end %>

--- a/app/components/primer/icon_button.rb
+++ b/app/components/primer/icon_button.rb
@@ -97,5 +97,11 @@ module Primer
         @tooltip_arguments[:type] = :label
       end
     end
+
+    private
+
+    def render_tooltip?
+      @system_arguments[:tag] != :summary
+    end
   end
 end

--- a/test/components/icon_button_test.rb
+++ b/test/components/icon_button_test.rb
@@ -35,7 +35,7 @@ class PrimerIconButtonTest < Minitest::Test
 
     assert_selector("summary.btn-octicon") do
       assert_selector(".octicon.octicon-star")
-      assert_selector("tool-tip", visible: false, text: "Label")
+      refute_selector("tool-tip", visible: false, text: "Label")
     end
   end
 


### PR DESCRIPTION
Currently there's an issue with the `IconButton` component when being rendered with a `tag: :summary` option. 

![image](https://user-images.githubusercontent.com/54012/183494612-c494db18-6339-478b-8210-000621dbe5ee.png)

The `<summary>` gets wrapped with a `div` that breaks any details dialog triggers.

I'm proposing that we don't render a tooltip when the tag is a summary. This is because to place it properly we would need to put the tooltip outside of the `<details>` element.