### PR TITLE
Update docs to discourage standalone tooltip use.

### DIFF
--- a/.changeset/serious-fireants-tie.md
+++ b/.changeset/serious-fireants-tie.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update docs to discourage standalone tooltip use.

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -2,82 +2,101 @@
 
 module Primer
   module Alpha
-    # `Tooltip` only appears on mouse hover or keyboard focus and contain a label or description text.
-    # Use tooltips sparingly and as a last resort.
+    # `Tooltip` only appears on mouse hover or keyboard focus and contain a label or description text. Use tooltips sparingly and as a last resort.
+    # Use tooltips as a last resort. Please consider [Tooltips alternatives](https://primer.style/design/accessibility/tooltip-alternatives).
     #
-    # When using a tooltip, follow the provided guidelines to avoid accessibility issues.
-    #
-    # - Tooltip text should be brief and to the point. The tooltip content must be a string.
-    # - Tooltips should contain only **non-essential text**. Tooltips can easily be missed and are not accessible on touch devices so never
-    #  use tooltips to convey critical information.
-    #
+    # When using a tooltip, follow the provided guidelines to avoid accessibility issues:
+    # - Tooltips should contain only **non-essential text**. Tooltips can easily be missed and are not accessible on touch devices so never use tooltips to convey critical information.
+    # - `Tooltip` should be rendered through the API of <%= link_to_component(Primer::ButtonComponent)%>, <%= link_to_component(Primer::LinkComponent)%>, or <%= link_to_component(Primer::IconButton)%>. Avoid using `Tooltip` a standalone component unless absolutely necessary (and **only** on interactive elements).
     # @accessibility
-    #   - **Never set tooltips on static elements.** Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
-    #   and screen reader users.
-    #   - Place `Tooltip` adjacent after its trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip
+    #   - Tooltip text must be brief and concise whether it is a label or a description.
+    #   - Tooltip can only hold string content.
+    #   - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
+    #   and screen reader users. Use of tooltip through <%= link_to_component(Primer::ButtonComponent) %>, <%= link_to_component(Primer::LinkComponent) %>, or <%= link_to_component(Primer::IconButton) %> will guarantee this.
+    #   - If you must use `Tooltip` as a standalone component, place it adjacent after the trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip
     #   content.
-    #   ### Which `type` should I set?
-    #   Setting `:description` establishes an `aria-describedby` relationship, while `:label` establishes an `aria-labelledby` relationship between the trigger element and the tooltip,
-    #
-    #   The `type` drastically changes semantics and screen reader behavior so follow these guidelines carefully:
-    #   - When there is already a visible label text on the trigger element, the tooltip is likely intended to supplement the existing text, so set `type: :description`.
+    #   ### Which type should I set?
+    #   Semantically, a tooltip will either act an accessible name or an accessible description for the element that it is associated with resulting in either a
+    #   `aria-labelledby` or an `aria-describedby` association. The `type` drastically changes semantics and screen reader behavior so follow these guidelines carefully:
+    #   - When there is already a visible label text on the trigger element, the tooltip is likely intended be supplementary, so set `type: :description`.
     #   The majority of tooltips will fall under this category.
     #   - When there is no visible text on the trigger element and the tooltip content is appropriate as a label for the element, set `type: :label`.
-    #   This type is usually only appropriate for an icon-only control.
+    #   `label` type is usually only appropriate for an icon-only control.
     class Tooltip < Primer::Component
       DIRECTION_DEFAULT = :s
       DIRECTION_OPTIONS = [DIRECTION_DEFAULT, :n, :e, :w, :ne, :nw, :se, :sw].freeze
 
       TYPE_FALLBACK = :description
       TYPE_OPTIONS = [:label, :description].freeze
-      # @example As a description for an icon-only button
+      # @example As a supplementary description for a button
       #   @description
-      #     If the tooltip content provides supplementary description, set `type: :description` to establish an `aria-describedby` relationship.
-      #     The trigger element should also have a _concise_ accessible label via `aria-label`.
+      #     In this example, the button has a visible label text, "Save". `type: :description` is set because the tooltip content is supplementary.
+      #     A screen reader user who encounters this button will hear the accessible name, "Save" followed by the accessible description, "This will immediately impact all organization members".
+      #   @code
+      #     <%= render(Primer::ButtonComponent.new(id: "save-button")) do |c| %>
+      #       <% c.with_tooltip(text: "This will immediately impact all organization members", type: :description, direction: :ne) %>
+      #       Save
+      #     <% end %>
+      # @example As a label for an `IconButton`
+      #   @description
+      #     An `IconButton` of `tag: :button` and `tag: :a` will render a tooltip using the `aria-label` content by default. While tooltips should generally be avoided, a tooltip on an `IconButton`
+      #     has usability benefits because it provides a textual label for sighted users.
+      #     A screen reader user who encounters the following button will hear the accessible name, "Bold".
       #   @code
       #     <%= render(Primer::IconButton.new(id: "bold-button-0", icon: :bold, "aria-label": "Bold")) %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "bold-button-0", type: :description, text: "Add bold text", direction: :ne)) %>
-      # @example As a label for an icon-only button
+      # @example As a supplementary description for an `IconButton`
       #   @description
-      #     If the tooltip labels the icon-only button, set `type: :label`. This tooltip content becomes the accessible name for the button.
+      #     If you want to provide a description for the `IconButton`, set both `aria-label` and `aria-description` text. The tooltip will use the `aria-description` text.
+      #     A screen reader user who encounters the following button will hear the accessible name "Search", followed by the accessible description "Use keywords like 'repo:' and 'org:' in your query".
       #   @code
-      #     <%= render(Primer::ButtonComponent.new(id: "like-button")) { "👍" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "like-button", type: :label, text: "Like", direction: :n)) %>
+      #     <%= render(Primer::IconButton.new(id: "search-button", icon: :search, "aria-label": "Search", "aria-description": "Use keywords like 'repo:' and 'org:' in your query")) %>
       #
-      # @example As a description for a button with visible label
-      #   @description
-      #     If the button already has visible label text, the tooltip content is likely supplementary so set `type: :description`.
-      #   @code
-      #     <%= render(Primer::ButtonComponent.new(id: "save-button", scheme: :primary)) { "Save" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "save-button", type: :description, text: "This will immediately impact all organization members", direction: :ne)) %>
       # @example With direction
       #   @description
       #     Set direction of tooltip with `direction`. The tooltip is responsive and will automatically adjust direction to avoid cutting off.
       #   @code
-      #     <%= render(Primer::ButtonComponent.new(id: "North", m: 2)) { "North" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "North", type: :description, text: "This is a North-facing tooltip, and is responsive.", direction: :n)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "South", m: 2)) { "South" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "South", type: :description, text: "This is a South-facing tooltip and is responsive.", direction: :s)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "East", m: 2)) { "East" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "East", type: :description, text: "This is a East-facing tooltip and is responsive.", direction: :e)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "West", m: 2)) { "West" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "West", type: :description, text: "This is a West-facing tooltip and is responsive.", direction: :w)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "Northeast", m: 2)) { "Northeast" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "Northeast", type: :description, text: "This is a Northeast-facing tooltip and is responsive.", direction: :ne)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "Southeast", m: 2)) { "Southeast" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "Southeast", type: :description, text: "This is a Southeast-facing tooltip and is responsive.", direction: :se)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "Northwest", m: 2)) { "Northwest" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "Northwest", type: :description, text: "This is a Northwest-facing tooltip and is responsive.", direction: :nw)) %>
-      #     <%= render(Primer::ButtonComponent.new(id: "Southwest", m: 2)) { "Southwest" } %>
-      #     <%= render(Primer::Alpha::Tooltip.new(for_id: "Southwest", type: :description, text: "This is a Southwest-facing tooltip and is responsive.", direction: :sw)) %>
-      # @example With relative parent
+      #     <%= render(Primer::ButtonComponent.new(id: "North", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a North-facing tooltip, and is responsive.", type: :description, direction: :n) %>
+      #       North
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "South", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a South-facing tooltip, and is responsive.", type: :description, direction: :s) %>
+      #       South
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "East", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a East-facing tooltip, and is responsive.", type: :description, direction: :e) %>
+      #       East
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "West", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a West-facing tooltip, and is responsive.", type: :description, direction: :w) %>
+      #       West
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "Northwest", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a Northwest-facing tooltip, and is responsive.", type: :description, direction: :nw) %>
+      #       Northwest
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "Southwest", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a Southwest-facing tooltip, and is responsive.", type: :description, direction: :sw) %>
+      #       Southwest
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "Northeast", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a Northeast-facing tooltip, and is responsive.", type: :description, direction: :ne) %>
+      #       Northeast
+      #     <% end %>
+      #     <%= render(Primer::ButtonComponent.new(id: "Southeast", m: 2)) do |c| %>
+      #       <% c.with_tooltip(text: "This is a Southeast-facing tooltip, and is responsive.", type: :description, direction: :se) %>
+      #       Southeast
+      #     <% end %>
+      # @example Directly using `Tooltip`
       #   @description
-      #     When the tooltip and trigger element have a parent container with `relative: position`, it should not affect width of the tooltip.
+      #     When you have a valid tooltip usecase for an interactive element that is not one of the supported components, you may need to use the `Tooltip` component directly.
+      #     The tooltip should be placed directly adjacent after the element you are associating it with.
+      #     The tooltip is absolutely positioned so ensure there is a wrapper with `position: relative` to avoid positioning issues.
       #   @code
-      #     <span style="position: relative;">
-      #       <%= render(Primer::ButtonComponent.new(id: "test-button", scheme: :primary)) { "Test" } %>
+      #     <div style="position: relative;">
+      #       <button type="button" id="test-button">Test</button>
       #       <%= render(Primer::Alpha::Tooltip.new(for_id: "test-button", type: :description, text: "This tooltip should take up the full width", direction: :ne)) %>
-      #     </span>
+      #     </div>
       # @param for_id [String] The ID of the element that the tooltip should be attached to.
       # @param type [Symbol] <%= one_of(Primer::Alpha::Tooltip::TYPE_OPTIONS) %>
       # @param direction [Symbol] <%= one_of(Primer::Alpha::Tooltip::DIRECTION_OPTIONS) %>

--- a/app/components/primer/icon_button.rb
+++ b/app/components/primer/icon_button.rb
@@ -3,6 +3,7 @@
 module Primer
   # Use `IconButton` to render Icon-only buttons without the default button styles.
   #
+  # `IconButton` will always render with a tooltip unless the tag is `:summary`.
   # @accessibility
   #   `IconButton` requires an `aria-label`, which will provide assistive technologies with an accessible label.
   #   The `aria-label` should describe the action to be invoked rather than the icon itself. For instance,

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -105,6 +105,8 @@
     url: "/components/timeago"
   - title: TimelineItem
     url: "/components/timelineitem"
+  - title: Tooltip
+    url: "/components/alpha/tooltip"
   - title: Truncate
     url: "/components/beta/truncate"
   - title: UnderlineNav


### PR DESCRIPTION
Fixes: https://github.com/primer/view_components/issues/1299

Since some Primer components now support tooltip and we want to emphasize not using tooltip directly, the examples in the tooltip docs should use `Button`, `IconButton`, or `Link`. This PR swaps the examples and makes some edits to the tooltip docs.