### PR TITLE
Delete the deprecated Primer::BaseButton component

### DIFF
--- a/.changeset/friendly-rats-wait.md
+++ b/.changeset/friendly-rats-wait.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Delete the deprecated Primer::BaseButton component

--- a/app/components/primer/base_button.rb
+++ b/app/components/primer/base_button.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class BaseButton < Primer::Beta::BaseButton
-    status :deprecated
-  end
-end

--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -49,8 +49,8 @@ module Primer
       # @param icon [String] Name of <%= link_to_octicons %> to use.
       # @param scheme [Symbol] <%= one_of(Primer::Beta::IconButton::SCHEME_OPTIONS) %>
       # @param size [Symbol] <%= one_of(Primer::Beta::Button::SIZE_OPTIONS) %>
-      # @param tag [Symbol] <%= one_of(Primer::BaseButton::TAG_OPTIONS) %>
-      # @param type [Symbol] <%= one_of(Primer::BaseButton::TYPE_OPTIONS) %>
+      # @param tag [Symbol] <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
+      # @param type [Symbol] <%= one_of(Primer::Beta::BaseButton::TYPE_OPTIONS) %>
       # @param aria-label [String] String that can be read by assistive technology. A label should be short and concise. See the accessibility section for more information.
       # @param aria-description [String] String that can be read by assistive technology. A description can be longer as it is intended to provide more context and information. See the accessibility section for more information.
       # @param tooltip_direction [Symbol] (Primer::Alpha::Tooltip::DIRECTION_DEFAULT) <%= one_of(Primer::Alpha::Tooltip::DIRECTION_OPTIONS) %>

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -7,7 +7,6 @@ module Primer
     DEPRECATED_COMPONENTS = {
       "Primer::Alpha::AutoComplete" => "Primer::Beta::AutoComplete",
       "Primer::Alpha::AutoComplete::Item" => "Primer::Beta::AutoComplete::Item",
-      "Primer::BaseButton" => "Primer::Beta::BaseButton",
       "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
       "Primer::BoxComponent" => "Primer::Box",
       "Primer::ButtonGroup" => "Primer::Beta::ButtonGroup",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -17,7 +17,6 @@
   "Primer::Alpha::Tooltip": "",
   "Primer::Alpha::UnderlineNav": "",
   "Primer::Alpha::UnderlinePanels": "",
-  "Primer::BaseButton": "",
   "Primer::BaseComponent": "",
   "Primer::Beta::AutoComplete": "",
   "Primer::Beta::AutoComplete::Item": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -236,8 +236,6 @@
   },
   "Primer::Alpha::UnderlinePanels": {
   },
-  "Primer::BaseButton": {
-  },
   "Primer::BaseComponent": {
     "SELF_CLOSING_TAGS": [
       "area",

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -17,7 +17,6 @@
   "Primer::Alpha::Tooltip": "alpha",
   "Primer::Alpha::UnderlineNav": "alpha",
   "Primer::Alpha::UnderlinePanels": "alpha",
-  "Primer::BaseButton": "deprecated",
   "Primer::BaseComponent": "beta",
   "Primer::Beta::AutoComplete": "beta",
   "Primer::Beta::AutoComplete::Item": "beta",

--- a/test/components/beta/base_button_test.rb
+++ b/test/components/beta/base_button_test.rb
@@ -38,12 +38,4 @@ class PrimerBetaBaseButtonTest < Minitest::Test
 
     assert_selector(".btn-block")
   end
-
-  def test_primer_base_button_references_beta_base_button
-    assert_equal(Primer::BaseButton.superclass, Primer::Beta::BaseButton)
-
-    render_inline(Primer::BaseButton.new) { "Primer::BaseButton content" }
-
-    assert_text("Primer::BaseButton content")
-  end
 end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -107,7 +107,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OcticonsSymbolComponent",
       "Primer::Content",
       "Primer::BoxComponent",
-      "Primer::BaseButton",
       "Primer::ButtonGroup"
     ]
 


### PR DESCRIPTION
The `Primer::BaseButton` has been migrated to `Primer::Beta::BaseButton` 100% on dotcom.

I'm removing the linked class with deprecation status.