### PR TITLE
Get attribute from trigger button and not event target

### DIFF
--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -15,7 +15,7 @@ function clickHandler(event: Event) {
 
   // If the user is clicking a valid dialog trigger
   let dialogId = button?.getAttribute('data-show-dialog-id')
-  if (target instanceof HTMLButtonElement && dialogId) {
+  if (button && dialogId) {
     event.stopPropagation()
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof ModalDialogElement) {

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -14,11 +14,11 @@ function clickHandler(event: Event) {
   const button = target?.closest('button')
 
   // If the user is clicking a valid dialog trigger
-  let dialogId = target.getAttribute('data-show-dialog-id')
+  let dialogId = button?.getAttribute('data-show-dialog-id')
   if (target instanceof HTMLButtonElement && dialogId) {
     event.stopPropagation()
-    const dialog = document.querySelector<ModalDialogElement>(`#${dialogId}`)
-    if (dialog) {
+    const dialog = document.getElementById(dialogId)
+    if (dialog instanceof ModalDialogElement) {
       dialog.openButton = button
       dialog.show()
       return


### PR DESCRIPTION
A fix for a small bug in shipped in #1480.