### PR TITLE
Support system arguments for ActionList item anchor tags

### DIFF
--- a/.changeset/ninety-balloons-reflect.md
+++ b/.changeset/ninety-balloons-reflect.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Support system arguments for ActionList item anchor tags

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -128,6 +128,7 @@ module Primer
         # @param parent [Primer::Alpha::ActionList::Item] This item's parent item. `nil` if this item is at the root. Used internally.
         # @param label [String] Item label.
         # @param label_classes [String] CSS classes that will be added to the label.
+        # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or span tag.
         # @param truncate_label [Boolean] Truncate label with ellipsis.
         # @param href [String] Link URL.
         # @param role [String] ARIA role describing the function of the item.
@@ -143,6 +144,7 @@ module Primer
           list:,
           label:,
           label_classes: nil,
+          content_arguments: {},
           parent: nil,
           truncate_label: false,
           href: nil,
@@ -166,6 +168,7 @@ module Primer
           @trailing_action_on_hover = false
           @id = id
           @system_arguments = system_arguments
+          @content_arguments = content_arguments
 
           @size = fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)
           @scheme = fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)
@@ -192,13 +195,12 @@ module Primer
             )
           }
 
-          @content_arguments = {
-            id: @id,
-            classes: class_names(
-              "ActionListContent",
-              SIZE_MAPPINGS[@size]
-            )
-          }
+          @content_arguments[:id] = @id
+          @content_arguments[:classes] = class_names(
+            @content_arguments[:classes],
+            "ActionListContent",
+            SIZE_MAPPINGS[@size]
+          )
 
           if @href && !@disabled
             @content_arguments[:tag] = :a

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -124,6 +124,12 @@
         "description": "CSS classes that will be added to the label."
       },
       {
+        "name": "content_arguments",
+        "type": "Hash",
+        "default": "`{}`",
+        "description": "[System arguments](/system-arguments) used to construct the item's anchor or span tag."
+      },
+      {
         "name": "truncate_label",
         "type": "Boolean",
         "default": "`false`",

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -63,6 +63,16 @@ module Primer
         id = page.find_css(".ActionList-sectionDivider h3")[0].attributes["id"].value
         assert_selector("ul.ActionListWrap[aria-labelledby='#{id}']")
       end
+
+      def test_allows_content_arguments
+        render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |c|
+          c.with_item(label: "Item 1", href: "/item1")
+          c.with_item(label: "Item 2", href: "/item2", content_arguments: { data: { foo: "bar" } })
+          c.with_item(label: "Item 3", href: "/item3")
+        end
+
+        assert_selector(".ActionListItem a[data-foo=bar]")
+      end
     end
   end
 end


### PR DESCRIPTION
It's currently possible to pass arbitrary system arguments to a number of the elements that make up action lists and their associated items. However there's no mechanism for doing so for the actual links or list items (i.e. `<a>` or `<span>` tags). The `ActionList` class internally already supported the concept of "content arguments," so this PR simply makes them part of the component's public API.