### PR TITLE
Instruct terser to not mangle class names so Catalyst works

### DIFF
--- a/.changeset/rude-grapes-clean.md
+++ b/.changeset/rude-grapes-clean.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Instruct terser to not mangle class names so Catalyst works

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ export default {
   plugins: [
     resolve(),
     typescript(),
-    terser()
+    terser({keep_classnames: /Element$/})
   ],
   onwarn: (warning, warn) => {
     if (warning.code === "THIS_IS_UNDEFINED") return


### PR DESCRIPTION
@langermank and I have been running into weird issues viewing Lookbook previews where JavaScript for Catalyst components is throwing uncaught errors. The problem turns out to be that terser mangles class names to make them shorter. Catalyst depends on class names to automatically define custom elements. In their [docs](https://github.github.io/catalyst/guide/you-will-need/), the terser section says to pass a special option that disables class name mangling. Adding this to my local rollup config fixes the problem.