### PR TITLE
Building PostCSS components separately 

### DIFF
--- a/.changeset/modern-pets-grab.md
+++ b/.changeset/modern-pets-grab.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Building PostCSS components separately 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Generated from npm prepare
 app/components/**/*.js
+app/components/**/*.css
+app/components/**/*.css.map
 app/components/**/*.d.ts
 app/assets/
 

--- a/demo/kuby.rb
+++ b/demo/kuby.rb
@@ -114,6 +114,7 @@ Kuby.define("ViewComponentsStorybook") do
           package.json
           package-lock.json
           previews
+          script
         ]
 
         files.each { |f| dockerfile.copy(f, f) }

--- a/package.json
+++ b/package.json
@@ -27,18 +27,17 @@
     "app/components/primer/**/*.d.ts"
   ],
   "scripts": {
-    "clean": "git clean -fdX -- app/",
     "build:docs": "npm run --prefix ./docs/ build",
     "build:docs:preview": "cd docs && npx gatsby build",
-    "prepare": "rm -rf docs/static && mkdir -p docs/static && npm run build:js && npm run build:css && cp app/assets/**/primer_view_components.* docs/static/",
+    "prepare": "rm -rf docs/static && mkdir -p docs/static && script/build-assets && cp app/assets/**/primer_view_components.* docs/static/",
     "lint": "npm run lint:stylelint && npm run lint:eslint",
     "lint:stylelint": "stylelint 'app/components/**/*.pcss'",
     "lint:stylelint:fix": "stylelint 'app/components/**/*.pcss' --fix",
     "lint:eslint": "eslint 'app/components/**/*.ts'",
     "lint:eslint:fix": "eslint 'app/components/**/*.ts' --fix",
     "changeset:version": "changeset version && script/version",
-    "build:js": "tsc && rollup -c",
-    "build:css": "postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss"
+    "build:js": "script/build-assets js",
+    "build:css": "script/build-assets css"
   },
   "dependencies": {
     "@github/auto-complete-element": "^3.3.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "app/components/primer/**/*.d.ts"
   ],
   "scripts": {
+    "clean": "git clean -fdX -- app/",
     "build:docs": "npm run --prefix ./docs/ build",
     "build:docs:preview": "cd docs && npx gatsby build",
     "prepare": "rm -rf docs/static && mkdir -p docs/static && script/build-assets && cp app/assets/**/primer_view_components.* docs/static/",

--- a/script/build-assets
+++ b/script/build-assets
@@ -1,51 +1,31 @@
-#!/usr/bin/env ruby
-# frozen_string_literal: true
+#!/bin/bash
 
-require "thor"
-require_relative "../lib/primer/view_components/version"
+export INPUT_TYPE=$1
 
-# Publishes `primer_view_components` gem and npm package.
-#
-# Usage:
-#
-# script/build-assets
-class BuildAssetsCLI < Thor::Group
-  include Thor::Actions
+build_css() {
+  # Get a list of all the CSS files in the src directory
+  CSS_FILES=$(find app/components/primer -name '*.pcss' ! -path '*/primer.pcss')
+  npx postcss $CSS_FILES --dir app/components --base app/components --ext css
+  # Build main CSS bundle
+  npx postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss
+}
 
-  def exit_on_failure?
-    true
-  end
+# Function to build the assets
+build_js() {
+  # Build the assets
+  npx tsc
+  npx rollup -c
+}
 
-  def build_js
-    return unless build?("js")
-
-    # Build typescript files
-    run("npx tsc")
-
-    # Build main JS file
-    run("npx rollup -c")
-  end
-
-  def build_css
-    return unless build?("css")
-
-    files = Dir.glob("app/components/**/*.pcss").reject { |f| f.include?("primer.pcss") }
-    # Build individual CSS files for each component
-    run("npx postcss #{files.join(" ")} --dir app/components --base app/components --ext css")
-
-    # Build main CSS file
-    run("npx postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss -m")
-  end
-
-  private
-
-  def build?(type)
-    input_type = args[0] || "all"
-
-    return true if input_type == "all"
-
-    return input_type == type
-  end
-end
-
-BuildAssetsCLI.start(ARGV)
+if [ "$INPUT_TYPE" = "css" ]; then
+  echo "Building css assets"
+  build_css
+elif [ "$INPUT_TYPE" = "js" ]; then
+  # run build_js
+  echo "Building js assets"
+  build_js
+else
+  echo "Building all assets"
+  build_js
+  build_css
+fi

--- a/script/build-assets
+++ b/script/build-assets
@@ -1,0 +1,51 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "thor"
+require_relative "../lib/primer/view_components/version"
+
+# Publishes `primer_view_components` gem and npm package.
+#
+# Usage:
+#
+# script/build-assets
+class BuildAssetsCLI < Thor::Group
+  include Thor::Actions
+
+  def exit_on_failure?
+    true
+  end
+
+  def build_js
+    return unless build?("js")
+
+    # Build typescript files
+    run("npx tsc")
+
+    # Build main JS file
+    run("npx rollup -c")
+  end
+
+  def build_css
+    return unless build?("css")
+
+    files = Dir.glob("app/components/**/*.pcss").reject { |f| f.include?("primer.pcss") }
+    # Build individual CSS files for each component
+    run("npx postcss #{files.join(" ")} --dir app/components --base app/components --ext css")
+
+    # Build main CSS file
+    run("npx postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss -m")
+  end
+
+  private
+
+  def build?(type)
+    input_type = args[0] || "all"
+
+    return true if input_type == "all"
+
+    return input_type == type
+  end
+end
+
+BuildAssetsCLI.start(ARGV)


### PR DESCRIPTION
### Description

This PR compiles the separate PostCSS `*.pcss` files into `*.css` files that can be imported separately. [Example output](https://unpkg.com/browse/@primer/view-components@0.0.0-20221012231141/app/components/primer/beta/button.css)

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
