### PR TITLE
Only register click handler once

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,0 @@
-# Supported Browsers: https://docs.github.com/articles/supported-browsers/
-
-last 10 Chrome versions
-last 10 Edge versions
-last 10 Firefox versions
-last 3 Safari major versions
-Firefox ESR

--- a/.changeset/eight-ads-kneel.md
+++ b/.changeset/eight-ads-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix nested dialogs

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,7 +33,8 @@
       "extends": [
         "plugin:@typescript-eslint/recommended",
         "plugin:github/recommended",
-        "plugin:github/browser"
+        "plugin:github/browser",
+        "plugin:github/typescript"
       ],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -1,17 +1,64 @@
 import {focusTrap} from '@primer/behaviors'
 import {getFocusableChild} from '@primer/behaviors/utils'
 
-function focusIfNeeded(elem?: HTMLElement) {
+function focusIfNeeded(elem: HTMLElement | undefined | null) {
   if (document.activeElement !== elem) {
     elem?.focus()
+  }
+}
+
+const overlayStack: ModalDialogElement[] = []
+
+function clickHandler(event: Event) {
+  const target = event.target as HTMLElement
+  const button = target?.closest('button')
+
+  // If the user is clicking a valid dialog trigger
+  let dialogId = target.getAttribute('data-show-dialog-id')
+  if (target instanceof HTMLButtonElement && dialogId) {
+    event.stopPropagation()
+    const dialog = document.querySelector<ModalDialogElement>(`#${dialogId}`)
+    if (dialog) {
+      dialog.openButton = button
+      dialog.show()
+      return
+    }
+  }
+
+  // Find the top level dialog that is open.
+  const topLevelDialog = overlayStack[overlayStack.length - 1]
+  if (!topLevelDialog) return
+
+  // Check if the click happened outside the boundary of the top level dialog
+  const clickOutsideDialog = !target.closest(`#${topLevelDialog.getAttribute('id')}`)
+
+  // Only close dialog if it's a click outside the dialog and the dialog has a
+  // button?
+  if (!button) {
+    if (clickOutsideDialog) {
+      overlayStack.pop()
+      topLevelDialog.close()
+    }
+    return
+  }
+
+  dialogId = button.getAttribute('data-close-dialog-id')
+  if (dialogId === topLevelDialog.id) {
+    overlayStack.pop()
+    topLevelDialog.close()
+  }
+
+  dialogId = button.getAttribute('data-submit-dialog-id')
+  if (dialogId === topLevelDialog.id) {
+    overlayStack.pop()
+    topLevelDialog.close(true)
   }
 }
 
 export class ModalDialogElement extends HTMLElement {
   //TODO: Do we remove the abortController from focusTrap?
   #focusAbortController = new AbortController()
-  #abortController: AbortController | null = null
-  #openButton: HTMLButtonElement | undefined
+  openButton: HTMLButtonElement | null
 
   get open() {
     return this.hasAttribute('open')
@@ -26,6 +73,7 @@ export class ModalDialogElement extends HTMLElement {
         this.#focusAbortController = new AbortController()
       }
       focusTrap(this, undefined, this.#focusAbortController.signal)
+      overlayStack.push(this)
     } else {
       if (!this.open) return
       this.removeAttribute('open')
@@ -34,13 +82,13 @@ export class ModalDialogElement extends HTMLElement {
       this.#focusAbortController.abort()
       // if #openButton is a child of a menu, we need to focus a suitable child of the menu
       // element since it is expected for the menu to close on click
-      const menu = this.#openButton?.closest('details') || this.#openButton?.closest('action-menu')
+      const menu = this.openButton?.closest('details') || this.openButton?.closest('action-menu')
       if (menu) {
         focusIfNeeded(getFocusableChild(menu))
       } else {
-        focusIfNeeded(this.#openButton)
+        focusIfNeeded(this.openButton)
       }
-      this.#openButton = undefined
+      this.openButton = null
     }
   }
 
@@ -60,48 +108,9 @@ export class ModalDialogElement extends HTMLElement {
   connectedCallback(): void {
     if (!this.hasAttribute('role')) this.setAttribute('role', 'dialog')
 
-    const {signal} = (this.#abortController = new AbortController())
-
-    this.ownerDocument.addEventListener(
-      'click',
-      event => {
-        const target = event.target as HTMLElement
-        const clickOutsideDialog = !target.closest(`#${this.getAttribute('id')}`)
-        const button = target?.closest('button')
-        // go over this logic:
-        if (!button) {
-          if (clickOutsideDialog) {
-            // This click is outside the dialog
-            this.close()
-          }
-          return
-        }
-
-        let dialogId = button.getAttribute('data-close-dialog-id')
-        if (dialogId === this.id) {
-          this.close()
-        }
-
-        dialogId = button.getAttribute('data-submit-dialog-id')
-        if (dialogId === this.id) {
-          this.close(true)
-        }
-
-        dialogId = button.getAttribute('data-show-dialog-id')
-        if (dialogId === this.id) {
-          event.stopPropagation()
-          this.#openButton = button
-          this.show()
-        }
-      },
-      {signal}
-    )
+    document.addEventListener('click', clickHandler)
 
     this.addEventListener('keydown', e => this.#keydown(e))
-  }
-
-  disconnectedCallback(): void {
-    this.#abortController?.abort()
   }
 
   show() {

--- a/app/components/primer/alpha/nav_list.ts
+++ b/app/components/primer/alpha/nav_list.ts
@@ -60,10 +60,10 @@ class NavListElement extends HTMLElement {
 
   // expand/collapse item
   handleItemWithSubItemClick(e: Event) {
-    const target = e.target
-    if (!(target instanceof HTMLElement)) return
+    const el = e.target
+    if (!(el instanceof HTMLElement)) return
 
-    const button = target.closest<HTMLButtonElement>('button')
+    const button = el.closest<HTMLButtonElement>('button')
     if (!button) return
     if (this.itemIsExpanded(button)) {
       this.collapseItem(button)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.6",
         "@changesets/cli": "^2.24.1",
+        "@github/browserslist-config": "^1.0.0",
         "@github/prettier-config": "0.0.4",
         "@primer/css": "20.4.6",
         "@primer/primitives": "^7.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "cssnano": "^5.1.13",
         "eslint": "^8.23.1",
         "eslint-plugin-custom-elements": "^0.0.6",
-        "eslint-plugin-github": "^4.3.7",
+        "eslint-plugin-github": "^4.4.0",
         "eslint-plugin-prettier": "^4.2.1",
         "markdownlint-cli": "^0.32.2",
         "mocha": "^10.0.0",
@@ -761,6 +761,12 @@
       "dependencies": {
         "@github/combobox-nav": "^2.0.2"
       }
+    },
+    "node_modules/@github/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gIhjdJp/c2beaIWWIlsXdqXVRUz3r2BxBCpfz/F3JXHvSAQ1paMYjLH+maEATtENg+k5eLV7gA+9yPp762ieuw==",
+      "dev": true
     },
     "node_modules/@github/catalyst": {
       "version": "1.6.0",
@@ -3197,11 +3203,10 @@
       }
     },
     "node_modules/eslint-plugin-escompat": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.2.0.tgz",
-      "integrity": "sha512-obXAKKiZE/wB2fgIw0ZxCmp+8vpDsUw2inkaok1i7OVxY4cEds4Y9YCoky0f5V+q8rqZpTUJDv1R9ykWbXLX8Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.3.3.tgz",
+      "integrity": "sha512-rB3t15s0d504y3kwHotSt3wkFQG/dhS6SS5DIKL86mPILzoMcYeFN+hWim+Au7nvXGtkR1dOuq2sU5qKlOKhkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.21.0"
       },
@@ -3246,22 +3251,22 @@
       }
     },
     "node_modules/eslint-plugin-github": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.3.7.tgz",
-      "integrity": "sha512-tYZdXvAEz4JCMrC4NHIUoJTsLUvydCxff5OqB5hgU0vQbLmMkw6VOipN2KNe+T06pEhAWs1KBEwyq9cmMWRe7A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.4.0.tgz",
+      "integrity": "sha512-jmVjy86WqVblKuvWnAQAEUMPZnAWbOUuV2hmAjQ54BvmukUW5PBml84NnyKe1QMt6k5a6JoIrbkLkyISTUDSxA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
+        "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "eslint-config-prettier": ">=8.0.0",
-        "eslint-plugin-escompat": "^3.1.0",
+        "eslint-plugin-escompat": "^3.3.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jsx-a11y": "^6.6.0",
-        "eslint-plugin-no-only-tests": "^2.6.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-rule-documentation": ">=1.0.0",
         "jsx-ast-utils": "^3.3.2",
@@ -3420,13 +3425,12 @@
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
-      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.0.0.tgz",
+      "integrity": "sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=5.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -9821,6 +9825,12 @@
         "@github/combobox-nav": "^2.0.2"
       }
     },
+    "@github/browserslist-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@github/browserslist-config/-/browserslist-config-1.0.0.tgz",
+      "integrity": "sha512-gIhjdJp/c2beaIWWIlsXdqXVRUz3r2BxBCpfz/F3JXHvSAQ1paMYjLH+maEATtENg+k5eLV7gA+9yPp762ieuw==",
+      "dev": true
+    },
     "@github/catalyst": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
@@ -11561,9 +11571,9 @@
       "requires": {}
     },
     "eslint-plugin-escompat": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.2.0.tgz",
-      "integrity": "sha512-obXAKKiZE/wB2fgIw0ZxCmp+8vpDsUw2inkaok1i7OVxY4cEds4Y9YCoky0f5V+q8rqZpTUJDv1R9ykWbXLX8Q==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-escompat/-/eslint-plugin-escompat-3.3.3.tgz",
+      "integrity": "sha512-rB3t15s0d504y3kwHotSt3wkFQG/dhS6SS5DIKL86mPILzoMcYeFN+hWim+Au7nvXGtkR1dOuq2sU5qKlOKhkA==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.0"
@@ -11592,21 +11602,22 @@
       }
     },
     "eslint-plugin-github": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.3.7.tgz",
-      "integrity": "sha512-tYZdXvAEz4JCMrC4NHIUoJTsLUvydCxff5OqB5hgU0vQbLmMkw6VOipN2KNe+T06pEhAWs1KBEwyq9cmMWRe7A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-github/-/eslint-plugin-github-4.4.0.tgz",
+      "integrity": "sha512-jmVjy86WqVblKuvWnAQAEUMPZnAWbOUuV2hmAjQ54BvmukUW5PBml84NnyKe1QMt6k5a6JoIrbkLkyISTUDSxA==",
       "dev": true,
       "requires": {
+        "@github/browserslist-config": "^1.0.0",
         "@typescript-eslint/eslint-plugin": "^5.1.0",
         "@typescript-eslint/parser": "^5.1.0",
         "eslint-config-prettier": ">=8.0.0",
-        "eslint-plugin-escompat": "^3.1.0",
+        "eslint-plugin-escompat": "^3.3.3",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-i18n-text": "^1.0.1",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-jsx-a11y": "^6.6.0",
-        "eslint-plugin-no-only-tests": "^2.6.0",
+        "eslint-plugin-no-only-tests": "^3.0.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-rule-documentation": ">=1.0.0",
         "jsx-ast-utils": "^3.3.2",
@@ -11724,9 +11735,9 @@
       }
     },
     "eslint-plugin-no-only-tests": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz",
-      "integrity": "sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.0.0.tgz",
+      "integrity": "sha512-I0PeXMs1vu21ap45hey4HQCJRqpcoIvGcNTPJe+UhUm8TwjQ6//mCrDqF8q0WS6LgmRDwQ4ovQej0AQsAHb5yg==",
       "dev": true
     },
     "eslint-plugin-prettier": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1885,9 +1885,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001377",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001377.tgz",
-      "integrity": "sha512-I5XeHI1x/mRSGl96LFOaSk528LA/yZG3m3iQgImGujjO8gotd/DL8QaI1R1h1dg5ATeI2jqPblMpKq4Tr5iKfQ==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true,
       "funding": [
         {
@@ -1898,8 +1898,7 @@
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -10579,9 +10578,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001377",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001377.tgz",
-      "integrity": "sha512-I5XeHI1x/mRSGl96LFOaSk528LA/yZG3m3iQgImGujjO8gotd/DL8QaI1R1h1dg5ATeI2jqPblMpKq4Tr5iKfQ==",
+      "version": "1.0.30001418",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz",
+      "integrity": "sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "cssnano": "^5.1.13",
     "eslint": "^8.23.1",
     "eslint-plugin-custom-elements": "^0.0.6",
-    "eslint-plugin-github": "^4.3.7",
+    "eslint-plugin-github": "^4.4.0",
     "eslint-plugin-prettier": "^4.2.1",
     "markdownlint-cli": "^0.32.2",
     "mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.24.1",
+    "@github/browserslist-config": "^1.0.0",
     "@github/prettier-config": "0.0.4",
     "@primer/css": "20.4.6",
     "@primer/primitives": "^7.9.0",
@@ -83,5 +84,6 @@
     "tslib": "^2.4.0",
     "typescript": "^4.7.4"
   },
-  "prettier": "@github/prettier-config"
+  "prettier": "@github/prettier-config",
+  "browserslist": "extends @github/browserslist-config"
 }


### PR DESCRIPTION
### Description

The `<modal-dialog>` registers a global event handler each time it connects to the DOM. We actually just want one global event handler so that we don't open or close multiple dialogs when clicking around on the page.

This PR makes sure we only register the event handler once by using a function reference instead of a inlined function for the click handler.

Closes https://github.com/primer/view_components/issues/1366 (again :)