### PR TITLE
Un-Deprecate Primer::ButtonComponent

### DIFF
--- a/.changeset/four-donuts-call.md
+++ b/.changeset/four-donuts-call.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+un-deprecate Primer::ButtonComponent for now, due to inconsistencies and issues in migrating to Primer::Beta::Button

--- a/app/components/primer/button_component.rb
+++ b/app/components/primer/button_component.rb
@@ -3,7 +3,7 @@
 module Primer
   # Use `Button` for actions (e.g. in forms). Use links for destinations, or moving from one page to another.
   class ButtonComponent < Primer::Component
-    status :deprecated
+    status :beta
 
     DEFAULT_SCHEME = :default
     LINK_SCHEME = :link

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -32,7 +32,7 @@
   - title: Breadcrumbs
     url: "/components/beta/breadcrumbs"
   - title: Button
-    url: "/components/button"
+    url: "/components/beta/button"
   - title: ButtonGroup
     url: "/components/beta/buttongroup"
   - title: ButtonMarketing

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -32,7 +32,7 @@
   - title: Breadcrumbs
     url: "/components/beta/breadcrumbs"
   - title: Button
-    url: "/components/beta/button"
+    url: "/components/button"
   - title: ButtonGroup
     url: "/components/beta/buttongroup"
   - title: ButtonMarketing

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -9,7 +9,6 @@ module Primer
       "Primer::Alpha::AutoComplete::Item" => "Primer::Beta::AutoComplete::Item",
       "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
       "Primer::BoxComponent" => "Primer::Box",
-      "Primer::ButtonComponent" => "Primer::Beta::Button",
       "Primer::CloseButton" => "Primer::Beta::CloseButton",
       "Primer::CounterComponent" => "Primer::Beta::Counter",
       "Primer::DetailsComponent" => "Primer::Beta::Details",

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -49,7 +49,7 @@
   "Primer::BlankslateComponent": "deprecated",
   "Primer::Box": "stable",
   "Primer::BoxComponent": "deprecated",
-  "Primer::ButtonComponent": "deprecated",
+  "Primer::ButtonComponent": "beta",
   "Primer::ClipboardCopy": "beta",
   "Primer::CloseButton": "deprecated",
   "Primer::ConditionalWrapper": "alpha",


### PR DESCRIPTION
due to a number of issues encountered with migrating `Primer::ButtonComponent` to `Primer::Beta::Button` in dotcom, the deprecation of `Primer::ButtonComponent` needs to be reverted for now.

this PR reverts #1396, except for the `nav.yml` file for the site navigation. that file remains as-is, since it corrected the site navigation for Button