### PR TITLE
Deploy production docs and lookbook app only when a release is created

### DIFF
--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -3,6 +3,7 @@
 name: Demo Production
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -3,9 +3,8 @@
 name: Demo Production
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -1,5 +1,6 @@
 name: Docs Production
 on:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -1,8 +1,7 @@
 name: Docs Production
 on:
-  push:
-    branches:
-      - 'main'
+  release:
+    types: [published]
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

This might be a useful change because it will keep our docs/lookbooks pinned to the previous release. This could help any confusion caused by unreleased docs making their way into the site.

However there might be emergencies where we would need to deploy the site manually. For that I'm adding a `workflow_dispatch` trigger which will allow us to deploy at the click of a button. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

### Integration

> Does this change require any updates to code in production?

no

