### PR TITLE
Roll back Doctocat upgrade

### DIFF
--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -1,76 +1,74 @@
-
-
 name: Demo Production
 
 on:
-  workflow_dispatch:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   build:
     if: ${{ github.repository == 'primer/view_components' }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Setup Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 3.0.x
-    - uses: actions/cache@v2
-      with:
-        path: demo/gemfiles/vendor/bundle
-        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
-    - name: Docker login
-      env:
-        AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
-      run: echo $AZURE_ACR_PASSWORD | docker login primer.azurecr.io --username GitHubActions --password-stdin
-    - uses: Azure/login@v1
-      with:
-        creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
-    - name: Purge tags
-      run: |
-        az acr run \
-          --cmd "acr purge --filter 'primer/view_components_storybook:.*'  --ago 0d --keep 10" \
-          --registry primer \
-          /dev/null
-    - name: Bundle
-      run: |
-        gem install bundler -v '~> 2.3'
-        bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
-    - name: Pull latest
-      run: |
-        docker pull primer.azurecr.io/primer/view_components_storybook:latest
-        docker pull primer.azurecr.io/primer/view_components_storybook:latest-assets
-    - name: Build
-      env:
-        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-      run: |
-        bin/kuby -e production build --only app -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest
-        bin/kuby -e production build --only assets -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest-assets
-    - name: Push
-      run: bin/kuby -e production push
+      - uses: actions/checkout@master
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.0.x
+      - uses: actions/cache@v2
+        with:
+          path: demo/gemfiles/vendor/bundle
+          key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+      - name: Docker login
+        env:
+          AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+        run: echo $AZURE_ACR_PASSWORD | docker login primer.azurecr.io --username GitHubActions --password-stdin
+      - uses: Azure/login@v1
+        with:
+          creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
+      - name: Purge tags
+        run: |
+          az acr run \
+            --cmd "acr purge --filter 'primer/view_components_storybook:.*'  --ago 0d --keep 10" \
+            --registry primer \
+            /dev/null
+      - name: Bundle
+        run: |
+          gem install bundler -v '~> 2.3'
+          bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
+      - name: Pull latest
+        run: |
+          docker pull primer.azurecr.io/primer/view_components_storybook:latest
+          docker pull primer.azurecr.io/primer/view_components_storybook:latest-assets
+      - name: Build
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: |
+          bin/kuby -e production build --only app -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest
+          bin/kuby -e production build --only assets -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest-assets
+      - name: Push
+        run: bin/kuby -e production push
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/checkout@master
-    - name: Setup Ruby
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 3.0.x
-    - uses: actions/cache@v2
-      with:
-        path: demo/gemfiles/vendor/bundle
-        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
-    - name: Bundle
-      run: |
-        gem install bundler -v '~> 2.3'
-        bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
-    - name: Deploy
-      env:
-        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
-        AZURE_SPN_CLIENT_SECRET: ${{ secrets.AZURE_SPN_CLIENT_SECRET }}
-      run: bin/kuby -e production deploy
+      - uses: actions/checkout@master
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 3.0.x
+      - uses: actions/cache@v2
+        with:
+          path: demo/gemfiles/vendor/bundle
+          key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+      - name: Bundle
+        run: |
+          gem install bundler -v '~> 2.3'
+          bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
+      - name: Deploy
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+          AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+          AZURE_SPN_CLIENT_SECRET: ${{ secrets.AZURE_SPN_CLIENT_SECRET }}
+        run: bin/kuby -e production deploy

--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -1,3 +1,5 @@
+
+
 name: Demo Production
 
 on:
@@ -10,65 +12,65 @@ jobs:
     if: ${{ github.repository == 'primer/view_components' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 3.0.x
-      - uses: actions/cache@v2
-        with:
-          path: demo/gemfiles/vendor/bundle
-          key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
-      - name: Docker login
-        env:
-          AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
-        run: echo $AZURE_ACR_PASSWORD | docker login primer.azurecr.io --username GitHubActions --password-stdin
-      - uses: Azure/login@v1
-        with:
-          creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
-      - name: Purge tags
-        run: |
-          az acr run \
-            --cmd "acr purge --filter 'primer/view_components_storybook:.*'  --ago 0d --keep 10" \
-            --registry primer \
-            /dev/null
-      - name: Bundle
-        run: |
-          gem install bundler -v '~> 2.3'
-          bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
-      - name: Pull latest
-        run: |
-          docker pull primer.azurecr.io/primer/view_components_storybook:latest
-          docker pull primer.azurecr.io/primer/view_components_storybook:latest-assets
-      - name: Build
-        env:
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        run: |
-          bin/kuby -e production build --only app -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest
-          bin/kuby -e production build --only assets -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest-assets
-      - name: Push
-        run: bin/kuby -e production push
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 3.0.x
+    - uses: actions/cache@v2
+      with:
+        path: demo/gemfiles/vendor/bundle
+        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+    - name: Docker login
+      env:
+        AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+      run: echo $AZURE_ACR_PASSWORD | docker login primer.azurecr.io --username GitHubActions --password-stdin
+    - uses: Azure/login@v1
+      with:
+        creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
+    - name: Purge tags
+      run: |
+        az acr run \
+          --cmd "acr purge --filter 'primer/view_components_storybook:.*'  --ago 0d --keep 10" \
+          --registry primer \
+          /dev/null
+    - name: Bundle
+      run: |
+        gem install bundler -v '~> 2.3'
+        bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
+    - name: Pull latest
+      run: |
+        docker pull primer.azurecr.io/primer/view_components_storybook:latest
+        docker pull primer.azurecr.io/primer/view_components_storybook:latest-assets
+    - name: Build
+      env:
+        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+      run: |
+        bin/kuby -e production build --only app -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest
+        bin/kuby -e production build --only assets -- --cache-from primer.azurecr.io/primer/view_components_storybook:latest-assets
+    - name: Push
+      run: bin/kuby -e production push
 
   deploy:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - uses: actions/checkout@master
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 3.0.x
-      - uses: actions/cache@v2
-        with:
-          path: demo/gemfiles/vendor/bundle
-          key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
-      - name: Bundle
-        run: |
-          gem install bundler -v '~> 2.3'
-          bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
-      - name: Deploy
-        env:
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-          AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
-          AZURE_SPN_CLIENT_SECRET: ${{ secrets.AZURE_SPN_CLIENT_SECRET }}
-        run: bin/kuby -e production deploy
+    - uses: actions/checkout@master
+    - name: Setup Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 3.0.x
+    - uses: actions/cache@v2
+      with:
+        path: demo/gemfiles/vendor/bundle
+        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+    - name: Bundle
+      run: |
+        gem install bundler -v '~> 2.3'
+        bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
+    - name: Deploy
+      env:
+        RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
+        AZURE_SPN_CLIENT_SECRET: ${{ secrets.AZURE_SPN_CLIENT_SECRET }}
+      run: bin/kuby -e production deploy

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@primer/behaviors": "^1.2.0",
         "@primer/css": "^20.4.6",
-        "@primer/gatsby-theme-doctocat": "^4.2.0",
+        "@primer/gatsby-theme-doctocat": "4.1.0",
         "@primer/primitives": "^6.0.0",
         "@primer/react": "^35.2.2",
         "gatsby": "^2.24.63",
@@ -2150,16 +2150,16 @@
       "license": "MIT"
     },
     "node_modules/@primer/gatsby-theme-doctocat": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.2.0.tgz",
-      "integrity": "sha512-WgptcLQHZ565IQbp9WETRCVCiapnkk1HURyWk26XhAZfeDHNFoKKNgZRzW1wzZU/nkRuzw6jCgUduZG6wICpBw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.1.0.tgz",
+      "integrity": "sha512-eRxPUjrGWzbTXxoW7Fp/kVs5OiREsoqb/6YW1nFyRRN0XY6+oZPc6SynhyKt7whN7+xVIlF9W13t7iC5nK1TJQ==",
       "dependencies": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
         "@mdx-js/mdx": "^1.0.21",
         "@mdx-js/react": "^1.0.21",
         "@primer/component-metadata": "^0.4.0",
-        "@primer/octicons-react": "^17.5.0",
+        "@primer/octicons-react": "^16.3.1",
         "@primer/react": "^35.2.2",
         "@styled-system/theme-get": "^5.0.12",
         "@testing-library/jest-dom": "^5.16.2",
@@ -2213,9 +2213,9 @@
       }
     },
     "node_modules/@primer/gatsby-theme-doctocat/node_modules/@primer/octicons-react": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-17.6.0.tgz",
-      "integrity": "sha512-jn1fWag3eU6BvOltMS2MqLPNh39D45cpegsTO2Qhb8SlJoUsj/ZO1qbJgYd9ibvZo8evDyXx3syh4kDbxJQFsg==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-16.3.1.tgz",
+      "integrity": "sha512-uzTs8/CvLiW1/47cgMRkIK9bKWpnw+UonCbgczXErwSSLqMDHfiiTpobW1trvRuoiMgLwsPo0l7kBBdKBnmq3g==",
       "engines": {
         "node": ">=8"
       },
@@ -25461,16 +25461,16 @@
       }
     },
     "@primer/gatsby-theme-doctocat": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.2.0.tgz",
-      "integrity": "sha512-WgptcLQHZ565IQbp9WETRCVCiapnkk1HURyWk26XhAZfeDHNFoKKNgZRzW1wzZU/nkRuzw6jCgUduZG6wICpBw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.1.0.tgz",
+      "integrity": "sha512-eRxPUjrGWzbTXxoW7Fp/kVs5OiREsoqb/6YW1nFyRRN0XY6+oZPc6SynhyKt7whN7+xVIlF9W13t7iC5nK1TJQ==",
       "requires": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
         "@mdx-js/mdx": "^1.0.21",
         "@mdx-js/react": "^1.0.21",
         "@primer/component-metadata": "^0.4.0",
-        "@primer/octicons-react": "^17.5.0",
+        "@primer/octicons-react": "^16.3.1",
         "@primer/react": "^35.2.2",
         "@styled-system/theme-get": "^5.0.12",
         "@testing-library/jest-dom": "^5.16.2",
@@ -25519,9 +25519,9 @@
       },
       "dependencies": {
         "@primer/octicons-react": {
-          "version": "17.6.0",
-          "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-17.6.0.tgz",
-          "integrity": "sha512-jn1fWag3eU6BvOltMS2MqLPNh39D45cpegsTO2Qhb8SlJoUsj/ZO1qbJgYd9ibvZo8evDyXx3syh4kDbxJQFsg=="
+          "version": "16.3.1",
+          "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-16.3.1.tgz",
+          "integrity": "sha512-uzTs8/CvLiW1/47cgMRkIK9bKWpnw+UonCbgczXErwSSLqMDHfiiTpobW1trvRuoiMgLwsPo0l7kBBdKBnmq3g=="
         },
         "axios": {
           "version": "0.21.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@primer/behaviors": "^1.2.0",
     "@primer/css": "^20.4.6",
-    "@primer/gatsby-theme-doctocat": "^4.2.0",
+    "@primer/gatsby-theme-doctocat": "^4.1.0",
     "@primer/primitives": "^6.0.0",
     "@primer/react": "^35.2.2",
     "gatsby": "^2.24.63",

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@primer/behaviors": "^1.2.0",
     "@primer/css": "^20.4.6",
-    "@primer/gatsby-theme-doctocat": "^4.1.0",
+    "@primer/gatsby-theme-doctocat": "4.1.0",
     "@primer/primitives": "^6.0.0",
     "@primer/react": "^35.2.2",
     "gatsby": "^2.24.63",


### PR DESCRIPTION
### Description

https://primer.style/status is not rendering correctly because the `components.json` data specific to ViewComponents is returning a 404. 

It seems to have stopped building after upgrading to Doctocat v4.2.0. [See here](https://github.com/primer/view_components/actions/runs/3206088534/jobs/5239394918#step:8:15613). 

This PR rolls back the Doctocat version to 4.1.0, which [does seem to build successfully](https://github.com/primer/view_components/actions/runs/3202143410/jobs/5230828185#step:8:15613). 

This PR also reverts the changes in https://github.com/primer/view_components/pull/1482 to the deployment workflow, to ensure the fix eventually gets published when this PR merges. 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
