### PR TITLE
Switchover to official pages deployment workflows

### DIFF
--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -73,6 +73,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1
         with:
           preview: true

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -75,6 +75,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1
         with:
           preview: false


### PR DESCRIPTION
`paper-spa/deploy-pages` has been deprecated now that the BYO workflows have gone to GA. 

This PR is a like-for-like change, which is being made across the Primer org. This repo doesn't use our reusable workflow so it doesn't receive the update automatically.