### PR TITLE
Revert "rubocop/config/default: Unset `DisabledByDefault`"

### DIFF
--- a/.changeset/famous-teachers-lay.md
+++ b/.changeset/famous-teachers-lay.md
@@ -1,5 +1,0 @@
----
-"@primer/view-components": patch
----
-
-rubocop/config/default: Unset `DisabledByDefault`

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -1,6 +1,9 @@
 require:
   - rubocop/cop/primer
 
+AllCops:
+  DisabledByDefault: true
+
 Primer/SystemArgumentInsteadOfClass:
   Enabled: true
 


### PR DESCRIPTION
Reverts primer/view_components#1531

See: https://github.com/primer/view_components/pull/1531#issuecomment-1287506765