### PR TITLE
Fixing Primer::Forms::ActsAsComponent::TemplateParams keyword args

### DIFF
--- a/.changeset/cyan-fireants-kneel.md
+++ b/.changeset/cyan-fireants-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fixing Primer::Forms::ActsAsComponent::TemplateParams keyword args

--- a/lib/primer/forms/acts_as_component.rb
+++ b/lib/primer/forms/acts_as_component.rb
@@ -38,7 +38,7 @@ module Primer
       end
 
       TemplateGlob = Struct.new(:glob_pattern, :method_name, :on_compile_callback)
-      TemplateParams = Struct.new(:source, :identifier, :type, :format)
+      TemplateParams = Struct.new(:source, :identifier, :type, :format, keyword_init: true)
 
       attr_accessor :template_root_path
 


### PR DESCRIPTION
When using in conjunction with BetterHtml gem, the template params for the struct are not properly identified.

```
#<struct Primer::Forms::ActsAsComponent::TemplateParams source={:source=>"<%= render(SpacingWrapper.new) do %>\n  <% inputs.each do |input| %>\n    <%= render(input.to_component) %>\n  <% end %>\n<% end %>\n<% if after_content? %>\n  <%= render_after_content %>\n<% end %>\n", :identifier=>"/danielnc/.rbenv/versions/3.1.2/gemsets/gemset-v1/gems/primer_view_components-0.0.90/lib/primer/forms/acts_as_component.rb", :type=>"text/html", :format=>"text/html"}, identifier=nil, type=nil, format=nil>
```

You can see that identifier, type and format are `nil` while the source has the entire hash that is expected to be keyword args for the component

With the fix, all keyword arguments work as expected and primer is able to be used with the better_html gem

I am not sure where/how to add tests and if I should add anything to the change log, help is greatly appreciated