### PR TITLE
Fix Beta::Button visual regressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "explorer.fileNesting.patterns": {
+    "*.rb": "${basename}.rb, ${basename}.html.erb, ${basename}.ts, ${basename}.pcss"
+  }
+}

--- a/app/components/primer/beta/button.html.erb
+++ b/app/components/primer/beta/button.html.erb
@@ -6,7 +6,7 @@
           <%= leading_visual %>
         </span>
       <% end %>
-      <span class="Button-label"><%= trimmed_content %></span>
+      <div class="Button-label"><%= trimmed_content %></div>
       <% if trailing_visual %>
         <span class="Button-visual Button-trailingVisual">
           <%= trailing_visual %>

--- a/app/components/primer/beta/button.html.erb
+++ b/app/components/primer/beta/button.html.erb
@@ -6,7 +6,7 @@
           <%= leading_visual %>
         </span>
       <% end %>
-      <div class="Button-label"><%= trimmed_content %></div>
+      <span class="Button-label"><%= trimmed_content %></span>
       <% if trailing_visual %>
         <span class="Button-visual Button-trailingVisual">
           <%= trailing_visual %>

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -243,6 +243,10 @@ summary.Button {
 .Button--invisible {
   color: var(--color-accent-fg);
 
+  &.invisible_button_class.invisible_button_class .Button-label.Button-label {
+    color: red !important;
+  }
+
   &:hover {
     background-color: var(--color-action-list-item-default-hover-bg);
   }

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -241,11 +241,7 @@ summary.Button {
 }
 
 .Button--invisible {
-  color: var(--color-accent-fg);
-
-  &.invisible_button_class.invisible_button_class .Button-label.Button-label {
-    color: red !important;
-  }
+  color: var(--color-btn-text);
 
   &:hover {
     background-color: var(--color-action-list-item-default-hover-bg);
@@ -267,32 +263,13 @@ summary.Button {
     fill: var(--color-primer-fg-disabled);
   }
 
+  /* if button has no visuals, use link blue for text */
+  &.Button--invisible-noVisuals .Button-label {
+    color: var(--color-accent-fg);
+  }
+
   & .Button-visual {
     color: var(--color-fg-muted);
-  }
-
-  /* the section below can be replace with :has()
-  * .Button--invisible:has(.Button-visual) {
-  *   color: var(--color-btn-text);
-  * }
-  */
-
-  /* select label content when visuals are present */
-  & .Button-content:nth-child(odd) {
-    color: var(--color-btn-text);
-
-    /* if label is only child, use link color */
-    & > .Button-label:only-child {
-      color: var(--color-accent-fg);
-    }
-  }
-
-  /* if trailing action, button label should be default */
-  & .Button-content:not(:only-child) {
-    /* need important to override previous selector */
-    & > .Button-label {
-      color: var(--color-btn-text) !important;
-    }
   }
 }
 

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -264,66 +264,49 @@ summary.Button {
   }
 
   & .Button-visual {
-    color: var(--color-btn-text);
+    color: var(--color-fg-muted);
   }
 
-  /* & .Button-label:is(:last-child) {
-    color: var(--color-btn-text);
-  } */
+  /* the section below can be replace with :has()
+  * .Button--invisible:has(.Button-visual) {
+  *   color: var(--color-btn-text);
+  * }
+  */
 
+  /* select label content when visuals are present */
   & .Button-content:nth-child(odd) {
     color: var(--color-btn-text);
 
+    /* if label is only child, use link color */
     & > .Button-label:only-child {
       color: var(--color-accent-fg);
     }
   }
 
+  /* if trailing action, button label should be default */
   & .Button-content:not(:only-child) {
+    /* need important to override previous selector */
     & > .Button-label {
       color: var(--color-btn-text) !important;
     }
   }
-
-  /* & .Button-label:only-child {
-      color: var(--color-accent-fg);
-  }
-
-  & .Button-content:only-child {
-    color: var(--color-btn-text);
-  } */
-
-  /* & .Button-content:not(:only-child) {
-      color: var(--color-btn-text);
-
-    & + .Button-visual {
-      color: var(--color-btn-text);
-    }
-  } */
-
-  /* & .Button-content {
-    & .Button-visual + .Button-label {
-        color: var(--color-btn-text);
-        color: deeppink;
-    }
-  } */
 }
 
 .Button--link {
   color: var(--color-accent-fg);
   fill: var(--color-accent-fg);
+  display: inline-block;
+  font-size: inherit;
   border: none;
+  height: unset;
+  padding: 0;
 
-  &:hover {
-    background-color: var(--color-action-list-item-default-hover-bg);
+  &:hover:not(:disabled) {
+    text-decoration: underline;
   }
 
-  &[aria-pressed='true'],
-  &:active,
-  &.Button--active,
-  &.Button--pressed {
-    background-color: var(--color-action-list-item-default-active-bg);
-    /* box-shadow: var(--color-primer-shadow-inset); */
+  &:focus-visible, &:focus {
+    outline-offset: 2px;
   }
 
   &:disabled,

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -103,7 +103,7 @@ summary.Button {
 .Button-label {
   grid-area: text;
   white-space: nowrap;
-  line-height: var(--primer-text-body-lineHeight-medium, calc(20/14));
+  line-height: var(--primer-text-body-lineHeight-medium, calc(20 / 14));
 }
 
 .Button-leadingVisual {
@@ -127,7 +127,7 @@ summary.Button {
   gap: var(--primer-control-small-gap, 4px);
 
   .Button-label {
-    line-height: var(--primer-text-body-lineHeight-small, calc(20/12));
+    line-height: var(--primer-text-body-lineHeight-small, calc(20 / 12));
   }
 
   .Button-content {
@@ -143,7 +143,7 @@ summary.Button {
   gap: var(--primer-control-large-gap, 8px);
 
   .Button-label {
-    line-height: var(--primer-text-body-lineHeight-large, calc(48/32));
+    line-height: var(--primer-text-body-lineHeight-large, calc(48 / 32));
   }
 
   .Button-content {
@@ -213,7 +213,7 @@ summary.Button {
   border-color: var(--color-btn-border);
   box-shadow: var(--color-btn-shadow), var(--color-btn-inset-shadow);
 
-  &:hover  {
+  &:hover {
     background-color: var(--color-btn-hover-bg);
     border-color: var(--color-btn-hover-border);
   }
@@ -241,8 +241,7 @@ summary.Button {
 }
 
 .Button--invisible {
-  color: var(--color-btn-text);
-  fill: var(--color-btn-text);
+  color: var(--color-accent-fg);
 
   &:hover {
     background-color: var(--color-action-list-item-default-hover-bg);
@@ -263,11 +262,16 @@ summary.Button {
     border-color: var(--color-btn-border);
     fill: var(--color-primer-fg-disabled);
   }
+
+  .Button-label:not(:only-child) {
+    color: var(--color-btn-text);
+    fill: var(--color-btn-text);
+  }
 }
 
 .Button--link {
-  color: var(--color-accent-default);
-  fill: var(--color-accent-default);
+  color: var(--color-accent-fg);
+  fill: var(--color-accent-fg);
   border: none;
 
   &:hover {

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -263,10 +263,50 @@ summary.Button {
     fill: var(--color-primer-fg-disabled);
   }
 
-  .Button-label:not(:only-child) {
+  & .Button-visual {
     color: var(--color-btn-text);
-    fill: var(--color-btn-text);
   }
+
+  /* & .Button-label:is(:last-child) {
+    color: var(--color-btn-text);
+  } */
+
+  & .Button-content:nth-child(odd) {
+    color: var(--color-btn-text);
+
+    & > .Button-label:only-child {
+      color: var(--color-accent-fg);
+    }
+  }
+
+  & .Button-content:not(:only-child) {
+    & > .Button-label {
+      color: var(--color-btn-text) !important;
+    }
+  }
+
+  /* & .Button-label:only-child {
+      color: var(--color-accent-fg);
+  }
+
+  & .Button-content:only-child {
+    color: var(--color-btn-text);
+  } */
+
+  /* & .Button-content:not(:only-child) {
+      color: var(--color-btn-text);
+
+    & + .Button-visual {
+      color: var(--color-btn-text);
+    }
+  } */
+
+  /* & .Button-content {
+    & .Button-visual + .Button-label {
+        color: var(--color-btn-text);
+        color: deeppink;
+    }
+  } */
 }
 
 .Button--link {

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -174,7 +174,7 @@ module Primer
 
         @system_arguments[:classes] = class_names(
           @system_arguments[:classes],
-          "invisible_button_class"
+          "Button--invisible-noVisuals"
         )
       end
 

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -169,6 +169,15 @@ module Primer
 
       private
 
+      def before_render
+        return unless @scheme == :invisible && !trailing_visual && !leading_visual && !trailing_action
+
+        @system_arguments[:classes] = class_names(
+          @system_arguments[:classes],
+          "invisible_button_class"
+        )
+      end
+
       def trimmed_content
         return if content.blank?
 

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -4,6 +4,14 @@ module Primer
   module Beta
     # @label Button
     class ButtonPreview < ViewComponent::Preview
+      # Upgrade guide to Primer::Beta::Button
+      #
+      # | old param | new param | options |
+      # | -- | -- | -- |
+      # | variant | size | :small, :medium (default), :large |
+      # | :outline | :default or :invisible | option for :scheme |
+      # | dropdown | trailing action icon slot | see trailing action preview for markup |
+      #
       # @label Playground
       # @param scheme select [default, primary, danger, invisible, link]
       # @param size select [small, medium, large]
@@ -124,6 +132,28 @@ module Primer
       # @label Invisible all visuals
       def invisible_all_visuals
         render_with_template(locals: {})
+      end
+
+      # @label Link
+      # @param block toggle
+      # @param disabled toggle
+      # @param tag select [a, summary, button]
+      def primary(
+        id: "button-preview",
+        block: false,
+        tag: :button,
+        disabled: false
+      )
+        render(Primer::Beta::Button.new(
+                 scheme: :link,
+                 size: :medium,
+                 block: block,
+                 id: id,
+                 tag: tag,
+                 disabled: disabled
+               )) do |_c|
+          "Button"
+        end
       end
 
       # @label All schemes

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -182,7 +182,7 @@ module Primer
       end
 
       # @label Link as button
-      # @param scheme select [default, primary, danger, outline, invisible, link]
+      # @param scheme select [default, primary, danger, invisible, link]
       # @param size select [small, medium]
       # @param block toggle
       # @param align_content select [center, start]
@@ -207,7 +207,7 @@ module Primer
       end
 
       # @label Trailing visual
-      # @param scheme select [default, primary, danger, outline, invisible, link]
+      # @param scheme select [default, primary, danger, invisible, link]
       # @param size select [small, medium]
       # @param block toggle
       # @param align_content select [center, start]
@@ -231,7 +231,7 @@ module Primer
       end
 
       # @label Leading visual
-      # @param scheme select [default, primary, danger, outline, invisible, link]
+      # @param scheme select [default, primary, danger, invisible, link]
       # @param size select [small, medium]
       # @param block toggle
       # @param align_content select [center, start]
@@ -267,7 +267,7 @@ module Primer
       end
 
       # @label With tooltip
-      # @param scheme select [default, primary, danger, outline, invisible, link]
+      # @param scheme select [default, primary, danger, invisible, link]
       # @param size select [small, medium]
       # @param block toggle
       # @param align_content select [center, start]

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -121,6 +121,11 @@ module Primer
         end
       end
 
+      # @label Invisible all visuals
+      def invisible_all_visuals
+        render_with_template(locals: {})
+      end
+
       # @label All schemes
       def all_schemes
         render_with_template(locals: {})

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -138,7 +138,7 @@ module Primer
       # @param block toggle
       # @param disabled toggle
       # @param tag select [a, summary, button]
-      def primary(
+      def link(
         id: "button-preview",
         block: false,
         tag: :button,

--- a/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
+++ b/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
@@ -26,4 +26,21 @@
     <% c.trailing_visual_counter(count: "15") %>
     Button
   <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    <% c.leading_visual_icon(icon: :eye) %>
+    <% c.trailing_visual_counter(count: "15") %>
+    Button
+  <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    <% c.leading_visual_icon(icon: :eye) %>
+    <% c.trailing_visual_counter(count: "15") %>
+    <% c.trailing_action_icon(icon: "triangle-down") %>
+    Button
+  <% end %>
 </div>

--- a/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
+++ b/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
@@ -43,4 +43,12 @@
     <% c.trailing_action_icon(icon: "triangle-down") %>
     Button
   <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+      id: "my-id"
+  )) do |c| %>
+    <% c.with_tooltip(text: "Tooltip text") %>
+    Button with tooltip
+  <% end %>
 </div>

--- a/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
+++ b/previews/primer/beta/button_preview/invisible_all_visuals.html.erb
@@ -1,0 +1,29 @@
+<div style="display: flex; gap: 1rem;">
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    Button
+  <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    <% c.leading_visual_icon(icon: :search) %>
+    Button
+  <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    <% c.trailing_action_icon(icon: "triangle-down") %>
+    Button
+  <% end %>
+  <%= render(Primer::Beta::Button.new(
+      scheme: :invisible,
+      size: :medium,
+  )) do |c| %>
+    <% c.trailing_visual_counter(count: "15") %>
+    Button
+  <% end %>
+</div>


### PR DESCRIPTION
- Adjusts `:invisible` param to match more closely with original
- Add back proper "link" styles for buttons pretending to be links
- Add notes for upgrading to beta

<img width="893" alt="several invisible buttons in a row with different params set" src="https://user-images.githubusercontent.com/18661030/192916931-7742b79c-e9f6-4052-ae2c-d220214cb86c.png">
