### PR TITLE
Adding view components version to lookbook title

### DIFF
--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -37,6 +37,7 @@ module Demo
     }
 
     if config.respond_to?(:lookbook)
+      config.lookbook.project_name = "Primer ViewComponents v#{Primer::ViewComponents::VERSION::STRING}"
       config.lookbook.preview_display_options = {
         theme: [
           ["Light default", "light"],


### PR DESCRIPTION
### Description

This uses `project_name` [configuration](https://lookbook.build/guide/config/) to put the version in the title of the page.

<img width="456" alt="image" src="https://user-images.githubusercontent.com/54012/196305608-f3fb6918-419f-4258-a978-01474f93da87.png">

### Integration

> Does this change require any updates to code in production?

no

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews
