### PR TITLE
Cross-link the Ruby style guide from the Primer docs

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -13,6 +13,8 @@
     url: "/migration"
   - title: Component status
     url: "/status"
+  - title: Ruby Style Guide
+    url: "https://github.com/github/rubocop-github/blob/master/STYLEGUIDE.md"
 - title: Components
   children:
   - title: AutoComplete


### PR DESCRIPTION
This is where engineers using Primer Rails components will look for guidance, which is why this seemed like the most appropriate place for a Ruby code style guide.