### PR TITLE
Adding docs hero banner to PVC site

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -1,0 +1,21 @@
+import {Box, Heading, Text, ThemeProvider} from '@primer/react'
+import React from 'react'
+import {Container} from '@primer/gatsby-theme-doctocat'
+import heroIllustration from '../primer-components-hero.svg'
+import {version} from '../../../../../package.json'
+
+export default function Hero() {
+  return (
+    <ThemeProvider colorMode="night" nightScheme="dark_dimmed">
+      <Box bg="canvas.default" py={6}>
+        <Container>
+          <Heading sx={{color: 'accent.fg', fontSize: 7, lineHeight: 'condensed', pb: 3, m: 0}}>Primer ViewComponents</Heading>
+          <Text as="p" fontFamily="mono" mt={0} mb={2} color="fg.default" fontSize={2}>
+            v{version}
+          </Text>
+          <img src={heroIllustration} alt="" width="100%" />
+        </Container>
+      </Box>
+    </ThemeProvider>
+  )
+}

--- a/docs/src/@primer/gatsby-theme-doctocat/primer-components-hero.svg
+++ b/docs/src/@primer/gatsby-theme-doctocat/primer-components-hero.svg
@@ -1,0 +1,1411 @@
+<svg width="1068" height="426" viewBox="0 0 1068 426" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0)">
+<rect width="276" height="276" transform="translate(782 77)" fill="#22272e"/>
+<g clip-path="url(#clip1)">
+<circle cx="828" cy="279" r="2" fill="#044289"/>
+<circle cx="840" cy="279" r="2" fill="#044289"/>
+<circle cx="852" cy="279" r="2" fill="#044289"/>
+<circle cx="864" cy="279" r="2" fill="#044289"/>
+<circle cx="876" cy="279" r="2" fill="#044289"/>
+<circle cx="828" cy="291" r="2" fill="#044289"/>
+<circle cx="840" cy="291" r="2" fill="#044289"/>
+<circle cx="852" cy="291" r="2" fill="#044289"/>
+<circle cx="864" cy="291" r="2" fill="#044289"/>
+<circle cx="876" cy="291" r="2" fill="#044289"/>
+<circle cx="828" cy="303" r="2" fill="#044289"/>
+<circle cx="840" cy="303" r="2" fill="#044289"/>
+<circle cx="852" cy="303" r="2" fill="#044289"/>
+<circle cx="864" cy="303" r="2" fill="#044289"/>
+<circle cx="876" cy="303" r="2" fill="#044289"/>
+<circle cx="816" cy="279" r="2" fill="#044289"/>
+<circle cx="816" cy="291" r="2" fill="#044289"/>
+<circle cx="816" cy="303" r="2" fill="#044289"/>
+<circle cx="828" cy="315" r="2" fill="#044289"/>
+<circle cx="840" cy="315" r="2" fill="#044289"/>
+<circle cx="852" cy="315" r="2" fill="#044289"/>
+<circle cx="864" cy="315" r="2" fill="#044289"/>
+<circle cx="876" cy="315" r="2" fill="#044289"/>
+<circle cx="816" cy="315" r="2" fill="#044289"/>
+<circle cx="828" cy="327" r="2" fill="#044289"/>
+<circle cx="840" cy="327" r="2" fill="#044289"/>
+<circle cx="852" cy="327" r="2" fill="#044289"/>
+<circle cx="864" cy="327" r="2" fill="#044289"/>
+<circle cx="876" cy="327" r="2" fill="#044289"/>
+<circle cx="816" cy="327" r="2" fill="#044289"/>
+<circle cx="828" cy="339" r="2" fill="#044289"/>
+<circle cx="840" cy="339" r="2" fill="#044289"/>
+<circle cx="852" cy="339" r="2" fill="#044289"/>
+<circle cx="864" cy="339" r="2" fill="#044289"/>
+<circle cx="876" cy="339" r="2" fill="#044289"/>
+<circle cx="816" cy="339" r="2" fill="#044289"/>
+<circle cx="828" cy="351" r="2" fill="#044289"/>
+<circle cx="840" cy="351" r="2" fill="#044289"/>
+<circle cx="852" cy="351" r="2" fill="#044289"/>
+<circle cx="864" cy="351" r="2" fill="#044289"/>
+<circle cx="876" cy="351" r="2" fill="#044289"/>
+<circle cx="816" cy="351" r="2" fill="#044289"/>
+<circle cx="888" cy="279" r="2" fill="#044289"/>
+<circle cx="888" cy="291" r="2" fill="#044289"/>
+<circle cx="888" cy="303" r="2" fill="#044289"/>
+<circle cx="888" cy="315" r="2" fill="#044289"/>
+<circle cx="888" cy="327" r="2" fill="#044289"/>
+<circle cx="888" cy="339" r="2" fill="#044289"/>
+<circle cx="888" cy="351" r="2" fill="#044289"/>
+<circle cx="900" cy="279" r="2" fill="#044289"/>
+<circle cx="900" cy="291" r="2" fill="#044289"/>
+<circle cx="900" cy="303" r="2" fill="#044289"/>
+<circle cx="900" cy="315" r="2" fill="#044289"/>
+<circle cx="900" cy="327" r="2" fill="#044289"/>
+<circle cx="900" cy="339" r="2" fill="#044289"/>
+<circle cx="900" cy="351" r="2" fill="#044289"/>
+<circle cx="912" cy="279" r="2" fill="#044289"/>
+<circle cx="912" cy="291" r="2" fill="#044289"/>
+<circle cx="912" cy="303" r="2" fill="#044289"/>
+<circle cx="912" cy="315" r="2" fill="#044289"/>
+<circle cx="912" cy="327" r="2" fill="#044289"/>
+<circle cx="912" cy="339" r="2" fill="#044289"/>
+<circle cx="912" cy="351" r="2" fill="#044289"/>
+<circle cx="924" cy="279" r="2" fill="#044289"/>
+<circle cx="924" cy="291" r="2" fill="#044289"/>
+<circle cx="924" cy="303" r="2" fill="#044289"/>
+<circle cx="924" cy="315" r="2" fill="#044289"/>
+<circle cx="924" cy="327" r="2" fill="#044289"/>
+<circle cx="924" cy="339" r="2" fill="#044289"/>
+<circle cx="924" cy="351" r="2" fill="#044289"/>
+<circle cx="936" cy="279" r="2" fill="#044289"/>
+<circle cx="936" cy="291" r="2" fill="#044289"/>
+<circle cx="936" cy="303" r="2" fill="#044289"/>
+<circle cx="936" cy="315" r="2" fill="#044289"/>
+<circle cx="936" cy="327" r="2" fill="#044289"/>
+<circle cx="936" cy="339" r="2" fill="#044289"/>
+<circle cx="936" cy="351" r="2" fill="#044289"/>
+<circle cx="948" cy="279" r="2" fill="#044289"/>
+<circle cx="948" cy="291" r="2" fill="#044289"/>
+<circle cx="948" cy="303" r="2" fill="#044289"/>
+<circle cx="948" cy="315" r="2" fill="#044289"/>
+<circle cx="948" cy="327" r="2" fill="#044289"/>
+<circle cx="948" cy="339" r="2" fill="#044289"/>
+<circle cx="948" cy="351" r="2" fill="#044289"/>
+<circle cx="960" cy="279" r="2" fill="#044289"/>
+<circle cx="972" cy="279" r="2" fill="#044289"/>
+<circle cx="972" cy="291" r="2" fill="#044289"/>
+<circle cx="972" cy="303" r="2" fill="#044289"/>
+<circle cx="972" cy="315" r="2" fill="#044289"/>
+<circle cx="972" cy="327" r="2" fill="#044289"/>
+<circle cx="972" cy="339" r="2" fill="#044289"/>
+<circle cx="972" cy="351" r="2" fill="#044289"/>
+<circle cx="960" cy="291" r="2" fill="#044289"/>
+<circle cx="960" cy="303" r="2" fill="#044289"/>
+<circle cx="960" cy="315" r="2" fill="#044289"/>
+<circle cx="960" cy="327" r="2" fill="#044289"/>
+<circle cx="960" cy="339" r="2" fill="#044289"/>
+<circle cx="960" cy="351" r="2" fill="#044289"/>
+<circle cx="996" cy="279" r="2" fill="#044289"/>
+<circle cx="1008" cy="279" r="2" fill="#044289"/>
+<circle cx="1020" cy="279" r="2" fill="#044289"/>
+<circle cx="1032" cy="279" r="2" fill="#044289"/>
+<circle cx="1044" cy="279" r="2" fill="#044289"/>
+<circle cx="996" cy="291" r="2" fill="#044289"/>
+<circle cx="1008" cy="291" r="2" fill="#044289"/>
+<circle cx="1020" cy="291" r="2" fill="#044289"/>
+<circle cx="1032" cy="291" r="2" fill="#044289"/>
+<circle cx="1044" cy="291" r="2" fill="#044289"/>
+<circle cx="996" cy="303" r="2" fill="#044289"/>
+<circle cx="1008" cy="303" r="2" fill="#044289"/>
+<circle cx="1020" cy="303" r="2" fill="#044289"/>
+<circle cx="1032" cy="303" r="2" fill="#044289"/>
+<circle cx="1044" cy="303" r="2" fill="#044289"/>
+<circle cx="984" cy="279" r="2" fill="#044289"/>
+<circle cx="984" cy="291" r="2" fill="#044289"/>
+<circle cx="984" cy="303" r="2" fill="#044289"/>
+<circle cx="996" cy="315" r="2" fill="#044289"/>
+<circle cx="1008" cy="315" r="2" fill="#044289"/>
+<circle cx="1020" cy="315" r="2" fill="#044289"/>
+<circle cx="1032" cy="315" r="2" fill="#044289"/>
+<circle cx="1044" cy="315" r="2" fill="#044289"/>
+<circle cx="984" cy="315" r="2" fill="#044289"/>
+<circle cx="996" cy="327" r="2" fill="#044289"/>
+<circle cx="1008" cy="327" r="2" fill="#044289"/>
+<circle cx="1020" cy="327" r="2" fill="#044289"/>
+<circle cx="1032" cy="327" r="2" fill="#044289"/>
+<circle cx="1044" cy="327" r="2" fill="#044289"/>
+<circle cx="984" cy="327" r="2" fill="#044289"/>
+<circle cx="996" cy="339" r="2" fill="#044289"/>
+<circle cx="1008" cy="339" r="2" fill="#044289"/>
+<circle cx="1020" cy="339" r="2" fill="#044289"/>
+<circle cx="1032" cy="339" r="2" fill="#044289"/>
+<circle cx="1044" cy="339" r="2" fill="#044289"/>
+<circle cx="984" cy="339" r="2" fill="#044289"/>
+<circle cx="996" cy="351" r="2" fill="#044289"/>
+<circle cx="1008" cy="351" r="2" fill="#044289"/>
+<circle cx="1020" cy="351" r="2" fill="#044289"/>
+<circle cx="1032" cy="351" r="2" fill="#044289"/>
+<circle cx="1044" cy="351" r="2" fill="#044289"/>
+<circle cx="984" cy="351" r="2" fill="#044289"/>
+<circle cx="1056" cy="279" r="2" fill="#044289"/>
+<circle cx="1056" cy="291" r="2" fill="#044289"/>
+<circle cx="1056" cy="303" r="2" fill="#044289"/>
+<circle cx="1056" cy="315" r="2" fill="#044289"/>
+<circle cx="1056" cy="327" r="2" fill="#044289"/>
+<circle cx="1056" cy="339" r="2" fill="#044289"/>
+<circle cx="1056" cy="351" r="2" fill="#044289"/>
+<circle cx="828" cy="111" r="2" fill="#044289"/>
+<circle cx="840" cy="111" r="2" fill="#044289"/>
+<circle cx="852" cy="111" r="2" fill="#044289"/>
+<circle cx="864" cy="111" r="2" fill="#044289"/>
+<circle cx="876" cy="111" r="2" fill="#044289"/>
+<circle cx="828" cy="123" r="2" fill="#044289"/>
+<circle cx="840" cy="123" r="2" fill="#044289"/>
+<circle cx="852" cy="123" r="2" fill="#044289"/>
+<circle cx="864" cy="123" r="2" fill="#044289"/>
+<circle cx="876" cy="123" r="2" fill="#044289"/>
+<circle cx="828" cy="135" r="2" fill="#044289"/>
+<circle cx="840" cy="135" r="2" fill="#044289"/>
+<circle cx="852" cy="135" r="2" fill="#044289"/>
+<circle cx="864" cy="135" r="2" fill="#044289"/>
+<circle cx="876" cy="135" r="2" fill="#044289"/>
+<circle cx="816" cy="111" r="2" fill="#044289"/>
+<circle cx="816" cy="123" r="2" fill="#044289"/>
+<circle cx="816" cy="135" r="2" fill="#044289"/>
+<circle cx="828" cy="147" r="2" fill="#044289"/>
+<circle cx="840" cy="147" r="2" fill="#044289"/>
+<circle cx="852" cy="147" r="2" fill="#044289"/>
+<circle cx="864" cy="147" r="2" fill="#044289"/>
+<circle cx="876" cy="147" r="2" fill="#044289"/>
+<circle cx="816" cy="147" r="2" fill="#044289"/>
+<circle cx="828" cy="159" r="2" fill="#044289"/>
+<circle cx="840" cy="159" r="2" fill="#044289"/>
+<circle cx="852" cy="159" r="2" fill="#044289"/>
+<circle cx="864" cy="159" r="2" fill="#044289"/>
+<circle cx="876" cy="159" r="2" fill="#044289"/>
+<circle cx="816" cy="159" r="2" fill="#044289"/>
+<circle cx="828" cy="171" r="2" fill="#044289"/>
+<circle cx="840" cy="171" r="2" fill="#044289"/>
+<circle cx="852" cy="171" r="2" fill="#044289"/>
+<circle cx="864" cy="171" r="2" fill="#044289"/>
+<circle cx="876" cy="171" r="2" fill="#044289"/>
+<circle cx="816" cy="171" r="2" fill="#044289"/>
+<circle cx="828" cy="183" r="2" fill="#044289"/>
+<circle cx="840" cy="183" r="2" fill="#044289"/>
+<circle cx="852" cy="183" r="2" fill="#044289"/>
+<circle cx="864" cy="183" r="2" fill="#044289"/>
+<circle cx="876" cy="183" r="2" fill="#044289"/>
+<circle cx="816" cy="183" r="2" fill="#044289"/>
+<circle cx="828" cy="195" r="2" fill="#044289"/>
+<circle cx="840" cy="195" r="2" fill="#044289"/>
+<circle cx="852" cy="195" r="2" fill="#044289"/>
+<circle cx="864" cy="195" r="2" fill="#044289"/>
+<circle cx="876" cy="195" r="2" fill="#044289"/>
+<circle cx="816" cy="195" r="2" fill="#044289"/>
+<circle cx="828" cy="207" r="2" fill="#044289"/>
+<circle cx="840" cy="207" r="2" fill="#044289"/>
+<circle cx="852" cy="207" r="2" fill="#044289"/>
+<circle cx="864" cy="207" r="2" fill="#044289"/>
+<circle cx="876" cy="207" r="2" fill="#044289"/>
+<circle cx="816" cy="207" r="2" fill="#044289"/>
+<circle cx="828" cy="219" r="2" fill="#044289"/>
+<circle cx="840" cy="219" r="2" fill="#044289"/>
+<circle cx="852" cy="219" r="2" fill="#044289"/>
+<circle cx="864" cy="219" r="2" fill="#044289"/>
+<circle cx="876" cy="219" r="2" fill="#044289"/>
+<circle cx="816" cy="219" r="2" fill="#044289"/>
+<circle cx="828" cy="231" r="2" fill="#044289"/>
+<circle cx="840" cy="231" r="2" fill="#044289"/>
+<circle cx="852" cy="231" r="2" fill="#044289"/>
+<circle cx="864" cy="231" r="2" fill="#044289"/>
+<circle cx="876" cy="231" r="2" fill="#044289"/>
+<circle cx="816" cy="231" r="2" fill="#044289"/>
+<circle cx="828" cy="243" r="2" fill="#044289"/>
+<circle cx="840" cy="243" r="2" fill="#044289"/>
+<circle cx="852" cy="243" r="2" fill="#044289"/>
+<circle cx="864" cy="243" r="2" fill="#044289"/>
+<circle cx="876" cy="243" r="2" fill="#044289"/>
+<circle cx="816" cy="243" r="2" fill="#044289"/>
+<circle cx="828" cy="255" r="2" fill="#044289"/>
+<circle cx="840" cy="255" r="2" fill="#044289"/>
+<circle cx="852" cy="255" r="2" fill="#044289"/>
+<circle cx="864" cy="255" r="2" fill="#044289"/>
+<circle cx="876" cy="255" r="2" fill="#044289"/>
+<circle cx="816" cy="255" r="2" fill="#044289"/>
+<circle cx="888" cy="111" r="2" fill="#044289"/>
+<circle cx="888" cy="123" r="2" fill="#044289"/>
+<circle cx="888" cy="135" r="2" fill="#044289"/>
+<circle cx="888" cy="147" r="2" fill="#044289"/>
+<circle cx="888" cy="159" r="2" fill="#044289"/>
+<circle cx="888" cy="171" r="2" fill="#044289"/>
+<circle cx="888" cy="183" r="2" fill="#044289"/>
+<circle cx="888" cy="195" r="2" fill="#044289"/>
+<circle cx="888" cy="207" r="2" fill="#044289"/>
+<circle cx="888" cy="219" r="2" fill="#044289"/>
+<circle cx="888" cy="231" r="2" fill="#044289"/>
+<circle cx="888" cy="243" r="2" fill="#044289"/>
+<circle cx="888" cy="255" r="2" fill="#044289"/>
+<circle cx="900" cy="111" r="2" fill="#044289"/>
+<circle cx="900" cy="123" r="2" fill="#044289"/>
+<circle cx="900" cy="135" r="2" fill="#044289"/>
+<circle cx="900" cy="147" r="2" fill="#044289"/>
+<circle cx="900" cy="159" r="2" fill="#044289"/>
+<circle cx="900" cy="171" r="2" fill="#044289"/>
+<circle cx="900" cy="183" r="2" fill="#044289"/>
+<circle cx="900" cy="195" r="2" fill="#044289"/>
+<circle cx="900" cy="207" r="2" fill="#044289"/>
+<circle cx="900" cy="219" r="2" fill="#044289"/>
+<circle cx="900" cy="231" r="2" fill="#044289"/>
+<circle cx="900" cy="243" r="2" fill="#044289"/>
+<circle cx="900" cy="255" r="2" fill="#044289"/>
+<circle cx="912" cy="111" r="2" fill="#044289"/>
+<circle cx="912" cy="123" r="2" fill="#044289"/>
+<circle cx="912" cy="135" r="2" fill="#044289"/>
+<circle cx="912" cy="147" r="2" fill="#044289"/>
+<circle cx="912" cy="159" r="2" fill="#044289"/>
+<circle cx="912" cy="171" r="2" fill="#044289"/>
+<circle cx="912" cy="183" r="2" fill="#044289"/>
+<circle cx="912" cy="195" r="2" fill="#044289"/>
+<circle cx="912" cy="207" r="2" fill="#044289"/>
+<circle cx="912" cy="219" r="2" fill="#044289"/>
+<circle cx="912" cy="231" r="2" fill="#044289"/>
+<circle cx="912" cy="243" r="2" fill="#044289"/>
+<circle cx="912" cy="255" r="2" fill="#044289"/>
+<circle cx="924" cy="111" r="2" fill="#044289"/>
+<circle cx="924" cy="123" r="2" fill="#044289"/>
+<circle cx="924" cy="135" r="2" fill="#044289"/>
+<circle cx="924" cy="147" r="2" fill="#044289"/>
+<circle cx="924" cy="159" r="2" fill="#044289"/>
+<circle cx="924" cy="171" r="2" fill="#044289"/>
+<circle cx="924" cy="183" r="2" fill="#044289"/>
+<circle cx="924" cy="195" r="2" fill="#044289"/>
+<circle cx="924" cy="207" r="2" fill="#044289"/>
+<circle cx="924" cy="219" r="2" fill="#044289"/>
+<circle cx="924" cy="231" r="2" fill="#044289"/>
+<circle cx="924" cy="243" r="2" fill="#044289"/>
+<circle cx="924" cy="255" r="2" fill="#044289"/>
+<circle cx="936" cy="111" r="2" fill="#044289"/>
+<circle cx="936" cy="123" r="2" fill="#044289"/>
+<circle cx="936" cy="135" r="2" fill="#044289"/>
+<circle cx="936" cy="147" r="2" fill="#044289"/>
+<circle cx="936" cy="159" r="2" fill="#044289"/>
+<circle cx="936" cy="171" r="2" fill="#044289"/>
+<circle cx="936" cy="183" r="2" fill="#044289"/>
+<circle cx="936" cy="195" r="2" fill="#044289"/>
+<circle cx="936" cy="207" r="2" fill="#044289"/>
+<circle cx="936" cy="219" r="2" fill="#044289"/>
+<circle cx="936" cy="231" r="2" fill="#044289"/>
+<circle cx="936" cy="243" r="2" fill="#044289"/>
+<circle cx="936" cy="255" r="2" fill="#044289"/>
+<circle cx="948" cy="111" r="2" fill="#044289"/>
+<circle cx="948" cy="123" r="2" fill="#044289"/>
+<circle cx="948" cy="135" r="2" fill="#044289"/>
+<circle cx="948" cy="147" r="2" fill="#044289"/>
+<circle cx="948" cy="159" r="2" fill="#044289"/>
+<circle cx="948" cy="171" r="2" fill="#044289"/>
+<circle cx="948" cy="183" r="2" fill="#044289"/>
+<circle cx="948" cy="195" r="2" fill="#044289"/>
+<circle cx="948" cy="207" r="2" fill="#044289"/>
+<circle cx="948" cy="219" r="2" fill="#044289"/>
+<circle cx="948" cy="231" r="2" fill="#044289"/>
+<circle cx="948" cy="243" r="2" fill="#044289"/>
+<circle cx="948" cy="255" r="2" fill="#044289"/>
+<circle cx="960" cy="111" r="2" fill="#044289"/>
+<circle cx="972" cy="111" r="2" fill="#044289"/>
+<circle cx="972" cy="123" r="2" fill="#044289"/>
+<circle cx="972" cy="135" r="2" fill="#044289"/>
+<circle cx="972" cy="147" r="2" fill="#044289"/>
+<circle cx="972" cy="159" r="2" fill="#044289"/>
+<circle cx="972" cy="171" r="2" fill="#044289"/>
+<circle cx="972" cy="183" r="2" fill="#044289"/>
+<circle cx="972" cy="195" r="2" fill="#044289"/>
+<circle cx="972" cy="207" r="2" fill="#044289"/>
+<circle cx="972" cy="219" r="2" fill="#044289"/>
+<circle cx="972" cy="231" r="2" fill="#044289"/>
+<circle cx="972" cy="243" r="2" fill="#044289"/>
+<circle cx="972" cy="255" r="2" fill="#044289"/>
+<circle cx="960" cy="123" r="2" fill="#044289"/>
+<circle cx="960" cy="135" r="2" fill="#044289"/>
+<circle cx="960" cy="147" r="2" fill="#044289"/>
+<circle cx="960" cy="159" r="2" fill="#044289"/>
+<circle cx="960" cy="171" r="2" fill="#044289"/>
+<circle cx="960" cy="183" r="2" fill="#044289"/>
+<circle cx="960" cy="195" r="2" fill="#044289"/>
+<circle cx="960" cy="207" r="2" fill="#044289"/>
+<circle cx="960" cy="219" r="2" fill="#044289"/>
+<circle cx="960" cy="231" r="2" fill="#044289"/>
+<circle cx="960" cy="243" r="2" fill="#044289"/>
+<circle cx="960" cy="255" r="2" fill="#044289"/>
+<circle cx="828" cy="267" r="2" fill="#044289"/>
+<circle cx="840" cy="267" r="2" fill="#044289"/>
+<circle cx="852" cy="267" r="2" fill="#044289"/>
+<circle cx="864" cy="267" r="2" fill="#044289"/>
+<circle cx="876" cy="267" r="2" fill="#044289"/>
+<circle cx="816" cy="267" r="2" fill="#044289"/>
+<circle cx="888" cy="267" r="2" fill="#044289"/>
+<circle cx="900" cy="267" r="2" fill="#044289"/>
+<circle cx="912" cy="267" r="2" fill="#044289"/>
+<circle cx="924" cy="267" r="2" fill="#044289"/>
+<circle cx="936" cy="267" r="2" fill="#044289"/>
+<circle cx="948" cy="267" r="2" fill="#044289"/>
+<circle cx="972" cy="267" r="2" fill="#044289"/>
+<circle cx="960" cy="267" r="2" fill="#044289"/>
+<circle cx="996" cy="111" r="2" fill="#044289"/>
+<circle cx="1008" cy="111" r="2" fill="#044289"/>
+<circle cx="1020" cy="111" r="2" fill="#044289"/>
+<circle cx="1032" cy="111" r="2" fill="#044289"/>
+<circle cx="1044" cy="111" r="2" fill="#044289"/>
+<circle cx="996" cy="123" r="2" fill="#044289"/>
+<circle cx="1008" cy="123" r="2" fill="#044289"/>
+<circle cx="1020" cy="123" r="2" fill="#044289"/>
+<circle cx="1032" cy="123" r="2" fill="#044289"/>
+<circle cx="1044" cy="123" r="2" fill="#044289"/>
+<circle cx="996" cy="135" r="2" fill="#044289"/>
+<circle cx="1008" cy="135" r="2" fill="#044289"/>
+<circle cx="1020" cy="135" r="2" fill="#044289"/>
+<circle cx="1032" cy="135" r="2" fill="#044289"/>
+<circle cx="1044" cy="135" r="2" fill="#044289"/>
+<circle cx="984" cy="111" r="2" fill="#044289"/>
+<circle cx="984" cy="123" r="2" fill="#044289"/>
+<circle cx="984" cy="135" r="2" fill="#044289"/>
+<circle cx="996" cy="147" r="2" fill="#044289"/>
+<circle cx="1008" cy="147" r="2" fill="#044289"/>
+<circle cx="1020" cy="147" r="2" fill="#044289"/>
+<circle cx="1032" cy="147" r="2" fill="#044289"/>
+<circle cx="1044" cy="147" r="2" fill="#044289"/>
+<circle cx="984" cy="147" r="2" fill="#044289"/>
+<circle cx="996" cy="159" r="2" fill="#044289"/>
+<circle cx="1008" cy="159" r="2" fill="#044289"/>
+<circle cx="1020" cy="159" r="2" fill="#044289"/>
+<circle cx="1032" cy="159" r="2" fill="#044289"/>
+<circle cx="1044" cy="159" r="2" fill="#044289"/>
+<circle cx="984" cy="159" r="2" fill="#044289"/>
+<circle cx="996" cy="171" r="2" fill="#044289"/>
+<circle cx="1008" cy="171" r="2" fill="#044289"/>
+<circle cx="1020" cy="171" r="2" fill="#044289"/>
+<circle cx="1032" cy="171" r="2" fill="#044289"/>
+<circle cx="1044" cy="171" r="2" fill="#044289"/>
+<circle cx="984" cy="171" r="2" fill="#044289"/>
+<circle cx="996" cy="183" r="2" fill="#044289"/>
+<circle cx="1008" cy="183" r="2" fill="#044289"/>
+<circle cx="1020" cy="183" r="2" fill="#044289"/>
+<circle cx="1032" cy="183" r="2" fill="#044289"/>
+<circle cx="1044" cy="183" r="2" fill="#044289"/>
+<circle cx="984" cy="183" r="2" fill="#044289"/>
+<circle cx="996" cy="195" r="2" fill="#044289"/>
+<circle cx="1008" cy="195" r="2" fill="#044289"/>
+<circle cx="1020" cy="195" r="2" fill="#044289"/>
+<circle cx="1032" cy="195" r="2" fill="#044289"/>
+<circle cx="1044" cy="195" r="2" fill="#044289"/>
+<circle cx="984" cy="195" r="2" fill="#044289"/>
+<circle cx="996" cy="207" r="2" fill="#044289"/>
+<circle cx="1008" cy="207" r="2" fill="#044289"/>
+<circle cx="1020" cy="207" r="2" fill="#044289"/>
+<circle cx="1032" cy="207" r="2" fill="#044289"/>
+<circle cx="1044" cy="207" r="2" fill="#044289"/>
+<circle cx="984" cy="207" r="2" fill="#044289"/>
+<circle cx="996" cy="219" r="2" fill="#044289"/>
+<circle cx="1008" cy="219" r="2" fill="#044289"/>
+<circle cx="1020" cy="219" r="2" fill="#044289"/>
+<circle cx="1032" cy="219" r="2" fill="#044289"/>
+<circle cx="1044" cy="219" r="2" fill="#044289"/>
+<circle cx="984" cy="219" r="2" fill="#044289"/>
+<circle cx="996" cy="231" r="2" fill="#044289"/>
+<circle cx="1008" cy="231" r="2" fill="#044289"/>
+<circle cx="1020" cy="231" r="2" fill="#044289"/>
+<circle cx="1032" cy="231" r="2" fill="#044289"/>
+<circle cx="1044" cy="231" r="2" fill="#044289"/>
+<circle cx="984" cy="231" r="2" fill="#044289"/>
+<circle cx="996" cy="243" r="2" fill="#044289"/>
+<circle cx="1008" cy="243" r="2" fill="#044289"/>
+<circle cx="1020" cy="243" r="2" fill="#044289"/>
+<circle cx="1032" cy="243" r="2" fill="#044289"/>
+<circle cx="1044" cy="243" r="2" fill="#044289"/>
+<circle cx="984" cy="243" r="2" fill="#044289"/>
+<circle cx="996" cy="255" r="2" fill="#044289"/>
+<circle cx="1008" cy="255" r="2" fill="#044289"/>
+<circle cx="1020" cy="255" r="2" fill="#044289"/>
+<circle cx="1032" cy="255" r="2" fill="#044289"/>
+<circle cx="1044" cy="255" r="2" fill="#044289"/>
+<circle cx="984" cy="255" r="2" fill="#044289"/>
+<circle cx="1056" cy="111" r="2" fill="#044289"/>
+<circle cx="1056" cy="123" r="2" fill="#044289"/>
+<circle cx="1056" cy="135" r="2" fill="#044289"/>
+<circle cx="1056" cy="147" r="2" fill="#044289"/>
+<circle cx="1056" cy="159" r="2" fill="#044289"/>
+<circle cx="1056" cy="171" r="2" fill="#044289"/>
+<circle cx="1056" cy="183" r="2" fill="#044289"/>
+<circle cx="1056" cy="195" r="2" fill="#044289"/>
+<circle cx="1056" cy="207" r="2" fill="#044289"/>
+<circle cx="1056" cy="219" r="2" fill="#044289"/>
+<circle cx="1056" cy="231" r="2" fill="#044289"/>
+<circle cx="1056" cy="243" r="2" fill="#044289"/>
+<circle cx="1056" cy="255" r="2" fill="#044289"/>
+<circle cx="996" cy="267" r="2" fill="#044289"/>
+<circle cx="1008" cy="267" r="2" fill="#044289"/>
+<circle cx="1020" cy="267" r="2" fill="#044289"/>
+<circle cx="1032" cy="267" r="2" fill="#044289"/>
+<circle cx="1044" cy="267" r="2" fill="#044289"/>
+<circle cx="984" cy="267" r="2" fill="#044289"/>
+<circle cx="1056" cy="267" r="2" fill="#044289"/>
+</g>
+<rect x="782.5" y="77.5" width="255" height="255" fill="#22272e" stroke="#79B8FF"/>
+</g>
+<path d="M968 10L964 16.9282H956L952 10L956 3.0718L964 3.0718L968 10Z" stroke="#2188FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<ellipse cx="58" cy="18.0541" rx="6" ry="6.01408" stroke="#2188FF" stroke-width="2"/>
+<g clip-path="url(#clip2)">
+<rect width="276" height="276" transform="matrix(-1 0 0 1 286 37)" fill="#22272e"/>
+<g clip-path="url(#clip3)">
+<circle r="2" transform="matrix(-1 0 0 1 240 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 239)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 251)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 263)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 275)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 287)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 299)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 311)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 240 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 228 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 216 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 204 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 192 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 252 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 180 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 168 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 156 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 144 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 132 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 120 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 96 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 108 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 71)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 83)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 95)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 107)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 119)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 131)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 143)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 155)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 167)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 179)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 191)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 203)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 215)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 72 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 60 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 48 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 36 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 24 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 84 227)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 12 227)" fill="#044289"/>
+</g>
+<rect x="-0.5" y="0.5" width="255" height="255" transform="matrix(-1 0 0 1 285 37)" fill="#22272e" stroke="#79B8FF"/>
+</g>
+<path d="M156 255C148 255 148 239 140 239C132 239 132 255 124 255C116 255 116 239 108 239C100 239 100 255 92 255C84 255 84 239 76 239" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M596 303.709H588L594 289.676L576 307.718H584L578 321.751L596 303.709Z" fill="#C8E1FF"/>
+<rect x="62" y="175.408" width="24" height="32.0751" fill="#044289"/>
+<rect x="118" y="175.408" width="144" height="32.0751" fill="#044289"/>
+<rect x="298" y="175.408" width="40" height="32.0751" fill="#044289"/>
+<rect x="18" y="77.1784" width="24" height="48.1127" fill="#005CC5"/>
+<rect x="66" y="77.1784" width="116" height="48.1127" fill="#005CC5"/>
+<path d="M212 138.303L207 146.983H197L192 138.303L197 129.622H207L212 138.303Z" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<rect width="16.0188" height="16.0188" transform="matrix(0.706277 0.707935 -0.706277 0.707935 215.314 348)" stroke="#C8E1FF" stroke-linejoin="round"/>
+<g clip-path="url(#clip4)">
+<rect width="276" height="276" transform="matrix(-1 0 0 1 662 139)" fill="#22272e"/>
+<g clip-path="url(#clip5)">
+<circle r="2" transform="matrix(-1 0 0 1 616 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 341)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 353)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 365)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 377)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 389)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 401)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 413)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 616 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 604 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 592 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 580 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 568 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 628 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 556 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 544 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 532 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 520 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 508 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 496 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 472 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 484 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 173)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 185)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 197)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 209)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 221)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 233)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 245)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 257)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 269)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 281)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 293)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 305)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 317)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 448 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 436 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 424 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 412 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 400 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 460 329)" fill="#044289"/>
+<circle r="2" transform="matrix(-1 0 0 1 388 329)" fill="#044289"/>
+</g>
+<rect x="-0.5" y="0.5" width="255" height="255" transform="matrix(-1 0 0 1 661 139)" fill="#22272e" stroke="#79B8FF"/>
+</g>
+<rect width="116" height="48.1127" transform="matrix(-1 0 0 1 938 125.291)" fill="#044289"/>
+<rect width="32" height="32.0751" transform="matrix(-1 0 0 1 854 189.441)" fill="#0366D6"/>
+<path d="M978 248.636L968 265.997H948L938 248.636L948 231.275H968L978 248.636Z" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M849.703 368.161L839.311 386.182L828.937 368.172L849.703 368.161Z" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M900 253C900 257 892 257 892 261C892 265 900 265 900 269C900 273 892 273 892 277C892 281 900 281 900 285C900 289 892 289 892 293" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M982 139C984 139 984.009 143 986.009 143C988.009 143 988 139 990 139C992 139 992.009 143 994.009 143C996.009 143 996 139 998 139C1000 139 1000.01 143 1002.01 143" stroke="#C8E1FF" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M151 58.1479C245 -41.0845 396.545 0.18 324.5 107C304.395 136.81 281.334 167.984 271.5 216.519C253.697 304.379 294 367.5 357 311.742C494.595 189.964 567.5 208.5 585 299.212C603.341 394.287 683.384 400.634 695 216.519C711 -37.075 1054.5 -29.5574 903 122.298" stroke="#C8E1FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M900 114.279V116.284L901.25 118.79L890 126.308H880.5C879.4 126.308 878.825 127.636 879.65 128.463L887.5 136.331L877.5 148.86L890 138.837L897.85 146.705C898.675 147.532 900 146.931 900 145.853V136.331L907.5 125.055L910 126.308H912C913.1 126.308 913.675 124.979 912.85 124.153L902.15 113.427C901.325 112.6 900 113.202 900 114.279Z" fill="#79B8FF"/>
+<ellipse rx="11.8044" ry="4.34198" transform="matrix(0.708436 -0.705746 0.704112 0.710118 363.305 305.61)" fill="#22272e"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M368.412 300.448C367.877 299.902 367.482 299.338 367.168 298.673C366.853 298.049 366.639 297.345 366.506 296.623C365.34 297.274 364.173 298.005 363.026 298.857C361.858 299.729 360.73 300.722 359.62 301.795C358.208 303.186 356.929 305.4 356.018 306.675L350.018 306.622L343.966 312.604L349.965 312.656L354 308.682C353.307 310.22 351.908 314.638 351.948 314.678L353.93 316.701C353.97 316.741 358.401 315.457 359.948 314.748L355.913 318.723L355.86 324.737L361.913 318.775L361.965 312.761C363.253 311.87 365.484 310.607 366.896 309.236C368.005 308.143 369.015 306.989 369.865 305.854C370.755 304.699 371.506 303.543 372.175 302.426C371.457 302.259 370.779 302.033 370.121 301.726C369.504 301.4 368.948 300.994 368.412 300.448ZM376.139 292.838C376.139 292.838 375.952 293.598 375.52 294.957C375.108 296.357 374.393 298.115 373.354 300.271C371.956 300.098 370.82 299.587 370.047 298.799C369.274 298.01 368.803 296.903 368.675 295.499C370.844 294.475 372.591 293.769 373.974 293.38C375.378 292.991 376.139 292.838 376.139 292.838Z" fill="#79B8FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M102 95.2348V107.263H114L146 75.1879L134 63.1597L102 95.2348ZM114 103.254H106V95.2348H110V99.2442H114V103.254ZM155.2 65.9663L150 71.1785L138 59.1503L143.2 53.9381C144.76 52.3745 147.28 52.3745 148.84 53.9381L155.2 60.3131C156.76 61.8767 156.76 64.4026 155.2 65.9663Z" fill="#79B8FF"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M700 213.498C698.06 213.498 696.62 214.34 695.6 215.502C694.58 216.665 694.04 217.347 694 217.507C693.96 217.347 693.44 216.665 692.4 215.502C691.36 214.34 690.06 213.498 688 213.498C684.736 213.67 682.093 216.169 682 219.512C682 220.554 682.18 222.559 683.34 224.864C684.5 227.17 688.02 230.758 694 235.549C699.96 230.758 703.54 227.19 704.68 224.864C705.82 222.539 706 220.514 706 219.512C705.906 216.124 703.316 213.673 700 213.498Z" fill="#79B8FF"/>
+<path d="M397.713 68.8889L383.856 92.9453L370 68.8889L397.713 68.8889Z" stroke="#2188FF" stroke-width="2" stroke-linejoin="round"/>
+<circle cx="623" cy="97" r="10" stroke="#2188FF" stroke-width="2"/>
+<circle cx="640" cy="78" r="5.5" stroke="#C8E1FF"/>
+<rect x="467" y="333.779" width="30" height="24.0563" fill="#044289"/>
+<rect x="557" y="333.779" width="30" height="24.0563" fill="#044289"/>
+<rect x="521" y="333.779" width="12" height="24.0563" fill="#044289"/>
+<rect x="436" y="283.662" width="33.0236" height="33.0934" fill="#005CC5"/>
+<rect x="496.543" y="283.662" width="88.0628" height="33.0934" fill="#005CC5"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M600.04 394C608.919 380.203 621.719 330.529 621.719 291.312C621.719 239.788 601.346 214.127 592.328 214.127C583.311 214.127 562.938 239.788 562.938 291.312C562.938 330.529 575.737 380.203 584.617 394H600.04Z" fill="#2188FF"/>
+<mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="562" y="214" width="60" height="180">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M600.04 394C608.919 380.203 621.719 330.529 621.719 291.312C621.719 239.788 601.346 214.127 592.328 214.127C583.311 214.127 562.938 239.788 562.938 291.312C562.938 330.529 575.737 380.203 584.617 394H600.04Z" fill="#005CC5"/>
+</mask>
+<g mask="url(#mask0)">
+<path d="M593.906 244.564V265.979C593.906 272.263 588.939 277.357 582.811 277.357C576.684 277.357 571.716 272.263 571.716 265.979V244.564M597.822 253.264C597.822 242.915 589.64 234.525 579.548 234.525C569.456 234.525 561.274 242.915 561.274 253.264V278.695C561.274 289.044 569.456 297.434 579.548 297.434C589.64 297.434 597.822 289.044 597.822 278.695V253.264ZM637.632 325.769C637.632 316.899 630.62 309.708 621.969 309.708H603.695C595.045 309.708 588.032 316.899 588.032 325.769V403.402C588.032 412.272 595.045 419.463 603.695 419.463H621.969C630.62 419.463 637.632 412.272 637.632 403.402V325.769ZM629.801 336.477C629.801 330.564 625.126 325.769 619.359 325.769H608.917C603.149 325.769 598.474 330.564 598.474 336.477V372.616C598.474 378.53 603.149 383.324 608.917 383.324H619.359C625.126 383.324 629.801 378.53 629.801 372.616V336.477ZM627.19 345.847C627.19 341.411 623.684 337.816 619.359 337.816H612.832C608.507 337.816 605.001 341.411 605.001 345.847V365.924C605.001 370.359 608.507 373.955 612.832 373.955H619.359C623.684 373.955 627.19 370.359 627.19 365.924V345.847Z" stroke="#C8E1FF" stroke-linejoin="round"/>
+</g>
+<path d="M617.747 254.628H566.909C573.296 227.602 585.794 214.127 592.328 214.127C598.863 214.127 611.36 227.602 617.747 254.628Z" fill="#044289"/>
+<path d="M584.258 218.617C585.887 219.495 588.892 220.083 592.328 220.083C595.765 220.083 598.769 219.495 600.399 218.617C597.345 215.623 594.505 214.127 592.328 214.127C592.328 214.127 592.328 214.127 592.328 214.127C590.151 214.127 587.312 215.623 584.258 218.617Z" fill="#032F62"/>
+<path d="M624.601 185.015C624.601 202.685 610.285 217.01 592.625 217.01C574.965 217.01 560.649 202.685 560.649 185.015C560.649 164.351 591.293 139.688 592.625 123.691C593.958 139.688 624.601 165.018 624.601 185.015Z" fill="#005CC5" stroke="#005CC5" stroke-width="1.18421" stroke-linecap="round" stroke-linejoin="round"/>
+<mask id="mask1" mask-type="alpha" maskUnits="userSpaceOnUse" x="560" y="123" width="66" height="95">
+<path d="M624.601 185.015C624.601 202.685 610.285 217.01 592.625 217.01C574.965 217.01 560.649 202.685 560.649 185.015C560.649 164.351 591.293 139.688 592.625 123.691C593.958 139.688 624.601 165.018 624.601 185.015Z" fill="#C8E1FF" stroke="#C8E1FF" stroke-width="1.18421"/>
+</mask>
+<g mask="url(#mask1)">
+<ellipse cx="582.451" cy="193.533" rx="36.3363" ry="36.3884" fill="#2188FF"/>
+</g>
+<path d="M598 232C602 232 602 240 606 240C610 240 610 232 614 232C618 232 618 240 622 240C626 240 626 232 630 232C634 232 634 240 638 240" stroke="#2188FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<clipPath id="clip0">
+<rect width="276" height="276" fill="white" transform="translate(782 77)"/>
+</clipPath>
+<clipPath id="clip1">
+<rect width="250" height="248" fill="white" transform="translate(810 105)"/>
+</clipPath>
+<clipPath id="clip2">
+<rect width="276" height="276" fill="white" transform="matrix(-1 0 0 1 286 37)"/>
+</clipPath>
+<clipPath id="clip3">
+<rect width="250" height="248" fill="white" transform="matrix(-1 0 0 1 258 65)"/>
+</clipPath>
+<clipPath id="clip4">
+<rect width="276" height="276" fill="white" transform="matrix(-1 0 0 1 662 139)"/>
+</clipPath>
+<clipPath id="clip5">
+<rect width="250" height="248" fill="white" transform="matrix(-1 0 0 1 634 167)"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
### Description

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/54012/195204498-75f96ebf-a800-4401-b3fd-0896a6aa241b.png">

This PR adds the docs Hero.js banner found on [React](https://primer.style/react/) and [CSS](https://primer.style/css/). Both of those pages include a version in the Hero banner. ViewComponents was missing this.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated documentation
