### PR TITLE
ActionListItem `line-height` bug fix

### DIFF
--- a/.changeset/silly-foxes-sit.md
+++ b/.changeset/silly-foxes-sit.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+ActionListItem `line-height` bug fix

--- a/app/components/primer/alpha/action_list/action-list.pcss
+++ b/app/components/primer/alpha/action_list/action-list.pcss
@@ -520,6 +520,7 @@
 
 .ActionListItem--subItem > .ActionListContent > .ActionListItem-label {
   font-size: var(--primer-text-body-size-small, 12px);
+  line-height: var(--primer-text-body-lineHeight-small, calc(20 / 12));
 }
 
 /* trailing action icon button */
@@ -560,6 +561,7 @@
     padding-inline: var(--primer-actionListContent-paddingBlock);
     padding-block: var(--base-size-8, 8px);
     font-size: var(--primer-text-body-size-small, 12px);
+    line-height: var(--primer-text-body-lineHeight-small, calc(20 / 12));
     font-weight: var(--base-text-weight-semibold, 600);
     color: var(--color-fg-muted);
     flex-direction: column;


### PR DESCRIPTION
- Adds `line-height` declarations to all CSS that sets a `font-size`