### PR TITLE
Don't export ToggleSwitchElement

### DIFF
--- a/.changeset/cold-rules-cough.md
+++ b/.changeset/cold-rules-cough.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Don't export ToggleSwitchElement

--- a/app/components/primer/alpha/toggle_switch.ts
+++ b/app/components/primer/alpha/toggle_switch.ts
@@ -2,7 +2,7 @@ import {controller, target} from '@github/catalyst'
 import {debounce} from '@github/mini-throttle/decorators'
 
 @controller
-export class ToggleSwitchElement extends HTMLElement {
+class ToggleSwitchElement extends HTMLElement {
   @target switch: HTMLElement
   @target loadingSpinner: HTMLElement
   @target errorIcon: HTMLElement


### PR DESCRIPTION
Apparently you don't have to (and shouldn't) export web components. TIL!

Fixes #1440 