### PR TITLE
Disable cops for erblint only

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -36,6 +36,8 @@ linters:
     rubocop_config:
       inherit_from:
         - lib/rubocop/config/default.yml
+      AllCops:
+        DisabledByDefault: true
       Primer/DeprecatedComponents:
         Enabled: true
         Exclude:


### PR DESCRIPTION
### Description

A [recent PR](https://github.com/primer/view_components/pull/1531) started running all Rubocop cops on our .html.erb files, which has led to some [unusual build failures](https://github.com/primer/view_components/actions/runs/3300796576/jobs/5445655857). This PR disables Rubocop cops in the erblint config, which keeps the behavior from the original PR and fixes our build failures.