### PR TITLE
Bug Fix: Fixing bad CSS in action-list.css and writing test to check for error

### DIFF
--- a/.changeset/little-bees-doubt.md
+++ b/.changeset/little-bees-doubt.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Bug Fix: Fixing bad CSS in action-list.css and writing test to check for error

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,7 @@
     "no-descending-specificity": null,
     "declaration-block-no-redundant-longhand-properties": null,
     "color-function-notation": "legacy",
+    "selector-nested-pattern": "^&\\s?\\W",
     "at-rule-no-unknown": [
       true,
       {

--- a/app/components/primer/alpha/action_list/action-list.pcss
+++ b/app/components/primer/alpha/action_list/action-list.pcss
@@ -196,7 +196,7 @@
 
   &.ActionListItem--navActive {
     &:not(.ActionListItem--subItem) {
-      .ActionListItem-label {
+      & .ActionListItem-label {
         font-weight: var(--base-text-weight-semibold, 600);
       }
     }
@@ -579,7 +579,7 @@
     border: 0;
   }
 
-  .ActionList-sectionDivider-title {
+  & .ActionList-sectionDivider-title {
     font-size: var(--primer-text-body-size-small, 12px);
     font-weight: var(--base-text-weight-semibold, 600);
     color: var(--color-fg-muted);

--- a/app/components/primer/alpha/action_list/action-list.pcss
+++ b/app/components/primer/alpha/action_list/action-list.pcss
@@ -47,7 +47,7 @@
   /* hide divider if item is active */
   & .ActionListItem--navActive {
     & .ActionListItem-label::before,
-    + .ActionListItem .ActionListItem-label::before {
+    & + .ActionListItem .ActionListItem-label::before {
       visibility: hidden;
     }
   }
@@ -406,7 +406,7 @@
       }
 
       &::before,
-      + .ActionListItem::before {
+      & + .ActionListItem::before {
         visibility: hidden;
       }
 

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -127,11 +127,11 @@ summary.Button {
   padding: 0 var(--primer-control-small-paddingInline-condensed, 8px);
   gap: var(--primer-control-small-gap, 4px);
 
-  .Button-label {
+  & .Button-label {
     line-height: var(--primer-text-body-lineHeight-small, calc(20 / 12));
   }
 
-  .Button-content {
+  & .Button-content {
     & > :not(:last-child) {
       margin-right: var(--primer-control-small-gap, 4px);
     }
@@ -143,11 +143,11 @@ summary.Button {
   padding: 0 var(--primer-control-large-paddingInline-spacious, 16px);
   gap: var(--primer-control-large-gap, 8px);
 
-  .Button-label {
+  & .Button-label {
     line-height: var(--primer-text-body-lineHeight-large, calc(48 / 32));
   }
 
-  .Button-content {
+  & .Button-content {
     & > :not(:last-child) {
       margin-right: var(--primer-control-large-gap, 8px);
     }

--- a/test/components/component_css_test.rb
+++ b/test/components/component_css_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+class ComponentCssTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_css_gets_compiled
+    assert File.exist?("app/assets/styles/primer_view_components.css"), "Compiled CSS file not found"
+  end
+
+  def test_css_is_compiled_correctly
+    Dir["app/components/**/*.css"].each do |file|
+      css = File.read(file)
+
+      refute(css.include?("@import"), "CSS files should not import other CSS files:\n#{file} contains @import")
+      refute(css.include?("&"), "CSS Nesting wasn't compiled correctly:\n#{file} contains &")
+    end
+  end
+end


### PR DESCRIPTION
### Description

I noticed in our output we have some invalid CSS which is the result in typos from migrating SCSS to PostCSS. You can see this error on the [latest release of action-list.css](https://unpkg.com/@primer/view-components@0.0.106/app/components/primer/alpha/action_list/action-list.css) file. There's a `&` in the output which isn't valid CSS.

- I fixed the error in the CSS files
- Added a new test to check for things that might end up in bad output
- Added a stylelint rule to catch issues

### Integration

> Does this change require any updates to code in production?

no

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
