### PR TITLE
Docs change to fix typo and descriptions in dialog.rb

### DIFF
--- a/.changeset/neat-baboons-do.md
+++ b/.changeset/neat-baboons-do.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Docs change to fix typo and descriptions in dialog.rb

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -105,10 +105,10 @@ module Primer
       #     <% end %>
       # @param id [String] The id of the dialog.
       # @param title [String] Describes the content of the dialog.
-      # @param subtitle [String] Provides dditional context for the dialog, also setting the `aria-describedby` attribute.
+      # @param subtitle [String] Provides additional context for the dialog, also setting the `aria-describedby` attribute.
       # @param size [Symbol] The size of the dialog. <%= one_of(Primer::Alpha::Dialog::SIZE_OPTIONS) %>
-      # @param position [Symbol] The size of the dialog. <%= one_of(Primer::Alpha::Dialog::POSITION_OPTIONS) %>
-      # @param position_narrow [Symbol] The size of the dialog. <%= one_of(Primer::Alpha::Dialog::POSITION_NARROW_OPTIONS) %>
+      # @param position [Symbol] The position of the dialog. <%= one_of(Primer::Alpha::Dialog::POSITION_OPTIONS) %>
+      # @param position_narrow [Symbol] The position of the dialog when narrow. <%= one_of(Primer::Alpha::Dialog::POSITION_NARROW_OPTIONS) %>
       # @param visually_hide_title [Boolean] If true will hide the heading title, while still making it available to Screen Readers.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(


### PR DESCRIPTION
Fixed a small typo and what may have been missed copy pasta for the position & position_narrow attributes