### PR TITLE
Re-add array checkboxes

### DIFF
--- a/.changeset/tiny-meals-serve.md
+++ b/.changeset/tiny-meals-serve.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Support submitting a check box group as an array

--- a/lib/primer/forms/builder.rb
+++ b/lib/primer/forms/builder.rb
@@ -14,8 +14,8 @@ module Primer
         super(*args, classify(options), &block)
       end
 
-      def check_box(*args, **options, &block)
-        super(*args, classify(options), &block)
+      def check_box(method, options = {}, checked_value = 1, unchecked_value = 0, &block)
+        super(method, classify(options), checked_value, unchecked_value, &block)
       end
 
       def radio_button(*args, **options, &block)

--- a/lib/primer/forms/check_box.html.erb
+++ b/lib/primer/forms/check_box.html.erb
@@ -1,5 +1,9 @@
 <div class="FormControl-checkbox-wrap">
-  <%= builder.check_box(@input.name, **@input.input_arguments) %>
+  <% if @input.scheme == :array %>
+    <%= builder.check_box(@input.name, @input.input_arguments, checked_value, nil) %>
+  <% else %>
+    <%= builder.check_box(@input.name, @input.input_arguments) %>
+  <% end %>
   <span class="FormControl-checkbox-labelWrap">
     <%= builder.label(@input.name, **@input.label_arguments) do %>
       <%= @input.label %>

--- a/lib/primer/forms/check_box.rb
+++ b/lib/primer/forms/check_box.rb
@@ -10,6 +10,17 @@ module Primer
         @input = input
         @input.add_label_classes("FormControl-label")
         @input.add_input_classes("FormControl-checkbox")
+
+        return unless @input.scheme == :array
+
+        @input.input_arguments[:multiple] = true
+        @input.label_arguments[:value] = checked_value
+      end
+
+      private
+
+      def checked_value
+        @input.value || "1"
       end
     end
   end

--- a/lib/primer/forms/dsl/check_box_group_input.rb
+++ b/lib/primer/forms/dsl/check_box_group_input.rb
@@ -7,7 +7,8 @@ module Primer
       class CheckBoxGroupInput < Input
         attr_reader :label, :check_boxes
 
-        def initialize(label: nil, **system_arguments)
+        def initialize(name: nil, label: nil, **system_arguments)
+          @name = name
           @label = label
           @check_boxes = []
 
@@ -31,9 +32,21 @@ module Primer
         end
 
         def check_box(**system_arguments)
-          @check_boxes << CheckBoxInput.new(
-            builder: @builder, form: @form, **system_arguments
-          )
+          args = {
+            name: @name,
+            **system_arguments,
+            builder: @builder,
+            form: @form,
+            scheme: scheme
+          }
+
+          @check_boxes << CheckBoxInput.new(**args)
+        end
+
+        private
+
+        def scheme
+          @name ? :array : :boolean
         end
       end
     end

--- a/lib/primer/forms/dsl/check_box_input.rb
+++ b/lib/primer/forms/dsl/check_box_input.rb
@@ -5,11 +5,18 @@ module Primer
     module Dsl
       # :nodoc:
       class CheckBoxInput < Input
-        attr_reader :name, :label
+        DEFAULT_SCHEME = :boolean
+        SCHEMES = [DEFAULT_SCHEME, :array].freeze
 
-        def initialize(name:, label:, **system_arguments)
+        attr_reader :name, :label, :value, :scheme
+
+        def initialize(name:, label:, value: nil, scheme: DEFAULT_SCHEME, **system_arguments)
+          raise ArgumentError, "Check box scheme must be one of #{SCHEMES.join(', ')}" unless SCHEMES.include?(scheme)
+
           @name = name
           @label = label
+          @value = value
+          @scheme = scheme
 
           super(**system_arguments)
         end

--- a/lib/primer/forms/dsl/check_box_input.rb
+++ b/lib/primer/forms/dsl/check_box_input.rb
@@ -13,6 +13,8 @@ module Primer
         def initialize(name:, label:, value: nil, scheme: DEFAULT_SCHEME, **system_arguments)
           raise ArgumentError, "Check box scheme must be one of #{SCHEMES.join(', ')}" unless SCHEMES.include?(scheme)
 
+          raise ArgumentError, "Check box needs an explicit value if scheme is array" if scheme == :array && value.nil?
+
           @name = name
           @label = label
           @value = value
@@ -27,6 +29,16 @@ module Primer
 
         def type
           :check_box
+        end
+
+        private
+
+        def caption_template_name
+          @caption_template_name ||= if @scheme == :array
+                                       :"#{name}_#{value}"
+                                     else
+                                       name.to_sym
+                                     end
         end
       end
     end

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -209,7 +209,7 @@ module Primer
         def caption_template_name
           return nil unless name
 
-          @caption_template_name ||= if respond_to?(:value) && value
+          @caption_template_name ||= if respond_to?(:value)
                                        :"#{name}_#{value}"
                                      else
                                        name.to_sym

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -209,7 +209,7 @@ module Primer
         def caption_template_name
           return nil unless name
 
-          @caption_template_name ||= if respond_to?(:value)
+          @caption_template_name ||= if respond_to?(:value) && value
                                        :"#{name}_#{value}"
                                      else
                                        name.to_sym

--- a/test/forms/array_check_box_group_form.rb
+++ b/test/forms/array_check_box_group_form.rb
@@ -6,7 +6,7 @@ class ArrayCheckBoxGroupForm < ApplicationForm
     # In the case below, the name of each will be "places[]". If a box is checked, the
     # resulting array will contain the corresponding value.
     check_form.check_box_group(name: "places", label: "Cool places") do |check_group|
-      check_group.check_box(value: "lopez", label: "Lopez Island", caption: "Vacation getaway")
+      check_group.check_box(value: "lopez", label: "Lopez Island")
       check_group.check_box(value: "bellevue", label: "Bellevue", caption: "Beautiful view")
       check_group.check_box(value: "seattle", label: "Seattle", caption: "The emerald city")
     end

--- a/test/forms/array_check_box_group_form.rb
+++ b/test/forms/array_check_box_group_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ArrayCheckBoxGroupForm < ApplicationForm
+  form do |check_form|
+    # Passing a name: here causes the form to emit all the check boxes with the same name.
+    # In the case below, the name of each will be "places[]". If a box is checked, the
+    # resulting array will contain the corresponding value.
+    check_form.check_box_group(name: "places", label: "Cool places") do |check_group|
+      check_group.check_box(value: "lopez", label: "Lopez Island", caption: "Vacation getaway")
+      check_group.check_box(value: "bellevue", label: "Bellevue", caption: "Beautiful view")
+      check_group.check_box(value: "seattle", label: "Seattle", caption: "The emerald city")
+    end
+  end
+end

--- a/test/forms/array_check_box_group_form/places_lopez_caption.html.erb
+++ b/test/forms/array_check_box_group_form/places_lopez_caption.html.erb
@@ -1,0 +1,1 @@
+<span>Vacation getaway</span>

--- a/test/previews/primer/forms/forms_preview.rb
+++ b/test/previews/primer/forms/forms_preview.rb
@@ -19,6 +19,8 @@ module Primer
 
       def check_box_group_form; end
 
+      def array_check_box_group_form; end
+
       def select_list_form; end
 
       def radio_button_with_nested_form; end

--- a/test/previews/primer/forms/forms_preview/array_check_box_group_form.html.erb
+++ b/test/previews/primer/forms/forms_preview/array_check_box_group_form.html.erb
@@ -1,0 +1,3 @@
+<%= primer_form_with(url: "/foo") do |f| %>
+  <%= render(ArrayCheckBoxGroupForm.new(f)) %>
+<% end %>

--- a/test/primer/forms/checkbox_input_test.rb
+++ b/test/primer/forms/checkbox_input_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Primer::Forms::CheckboxInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class BadCheckboxesForm < ApplicationForm
+    form do |check_form|
+      check_form.check_box(name: "alpha", label: "Alpha", scheme: :array)
+    end
+  end
+
+  def test_array_checkboxes_require_values
+    error = assert_raises(ArgumentError) do
+      render_in_view_context do
+        primer_form_with(url: "/foo") do |f|
+          render(BadCheckboxesForm.new(f))
+        end
+      end
+    end
+
+    assert_includes error.message, "Check box needs an explicit value if scheme is array"
+  end
+end

--- a/test/primer/forms/forms_test.rb
+++ b/test/primer/forms/forms_test.rb
@@ -240,7 +240,27 @@ class Primer::Forms::FormsTest < Minitest::Test
   def test_renders_check_box_group
     render_preview :check_box_group_form
 
-    assert_selector "fieldset input[type=checkbox]", count: 3
+    %w[long_a long_i long_o].each do |sound|
+      assert_selector "fieldset input[type=hidden][value=0][name=#{sound}]", visible: false
+      assert_selector "fieldset input[type=checkbox][value=1][name=#{sound}]" do
+        assert_selector "label[for=#{sound}]"
+      end
+    end
+  end
+
+  def test_renders_array_check_box_group
+    render_preview :array_check_box_group_form
+
+    # check for rails' auto-inserted unchecked value field, which should not be present
+    # in this case since no unchecked value is provided (we want an unchecked item to
+    # simply not be present in the resulting array)
+    refute_selector "input[type=hidden][value=0]", visible: false
+
+    %w[lopez bellevue seattle].each do |place|
+      assert_selector "fieldset input[type=checkbox][value=#{place}][name='places[]']" do
+        assert_selector "label[for='places_#{place}']"
+      end
+    end
   end
 
   def test_renders_hidden_input

--- a/test/primer/forms/forms_test.rb
+++ b/test/primer/forms/forms_test.rb
@@ -261,6 +261,8 @@ class Primer::Forms::FormsTest < Minitest::Test
         assert_selector "label[for='places_#{place}']"
       end
     end
+
+    assert_selector ".FormControl-caption span", text: "Vacation getaway"
   end
 
   def test_renders_hidden_input


### PR DESCRIPTION
Initially array-style checkboxes were conflicting with existing checkbox components using caption templates. This will make it so only the array-style checkboxes will require a value in the template name.

(Because all of the checkboxes in an "array" have the same name, templates need to differ based on the value in that case.)