### PR TITLE
Pass select list options to Rails form builder

### DIFF
--- a/.changeset/gentle-stingrays-protect.md
+++ b/.changeset/gentle-stingrays-protect.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Pass select list options to Rails form builder

--- a/app/forms/select_list_form.rb
+++ b/app/forms/select_list_form.rb
@@ -3,7 +3,7 @@
 # :nodoc:
 class SelectListForm < ApplicationForm
   form do |check_form|
-    check_form.select_list(name: "cities", label: "Cool cities", caption: "Select your favorite!") do |city_list|
+    check_form.select_list(name: "cities", label: "Cool cities", caption: "Select your favorite!", include_blank: true) do |city_list|
       city_list.option(label: "Lopez Island", value: "lopez_island")
       city_list.option(label: "Bellevue", value: "bellevue")
       city_list.option(label: "Seattle", value: "seattle")

--- a/lib/primer/forms/dsl/select_list_input.rb
+++ b/lib/primer/forms/dsl/select_list_input.rb
@@ -5,6 +5,8 @@ module Primer
     module Dsl
       # :nodoc:
       class SelectListInput < Input
+        SELECT_ARGUMENTS = %i[multiple disabled include_blank prompt].freeze
+
         # :nodoc:
         class Option
           attr_reader :label, :value, :system_arguments
@@ -16,12 +18,18 @@ module Primer
           end
         end
 
-        attr_reader :name, :label, :options
+        attr_reader :name, :label, :options, :select_arguments
 
         def initialize(name:, label:, **system_arguments)
           @name = name
           @label = label
           @options = []
+
+          @select_arguments = {}.tap do |select_args|
+            SELECT_ARGUMENTS.each do |select_arg|
+              select_args[select_arg] = system_arguments.delete(select_arg)
+            end
+          end
 
           super(**system_arguments)
 

--- a/lib/primer/forms/select_list.html.erb
+++ b/lib/primer/forms/select_list.html.erb
@@ -1,5 +1,5 @@
 <%= render(FormControl.new(input: @input)) do %>
   <%= content_tag(:div, class: @field_wrap_classes) do %>
-    <%= builder.select(@input.name, options, {}, **@input.input_arguments) %>
+    <%= builder.select(@input.name, options, @input.select_arguments, **@input.input_arguments) %>
   <% end %>
 <% end %>

--- a/test/primer/forms/forms_test.rb
+++ b/test/primer/forms/forms_test.rb
@@ -240,6 +240,7 @@ class Primer::Forms::FormsTest < Minitest::Test
   def test_select_list_form
     render_preview :select_list_form
 
+    assert_selector ".FormControl-select option[value='']"
     assert_selector ".FormControl-select option[value=lopez_island]"
     assert_selector ".FormControl-select option[value=bellevue]"
     assert_selector ".FormControl-select option[value=seattle]"


### PR DESCRIPTION
### Description

Although not intentional, the current implementation of select lists does not allow passing options to the Rails form builder. This came up in #1485 when @raivil tried to add a blank option to the list, which Rails doesn't allow. Instead, you're expected to pass the `include_blank` argument in the options hash. This PR makes sure arguments like `include_blank` and its friends are extracted from the hash of input arguments and passed to Rails appropriately.

Closes #1485 

### Integration

No

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
