### PR TITLE
Removing Primer::DetailsComponent

### DIFF
--- a/.changeset/violet-houses-visit.md
+++ b/.changeset/violet-houses-visit.md
@@ -2,4 +2,4 @@
 "@primer/view-components": patch
 ---
 
-Removing Primer::DetailsComponent
+Removing the deprecated Primer::DetailsComponent component.

--- a/.changeset/violet-houses-visit.md
+++ b/.changeset/violet-houses-visit.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing Primer::DetailsComponent

--- a/app/components/primer/details_component.rb
+++ b/app/components/primer/details_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class DetailsComponent < Primer::Beta::Details
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -11,7 +11,6 @@ module Primer
       "Primer::BoxComponent" => "Primer::Box",
       "Primer::CloseButton" => "Primer::Beta::CloseButton",
       "Primer::CounterComponent" => "Primer::Beta::Counter",
-      "Primer::DetailsComponent" => "Primer::Beta::Details",
       "Primer::DropdownMenuComponent" => nil,
       "Primer::HeadingComponent" => "Primer::Beta::Heading",
       "Primer::HiddenTextExpander" => "Primer::Alpha::HiddenTextExpander",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -55,7 +55,6 @@
   "Primer::ConditionalWrapper": "",
   "Primer::Content": "",
   "Primer::CounterComponent": "",
-  "Primer::DetailsComponent": "",
   "Primer::Dropdown": "",
   "Primer::Dropdown::Menu": "",
   "Primer::Dropdown::Menu::Item": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -616,8 +616,6 @@
   },
   "Primer::CounterComponent": {
   },
-  "Primer::DetailsComponent": {
-  },
   "Primer::Dropdown": {
     "Menu": "Primer::Dropdown::Menu"
   },

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -55,7 +55,6 @@
   "Primer::ConditionalWrapper": "alpha",
   "Primer::Content": "stable",
   "Primer::CounterComponent": "deprecated",
-  "Primer::DetailsComponent": "deprecated",
   "Primer::Dropdown": "alpha",
   "Primer::Dropdown::Menu": "alpha",
   "Primer::Dropdown::Menu::Item": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -110,7 +110,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::HeadingComponent",
       "Primer::CloseButton",
       "Primer::CounterComponent",
-      "Primer::DetailsComponent",
       "Primer::Component",
       "Primer::OcticonsSymbolComponent",
       "Primer::Content",


### PR DESCRIPTION
This removes the `Primer::DetailsComponent` class. It is safe to merge when https://github.com/github/github/pull/241205 is merged.