### PR TITLE
Removing view_component/engine

### DIFF
--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -5,7 +5,6 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "view_component/engine"
 require "primer/view_components/engine"
 
 # Require the gems listed in Gemfile, including any gems

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -5,7 +5,6 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
-require "view_component/engine" unless Rails.version.to_i >= 7
 require "primer/view_components/engine"
 
 # Require the gems listed in Gemfile, including any gems

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -5,6 +5,7 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
+require "view_component"
 require "primer/view_components/engine"
 
 # Require the gems listed in Gemfile, including any gems

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -5,6 +5,7 @@ require_relative "boot"
 require "action_controller/railtie"
 require "action_view/railtie"
 require "sprockets/railtie"
+require "view_component/engine" unless Rails.version.to_i >= 7
 require "primer/view_components/engine"
 
 # Require the gems listed in Gemfile, including any gems


### PR DESCRIPTION
This removes the deprecated `require "view_component/engine"` call, since it'll be removed in 3.0.0

```
DEPRECATION WARNING: Manually loading the engine is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`.
```