### PR TITLE
Banner legacy classes

### DIFF
--- a/.changeset/weak-moose-itch.md
+++ b/.changeset/weak-moose-itch.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Include legacy flash classes in banners

--- a/app/components/primer/beta/banner.rb
+++ b/app/components/primer/beta/banner.rb
@@ -34,6 +34,13 @@ module Primer
         :success => "Banner--success"
       }.freeze
 
+      LEGACY_SCHEME_MAPPINGS = {
+        DEFAULT_SCHEME => "",
+        :warning => "flash-warn",
+        :danger => "flash-error",
+        :success => "flash-success"
+      }.freeze
+
       DEFAULT_ICONS = {
         default: :bell,
         warning: :alert,
@@ -95,8 +102,11 @@ module Primer
         @system_arguments[:classes] = class_names(
           @system_arguments[:classes],
           "Banner",
+          "flash", # legacy
           SCHEME_MAPPINGS[@scheme],
+          LEGACY_SCHEME_MAPPINGS[@scheme],
           "Banner--full": full,
+          "flash-full": full, # legacy
           "Banner--full-whenNarrow": full_when_narrow
         )
 

--- a/test/components/beta/banner_test.rb
+++ b/test/components/beta/banner_test.rb
@@ -19,22 +19,31 @@ class PrimerBannerTest < Minitest::Test
     assert_selector(".octicon")
   end
 
+  def test_includes_legacy_classes
+    render_inline(Primer::Beta::Banner.new) { "foo" }
+
+    assert_selector(".flash")
+  end
+
   def test_renders_danger_scheme
     render_inline(Primer::Beta::Banner.new(scheme: :danger)) { "foo" }
 
     assert_selector(".Banner.Banner--error", text: "foo")
+    assert_selector(".flash.flash-error", text: "foo") # legacy
   end
 
   def test_renders_warning_scheme
     render_inline(Primer::Beta::Banner.new(scheme: :warning)) { "foo" }
 
     assert_selector(".Banner.Banner--warning", text: "foo")
+    assert_selector(".flash.flash-warn", text: "foo") # legacy
   end
 
   def test_renders_success_scheme
     render_inline(Primer::Beta::Banner.new(scheme: :success)) { "foo" }
 
     assert_selector(".Banner.Banner--success", text: "foo")
+    assert_selector(".flash.flash-success", text: "foo") # legacy
   end
 
   def test_renders_default_icon
@@ -76,6 +85,7 @@ class PrimerBannerTest < Minitest::Test
     render_inline(Primer::Beta::Banner.new(full: true)) { "foo" }
 
     assert_selector(".Banner.Banner--full", text: "foo")
+    assert_selector(".flash.flash-full", text: "foo") # legacy
   end
 
   def test_renders_full_width_when_narrow


### PR DESCRIPTION
### Description

We've run into some issues attempting to migrate usages of `Primer::Beta::Flash` to `Primer::Beta::Banner`, namely that existing CSS and JS in dotcom select on the `flash` class and its friends. This has made it really difficult to migrate to the `Banner` component because the `flash` class is no longer used.

To ease the transition, we propose adding these legacy class names to banner elements while updating primer/css to only apply flash styles to elements that are not also banner elements.

### Integration

> Does this change require any updates to code in production?

No. At least, it shouldn't.

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
