### PR TITLE
Run script with bash

### DIFF
--- a/script/dev
+++ b/script/dev
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if ! command -v overmind &> /dev/null
 then


### PR DESCRIPTION
`pushd` and `popd` exist in `bash` but not in `sh`. `script/dev` therefor errors on my codespace but this patch fixes that issue.