### PR TITLE
Upgrades to our PostCSS build toolkit

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,7 @@
+# Supported Browsers: https://docs.github.com/articles/supported-browsers/
+
+last 10 Chrome versions
+last 10 Edge versions
+last 10 Firefox versions
+last 3 Safari major versions
+Firefox ESR

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": ["stylelint-config-standard", "stylelint-config-prettier"],
+  "ignoreFiles": ["app/**/*.css", "**/*.js", "**/*.ts"],
   "rules": {
     "custom-property-pattern": null,
     "selector-class-pattern": null,

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,11 +10,10 @@ module.exports = {
         mixinsDir: path.join(__dirname, './lib/postcss_mixins/')
     }),
     require('postcss-preset-env')({
-      stage: 3,
-      // https://preset-env.cssdb.org/
+      stage: 2,
+      // https://preset-env.cssdb.org/features/#stage-2
       features: {
-        'nesting-rules': true,
-        'has-pseudo-class': true
+        'nesting-rules': true
       }
     }),
     require('cssnano'),


### PR DESCRIPTION
This PR pulls a few of the upgrades out of https://github.com/primer/view_components/pull/1453 that are generally good.

- Adding a `.browserslistrc` file (copied from dotcom) to make sure we're autoprefixing for the correct browsers.
- In stylelint ignore any files that aren't `*.pcss` so vscode doesn't give random warnings in non-css files.
- Changing the preset-env stage to `stage: 2` https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env#stage this is the default and has more features turned on.