### PR TITLE
rubocop/config/default: Unset `DisabledByDefault`

### DIFF
--- a/.changeset/famous-teachers-lay.md
+++ b/.changeset/famous-teachers-lay.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+rubocop/config/default: Unset `DisabledByDefault`

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -1,9 +1,6 @@
 require:
   - rubocop/cop/primer
 
-AllCops:
-  DisabledByDefault: true
-
 Primer/SystemArgumentInsteadOfClass:
   Enabled: true
 


### PR DESCRIPTION
### Description

- The `DisabledByDefault` config option made it so that "all cops in the default configuration are disabled, and only cops in user configuration are enabled", which makes cops "opt-in rather than opt-out" (source: https://github.com/rubocop/rubocop/blob/d1270c468cdb9a211229e36aef8d568ae3bfe607/config/default.yml#L91-L102).
- It's not immediately obvious that this gem has this config option.  This means that people may write new, custom cops in downstream projects, with no configuration in .rubocop.yml, and then they never run because all cops are disabled unless explicitly enabled or otherwise configured with `Include`/`Exclude`.
- RuboCop does not warn users that the config inheritance has set `DisabledByDefault` somewhere up the line, leading to users mistakenly not enabling cops they may have intended to.
- Other of GitHub's open source gems, like `rubocop-github`[1] and `rubocop-rails-accessibility`[2], have moved away from `DisabledByDefault`. This is the last one (at least that I can find in GitHub's main project's RuboCop gem inheritance tree).

[1] - https://github.com/github/rubocop-github/pull/119
[2] - https://github.com/github/rubocop-rails-accessibility/pull/7


### Integration

> Does this change require any updates to code in production?

Nope.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
