### PR TITLE
add sshd feature to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -53,5 +53,8 @@
   },
   "hostRequirements": {
     "memory": "8gb"
+  },
+  "features": {
+    "sshd": "latest" 
   }
 }


### PR DESCRIPTION
This allows us to use `gh cs ssh` and use a local terminal.