### PR TITLE
Changing actions workflows to use ruby/setup-ruby

### DIFF
--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -14,13 +14,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.x
-    - uses: actions/cache@v3.0.11
-      with:
-        path: demo/gemfiles/vendor/bundle
-        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+        ruby-version: '3.0'
+        bundler-cache: true
+        working-directory: 'demo/'
     - name: Docker login
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
@@ -57,9 +55,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.x
+        ruby-version: '3.0'
+        bundler-cache: true
     - uses: actions/cache@v3.0.11
       with:
         path: demo/gemfiles/vendor/bundle

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -20,9 +20,10 @@ jobs:
           version: 14
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: '3.0'
+          bundler-cache: true
 
       - name: Set up Node
         uses: actions/setup-node@v3
@@ -33,22 +34,11 @@ jobs:
             package-lock.json
             docs/package-lock.json
 
-      - name: Cache dependencies
-        uses: actions/cache@v3.0.11
-        with:
-          path: vendor/bundle
-          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
-        run: npm i && cd docs && npm i && cd ..
+        run: npm ci && cd docs && npm ci && cd ..
 
       - name: Generate static files
         run: |
-          gem install bundler:2.2.9
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
           bundle exec rake utilities:build
           bundle exec rake docs:build
           bundle exec rake static:dump

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: 'tar --dereference --directory docs/public -cvf artifact.tar .'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: github-pages
           path: artifact.tar

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -115,19 +115,11 @@ jobs:
             package-lock.json
             docs/package-lock.json
 
-      - uses: actions/cache@v3.0.11
-        with:
-          path: vendor/bundle
-          key: gems-deploy-preview-${{ hashFiles('**/Gemfile.lock') }}
-
       - name: Install dependencies
-        run: npm i && cd docs && npm i && cd ..
+        run: npm ci && cd docs && npm ci && cd ..
 
       - name: Generate static files
         run: |
-          gem install bundler:2.2.9
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
           bundle exec rake utilities:build
           bundle exec rake docs:build
           bundle exec rake static:dump
@@ -139,7 +131,7 @@ jobs:
         run: 'tar --dereference --directory docs/public -cvf artifact.tar .'
 
       - name: Upload artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: github-pages
           path: artifact.tar

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -34,13 +34,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.x
-    - uses: actions/cache@v3.0.11
-      with:
-        path: demo/gemfiles/vendor/bundle
-        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+        ruby-version: '3.0'
+        bundler-cache: true
+        working-directory: 'demo/'
     - name: Docker login
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
@@ -103,9 +101,10 @@ jobs:
           version: 14
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: '3.0'
+          bundler-cache: true
 
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -38,7 +38,6 @@ jobs:
       with:
         ruby-version: '3.0'
         bundler-cache: true
-        working-directory: 'demo/'
     - name: Docker login
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}
@@ -46,10 +45,6 @@ jobs:
     - uses: Azure/login@v1
       with:
         creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
-    - name: Bundle
-      run: |
-        gem install bundler -v '~> 2.3'
-        bundle install --jobs 4 --retry 3 --gemfile demo/gemfiles/kuby.gemfile --path vendor/bundle
 
     - name: Get preview app info
       run: ./.github/workflows/demo-preview-app-info.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1.x"
-      - name: Bundle install
-        run: |
-          gem install bundler:2.2.9
-          bundle config path vendor/bundle
-          bundle install
+          ruby-version: '3.0'
+          bundler-cache: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
       - name: Create .gem credentials
         run: |
           mkdir -p $HOME/.gem
@@ -38,7 +38,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
       - name: NPM install
         run: |
-          npm i
+          npm ci
       - name: Publish Gem
         run: bundle exec rake release
       - name: Publish NPM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,17 +20,18 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
+          cache: 'npm'
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.x
+          ruby-version: '3.0'
+          bundler-cache: true
 
       - name: Install dependencies
         run: |
-          npm i
-          bundle install
+          npm ci
 
       - name: Create release pull request or publish to npm
         id: changesets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Create release pull request or publish to npm
         id: changesets
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           title: Release Tracking
           version: npm run changeset:version


### PR DESCRIPTION
### Description

Found that `actions/setup-ruby` was archived in favor of `ruby/setup-ruby` https://github.com/actions/setup-ruby

This converts our workflows to using `ruby/setup-ruby`. This also allowed us to simplify some of the cache calls.

### Integration

> Does this change require any updates to code in production?

no 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
