### PR TITLE
Update slot use in examples for all components in the root folder

### DIFF
--- a/.changeset/perfect-chefs-heal.md
+++ b/.changeset/perfect-chefs-heal.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+updating slot use for examples in all components in the root component folder

--- a/app/components/primer/blankslate_component.rb
+++ b/app/components/primer/blankslate_component.rb
@@ -41,7 +41,7 @@ module Primer
     #       title: "Title",
     #       description: "Description",
     #     ) do |component| %>
-    #       <% component.spinner(size: :large) %>
+    #       <% component.with_spinner(size: :large) %>
     #     <% end %>
     #
     # @example Custom content

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -89,20 +89,20 @@ module Primer
     #
     # @example With leading visual
     #   <%= render(Primer::ButtonComponent.new) do |c| %>
-    #     <% c.leading_visual_icon(icon: :star) %>
+    #     <% c.with_leading_visual_icon(icon: :star) %>
     #     Button
     #   <% end %>
     #
     # @example With trailing visual
     #   <%= render(Primer::ButtonComponent.new) do |c| %>
-    #     <% c.trailing_visual_counter(count: 15) %>
+    #     <% c.with_trailing_visual_counter(count: 15) %>
     #     Button
     #   <% end %>
     #
     # @example With leading and trailing visuals
     #   <%= render(Primer::ButtonComponent.new) do |c| %>
-    #     <% c.leading_visual_icon(icon: :star) %>
-    #     <% c.trailing_visual_counter(count: 15) %>
+    #     <% c.with_leading_visual_icon(icon: :star) %>
+    #     <% c.with_trailing_visual_counter(count: 15) %>
     #     Button
     #   <% end %>
     #
@@ -116,7 +116,7 @@ module Primer
     #     Use tooltips sparingly and as a last resort. Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
     #   @code
     #     <%= render(Primer::ButtonComponent.new(id: "button-with-tooltip")) do |c| %>
-    #       <% c.tooltip(text: "Tooltip text") %>
+    #       <% c.with_tooltip(text: "Tooltip text") %>
     #       Button
     #     <% end %>
     #

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -40,10 +40,10 @@ module Primer
     # @example Default
     #
     #   <%= render Primer::DetailsComponent.new do |c| %>
-    #     <% c.summary do %>
+    #     <% c.with_summary do %>
     #       Summary
     #     <% end %>
-    #     <% c.body do %>
+    #     <% c.with_body do %>
     #       Body
     #     <% end %>
     #   <% end %>

--- a/app/components/primer/dropdown.rb
+++ b/app/components/primer/dropdown.rb
@@ -25,11 +25,11 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::Dropdown.new) do |c| %>
-    #     <% c.button do %>
+    #     <% c.with_button do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(header: "Options") do |menu|
+    #     <% c.with_menu(header: "Options") do |menu|
     #       menu.item { "Item 1" }
     #       menu.item { "Item 2" }
     #       menu.item { "Item 3" }
@@ -42,11 +42,11 @@ module Primer
     #     Dividers can be used to separate a group of items. They don't have any content.
     #   @code
     #     <%= render(Primer::Dropdown.new) do |c| %>
-    #       <% c.button do %>
+    #       <% c.with_button do %>
     #         Dropdown
     #       <% end %>
     #
-    #       <% c.menu(header: "Options") do |menu|
+    #       <% c.with_menu(header: "Options") do |menu|
     #         menu.item { "Item 1" }
     #         menu.item { "Item 2" }
     #         menu.item(divider: true)
@@ -60,11 +60,11 @@ module Primer
     #
     # @example With direction
     #   <%= render(Primer::Dropdown.new(display: :inline_block)) do |c| %>
-    #     <% c.button do %>
+    #     <% c.with_button do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(header: "Options", direction: :s) do |menu|
+    #     <% c.with_menu(header: "Options", direction: :s) do |menu|
     #       menu.item { "Item 1" }
     #       menu.item { "Item 2" }
     #       menu.item { "Item 3" }
@@ -74,11 +74,11 @@ module Primer
     #
     # @example With caret
     #   <%= render(Primer::Dropdown.new(with_caret: true)) do |c| %>
-    #     <% c.button do %>
+    #     <% c.with_button do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(header: "Options") do |menu|
+    #     <% c.with_menu(header: "Options") do |menu|
     #       menu.item { "Item 1" }
     #       menu.item { "Item 2" }
     #       menu.item { "Item 3" }
@@ -88,11 +88,11 @@ module Primer
     #
     # @example Customizing the button
     #   <%= render(Primer::Dropdown.new) do |c| %>
-    #     <% c.button(scheme: :primary, size: :small) do %>
+    #     <% c.with_button(scheme: :primary, size: :small) do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(header: "Options") do |menu|
+    #     <% c.with_menu(header: "Options") do |menu|
     #       menu.item { "Item 1" }
     #       menu.item { "Item 2" }
     #       menu.item { "Item 3" }
@@ -102,11 +102,11 @@ module Primer
     #
     # @example Menu as list
     #   <%= render(Primer::Dropdown.new) do |c| %>
-    #     <% c.button do %>
+    #     <% c.with_button do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(as: :list, header: "Options") do |menu|
+    #     <% c.with_menu(as: :list, header: "Options") do |menu|
     #       menu.item { "Item 1" }
     #       menu.item { "Item 2" }
     #       menu.item(divider: true)
@@ -117,11 +117,11 @@ module Primer
     #
     # @example Customizing menu items
     #   <%= render(Primer::Dropdown.new) do |c| %>
-    #     <% c.button do %>
+    #     <% c.with_button do %>
     #       Dropdown
     #     <% end %>
     #
-    #     <% c.menu(header: "Options") do |menu|
+    #     <% c.with_menu(header: "Options") do |menu|
     #       menu.item(tag: :button) { "Item 1" }
     #       menu.item(classes: "custom-class") { "Item 2" }
     #       menu.item { "Item 3" }

--- a/app/components/primer/image_crop.rb
+++ b/app/components/primer/image_crop.rb
@@ -21,7 +21,7 @@ module Primer
     #
     # @example Cropper with a custom loader
     #   <%= render(Primer::ImageCrop.new(src: "https://github.com/koddsson.png", rounded: false)) do |cropper| %>
-    #     <% cropper.loading(style: "width: 120px").with_content("Loading...") %>
+    #     <% cropper.with_loading(style: "width: 120px").with_content("Loading...") %>
     #   <% end %>
     #
     # @param src [String] The path of the image to crop.

--- a/app/components/primer/layout_component.rb
+++ b/app/components/primer/layout_component.rb
@@ -38,14 +38,14 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::LayoutComponent.new) do |component| %>
-    #     <% component.sidebar { "Sidebar" } %>
-    #     <% component.main { "Main" } %>
+    #     <% component.with_sidebar { "Sidebar" } %>
+    #     <% component.with_main { "Main" } %>
     #   <% end %>
     #
     # @example Left sidebar
     #   <%= render(Primer::LayoutComponent.new(side: :left)) do |component| %>
-    #     <% component.sidebar { "Sidebar" } %>
-    #     <% component.main { "Main" } %>
+    #     <% component.with_sidebar { "Sidebar" } %>
+    #     <% component.with_main { "Main" } %>
     #   <% end %>
     #
     # @param responsive [Boolean] Whether to collapse layout to a single column at smaller widths.

--- a/app/components/primer/link_component.rb
+++ b/app/components/primer/link_component.rb
@@ -50,7 +50,7 @@ module Primer
     #     Use tooltips sparingly and as a last resort. Consult the <%= link_to_component(Primer::Alpha::Tooltip) %> documentation for more information.
     #   @code
     #     <%= render(Primer::LinkComponent.new(href: "#", id: "link-with-tooltip")) do |c| %>
-    #       <% c.tooltip(text: "Tooltip text") %>
+    #       <% c.with_tooltip(text: "Tooltip text") %>
     #       Link
     #     <% end %>
     #

--- a/app/components/primer/menu_component.rb
+++ b/app/components/primer/menu_component.rb
@@ -40,17 +40,17 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::MenuComponent.new) do |c| %>
-    #     <% c.heading(tag: :h2) do %>
+    #     <% c.with_heading(tag: :h2) do %>
     #       Heading
     #     <% end %>
-    #     <% c.item(selected: true, href: "#url") do %>
+    #     <% c.with_item(selected: true, href: "#url") do %>
     #       Item 1
     #     <% end %>
-    #     <% c.item(href: "#url") do %>
+    #     <% c.with_item(href: "#url") do %>
     #       <%= render(Primer::OcticonComponent.new("check")) %>
     #       With Icon
     #     <% end %>
-    #     <% c.item(href: "#url") do %>
+    #     <% c.with_item(href: "#url") do %>
     #       <%= render(Primer::OcticonComponent.new("check")) %>
     #       With Icon and Counter
     #       <%= render(Primer::Beta::Counter.new(count: 25)) %>

--- a/app/components/primer/navigation/tab_component.rb
+++ b/app/components/primer/navigation/tab_component.rb
@@ -64,30 +64,30 @@ module Primer
 
       # @example Default
       #   <%= render(Primer::Navigation::TabComponent.new(selected: true)) do |c| %>
-      #     <% c.text { "Selected" } %>
+      #     <% c.with_text { "Selected" } %>
       #   <% end %>
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.text { "Not selected" } %>
+      #     <% c.with_text { "Not selected" } %>
       #   <% end %>
       #
       # @example With icons and counters
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.icon(:star) %>
-      #     <% c.text { "Tab" } %>
+      #     <% c.with_icon(:star) %>
+      #     <% c.with_text { "Tab" } %>
       #   <% end %>
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.icon(:star) %>
-      #     <% c.text { "Tab" } %>
-      #     <% c.counter(count: 10) %>
+      #     <% c.with_icon(:star) %>
+      #     <% c.with_text { "Tab" } %>
+      #     <% c.with_counter(count: 10) %>
       #   <% end %>
       #   <%= render(Primer::Navigation::TabComponent.new) do |c| %>
-      #     <% c.text { "Tab" } %>
-      #     <% c.counter(count: 10) %>
+      #     <% c.with_text { "Tab" } %>
+      #     <% c.with_counter(count: 10) %>
       #   <% end %>
       #
       # @example Inside a list
       #   <%= render(Primer::Navigation::TabComponent.new(list: true)) do |c| %>
-      #     <% c.text { "Tab" } %>
+      #     <% c.with_text { "Tab" } %>
       #   <% end %>
       #
       # @example With custom HTML

--- a/app/components/primer/popover_component.rb
+++ b/app/components/primer/popover_component.rb
@@ -60,40 +60,40 @@ module Primer
 
     # @example Default
     #   <%= render Primer::PopoverComponent.new do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       Activity feed
     #     <% end %>
-    #     <% component.body do %>
+    #     <% component.with_body do %>
     #       This is the Popover body.
     #     <% end %>
     #   <% end %>
     #
     # @example Large
     #   <%= render Primer::PopoverComponent.new do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       Activity feed
     #     <% end %>
-    #     <% component.body(large: true) do %>
+    #     <% component.with_body(large: true) do %>
     #       This is the large Popover body.
     #     <% end %>
     #   <% end %>
     #
     # @example Caret position
     #   <%= render Primer::PopoverComponent.new do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       Activity feed
     #     <% end %>
-    #     <% component.body(caret: :left) do %>
+    #     <% component.with_body(caret: :left) do %>
     #       This is the Popover body.
     #     <% end %>
     #   <% end %>
     #
     # @example With multiple elements in the body
     #   <%= render Primer::PopoverComponent.new do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       Activity feed
     #     <% end %>
-    #     <% component.body(caret: :left) do %>
+    #     <% component.with_body(caret: :left) do %>
     #       <p>This is the Popover body.</p>
     #       <%= render Primer::ButtonComponent.new(type: :submit) do %>
     #         Got it!

--- a/app/components/primer/subhead_component.rb
+++ b/app/components/primer/subhead_component.rb
@@ -56,27 +56,27 @@ module Primer
 
     # @example Default
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.heading(tag: :h3) do %>
+    #     <% component.with_heading(tag: :h3) do %>
     #       My Heading
     #     <% end %>
-    #     <% component.description do %>
+    #     <% component.with_description do %>
     #       My Description
     #     <% end %>
     #   <% end %>
     #
     # @example With dangerous heading
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.heading(tag: :h3, danger: true) do %>
+    #     <% component.with_heading(tag: :h3, danger: true) do %>
     #       My Heading
     #     <% end %>
-    #     <% component.description do %>
+    #     <% component.with_description do %>
     #       My Description
     #     <% end %>
     #   <% end %>
     #
     # @example With long description
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.heading(tag: :h3) do %>
+    #     <% component.with_heading(tag: :h3) do %>
     #       My Heading
     #     <% end %>
     #   <% end %>
@@ -84,23 +84,23 @@ module Primer
     #
     # @example Without border
     #   <%= render(Primer::SubheadComponent.new(hide_border: true)) do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       My Heading
     #     <% end %>
-    #     <% component.description do %>
+    #     <% component.with_description do %>
     #       My Description
     #     <% end %>
     #   <% end %>
     #
     # @example With actions
     #   <%= render(Primer::SubheadComponent.new) do |component| %>
-    #     <% component.heading do %>
+    #     <% component.with_heading do %>
     #       My Heading
     #     <% end %>
-    #     <% component.description do %>
+    #     <% component.with_description do %>
     #       My Description
     #     <% end %>
-    #     <% component.actions do %>
+    #     <% component.with_actions do %>
     #       <%= render(
     #         Primer::ButtonComponent.new(
     #           tag: :a, href: "http://www.google.com", scheme: :danger

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -40,9 +40,9 @@ module Primer
     # @example Default
     #   <div style="padding-left: 60px">
     #     <%= render(Primer::TimelineItemComponent.new) do |component| %>
-    #       <% component.avatar(src: "https://github.com/github.png", alt: "github") %>
-    #       <% component.badge(bg: :success_emphasis, color: :on_emphasis, icon: :check) %>
-    #       <% component.body { "Success!" } %>
+    #       <% component.with_avatar(src: "https://github.com/github.png", alt: "github") %>
+    #       <% component.with_badge(bg: :success_emphasis, color: :on_emphasis, icon: :check) %>
+    #       <% component.with_body { "Success!" } %>
     #     <% end %>
     #   </div>
     #


### PR DESCRIPTION
this PR updates all components in the root `primer/` folder to use the new `.with_#{slot_name}` syntax in docs examples

## Updated components

* ButtonComponent
* DetailsComponent
* Dropdown
* ImageCrop
* LayoutComponent
* LinkComponent
* MenuComponent
* TabComponent
* PopoverComponent
* SubheadComponent

## Screenshots

button:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184005782-810d385d-11b8-4448-ad94-3dccea8af601.png">

details:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184005869-a269c6af-5088-43ad-87b5-3a51ef2a9d5d.png">

dropdown:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006058-3d2fc990-0f7a-412b-9954-30000cc696b1.png">

image crop:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006195-3ce07c66-b53c-44d6-97e8-2d698e62367f.png">

layout:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006291-5d0b67e8-fb07-48bf-b19b-b12fff8e4e4e.png">

link:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006361-27643150-fad4-404e-ba63-12719304f146.png">

menu:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006433-3e238bbc-6ebf-49d9-ae06-cd7ea7486099.png">

popover:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006609-a792d3f8-50f2-451a-b34c-93c82cba60ab.png">

subhead:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/184006677-b2da8b51-d56d-4f41-8bf3-646387faabb3.png">
