### PR TITLE
Removing deprecated Primer::ButtonGroup component

### DIFF
--- a/.changeset/long-spiders-shop.md
+++ b/.changeset/long-spiders-shop.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing deprecated Primer::ButtonGroup component

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class ButtonGroup < Primer::Beta::ButtonGroup
-    status :deprecated
-  end
-end

--- a/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
+++ b/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
@@ -9,7 +9,6 @@ module ERBLint
         COMPONENT_TO_USE_INSTEAD = {
           "Primer::HiddenTextExpander" => "Primer::Alpha::HiddenTextExpander",
           "Primer::HeadingComponent" => "Primer::Beta::Heading",
-          "Primer::ButtonGroup" => "Primer::Beta::ButtonGroup",
           "Primer::CloseButton" => "Primer::Beta::CloseButton",
           "Primer::CounterComponent" => "Primer::Beta::Counter",
           "Primer::DetailsComponent" => "Primer::Beta::Details",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -37,7 +37,6 @@
   "Primer::Box": "",
   "Primer::BoxComponent": "",
   "Primer::ButtonComponent": "",
-  "Primer::ButtonGroup": "",
   "Primer::ClipboardCopy": "",
   "Primer::CloseButton": "",
   "Primer::ConditionalWrapper": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -408,8 +408,6 @@
       "medium"
     ]
   },
-  "Primer::ButtonGroup": {
-  },
   "Primer::ClipboardCopy": {
   },
   "Primer::CloseButton": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -37,7 +37,6 @@
   "Primer::Box": "stable",
   "Primer::BoxComponent": "deprecated",
   "Primer::ButtonComponent": "beta",
-  "Primer::ButtonGroup": "deprecated",
   "Primer::ClipboardCopy": "beta",
   "Primer::CloseButton": "deprecated",
   "Primer::ConditionalWrapper": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -89,7 +89,6 @@ class PrimerComponentTest < Minitest::Test
     ignored_components = [
       "Primer::HiddenTextExpander",
       "Primer::HeadingComponent",
-      "Primer::ButtonGroup",
       "Primer::CloseButton",
       "Primer::CounterComponent",
       "Primer::DetailsComponent",


### PR DESCRIPTION
We have finished the migration of `Primer::ButtonGroup` in github/github. This cleans up the deprecated class and any references to the old component.