### PR TITLE
Purge tags from azure

### DIFF
--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -25,6 +25,11 @@ jobs:
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
       run: echo $AZURE_ACR_PASSWORD | docker login primer.azurecr.io --username GitHubActions --password-stdin
+    - uses: Azure/login@v1
+      with:
+        creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
+    - name: Purge tags
+      run: acr purge --filter 'primer/view_components_storybook:.*'  --ago 0d --keep 10
     - name: Bundle
       run: |
         gem install bundler -v '~> 2.3'


### PR DESCRIPTION
This purges all tagged images in `primer/view_components_storybook` except for the last 10.

This is to fix a problem with the production deploy that we've found it has too many tags, and is unable to deploy the latest