### PR TITLE
Remove dead Flex and FlexItem links from nav

### DIFF
--- a/.changeset/calm-games-wash.md
+++ b/.changeset/calm-games-wash.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove dead Flex and FlexItem links from nav

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -53,10 +53,6 @@
     url: "/components/dropdownmenu"
   - title: Flash
     url: "/components/beta/flash"
-  - title: Flex
-    url: "/components/flex"
-  - title: FlexItem
-    url: "/components/flexitem"
   - title: Heading
     url: "/components/beta/heading"
   - title: HiddenTextExpander


### PR DESCRIPTION
![primer-dead-links](https://user-images.githubusercontent.com/809707/194235784-d9459de4-ef31-458b-895d-52ffbba57d1f.png)

These components were deprecated in https://github.com/primer/view_components/pull/511 and then removed some time later on.