### PR TITLE
Continue axe tests when there's a failure

### DIFF
--- a/test/system/doc_examples_axe_test.rb
+++ b/test/system/doc_examples_axe_test.rb
@@ -18,6 +18,8 @@ class IntegrationDocExamplesAxeTest < ApplicationSystemTestCase
     puts "Running axe-core checks on previews generated from documentation examples..."
     puts "============================================================================="
 
+    failure_urls = []
+
     Primer::Docs.constants.each do |klass|
       next if NOT_STANDALONE.include?(klass)
       next if IGNORE.include?(klass)
@@ -31,14 +33,18 @@ class IntegrationDocExamplesAxeTest < ApplicationSystemTestCase
         rescue RuntimeError => e
           # :nocov:
           puts "=========================================================================="
+          puts e.to_s
           puts "#{component_uri}##{preview} failed check."
           puts "=========================================================================="
-          raise e
+          failure_urls.push("#{component_uri}/#{preview}")
+
           # :nocov:
         else
           puts "#{component_uri}##{preview} passed check."
         end
       end
     end
+
+    raise "#{failure_urls.count} components had axe failures:\n#{failure_urls}" if failure_urls.any?
   end
 end


### PR DESCRIPTION
### Motivation

I've been looking over the axe tests to understand what they're doing. While doing so, I introduced an intentional issue and noticed that the axe tests halt on error.

This code change collates all axe errors and then raises an error at the end of the process.

### Additional Notes

I switched off the skip `:"color-contract"` rule and there were 13 axe failures reported:

> Error:
> IntegrationDocExamplesAxeTest#test_accessibility_of_doc_examples:
> RuntimeError: There were 13 axe failures:
> ["button_group/default", "button_group/sizes", "dropdown/customizing_the_button", "state_component/schemes", "alpha_tooltip/as_a_description_for_a_button_with_visible_label", "alpha_tooltip/with_relative_parent", "beta_blankslate/primary_and_secondary_actions", "beta_blankslate/primary_action", "beta_button_group/default", "beta_button_group/sizes", "blankslate_component/action_button", "button_component/block", "button_component/schemes"]

It might be worth us putting some effort in to resolving these contrast errors so we can switch this rule on.

I also tried to enable rule-sets using [according_to](https://github.com/dequelabs/axe-core-gems/blob/develop/packages/axe-core-rspec/README.md#according_to---accessibility-standard-tag-clause) and I expected to see failures related to the pages not having an `h1` heading but the tests all passed. This is strange behavior so I would like to see if there's a way to confirm which tests are actually run by this code.