### PR TITLE
Disable focus-visible-pseudo-class plugin to fix primary Button

### DIFF
--- a/.changeset/metal-chicken-applaud.md
+++ b/.changeset/metal-chicken-applaud.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Disable focus-visible-pseudo-class plugin to fix primary Button

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -13,7 +13,8 @@ module.exports = {
       stage: 2,
       // https://preset-env.cssdb.org/features/#stage-2
       features: {
-        'nesting-rules': true
+        'nesting-rules': true,
+        'focus-visible-pseudo-class': false
       }
     }),
     require('cssnano'),


### PR DESCRIPTION
### Description

This fixes an issue with the primary scheme of the `Primer::Beta::Button` component. The button wasn't accepting a focus ring. 

I discovered the issue was that our PostCSS plugin `focus-visible-pseudo-class` was adding a polyfill class that was not being applied to our elements. This caused the button to never be focused. https://preset-env.cssdb.org/features/#focus-visible-pseudo-class

Closes https://github.com/primer/view_components/issues/1551

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
