### PR TITLE
Deprecate Primer::IconButton in favor of Primer::Beta::IconButton

### DIFF
--- a/.changeset/olive-eggs-dream.md
+++ b/.changeset/olive-eggs-dream.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+deprecated Primer::IconButton in favor of Primer::Beta::IconButton"

--- a/app/components/primer/icon_button.rb
+++ b/app/components/primer/icon_button.rb
@@ -12,7 +12,7 @@ module Primer
   #   Either `aria-label` or `aria-description` will be used for the `Tooltip` text, depending on which one is present.
   #   [Learn more about best functional image practices (WAI Images)](https://www.w3.org/WAI/tutorials/images/functional)
   class IconButton < Primer::Component
-    status :beta
+    status :deprecated
 
     DEFAULT_SCHEME = :default
     SCHEME_MAPPINGS = {

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -62,7 +62,7 @@
   - title: HiddenTextExpander
     url: "/components/alpha/hiddentextexpander"
   - title: IconButton
-    url: "/components/iconbutton"
+    url: "/components/beta/iconbutton"
   - title: Image
     url: "/components/image"
   - title: ImageCrop

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -17,6 +17,7 @@ module Primer
       "Primer::FlexItemComponent" => nil,
       "Primer::HeadingComponent" => "Primer::Beta::Heading",
       "Primer::HiddenTextExpander" => "Primer::Alpha::HiddenTextExpander",
+      "Primer::IconButton" => "Primer::Beta::IconButton",
       "Primer::Tooltip" => "Primer::Alpha::Tooltip"
     }.freeze
 

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -58,7 +58,7 @@
   "Primer::HeadingComponent": "deprecated",
   "Primer::HellipButton": "alpha",
   "Primer::HiddenTextExpander": "deprecated",
-  "Primer::IconButton": "beta",
+  "Primer::IconButton": "deprecated",
   "Primer::Image": "alpha",
   "Primer::ImageCrop": "alpha",
   "Primer::LabelComponent": "beta",


### PR DESCRIPTION
marks Primer::IconButton as deprecated in favor of Primer::Beta::IconButton, and corrects the primer.style navigation for `IconButton`

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/75190/191554599-6c1dc4e7-ddbb-4108-8ad1-16f79d37a843.png">
