### PR TITLE
Remove external classes from the the button content `<span>` in `Primer::beta::Button`

### DIFF
--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -154,7 +154,6 @@ module Primer
 
         @align_content_classes = class_names(
           "Button-content",
-          system_arguments[:classes],
           ALIGN_CONTENT_MAPPINGS[fetch_or_fallback(ALIGN_CONTENT_OPTIONS, align_content, DEFAULT_ALIGN_CONTENT)]
         )
 


### PR DESCRIPTION
## Context

We (the accessibility team) are using the `Primer::beta::Button` for the QueryBuilder component. We’ve seen that the prop `classes` is applied both to the `<button>` element and the `<span>` element inside the `<button>` element.

## Expected behavior

The prop `classes` should only be to the `<button>` element and not to the `<span>` element inside the `<button>` element.

