### PR TITLE
Updates to dependabot config to upgrade production packages (actions, npm, gems)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,61 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "skip changelog"
+    schedule:
+      interval: "monthly"
+
+  # NPM
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "skip changelog"
     allow:
-      - dependency-name: "@primer/css"
+      - dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/docs"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "skip changelog"
     allow:
-      - dependency-name: "@primer/gatsby-theme-doctocat"
-      - dependency-name: "@primer/css"
+      - dependency-type: "production"
   - package-ecosystem: "npm"
     directory: "/demo"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "skip changelog"
     allow:
-      - dependency-name: "@primer/css"
+      - dependency-type: "production"
+
+  # Bundler
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "skip changelog"
+    allow:
+      - dependency-type: "production"
+  - package-ecosystem: "bundler"
+    directory: "/demo"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "skip changelog"
+    allow:
+      - dependency-type: "production"


### PR DESCRIPTION
### Description

Previously it was only upgrading primer/css daily. I wanted to have more upgrade reminders, but not as often so I adjusted to monthly schedule and set it to only upgrade "production" level code.

### Integration

> Does this change require any updates to code in production?

no

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
