### PR TITLE
Automatically publish the package when a GitHub release is published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,16 +11,33 @@ jobs:
         uses: actions/setup-ruby@v1
         with:
           ruby-version: "3.1.x"
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 14
-      - run: |
+      - name: Bundle install
+        run: |
           gem install bundler:2.2.9
           bundle config path vendor/bundle
           bundle install
-          yarn
-          script/publish
+      - name: Create .gem credentials
+        run: |
+          mkdir -p ~/.gem
+          cat << EOF > ~/.gem/credentials
+          ---
+          :rubygems_api_key: ${RUBYGEMS_TOKEN}
+          EOF
+          chmod 0600 ~/.gem/credentials
         env:
-          GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
           RUBYGEMS_TOKEN: ${{ secrets.RUBYGEMS_TOKEN_SHARED }}
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - name: Create .npmrc
+        run: |
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+      - name: Yarn install
+        run: |
+          yarn
+      - name: Publish
+        run: script/publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+on:
+  release:
+    types: [published]
+name: Publish primer_view_components and @primer/view-components
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: "3.1.x"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: |
+          gem install bundler:2.2.9
+          bundle config path vendor/bundle
+          bundle install
+          script/publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
+          RUBYGEMS_TOKEN: ${{ secrets.RUBYGEMS_TOKEN_SHARED }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,12 +18,12 @@ jobs:
           bundle install
       - name: Create .gem credentials
         run: |
-          mkdir -p ~/.gem
-          cat << EOF > ~/.gem/credentials
+          mkdir -p $HOME/.gem
+          cat << EOF > $HOME/.gem/credentials
           ---
           :rubygems_api_key: ${RUBYGEMS_TOKEN}
           EOF
-          chmod 0600 ~/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
         env:
           RUBYGEMS_TOKEN: ${{ secrets.RUBYGEMS_TOKEN_SHARED }}
       - uses: actions/setup-node@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ jobs:
           gem install bundler:2.2.9
           bundle config path vendor/bundle
           bundle install
+          yarn
           script/publish
         env:
           GITHUB_TOKEN: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
This is based on how `octicons` currently publishes. https://github.com/primer/octicons/pull/681

The `tl;dr;` is that everything currently stays how it is.

1. Changeset creates release PR
2. Release PR is merged
3. Changeset creates GitHub release

Previously after that last step, we would need to manually run `script/publish`.

This PR setups a workflow to listen for the `release: published` event and then prepares and then runs `script/publish`