### PR TITLE
Removing deprecated HiddenTextExpander

### DIFF
--- a/.changeset/hungry-shrimps-burn.md
+++ b/.changeset/hungry-shrimps-burn.md
@@ -2,4 +2,4 @@
 "@primer/view-components": patch
 ---
 
-Removing deprecated Primer::HiddenTextExpander
+Removing the deprecated Primer::HiddenTextExpander component.

--- a/.changeset/hungry-shrimps-burn.md
+++ b/.changeset/hungry-shrimps-burn.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing deprecated Primer::HiddenTextExpander

--- a/app/components/primer/hidden_text_expander.rb
+++ b/app/components/primer/hidden_text_expander.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class HiddenTextExpander < Primer::Alpha::HiddenTextExpander
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -14,7 +14,6 @@ module Primer
       "Primer::DetailsComponent" => "Primer::Beta::Details",
       "Primer::DropdownMenuComponent" => nil,
       "Primer::HeadingComponent" => "Primer::Beta::Heading",
-      "Primer::HiddenTextExpander" => "Primer::Alpha::HiddenTextExpander",
       "Primer::IconButton" => "Primer::Beta::IconButton",
       "Primer::Tooltip" => "Primer::Alpha::Tooltip"
     }.freeze

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -62,7 +62,6 @@
   "Primer::DropdownMenuComponent": "",
   "Primer::HeadingComponent": "",
   "Primer::HellipButton": "",
-  "Primer::HiddenTextExpander": "",
   "Primer::IconButton": "",
   "Primer::Image": "",
   "Primer::ImageCrop": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -675,8 +675,6 @@
   },
   "Primer::HellipButton": {
   },
-  "Primer::HiddenTextExpander": {
-  },
   "Primer::IconButton": {
     "DEFAULT_SCHEME": "default",
     "SCHEME_MAPPINGS": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -62,7 +62,6 @@
   "Primer::DropdownMenuComponent": "deprecated",
   "Primer::HeadingComponent": "deprecated",
   "Primer::HellipButton": "alpha",
-  "Primer::HiddenTextExpander": "deprecated",
   "Primer::IconButton": "deprecated",
   "Primer::Image": "alpha",
   "Primer::ImageCrop": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -106,7 +106,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Alpha::ActionList::Item",
       "Primer::Alpha::ActionList::Separator",
       "Primer::Alpha::NavList::Section",
-      "Primer::HiddenTextExpander",
       "Primer::HeadingComponent",
       "Primer::CloseButton",
       "Primer::CounterComponent",


### PR DESCRIPTION
Removing the deprecated `HiddenTextExpander` component. All of the use cases have been migrated: 

https://github.com/search?q=repo%3Agithub%2Fgithub+%22Primer%3A%3AHiddenTextExpander%22&type=code