### PR TITLE
Simplify CI configuration to a single build per Ruby/Rails version.

### DIFF
--- a/.changeset/tricky-tomatoes-thank.md
+++ b/.changeset/tricky-tomatoes-thank.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Simplify CI configuration to a single build per Ruby/Rails version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: [6.1.1, 7.0.3, main]
-        ruby_version: [2.7.x, 3.0.x, 3.1.x]
+        include:
+          - rails_version: "6.1.1"
+            ruby_version: "2.7.x"
+          - rails_version: "7.0.3"
+            ruby_version: "3.0.x"
+          - rails_version: "main"
+            ruby_version: "3.1.x"
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rails_version: [6.1.1, 7.0.3, main]
-        ruby_version: [2.7.x, 3.0.x, 3.1.x]
+        include:
+          - rails_version: "6.1.1"
+            ruby_version: "2.7.x"
+          - rails_version: "7.0.3"
+            ruby_version: "3.0.x"
+          - rails_version: "main"
+            ruby_version: "3.1.x"
     steps:
     - uses: actions/checkout@master
     - name: Setup Ruby


### PR DESCRIPTION
Our existing CI configuration runs a multi-build matrix for the main test suite. I think this is overkill for our needs. In my experience, our matrix builds have mainly served us by testing each version of Rails and Ruby we support, not every combination of Ruby and Rails we support. I think we can get by with just 3 builds.