### PR TITLE
Raise on usage of deprecated arguments in Primer::Beta::Button

### DIFF
--- a/.changeset/popular-olives-visit.md
+++ b/.changeset/popular-olives-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Raise on usage of deprecated arguments in Primer::Beta::Button

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -149,6 +149,9 @@ module Primer
 
         @id = @system_arguments[:id]
 
+        raise ArgumentError, "The `variant:` argument is no longer supported on Primer::Beta::Button. Consider `scheme:` or `size:`." if !Rails.env.production? && @system_arguments[:variant].present?
+        raise ArgumentError, "The `dropdown:` argument is no longer supported on Primer::Beta::Button. Use the `trailing_action` slot instead." if !Rails.env.production? && @system_arguments[:dropdown].present?
+
         @align_content_classes = class_names(
           "Button-content",
           system_arguments[:classes],

--- a/test/components/primer/beta/button_test.rb
+++ b/test/components/primer/beta/button_test.rb
@@ -10,4 +10,20 @@ class PrimerBetaButtonTest < Minitest::Test
 
     assert_selector(".Button", text: "Button")
   end
+
+  def test_warns_on_uses_of_variant
+    err = assert_raises ArgumentError do
+      render_inline(Primer::Beta::Button.new(variant: :small)) { "Button" }
+    end
+
+    assert_equal "The `variant:` argument is no longer supported on Primer::Beta::Button. Consider `scheme:` or `size:`.", err.message
+  end
+
+  def test_warns_on_uses_of_dropdown
+    err = assert_raises ArgumentError do
+      render_inline(Primer::Beta::Button.new(dropdown: true)) { "Button" }
+    end
+
+    assert_equal "The `dropdown:` argument is no longer supported on Primer::Beta::Button. Use the `trailing_action` slot instead.", err.message
+  end
 end

--- a/test/previews/primer/beta/icon_button_preview.rb
+++ b/test/previews/primer/beta/icon_button_preview.rb
@@ -28,9 +28,7 @@ module Primer
                  disabled: disabled,
                  icon: icon,
                  "aria-label": aria_label
-               )) do |_c|
-          "Button"
-        end
+               ))
       end
 
       # @label Default
@@ -54,9 +52,7 @@ module Primer
                  disabled: disabled,
                  icon: icon,
                  "aria-label": aria_label
-               )) do |_c|
-          "Button"
-        end
+               ))
       end
 
       # @label Invisible
@@ -80,9 +76,7 @@ module Primer
                  disabled: disabled,
                  icon: icon,
                  "aria-label": aria_label
-               )) do |_c|
-          "Button"
-        end
+               ))
       end
 
       # @label Danger
@@ -106,9 +100,7 @@ module Primer
                  disabled: disabled,
                  icon: icon,
                  "aria-label": aria_label
-               )) do |_c|
-          "Button"
-        end
+               ))
       end
     end
   end


### PR DESCRIPTION
These arguments have been deprecated for use in `Primer::ButtonComponent` for a long time, but we wanted to make sure when converting over, users know that the arguments have changed.