### PR TITLE
Removing deprecated Primer::CloseButton

### DIFF
--- a/.changeset/soft-horses-compare.md
+++ b/.changeset/soft-horses-compare.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing the deprecated Primer::CloseButton component.

--- a/app/components/primer/close_button.rb
+++ b/app/components/primer/close_button.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class CloseButton < Primer::Beta::CloseButton
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -9,7 +9,6 @@ module Primer
       "Primer::Alpha::AutoComplete::Item" => "Primer::Beta::AutoComplete::Item",
       "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
       "Primer::BoxComponent" => "Primer::Box",
-      "Primer::CloseButton" => "Primer::Beta::CloseButton",
       "Primer::CounterComponent" => "Primer::Beta::Counter",
       "Primer::DetailsComponent" => "Primer::Beta::Details",
       "Primer::DropdownMenuComponent" => nil,

--- a/lib/primer/view_components/linters/close_button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/close_button_component_migration_counter.rb
@@ -14,7 +14,7 @@ module ERBLint
 
       TAGS = %w[button].freeze
       CLASSES = %w[close-button].freeze
-      MESSAGE = "We are migrating close-button to use [Primer::Beta::CloseButton](https://primer.style/view-components/components/closebutton), please try to use that instead of raw HTML."
+      MESSAGE = "We are migrating close-button to use [Primer::Beta::CloseButton](https://primer.style/view-components/components/beta/closebutton), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::CloseButton
       COMPONENT = "Primer::Beta::CloseButton"
 

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -51,7 +51,6 @@
   "Primer::BoxComponent": "",
   "Primer::ButtonComponent": "",
   "Primer::ClipboardCopy": "",
-  "Primer::CloseButton": "",
   "Primer::ConditionalWrapper": "",
   "Primer::Content": "",
   "Primer::CounterComponent": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -608,8 +608,6 @@
   },
   "Primer::ClipboardCopy": {
   },
-  "Primer::CloseButton": {
-  },
   "Primer::ConditionalWrapper": {
   },
   "Primer::Content": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -51,7 +51,6 @@
   "Primer::BoxComponent": "deprecated",
   "Primer::ButtonComponent": "beta",
   "Primer::ClipboardCopy": "beta",
-  "Primer::CloseButton": "deprecated",
   "Primer::ConditionalWrapper": "alpha",
   "Primer::Content": "stable",
   "Primer::CounterComponent": "deprecated",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -108,7 +108,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Alpha::NavList::Section",
       "Primer::HiddenTextExpander",
       "Primer::HeadingComponent",
-      "Primer::CloseButton",
       "Primer::CounterComponent",
       "Primer::DetailsComponent",
       "Primer::Component",


### PR DESCRIPTION
This removes the deprecated `Primer::CloseButton` component. It should be safe to ship when https://github.com/github/github/pull/241204 is merged