### PR TITLE
Only listten to /workspaces path if it exists

### DIFF
--- a/lookbook/config/environments/development.rb
+++ b/lookbook/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
-  config.hotwire_livereload.listen_paths << "/workspaces/css/src/"
+  config.hotwire_livereload.listen_paths << "/workspaces/css/src/" if File.exist?("/workspaces/css/src")
   config.hotwire_livereload.listen_paths << Rails.root.join("../app/assets/javascripts")
   config.hotwire_livereload.force_reload_paths << Rails.root.join("../app/assets/javascripts")
 


### PR DESCRIPTION
This allows for development outside of codespaces, such as on a local machine.

Without this `./script/lookbook` will crash unless `/workspaces/` exists on the local filesystem.