### PR TITLE
Add VS Code fileNesting patterns for view_components

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
     "*.rb": "${basename}.rb, ${basename}.html.erb, ${basename}.ts, ${basename}.pcss"
   }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.rb": "${basename}.rb, ${basename}.html.erb, ${basename}.ts, ${basename}.pcss"
+  }
+}


### PR DESCRIPTION
This adds the file nesting patterns to the vscode settings to combine view component files into matching. [File Nesting information](https://code.visualstudio.com/updates/v1_67#_explorer-file-nesting)

**Before**
<img width="428" alt="image" src="https://user-images.githubusercontent.com/54012/192863044-d2e778ad-91d8-4287-b59f-cfac199223cf.png">

**After**
<img width="418" alt="image" src="https://user-images.githubusercontent.com/54012/192862751-816953f8-6270-4379-ac94-964be6d11c21.png">


However, I left out turning it on/off so the user can decide if they want to have this feature on.

<img width="465" alt="image" src="https://user-images.githubusercontent.com/54012/192863288-d2813ddf-c436-4fcd-a861-4b6b8d4fc5f7.png">
