### PR TITLE
Ignore .d.ts file in chokidar

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 rails: cd demo; bin/rails s -p 4000
 doctocat: cd docs; npm run develop
-assets: npx chokidar "app/components/**/*.pcss" "app/components/**/*.ts" -c "npm run build:css && npm run build:js"
+assets: npx chokidar "app/components/**/*.pcss" "app/components/**/*!(.d).ts" -c "npm run build:css && npm run build:js"


### PR DESCRIPTION
It seems saving JS results in an infinite compile loop:

 1. Run `./script/dev`, which runs `chokidar ... npm run build:js`
 2. Save a JS file
 3. Chokidar detects the `.ts` file changed
 4. Chokidar runs `npm run build:js`.
 5. `build:js` runs `tsc`
 6. `tsc` writes `.js` and `.d.ts` files alongside all `.ts` files.
 7. Chokidar detects `.d.ts` files have changed
 8. Goto 4

The problem is that Chokidar is watching for `...*.ts` which includes both `ts` TypeScript files and `d.ts` TypeScript definition files. 

One solution here is to set `noEmit: true` in our `tsconfig.json`, but it seems as though these files are intentionally required as part of our package.json: https://github.com/primer/view_components/blob/0a5cb98dc151bc4bfa7c72ff265077b3d534a6c7/package.json#L27

So another solution is to tweak the glob to `*!(.d).ts` which will include files ending in `.ts` as long as they don't end in `.d.ts`.