### PR TITLE
Unblock codespaces githubpreview.dev domain

### DIFF
--- a/lookbook/config/environments/development.rb
+++ b/lookbook/config/environments/development.rb
@@ -77,4 +77,7 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+  
+  # Unblock codespaces githubpreview.dev domain
+  config.hosts << /.*githubpreview\.dev/
 end


### PR DESCRIPTION
This allows us to use the `githubpreview.dev` domain which means we can use `github.dev` with lookbook without it blocking us.