### PR TITLE
Fix link to Flash component

### DIFF
--- a/lib/primer/view_components/linters/flash_migration_counter.rb
+++ b/lib/primer/view_components/linters/flash_migration_counter.rb
@@ -12,7 +12,7 @@ module ERBLint
 
       TAGS = %w[div].freeze
       CLASSES = %w[flash].freeze
-      MESSAGE = "We are migrating flashes to use [Primer::Beta::Flash](https://primer.style/view-components/components/flash), please try to use that instead of raw HTML."
+      MESSAGE = "We are migrating flashes to use [Primer::Beta::Flash](https://primer.style/view-components/components/beta/flash), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Flash
       COMPONENT = "Primer::Beta::Flash"
 


### PR DESCRIPTION
The current link 404s, https://primer.style/view-components/components/beta/flash seems to be the correct one.