### PR TITLE
output iife in rollup build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,7 +7,7 @@ export default {
   input: pkg.module,
   output: {
     file: pkg.main,
-    format: "es",
+    format: "iife",
     sourcemap: true
   },
   plugins: [


### PR DESCRIPTION
Our current build outputs code which creates functions and variables inside the global scope, which could result in clobbering expected globals like `$`. 

This changes it to use an [`iife`](https://developer.mozilla.org/en-US/docs/Glossary/IIFE), which'll ensure every function and variable declaration is scoped away from the global scope. 