### PR TITLE
Change header to div on dialog

### DIFF
--- a/.changeset/sharp-camels-push.md
+++ b/.changeset/sharp-camels-push.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Change header tag to div on `Primer::Alpha::Dialog`

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -24,7 +24,7 @@ module Primer
           @subtitle = subtitle
           @visually_hide_title = visually_hide_title
           @system_arguments = deny_tag_argument(**system_arguments)
-          @system_arguments[:tag] = :header
+          @system_arguments[:tag] = :div
           @system_arguments[:classes] = class_names(
             "Overlay-header",
             { "Overlay-header--divided": show_divider },


### PR DESCRIPTION
### Motivation

When the dialog appears outside of a sectioning element (like `<main>`) it looks like some browser add the `banner` role to the element. This behaviour is undesired so we're changing the header to a div.

Looks like the `<footer>` has already been removed.