### PR TITLE
Bump axe-core-api 4.4.1

### DIFF
--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "allocation_stats", "~> 0.1"
   spec.add_development_dependency "allocation_tracer", "~> 0.6.3"
-  spec.add_development_dependency "axe-core-api", "~> 4.2.0"
+  spec.add_development_dependency "axe-core-api", "~> 4.4.1"
   spec.add_development_dependency "benchmark-ips", "~> 2.8.4"
   spec.add_development_dependency "capybara", "~> 3"
   spec.add_development_dependency "cuprite", "= 0.13"


### PR DESCRIPTION
Supercedes https://github.com/primer/view_components/pull/1246

It's been several months since we bumped this gem. `doc_examples_test` which runs accessibility checks against every documentation example makes use of this gem so we should make sure it's up-to-date for ensuring accessibilit coverage.
 
Here is the [CHANGELOG](https://github.com/dequelabs/axe-core-gems/blob/develop/CHANGELOG.md).
