### PR TITLE
updating slot use in BorderBox examples to the '.with_#{slot_name}' syntax

### DIFF
--- a/.changeset/ninety-feet-melt.md
+++ b/.changeset/ninety-feet-melt.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+updating BorderBox slot use to the new `.with_#{slot_name}` syntax

--- a/app/components/primer/beta/border_box.rb
+++ b/app/components/primer/beta/border_box.rb
@@ -72,55 +72,55 @@ module Primer
 
       # @example Header with title, body, rows, and footer
       #   <%= render(Primer::Beta::BorderBox.new) do |component| %>
-      #     <% component.header do |h| %>
+      #     <% component.with_header do |h| %>
       #       <% h.title(tag: :h2) do %>
       #         Header
       #       <% end %>
       #     <% end %>
-      #     <% component.body do %>
+      #     <% component.with_body do %>
       #       Body
       #     <% end %>
-      #     <% component.row do %>
+      #     <% component.with_row do %>
       #       <% if true %>
       #         Row one
       #       <% end %>
       #     <% end %>
-      #     <% component.row do %>
+      #     <% component.with_row do %>
       #       Row two
       #     <% end %>
-      #     <% component.footer do %>
+      #     <% component.with_footer do %>
       #       Footer
       #     <% end %>
       #   <% end %>
       #
       # @example Padding density
       #   <%= render(Primer::Beta::BorderBox.new(padding: :condensed)) do |component| %>
-      #     <% component.header do %>
+      #     <% component.with_header do %>
       #       Header
       #     <% end %>
-      #     <% component.body do %>
+      #     <% component.with_body do %>
       #       Body
       #     <% end %>
-      #     <% component.row do %>
+      #     <% component.with_row do %>
       #       Row two
       #     <% end %>
-      #     <% component.footer do %>
+      #     <% component.with_footer do %>
       #       Footer
       #     <% end %>
       #   <% end %>
       #
       # @example Row colors
       #   <%= render(Primer::Beta::BorderBox.new) do |component| %>
-      #     <% component.row do %>
+      #     <% component.with_row do %>
       #       Default
       #     <% end %>
-      #     <% component.row(scheme: :neutral) do %>
+      #     <% component.with_row(scheme: :neutral) do %>
       #       Neutral
       #     <% end %>
-      #     <% component.row(scheme: :info) do %>
+      #     <% component.with_row(scheme: :info) do %>
       #       Info
       #     <% end %>
-      #     <% component.row(scheme: :warning) do %>
+      #     <% component.with_row(scheme: :warning) do %>
       #       Warning
       #     <% end %>
       #   <% end %>


### PR DESCRIPTION
as part of the slot use migration, this PR updates all slot use in the `Primer::Beta::BorderBox` examples to use `.with_#{slot_name}` instead of `.#{slot_name}`

* `.header` -> `.with_header`
* `.row` -> `.with_row`
* `.body` -> `.with_body`
* `.footer` -> `.with_footer`

## notes

this PR is intentionally limited to one component, as a test to make sure everything is updated correctly

## screenshots

updated docs site:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183748176-929074b1-fcb2-4ed6-8bbf-c84d708cfbee.png">
