### PR TITLE
Fix our custom Octicon input type in Lookbook

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,17 +116,19 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (1.0.8)
+    lookbook (1.1.1)
       actioncable
+      activemodel
       css_parser
       htmlbeautifier (~> 1.3)
       htmlentities (~> 4.3.4)
       listen (~> 3.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
-      rouge (~> 3.26)
+      rouge (>= 3.26, < 5.0)
       view_component (~> 2.0)
       yard (~> 0.9.25)
+      zeitwerk (~> 2.5)
     matrix (0.4.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
@@ -178,7 +180,7 @@ GEM
     redcarpet (3.5.1)
     regexp_parser (2.5.0)
     rexml (3.2.5)
-    rouge (3.30.0)
+    rouge (4.0.0)
     rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -306,4 +308,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.2.33
+   2.3.6

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -243,17 +243,19 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (1.0.8)
+    lookbook (1.1.1)
       actioncable
+      activemodel
       css_parser
       htmlbeautifier (~> 1.3)
       htmlentities (~> 4.3.4)
       listen (~> 3.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
-      rouge (~> 3.26)
+      rouge (>= 3.26, < 5.0)
       view_component (~> 2.0)
       yard (~> 0.9.25)
+      zeitwerk (~> 2.5)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)

--- a/demo/app/views/lookbook/previews/inputs/_octicon.html.erb
+++ b/demo/app/views/lookbook/previews/inputs/_octicon.html.erb
@@ -1,1 +1,1 @@
-<%= render "lookbook/previews/inputs/select", **local_assigns, options: [:none, *Octicons::OCTICON_SYMBOLS.keys] %>
+<%= select_tag(name, options_for_select([:none, *Octicons::OCTICON_SYMBOLS.keys], value), **input_options, "x-model": "value") %>

--- a/demo/config/initializers/custom_inputs.rb
+++ b/demo/config/initializers/custom_inputs.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")

--- a/demo/config/initializers/custom_inputs.rb
+++ b/demo/config/initializers/custom_inputs.rb
@@ -1,3 +1,8 @@
 # frozen_string_literal: true
 
-Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
+begin
+  require "lookbook"
+
+  Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
+rescue NameError
+end

--- a/demo/config/initializers/custom_inputs.rb
+++ b/demo/config/initializers/custom_inputs.rb
@@ -4,5 +4,9 @@ begin
   require "lookbook"
 
   Lookbook.define_param_input(:octicon, "lookbook/previews/inputs/octicon")
-rescue NameError
+rescue LoadError
+  # Happens during docs:build, which runs in the context of the
+  # PVC gem's bundle (i.e. not the demo app's bundle). Lookbook
+  # may not be available in this bundle because it targets Rails
+  # version >= 7.0.
 end

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "demo",
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {


### PR DESCRIPTION
### Description

This PR bumps Lookbook to v1.1, which introduced support for [custom input types](https://lookbook.build/guide/extend/inputs/). In conjunction, I've taken the liberty of updating our old (and broken) custom Octicons input type so it works with the new system.

![image](https://user-images.githubusercontent.com/575280/195462717-d0f16772-a229-475c-b135-6b349050d1a5.png)

### Integration

> Does this change require any updates to code in production?
No.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (sort of)
