### PR TITLE
Adding lookbook links to docs output

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -131,7 +131,6 @@ namespace :docs do
         f.puts("componentId: #{data[:component_id]}")
         f.puts("status: #{data[:status]}")
         f.puts("source: #{data[:source]}")
-        f.puts("storybook: #{data[:storybook]}")
         f.puts("lookbook: #{data[:lookbook]}") if preview_exists?(component)
         f.puts("---")
         f.puts
@@ -467,7 +466,6 @@ namespace :docs do
       component_id: short_name.underscore,
       status: status.capitalize,
       source: source_url(component),
-      storybook: storybook_url(component),
       lookbook: lookbook_url(component),
       path: "docs/content/components/#{status_path}#{short_name.downcase}.md",
       example_path: example_path(component),
@@ -479,12 +477,6 @@ namespace :docs do
     path = component.name.split("::").map(&:underscore).join("/")
 
     "https://github.com/primer/view_components/tree/main/app/components/#{path}.rb"
-  end
-
-  def storybook_url(component)
-    path = component.name.split("::").map { |n| n.underscore.dasherize }.join("-")
-
-    "https://primer.style/view-components/stories/?path=/story/#{path}"
   end
 
   def lookbook_url(component)

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -488,7 +488,7 @@ namespace :docs do
   end
 
   def lookbook_url(component)
-    path = component.name.underscore
+    path = component.name.underscore.gsub("_component", "")
 
     "https://primer.style/view-components/lookbook/inspect/#{path}/default/"
   end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -132,6 +132,7 @@ namespace :docs do
         f.puts("status: #{data[:status]}")
         f.puts("source: #{data[:source]}")
         f.puts("storybook: #{data[:storybook]}")
+        f.puts("lookbook: #{data[:lookbook]}") if preview_exists?(component)
         f.puts("---")
         f.puts
         f.puts("import Example from '#{data[:example_path]}'")
@@ -467,6 +468,7 @@ namespace :docs do
       status: status.capitalize,
       source: source_url(component),
       storybook: storybook_url(component),
+      lookbook: lookbook_url(component),
       path: "docs/content/components/#{status_path}#{short_name.downcase}.md",
       example_path: example_path(component),
       require_js_path: require_js_path(component)
@@ -483,6 +485,18 @@ namespace :docs do
     path = component.name.split("::").map { |n| n.underscore.dasherize }.join("-")
 
     "https://primer.style/view-components/stories/?path=/story/#{path}"
+  end
+
+  def lookbook_url(component)
+    path = component.name.underscore
+
+    "https://primer.style/view-components/lookbook/inspect/#{path}/default/"
+  end
+
+  def preview_exists?(component)
+    path = component.name.underscore
+
+    File.exist?("test/previews/#{path}_preview.rb")
   end
 
   def example_path(component)

--- a/templates/preview.tt
+++ b/templates/preview.tt
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-# Setup Playground to use all available component props
+# Setup Default to use all available component props
 # Setup Features to use individual component props and combinations
 
 module <%= module_name %>
   # @label <%= class_name %>
   class <%= class_name %>Preview < ViewComponent::Preview
-    # @label Playground
+    # @label Default
     # @param string_example text
     # @param boolean_example toggle
     # @param email_example email
@@ -18,7 +18,7 @@ module <%= module_name %>
     # @param select_custom_labels select [[One label, one], [Two label, two], [Three label, three]]
     # With empty option (`~` in YAML)
     # @param select_empty_option select [~, one, two, three]
-    def playground(string_example: "Default value", boolean_example: false, select_example: :one)
+    def default(string_example: "Default value", boolean_example: false, select_example: :one)
       render(Primer::<%= module_name %>::<%= class_name %>.new(string_example: string_example, boolean_example: boolean_example, select_example: select_example))
     end
   end

--- a/test/previews/preview_test.rb
+++ b/test/previews/preview_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PreviewTest < Minitest::Test
+  def setup
+    @previews = Dir.glob("test/previews/**/*.rb").reject { |f| f.include?("forms_preview") }
+  end
+
+  def test_previews_exist
+    refute_empty(@previews)
+  end
+
+  def test_previews_have_default_method
+    @previews.each do |preview|
+      assert_includes(File.read(preview), "def default", "The preview `#{preview}` does not have a default method. Please include at one `def default` method")
+    end
+  end
+end

--- a/test/previews/preview_test.rb
+++ b/test/previews/preview_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class PreviewTest < Minitest::Test
   def setup
-    @previews = Dir.glob("test/previews/**/*.rb").reject { |f| f.include?("forms_preview") }
+    @previews = Dir.glob("test/previews/**/*.rb").reject { |f| f.include?("forms_preview.rb") || f.include?("/docs/") }
   end
 
   def test_previews_exist

--- a/test/previews/primer/alpha/text_field_preview.rb
+++ b/test/previews/primer/alpha/text_field_preview.rb
@@ -4,7 +4,7 @@ module Primer
   module Alpha
     # @label TextField
     class TextFieldPreview < ViewComponent::Preview
-      # @label Playground
+      # @label Default
       #
       # @param name text
       # @param id text
@@ -20,7 +20,7 @@ module Primer
       # @param inset toggle
       # @param monospace toggle
       # @param leading_visual_icon text
-      def playground(
+      def default(
         name: "my-text-field",
         id: "my-text-field",
         label: "My text field",

--- a/test/previews/primer/beta/auto_complete_item_preview.rb
+++ b/test/previews/primer/beta/auto_complete_item_preview.rb
@@ -4,6 +4,20 @@ module Primer
   module Beta
     # @label AutoCompleteItem
     class AutoCompleteItemPreview < ViewComponent::Preview
+      # @label Default
+      # @param selected toggle
+      # @param disabled toggle
+      # @param value text
+      def default(value: "", selected: false, disabled: false)
+        render_with_template(
+          locals: {
+            selected: selected,
+            disabled: disabled,
+            value: value
+          }
+        )
+      end
+
       # @label WithDescription
       # @param description_variant select [block, inline]
       # @param selected toggle

--- a/test/previews/primer/beta/auto_complete_item_preview/default.html.erb
+++ b/test/previews/primer/beta/auto_complete_item_preview/default.html.erb
@@ -1,0 +1,9 @@
+<%= render(
+        Primer::Beta::AutoComplete::Item.new(
+            selected: selected,
+            disabled: disabled,
+            value: ''
+    )) do |c| %>
+        <% c.leading_visual_icon(icon: :search) %>
+        Label text
+<% end %>

--- a/test/previews/primer/beta/auto_complete_preview.rb
+++ b/test/previews/primer/beta/auto_complete_preview.rb
@@ -210,11 +210,6 @@ module Primer
       end
 
       # @hidden
-      def default
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete"))
-      end
-
-      # @hidden
       def with_non_visible_label
         render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", visually_hide_label: true))
       end

--- a/test/previews/primer/beta/auto_complete_preview.rb
+++ b/test/previews/primer/beta/auto_complete_preview.rb
@@ -4,7 +4,7 @@ module Primer
   module Beta
     # @label AutoComplete
     class AutoCompletePreview < ViewComponent::Preview
-      # @label Playground
+      # @label Default
       # @param label_text text
       # @param show_clear_button toggle
       # @param visually_hide_label toggle
@@ -18,7 +18,7 @@ module Primer
       # @param input_name text
       # @param inset toggle
       # @param monospace toggle
-      def playground(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
+      def default(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
         render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |c|
           c.leading_visual_icon(icon: :search)
         end

--- a/test/previews/primer/beta/button_preview.rb
+++ b/test/previews/primer/beta/button_preview.rb
@@ -4,7 +4,7 @@ module Primer
   module Beta
     # @label Button
     class ButtonPreview < ViewComponent::Preview
-      # @label Playground
+      # @label Default
       # @param scheme select [default, primary, danger, outline, invisible, link]
       # @param size select [small, medium, large]
       # @param full_width toggle
@@ -12,7 +12,7 @@ module Primer
       # @param pressed toggle
       # @param align_content select [center, start]
       # @param tag select [a, summary, button]
-      def playground(
+      def default(
         scheme: :default,
         size: :medium,
         full_width: false,

--- a/test/previews/primer/beta/flash_preview.rb
+++ b/test/previews/primer/beta/flash_preview.rb
@@ -4,7 +4,7 @@ module Primer
   module Beta
     # @label Flash
     class FlashPreview < ViewComponent::Preview
-      # @label Playground
+      # @label Default
       #
       # @param full toggle
       # @param spacious toggle
@@ -12,7 +12,7 @@ module Primer
       # @param icon [Symbol] select [alert, check, info, people]
       # @param scheme [Symbol] select [default, warning, danger, success]
       # @param content text
-      def playground(full: false, spacious: false, dismissible: false, icon: :people, scheme: Primer::Beta::Flash::DEFAULT_SCHEME, content: "This is a flash message!")
+      def default(full: false, spacious: false, dismissible: false, icon: :people, scheme: Primer::Beta::Flash::DEFAULT_SCHEME, content: "This is a flash message!")
         render(Primer::Beta::Flash.new(full: full, spacious: spacious, dismissible: dismissible, icon: icon, scheme: scheme)) { content }
       end
     end

--- a/test/previews/primer/beta/icon_button_preview.rb
+++ b/test/previews/primer/beta/icon_button_preview.rb
@@ -9,7 +9,6 @@ module Primer
       # @param size select [small, medium, large]
       # @param aria_label text
       # @param disabled toggle
-      # @param pressed toggle
       # @param tag select [a, summary, button]
       def default(
         scheme: :default,

--- a/test/previews/primer/beta/icon_button_preview.rb
+++ b/test/previews/primer/beta/icon_button_preview.rb
@@ -4,14 +4,14 @@ module Primer
   module Beta
     # @label IconButton
     class IconButtonPreview < ViewComponent::Preview
-      # @label Playground
+      # @label Default
       # @param scheme select [default, danger, invisible]
       # @param size select [small, medium, large]
       # @param aria_label text
       # @param disabled toggle
       # @param pressed toggle
       # @param tag select [a, summary, button]
-      def playground(
+      def default(
         scheme: :default,
         size: :medium,
         id: "button-preview",

--- a/test/system/beta/auto_complete_component_test.rb
+++ b/test/system/beta/auto_complete_component_test.rb
@@ -7,9 +7,9 @@ module Beta
     def test_renders_component
       visit_preview(:default)
 
-      assert_selector("auto-complete[for=\"test-id\"][src=\"/auto_complete\"]") do
+      assert_selector("auto-complete[for=\"list-id\"][src=\"/auto_complete\"]") do
         assert_selector("input.FormControl-input")
-        assert_selector("ul[id=\"test-id\"].ActionList", visible: false)
+        assert_selector("ul[id=\"list-id\"].ActionList", visible: false)
       end
       refute_selector(".ActionList-item")
     end
@@ -21,7 +21,7 @@ module Beta
       fill_in "input-id", with: "a"
 
       # results are now visible
-      assert_selector("ul[id=\"test-id\"].ActionList", visible: true)
+      assert_selector("ul[id=\"list-id\"].ActionList", visible: true)
       assert_selector(".ActionList-item")
     end
 


### PR DESCRIPTION
<img width="482" alt="image" src="https://user-images.githubusercontent.com/54012/190491209-6c5ca850-b6a5-461a-91dc-bc2230e77c07.png">

- The links will only show up if the component has a preview written.
- I had to suffix the url with `/default/` which assumes all components have a `def default` preview. I did this because leaving it off rails ends up redirecting to the azure server url example https://primer.style/view-components/lookbook/inspect/primer/beta/avatar/