### PR TITLE
Run accessibility tests in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   accessibility:
     name: Accessibility
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   accessibility:
     name: Accessibility
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   accessibility:
     name: Accessibility
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   accessibility:
     name: Accessibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+STDOUT.sync = true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "yard"

--- a/test/accessibility_test.rb
+++ b/test/accessibility_test.rb
@@ -21,7 +21,7 @@ class AccessibilityTest < System::TestCase
     component_uri = klass.to_s.underscore.gsub("_preview", "")
 
     component_previews.each do |preview|
-      define_method(:"test_#{component_uri.parameterize(separator: '_')}_#{preview}") do
+      define_method(:"test_#{component_uri.parameterize(separator: "_")}_#{preview}") do
         visit("/rails/view_components/#{component_uri}/#{preview}")
         assert_accessible(page)
         puts "#{component_uri}##{preview} passed check."

--- a/test/accessibility_test.rb
+++ b/test/accessibility_test.rb
@@ -23,7 +23,12 @@ class AccessibilityTest < System::TestCase
     component_previews.each do |preview|
       define_method(:"test_#{component_uri.parameterize(separator: '_')}_#{preview}") do
         visit("/rails/view_components/#{component_uri}/#{preview}")
-        assert_accessible(page)
+
+        begin
+          assert_accessible(page)
+        else
+          puts "#{component_uri}##{preview} passed check."
+        end
       end
     end
   end

--- a/test/accessibility_test.rb
+++ b/test/accessibility_test.rb
@@ -23,12 +23,8 @@ class AccessibilityTest < System::TestCase
     component_previews.each do |preview|
       define_method(:"test_#{component_uri.parameterize(separator: '_')}_#{preview}") do
         visit("/rails/view_components/#{component_uri}/#{preview}")
-
-        begin
-          assert_accessible(page)
-        else
-          puts "#{component_uri}##{preview} passed check."
-        end
+        assert_accessible(page)
+        puts "#{component_uri}##{preview} passed check."
       end
     end
   end

--- a/test/accessibility_test.rb
+++ b/test/accessibility_test.rb
@@ -3,7 +3,7 @@
 require "system/test_case"
 
 class AccessibilityTest < System::TestCase
-  parallelize workers: 2
+  parallelize workers: 4
 
   # Skip components that should be tested as part of a larger component.
   # Do not add to this list for any other reason!


### PR DESCRIPTION
### Description

This PR runs our accessibility tests in parallel to speed them up. It uses our org's newly-available 8-core runners and spins up 4 test workers (plus 4 puma servers).

A recent build of this branch completed running our accessibility tests in 2 minutes and 34 seconds. A recent build of main did the same in 6 minutes and 18 seconds, meaning **this PR reduces a11y run time by about 3 minutes and 34 seconds**. I have observed that our accessibility tests now take about as long to run as our system tests.

NOTE: a change will need to be made to the view_component test suite so it continues to run our accessibility tests in a single process, as its org does not have access to larger runners.

### Integration

> Does this change require any updates to code in production?

Nope! These changes only affect tests.

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
