### PR TITLE
Adding experimental as a status option for components developed in PVC

### DIFF
--- a/app/lib/primer/status/dsl.rb
+++ b/app/lib/primer/status/dsl.rb
@@ -20,7 +20,8 @@ module Primer
         alpha: :alpha,
         beta: :beta,
         stable: :stable,
-        deprecated: :deprecated
+        deprecated: :deprecated,
+        experimental: :experimental
       }.freeze
 
       class UnknownStatusError < StandardError; end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -12,7 +12,7 @@ require "active_support/core_ext/string/inflections"
 class ComponentStatusMigrator < Thor::Group
   include Thor::Actions
 
-  STATUSES = %w[alpha beta deprecated stable].freeze
+  STATUSES = %w[alpha beta deprecated stable experimental].freeze
 
   # Define arguments and options
   argument :name

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -109,7 +109,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::BoxComponent"
     ]
 
-    primer_component_files_count = Dir["app/components/**/*.rb"].count
+    primer_component_files_count = Dir["app/components/**/*.rb"].count { |p| p.exclude?("/experimental/") }
     assert_equal primer_component_files_count, COMPONENTS_WITH_ARGS.length + ignored_components.count, "Primer component added. Please update this test with an entry for your new component <3"
   end
 


### PR DESCRIPTION
This updates tests and config to allow us to use the [Experimental](https://primer.style/contribute/component-lifecycle#experimental) status on new components in PVC.