### PR TITLE
move Octicon cache preload to initializer

### DIFF
--- a/.changeset/spotty-tips-march.md
+++ b/.changeset/spotty-tips-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move Octicon cache preload to initializer.

--- a/app/components/primer/octicon_component.rb
+++ b/app/components/primer/octicon_component.rb
@@ -82,9 +82,5 @@ module Primer
       )
       @system_arguments.merge!(@icon.options.except(:class, :'aria-hidden'))
     end
-
-    def self._after_compile
-      Primer::Octicon::Cache.preload!
-    end
   end
 end

--- a/app/components/primer/octicon_symbols_component.rb
+++ b/app/components/primer/octicon_symbols_component.rb
@@ -39,10 +39,6 @@ module Primer
       @icons.any?
     end
 
-    def self._after_compile
-      Primer::Octicon::Cache.preload!
-    end
-
     def symbol_tags
       safe_join(
         @icons.values.map do |icon|

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -30,12 +30,13 @@ module Primer
         app.config.assets.precompile += %w[primer_view_components] if app.config.respond_to?(:assets)
       end
 
-      initializer "primer.forms.eager_load_actions" do
+      initializer "primer.eager_load_actions" do
         ActiveSupport.on_load(:after_initialize) do
           if Rails.application.config.eager_load
             Primer::Forms::Base.compile!
             Primer::Forms::Base.descendants.each(&:compile!)
             Primer::Forms::BaseComponent.descendants.each(&:compile!)
+            Primer::Octicon::Cache.preload!
           end
         end
       end


### PR DESCRIPTION
I believe we can move this code to be with the other compilation optimizations and not at the component level. This will allow us to remove `_after_compile` from ViewComponent.