### PR TITLE
Add the Requested-With header to toggle switch requests

### DIFF
--- a/.changeset/modern-masks-pump.md
+++ b/.changeset/modern-masks-pump.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add the Requested-With header to toggle switch requests

--- a/app/components/primer/alpha/toggle_switch.ts
+++ b/app/components/primer/alpha/toggle_switch.ts
@@ -124,6 +124,9 @@ export class ToggleSwitchElement extends HTMLElement {
       const response = await fetch(this.src, {
         credentials: 'same-origin',
         method: 'POST',
+        headers: {
+          'Requested-With': 'XMLHttpRequest'
+        },
         body
       })
       if (response.ok) {

--- a/demo/app/controllers/toggle_switch_controller.rb
+++ b/demo/app/controllers/toggle_switch_controller.rb
@@ -3,10 +3,22 @@
 # For toggle switch previews/tests
 # :nocov:
 class ToggleSwitchController < ApplicationController
+  class << self
+    attr_accessor :last_request
+  end
+
   skip_before_action :verify_authenticity_token
 
   def create
+    self.class.last_request = request
+
     sleep 1 unless Rails.env.test?
+
+    # this mimics dotcom behavior
+    if request.headers["HTTP_REQUESTED_WITH"] != "XMLHttpRequest"
+      head :unprocessable_entity
+      return
+    end
 
     if form_params[:authenticity_token] && form_params[:authenticity_token] != "let_me_in"
       head :unauthorized

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -44,5 +44,15 @@ module Alpha
       find("toggle-switch").click
       assert_selector("[data-target='toggle-switch.errorIcon']")
     end
+
+    def test_fetch_made_with_correct_headers
+      visit_preview(:default)
+
+      refute_selector(".ToggleSwitch--checked")
+      find("toggle-switch").click
+      assert_selector(".ToggleSwitch--checked")
+
+      assert_equal "XMLHttpRequest", ToggleSwitchController.last_request.headers["HTTP_REQUESTED_WITH"]
+    end
   end
 end


### PR DESCRIPTION
This is apparently something libraries like jQuery do to inform the server the request was made via AJAX. It's something dotcom expects as well.