### PR TITLE
Allow NavLists to define sub-items as well as a trailing visual

### DIFF
--- a/.changeset/long-boats-remain.md
+++ b/.changeset/long-boats-remain.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow NavLists to define sub-items as well as a trailing visual

--- a/app/components/primer/alpha/nav_list/item.rb
+++ b/app/components/primer/alpha/nav_list/item.rb
@@ -73,7 +73,7 @@ module Primer
 
           super
 
-          raise "Cannot render a trailing visual for an item with subitems" if items.present? && trailing_visual.present?
+          raise "Cannot render a trailing action for an item with subitems" if items.present? && trailing_action.present?
 
           return if items.blank?
 

--- a/test/components/alpha/nav_list_test.rb
+++ b/test/components/alpha/nav_list_test.rb
@@ -113,6 +113,21 @@ module Primer
 
         assert_selector("#ActionList--showMoreItem", visible: false, text: "Show more")
       end
+
+      def test_disallow_subitems_and_trailing_action
+        error = assert_raises(RuntimeError) do
+          render_inline(Primer::Alpha::NavList.new) do |c|
+            c.with_section(aria: { label: "List" }) do |section|
+              section.with_item(label: "Level 1", href: "/level1") do |item|
+                item.with_item(label: "Level 2", href: "/level2")
+                item.with_trailing_action(icon: :megaphone, aria: { label: "Action" })
+              end
+            end
+          end
+        end
+
+        assert_equal "Cannot render a trailing action for an item with subitems", error.message
+      end
     end
   end
 end


### PR DESCRIPTION
The current implementation of `NavList` disallows attaching a trailing visual to items that also define sub items. This used to be because the trailing visual slot was used for the expand/collapse chevron icon that shows/hides the list of sub items. However, the component uses the `private_trailing_action_icon` slot for the chevron now, and should no longer raise an error if sub items are present and the `trailing_visual` slot has been provided. I believe it should instead raise an error if sub items are present and the `trailing_action` slot is provided, since it doesn't make sense to render two trailing actions.