### PR TITLE
Removing deprecated ImageCrop component

### DIFF
--- a/.changeset/moody-olives-hammer.md
+++ b/.changeset/moody-olives-hammer.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing deprecated `Primer::ImageCrop` component

--- a/app/components/primer/image_crop.rb
+++ b/app/components/primer/image_crop.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class ImageCrop < Primer::Alpha::ImageCrop
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -7,7 +7,6 @@ module Primer
     DEPRECATED_COMPONENTS = {
       "Primer::LabelComponent" => "Primer::Beta::Label",
       "Primer::LinkComponent" => "Primer::Beta::Link",
-      "Primer::ImageCrop" => "Primer::Alpha::ImageCrop",
       "Primer::Image" => "Primer::Alpha::Image",
       "Primer::Alpha::AutoComplete" => "Primer::Beta::AutoComplete",
       "Primer::Alpha::AutoComplete::Item" => "Primer::Beta::AutoComplete::Item",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -68,7 +68,6 @@
   "Primer::HellipButton": "",
   "Primer::IconButton": "",
   "Primer::Image": "",
-  "Primer::ImageCrop": "",
   "Primer::LabelComponent": "",
   "Primer::LayoutComponent": "",
   "Primer::LinkComponent": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -783,8 +783,6 @@
   },
   "Primer::Image": {
   },
-  "Primer::ImageCrop": {
-  },
   "Primer::LabelComponent": {
   },
   "Primer::LayoutComponent": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -68,7 +68,6 @@
   "Primer::HellipButton": "alpha",
   "Primer::IconButton": "deprecated",
   "Primer::Image": "deprecated",
-  "Primer::ImageCrop": "deprecated",
   "Primer::LabelComponent": "deprecated",
   "Primer::LayoutComponent": "alpha",
   "Primer::LinkComponent": "deprecated",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -112,7 +112,6 @@ class PrimerComponentTest < Minitest::Test
     ignored_components = [
       "Primer::LabelComponent",
       "Primer::LinkComponent",
-      "Primer::ImageCrop",
       "Primer::Image",
       "Primer::Alpha::ActionList::Heading",
       "Primer::Alpha::ActionList::Item",


### PR DESCRIPTION
### Description

There are currently [no uses of Primer::ImageCrop in production](https://github.com/search?q=repo%3Agithub%2Fgithub+ImageCrop&type=code). Removing the deprecated component from the repository. We moved this component to `Primer::Alpha::ImageCrop` which is the same component.

### Integration

> Does this change require any updates to code in production?

Verify no uses popped up before shipping. We have a linter to discourage it, but it could still have happened.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
