### PR TITLE
Make sure duplicate ID associations aren't created

### DIFF
--- a/.changeset/fifty-yaks-fail.md
+++ b/.changeset/fifty-yaks-fail.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Make sure duplicate ID associations aren't created for the Button

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -263,7 +263,7 @@ class ToolTipElement extends HTMLElement {
       if (!this.id || !this.control) return
       if (this.type === 'label') {
         let labelledBy = this.control.getAttribute('aria-labelledby')
-        if (labelledBy) {
+        if (labelledBy && labelledBy !== this.id) {
           labelledBy = `${labelledBy} ${this.id}`
         } else {
           labelledBy = this.id
@@ -274,7 +274,11 @@ class ToolTipElement extends HTMLElement {
         this.setAttribute('aria-hidden', 'true')
       } else {
         let describedBy = this.control.getAttribute('aria-describedby')
-        describedBy ? (describedBy = `${describedBy} ${this.id}`) : (describedBy = this.id)
+        if (describedBy && describedBy !== this.id) {
+          describedBy = `${describedBy} ${this.id}`
+        } else {
+          describedBy = this.id
+        }
         this.control.setAttribute('aria-describedby', describedBy)
       }
     } else if (name === 'data-direction') {

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -263,8 +263,12 @@ class ToolTipElement extends HTMLElement {
       if (!this.id || !this.control) return
       if (this.type === 'label') {
         let labelledBy = this.control.getAttribute('aria-labelledby')
-        if (labelledBy && labelledBy !== this.id) {
-          labelledBy = `${labelledBy} ${this.id}`
+        if (labelledBy) {
+          if (!labelledBy.split(' ').includes(this.id)) {
+            labelledBy = `${labelledBy} ${this.id}`
+          } else {
+            labelledBy = `${labelledBy}`
+          }
         } else {
           labelledBy = this.id
         }
@@ -274,8 +278,12 @@ class ToolTipElement extends HTMLElement {
         this.setAttribute('aria-hidden', 'true')
       } else {
         let describedBy = this.control.getAttribute('aria-describedby')
-        if (describedBy && describedBy !== this.id) {
-          describedBy = `${describedBy} ${this.id}`
+        if (describedBy) {
+          if (!describedBy.split(' ').includes(this.id)) {
+            describedBy = `${describedBy} ${this.id}`
+          } else {
+            describedBy = `${describedBy}`
+          }
         } else {
           describedBy = this.id
         }

--- a/test/system/alpha/tooltip_test.rb
+++ b/test/system/alpha/tooltip_test.rb
@@ -66,6 +66,42 @@ module Alpha
       assert_equal("existing-description-id #{tooltip_id}", find("button")["aria-describedby"])
     end
 
+    def test_does_not_render_duplicate_describedby_id_when_attribute_callback_triggered
+      visit_preview(:description_tooltip_on_button_with_existing_describedby)
+
+      tooltip_id = find("tool-tip", visible: :hidden)["id"]
+      assert_equal("existing-description-id #{tooltip_id}", find("button")["aria-describedby"])
+      evaluate_script("(function(el) {
+        return (
+          el.setAttribute('data-type', 'label')
+        );
+      })(arguments[0]);", find("tool-tip", visible: :hidden))
+      evaluate_script("(function(el) {
+        return (
+          el.setAttribute('data-type', 'description')
+        );
+      })(arguments[0]);", find("tool-tip", visible: :hidden))
+      assert_equal("existing-description-id #{tooltip_id}", find("button")["aria-describedby"])
+    end
+
+    def test_does_not_render_duplicate_labelledby_id_when_attribute_callback_triggered
+      visit_preview(:label_tooltip_on_button_with_existing_labelledby)
+
+      tooltip_id = find("tool-tip", visible: :hidden)["id"]
+      assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
+      evaluate_script("(function(el) {
+        return (
+          el.setAttribute('data-type', 'description')
+        );
+      })(arguments[0]);", find("tool-tip", visible: :hidden))
+      evaluate_script("(function(el) {
+        return (
+          el.setAttribute('data-type', 'label')
+        );
+      })(arguments[0]);", find("tool-tip", visible: :hidden))
+      assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
+    end
+
     def test_always_aria_hidden_when_tooltip_is_label
       visit_preview(:label_tooltip_on_button_with_existing_labelledby)
 


### PR DESCRIPTION
I observed that some buttons labelled or described by a tooltip can end up with multiple duplicated `aria-labelledby` and `aria-describedby` association resulting in duplicate screen reader announcements. The button attribute can end up like:

```
aria-labelledby="tooltip-1663617441252-3721 tooltip-1663617441252-3721 tooltip-1663617441252-3721"
```

which is definitely unintentional/ an annoying bug.

I observed this particularly on pages with soft navigation where `attributeChangedCallback` can end up getting triggered multiple times for `name === 'id' || name === 'data-type'` attributes.

We want to both make sure that `aria-labelledby` or `aria-describedby` includes any IDs that a user may have set in addition to the IDs that our tooltip JS provides. At the same time, we want to ensure that IDs don't get set multiple times. Our current logic is resulting in the same IDs being appended in some scenarios while trying to accomplish the former.

This PR introduces a conditional check which will ensure that IDs don't get duplicated. I've also added a test that mimics the `attributeChangedCallback` triggering. 

I'd like to get this out soon since it's likely very annoying for screen reader users. 🙏