### PR TITLE
Update slot use in examples for all components in the alpha folder

### DIFF
--- a/.changeset/shiny-cooks-tap.md
+++ b/.changeset/shiny-cooks-tap.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+updating slot use in examples, for all `status :alpha` components

--- a/app/components/primer/alpha/auto_complete.rb
+++ b/app/components/primer/alpha/auto_complete.rb
@@ -94,12 +94,12 @@ module Primer
       #
       # @example With custom classes for the input
       #   <%= render(Primer::Alpha::AutoComplete.new(label_text: "Fruits", src: "/auto_complete", input_id: "fruits-input--custom-input", list_id: "fruits-popup--custom-input")) do |c| %>
-      #     <% c.input(classes: "custom-class") %>
+      #     <% c.with_input(classes: "custom-class") %>
       #   <% end %>
       #
       # @example With custom classes for the results
       #   <%= render(Primer::Alpha::AutoComplete.new(label_text: "Fruits", src: "/auto_complete", input_id: "fruits-input--custom-results", list_id: "fruits-popup--custom-results")) do |c| %>
-      #     <% c.results(classes: "custom-class") do %>
+      #     <% c.with_results(classes: "custom-class") do %>
       #       <%= render(Primer::Alpha::AutoComplete::Item.new(selected: true, value: "apple")) do |c| %>
       #         Apple
       #       <% end %>

--- a/app/components/primer/alpha/layout.rb
+++ b/app/components/primer/alpha/layout.rb
@@ -14,6 +14,8 @@ module Primer
     #   Keyboard navigation follows the markup order. Decide carefully how the focus order should be be by deciding whether
     #   `main` or `sidebar` comes first in code. The code order won’t affect the visual position.
     class Layout < Primer::Component
+      status :alpha
+
       FIRST_IN_SOURCE_DEFAULT = :sidebar
       FIRST_IN_SOURCE_OPTIONS = [FIRST_IN_SOURCE_DEFAULT, :main].freeze
 

--- a/app/components/primer/alpha/layout.rb
+++ b/app/components/primer/alpha/layout.rb
@@ -80,8 +80,8 @@ module Primer
       # @example Default
       #
       #   <%= render(Primer::Alpha::Layout.new) do |c| %>
-      #     <% c.main(border: true) { "Main" } %>
-      #     <% c.sidebar(border: true) { "Sidebar" } %>
+      #     <% c.with_main(border: true) { "Main" } %>
+      #     <% c.with_sidebar(border: true) { "Sidebar" } %>
       #   <% end %>
       #
       # @example Main widths
@@ -96,20 +96,20 @@ module Primer
       #
       #   @code
       #     <%= render(Primer::Alpha::Layout.new) do |c| %>
-      #       <% c.main(width: :full, border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(width: :full, border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(width: :md, border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(width: :md, border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(width: :lg, border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(width: :lg, border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(width: :xl, border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(width: :xl, border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #
       # @example Sidebar widths
@@ -125,16 +125,16 @@ module Primer
       #
       #   @code
       #     <%= render(Primer::Alpha::Layout.new) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(width: :default, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(width: :default, border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(width: :narrow, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(width: :narrow, border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(width: :wide, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(width: :wide, border: true) { "Sidebar" } %>
       #     <% end %>
       #
       # @example Sidebar placement
@@ -144,12 +144,12 @@ module Primer
       #
       #   @code
       #     <%= render(Primer::Alpha::Layout.new) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(col_placement: :start, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(col_placement: :start, border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new( mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(col_placement: :end, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(col_placement: :end, border: true) { "Sidebar" } %>
       #     <% end %>
       #
       # @example Sidebar placement as row
@@ -163,16 +163,16 @@ module Primer
       #
       #   @code
       #     <%= render(Primer::Alpha::Layout.new) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(row_placement: :start, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(row_placement: :start, border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(row_placement: :end, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(row_placement: :end, border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(row_placement: :none, border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(row_placement: :none, border: true) { "Sidebar" } %>
       #     <% end %>
       #
       # @example Changing when to render `Layout` as columns
@@ -183,16 +183,16 @@ module Primer
       #
       #   @code
       #     <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :sm)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :md, mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #     <%= render(Primer::Alpha::Layout.new(stacking_breakpoint: :lg, mt: 5)) do |c| %>
-      #       <% c.main(border: true) { "Main" } %>
-      #       <% c.sidebar(border: true) { "Sidebar" } %>
+      #       <% c.with_main(border: true) { "Main" } %>
+      #       <% c.with_sidebar(border: true) { "Sidebar" } %>
       #     <% end %>
       #
       # @param stacking_breakpoint [Symbol] When the `Layout` should change from rows into columns. <%= one_of(Primer::Alpha::Layout::STACKING_BREAKPOINT_OPTIONS) %>

--- a/app/components/primer/alpha/tab_nav.rb
+++ b/app/components/primer/alpha/tab_nav.rb
@@ -49,30 +49,30 @@ module Primer
       #     `<nav>` is a landmark and should be reserved for main navigation links. See <%= link_to_accessibility %>.
       #   @code
       #     <%= render(Primer::Alpha::TabNav.new(label: "Default")) do |c| %>
-      #       <% c.tab(selected: true, href: "#") { "Tab 1" } %>
-      #       <% c.tab(href: "#") { "Tab 2" } %>
-      #       <% c.tab(href: "#") { "Tab 3" } %>
+      #       <% c.with_tab(selected: true, href: "#") { "Tab 1" } %>
+      #       <% c.with_tab(href: "#") { "Tab 2" } %>
+      #       <% c.with_tab(href: "#") { "Tab 3" } %>
       #     <% end %>
       #
       # @example Default with `<div>`
       #   <%= render(Primer::Alpha::TabNav.new(label: "Default")) do |c| %>
-      #     <% c.tab(selected: true, href: "#") { "Tab 1" } %>
-      #     <% c.tab(href: "#") { "Tab 2" } %>
-      #     <% c.tab(href: "#") { "Tab 3" } %>
+      #     <% c.with_tab(selected: true, href: "#") { "Tab 1" } %>
+      #     <% c.with_tab(href: "#") { "Tab 2" } %>
+      #     <% c.with_tab(href: "#") { "Tab 3" } %>
       #   <% end %>
       #
       # @example With icons and counters
       #   <%= render(Primer::Alpha::TabNav.new(label: "With icons and counters")) do |component| %>
-      #     <% component.tab(href: "#", selected: true) do |t| %>
+      #     <% component.with_tab(href: "#", selected: true) do |t| %>
       #       <% t.icon(icon: :star) %>
       #       <% t.text { "Item 1" } %>
       #     <% end %>
-      #     <% component.tab(href: "#") do |t| %>
+      #     <% component.with_tab(href: "#") do |t| %>
       #       <% t.icon(icon: :star) %>
       #       <% t.text { "Item 2" } %>
       #       <% t.counter(count: 10) %>
       #     <% end %>
-      #     <% component.tab(href: "#") do |t| %>
+      #     <% component.with_tab(href: "#") do |t| %>
       #       <% t.text { "Item 3" } %>
       #       <% t.counter(count: 10) %>
       #     <% end %>
@@ -80,20 +80,20 @@ module Primer
       #
       # @example With extra content
       #   <%= render(Primer::Alpha::TabNav.new(label: "With extra content")) do |c| %>
-      #     <% c.tab(selected: true, href: "#") { "Tab 1" }%>
-      #     <% c.tab(href: "#") { "Tab 2" } %>
-      #     <% c.tab(href: "#") { "Tab 3" } %>
-      #     <% c.extra do %>
+      #     <% c.with_tab(selected: true, href: "#") { "Tab 1" }%>
+      #     <% c.with_tab(href: "#") { "Tab 2" } %>
+      #     <% c.with_tab(href: "#") { "Tab 3" } %>
+      #     <% c.with_extra do %>
       #       <%= render(Primer::ButtonComponent.new(float: :right)) { "Button" } %>
       #     <% end %>
       #   <% end %>
       #
       # @example Adding extra content after the tabs
       #   <%= render(Primer::Alpha::TabNav.new(label: "Adding extra content after the tabs", display: :flex, body_arguments: { flex: 1 })) do |c| %>
-      #     <% c.tab(selected: true, href: "#") { "Tab 1" }%>
-      #     <% c.tab(href: "#") { "Tab 2" } %>
-      #     <% c.tab(href: "#") { "Tab 3" } %>
-      #     <% c.extra(align: :right) do %>
+      #     <% c.with_tab(selected: true, href: "#") { "Tab 1" }%>
+      #     <% c.with_tab(href: "#") { "Tab 2" } %>
+      #     <% c.with_tab(href: "#") { "Tab 3" } %>
+      #     <% c.with_extra(align: :right) do %>
       #       <div>
       #         <%= render(Primer::ButtonComponent.new) { "Button" } %>
       #       </div>
@@ -102,9 +102,9 @@ module Primer
       #
       # @example Customizing the body
       #   <%= render(Primer::Alpha::TabNav.new(label: "Default", body_arguments: { classes: "custom-class", border: true, border_color: :accent_emphasis })) do |c| %>
-      #     <% c.tab(selected: true, href: "#") { "Tab 1" }%>
-      #     <% c.tab(href: "#") { "Tab 2" } %>
-      #     <% c.tab(href: "#") { "Tab 3" } %>
+      #     <% c.with_tab(selected: true, href: "#") { "Tab 1" }%>
+      #     <% c.with_tab(href: "#") { "Tab 2" } %>
+      #     <% c.with_tab(href: "#") { "Tab 3" } %>
       #   <% end %>
       #
       # @param tag [Symbol] <%= one_of(Primer::Alpha::TabNav::TAG_OPTIONS) %>

--- a/app/components/primer/alpha/tab_panels.rb
+++ b/app/components/primer/alpha/tab_panels.rb
@@ -43,13 +43,13 @@ module Primer
 
       # @example Default
       #   <%= render(Primer::Alpha::TabPanels.new(label: "With panels")) do |component| %>
-      #     <% component.tab(id: "tab-1", selected: true) do |t| %>
+      #     <% component.with_tab(id: "tab-1", selected: true) do |t| %>
       #       <% t.text { "Tab 1" } %>
       #       <% t.panel do %>
       #         Panel 1
       #       <% end %>
       #     <% end %>
-      #     <% component.tab(id: "tab-2") do |t| %>
+      #     <% component.with_tab(id: "tab-2") do |t| %>
       #       <% t.text { "Tab 2" } %>
       #       <% t.panel do %>
       #         Panel 2

--- a/app/components/primer/alpha/underline_nav.rb
+++ b/app/components/primer/alpha/underline_nav.rb
@@ -53,60 +53,60 @@ module Primer
       #     `<nav>` is a landmark and should be reserved for main navigation links. See <%= link_to_accessibility %>.
       #   @code
       #     <%= render(Primer::Alpha::UnderlineNav.new(label: "Default with nav element")) do |component| %>
-      #       <% component.tab(href: "#", selected: true) { "Item 1" } %>
-      #       <% component.tab(href: "#") { "Item 2" } %>
-      #       <% component.actions do %>
+      #       <% component.with_tab(href: "#", selected: true) { "Item 1" } %>
+      #       <% component.with_tab(href: "#") { "Item 2" } %>
+      #       <% component.with_actions do %>
       #         <%= render(Primer::ButtonComponent.new) { "Button!" } %>
       #       <% end %>
       #     <% end %>
       #
       # @example With `<div>`
       #   <%= render(Primer::Alpha::UnderlineNav.new(tag: :div, label: "With div element")) do |component| %>
-      #     <% component.tab(href: "#", selected: true) { "Item 1" } %>
-      #     <% component.tab(href: "#") { "Item 2" } %>
-      #     <% component.actions do %>
+      #     <% component.with_tab(href: "#", selected: true) { "Item 1" } %>
+      #     <% component.with_tab(href: "#") { "Item 2" } %>
+      #     <% component.with_actions do %>
       #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
       #     <% end %>
       #   <% end %>
       #
       # @example With icons and counters
       #   <%= render(Primer::Alpha::UnderlineNav.new(label: "With icons and counters")) do |component| %>
-      #     <% component.tab(href: "#", selected: true) do |t| %>
+      #     <% component.with_tab(href: "#", selected: true) do |t| %>
       #       <% t.icon(icon: :star) %>
       #       <% t.text { "Item 1" } %>
       #     <% end %>
-      #     <% component.tab(href: "#") do |t| %>
+      #     <% component.with_tab(href: "#") do |t| %>
       #       <% t.icon(icon: :star) %>
       #       <% t.text { "Item 2" } %>
       #       <% t.counter(count: 10) %>
       #     <% end %>
-      #     <% component.tab(href: "#") do |t| %>
+      #     <% component.with_tab(href: "#") do |t| %>
       #       <% t.text { "Item 3" } %>
       #       <% t.counter(count: 10) %>
       #     <% end %>
-      #     <% component.actions do %>
+      #     <% component.with_actions do %>
       #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
       #     <% end %>
       #   <% end %>
       #
       # @example Align right
       #   <%= render(Primer::Alpha::UnderlineNav.new(label: "Align right", align: :right)) do |component| %>
-      #     <% component.tab(href: "#", selected: true) do |t| %>
+      #     <% component.with_tab(href: "#", selected: true) do |t| %>
       #       <% t.text { "Item 1" } %>
       #     <% end %>
-      #     <% component.tab(href: "#") do |t| %>
+      #     <% component.with_tab(href: "#") do |t| %>
       #       <% t.text { "Item 2" } %>
       #     <% end %>
-      #     <% component.actions do %>
+      #     <% component.with_actions do %>
       #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
       #     <% end %>
       #   <% end %>
       #
       # @example Customizing the body
       #   <%= render(Primer::Alpha::UnderlineNav.new(label: "Default", body_arguments: { classes: "custom-class", border: true, border_color: :accent_emphasis })) do |c| %>
-      #     <% c.tab(selected: true, href: "#") { "Tab 1" }%>
-      #     <% c.tab(href: "#") { "Tab 2" } %>
-      #     <% c.tab(href: "#") { "Tab 3" } %>
+      #     <% c.with_tab(selected: true, href: "#") { "Tab 1" }%>
+      #     <% c.with_tab(href: "#") { "Tab 2" } %>
+      #     <% c.with_tab(href: "#") { "Tab 3" } %>
       #   <% end %>
       #
       # @param tag [Symbol] <%= one_of(Primer::Alpha::UnderlineNav::TAG_OPTIONS) %>

--- a/app/components/primer/alpha/underline_panels.rb
+++ b/app/components/primer/alpha/underline_panels.rb
@@ -38,19 +38,19 @@ module Primer
 
       # @example Default
       #   <%= render(Primer::Alpha::UnderlinePanels.new(label: "With panels")) do |component| %>
-      #     <% component.tab(id: "tab-1", selected: true) do |t| %>
+      #     <% component.with_tab(id: "tab-1", selected: true) do |t| %>
       #       <% t.text { "Tab 1" } %>
       #       <% t.panel do %>
       #         Panel 1
       #       <% end %>
       #     <% end %>
-      #     <% component.tab(id: "tab-2") do |t| %>
+      #     <% component.with_tab(id: "tab-2") do |t| %>
       #       <% t.text { "Tab 2" } %>
       #       <% t.panel do %>
       #         Panel 2
       #       <% end %>
       #     <% end %>
-      #     <% component.actions do %>
+      #     <% component.with_actions do %>
       #       <%= render(Primer::ButtonComponent.new) { "Button!" } %>
       #     <% end %>
       #   <% end %>

--- a/docs/content/components/label.md
+++ b/docs/content/components/label.md
@@ -31,7 +31,7 @@ Use `aria-label` if the `Label` or the context around it don't explain the label
 
 ### Schemes
 
-<Example src="<span data-view-component='true' class='Label Label--large'>Default</span><span data-view-component='true' class='Label Label--primary Label--large'>Primary</span><span data-view-component='true' class='Label Label--secondary Label--large'>Secondary</span><span data-view-component='true' class='Label Label--accent Label--large'>Accent</span><span data-view-component='true' class='Label Label--success Label--large'>Success</span><span data-view-component='true' class='Label Label--attention Label--large'>Attention</span><span data-view-component='true' class='Label Label--danger Label--large'>Danger</span><span data-view-component='true' class='Label Label--severe Label--large'>Severe</span><span data-view-component='true' class='Label Label--done Label--large'>Done</span><span data-view-component='true' class='Label Label--sponsors Label--large'>Sponsors</span>" />
+<Example src="<span data-view-component='true' class='Label'>Default</span><span data-view-component='true' class='Label Label--primary'>Primary</span><span data-view-component='true' class='Label Label--secondary'>Secondary</span><span data-view-component='true' class='Label Label--accent'>Accent</span><span data-view-component='true' class='Label Label--success'>Success</span><span data-view-component='true' class='Label Label--attention'>Attention</span><span data-view-component='true' class='Label Label--danger'>Danger</span><span data-view-component='true' class='Label Label--severe'>Severe</span><span data-view-component='true' class='Label Label--done'>Done</span><span data-view-component='true' class='Label Label--sponsors'>Sponsors</span>" />
 
 ```erb
 <%= render(Primer::LabelComponent.new) { "Default" } %>
@@ -48,7 +48,7 @@ Use `aria-label` if the `Label` or the context around it don't explain the label
 
 ### Sizes
 
-<Example src="<span data-view-component='true' class='Label Label--large'>Medium</span><span data-view-component='true' class='Label Label--large'>Large</span>" />
+<Example src="<span data-view-component='true' class='Label'>Medium</span><span data-view-component='true' class='Label Label--large'>Large</span>" />
 
 ```erb
 <%= render(Primer::LabelComponent.new) { "Medium" } %>
@@ -57,7 +57,7 @@ Use `aria-label` if the `Label` or the context around it don't explain the label
 
 ### Inline
 
-<Example src="<span data-view-component='true' class='Label Label--large'>Default</span><span data-view-component='true' class='Label Label--large Label--inline'>Inline</span>" />
+<Example src="<span data-view-component='true' class='Label'>Default</span><span data-view-component='true' class='Label Label--inline'>Inline</span>" />
 
 ```erb
 <%= render(Primer::LabelComponent.new) { "Default" } %>

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -68,7 +68,7 @@
   - title: Label
     url: "/components/label"
   - title: Layout
-    url: "/components/layout"
+    url: "/components/alpha/layout"
   - title: Link
     url: "/components/link"
   - title: LocalTime


### PR DESCRIPTION
this PR updates all components in the `alpha/` folder to use the new `.with_#{slot_name}` syntax in docs examples

additionally, an error was found with the `Alpha::Layout` component that prevented it's docs from generating and updating correctly. the `status :alpha` flag was missing, and the gatsby `nav.yml` link was pointing to an incorrect (old) location. both of these have been corrected.

## Updated components

* Alpha::AutoComplete (deprecated)
* Alpha::Layout
* Alpha::TabNav
* Alpha::TabPanels
* Alpha::UnderlineNav
* Alpha::UnderlinePanels

## Screenshots

layout:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183907241-5ee5ac6e-5a80-4d46-a395-1bdf78d6036c.png">

tab nav:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183907392-1f8927d5-c58b-499c-a80d-b28e9ef0da82.png">

tab panels:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183907549-e367c088-2594-4e50-bc23-6690d5b60e7c.png">

underline nav:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183907671-6d465b01-27a4-4353-95fd-1a0363cf62f9.png">

underline panels:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/183907771-533b4d24-f5d7-4975-a244-ed48408eca79.png">
