### PR TITLE
Delete the deprecated Primer::ButtonGroup component

### DIFF
--- a/.changeset/eight-pants-yell.md
+++ b/.changeset/eight-pants-yell.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Delete the deprecated Primer::ButtonGroup component

--- a/app/components/primer/button_group.rb
+++ b/app/components/primer/button_group.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class ButtonGroup < Primer::Beta::ButtonGroup
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -10,7 +10,6 @@ module Primer
       "Primer::BaseButton" => "Primer::Beta::BaseButton",
       "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
       "Primer::BoxComponent" => "Primer::Box",
-      "Primer::ButtonGroup" => "Primer::Beta::ButtonGroup",
       "Primer::CloseButton" => "Primer::Beta::CloseButton",
       "Primer::CounterComponent" => "Primer::Beta::Counter",
       "Primer::DetailsComponent" => "Primer::Beta::Details",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -44,7 +44,6 @@
   "Primer::Box": "",
   "Primer::BoxComponent": "",
   "Primer::ButtonComponent": "",
-  "Primer::ButtonGroup": "",
   "Primer::ClipboardCopy": "",
   "Primer::CloseButton": "",
   "Primer::ConditionalWrapper": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -535,8 +535,6 @@
       "medium"
     ]
   },
-  "Primer::ButtonGroup": {
-  },
   "Primer::ClipboardCopy": {
   },
   "Primer::CloseButton": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -44,7 +44,6 @@
   "Primer::Box": "stable",
   "Primer::BoxComponent": "deprecated",
   "Primer::ButtonComponent": "beta",
-  "Primer::ButtonGroup": "deprecated",
   "Primer::ClipboardCopy": "beta",
   "Primer::CloseButton": "deprecated",
   "Primer::ConditionalWrapper": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -108,7 +108,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Content",
       "Primer::BoxComponent",
       "Primer::BaseButton",
-      "Primer::ButtonGroup"
     ]
 
     primer_component_files_count = Dir["app/components/**/*.rb"].count { |p| p.exclude?("/experimental/") }


### PR DESCRIPTION
The `Primer::ButtonGroup` has been migrated to `Primer::Beta::ButtonGroup` 100% on dotcom.

I'm removing the linked class with deprecation status.