### PR TITLE
Adding theme param to render preview with theme

### DIFF
--- a/demo/app/helpers/application_helper.rb
+++ b/demo/app/helpers/application_helper.rb
@@ -16,27 +16,19 @@ module ApplicationHelper
 
   def color_theme_attributes
     theme = color_themes.include?(params[:theme]) ? params[:theme] : "light"
+    mode = theme.include?("dark") ? "dark" : "light"
 
     attributes = {
-      "data-color-mode": theme.start_with?("dark") ? "dark" : "light",
+      "data-color-mode": mode,
+      "data-#{mode}-theme": theme
     }
-
-    if theme.start_with?("dark")
-      attributes["data-dark-theme"] = theme
-    else
-      attributes["data-light-theme"] = theme
-    end
 
     tag_attributes(attributes)
   end
 
   def tag_attributes(hash)
     parts = hash.map do |key, value|
-      safe_join([
-        key,
-        "=",
-        value
-      ])
+      safe_join([key, "=", value])
     end
 
     safe_join(parts, " ")

--- a/demo/app/helpers/application_helper.rb
+++ b/demo/app/helpers/application_helper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# no doc
+module ApplicationHelper
+  def color_themes
+    %w[
+      light
+      light_colorblind
+      light_high_contrast
+      dark
+      dark_dimmed
+      dark_high_contrast
+      dark_colorblind
+    ]
+  end
+
+  def color_theme_attributes
+    theme = color_themes.include?(params[:theme]) ? params[:theme] : "light"
+
+    attributes = {
+      "data-color-mode": theme.start_with?("dark") ? "dark" : "light",
+    }
+
+    if theme.start_with?("dark")
+      attributes["data-dark-theme"] = theme
+    else
+      attributes["data-light-theme"] = theme
+    end
+
+    tag_attributes(attributes)
+  end
+
+  def tag_attributes(hash)
+    parts = hash.map do |key, value|
+      safe_join([
+        key,
+        "=",
+        value
+      ])
+    end
+
+    safe_join(parts, " ")
+  end
+end

--- a/demo/app/views/layouts/component_preview.html.erb
+++ b/demo/app/views/layouts/component_preview.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html <%= color_theme_attributes %>>
   <head>
     <title>Component Preview</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
This adds a theme parameter to the component preview layout that will allow us to render a component preview in a supported theme.

[Example Url](http://primer-view-components-preview-1451.eastus.azurecontainer.io/view-components/lookbook/preview/primer/alpha/action_list/default?theme=dark)

<img width="496" alt="image" src="https://user-images.githubusercontent.com/54012/193950982-c2b87464-30ba-4da1-98f2-5cc7bad69bf2.png">
