### PR TITLE
Apply browser options to driver in ApplicationSystemTestCase

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -10,10 +10,8 @@ require "axe/expectation"
 require "test_helpers/cuprite_setup"
 require "test_helpers/retry"
 
-Ferrum::Browser.new(process_timeout: 240, timeout: 240)
-
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400]
+  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: { process_timeout: 240, timeout: 240 }
 
   # Skip `:region` which relates to preview page structure rather than individual component.
   # Skip `:color-contrast` which requires primer design-level change.


### PR DESCRIPTION
I was poking around in this file while investigating swapping out the cuprite driver for selenium in order to be able to bump axe-core-api to v4.4.2. It looks like the intent of `Ferrum::Browser.new(process_timeout: 240, timeout: 240)` was to apply these options to the system tests.