### PR TITLE
Don't export web components

### DIFF
--- a/.changeset/dull-rabbits-glow.md
+++ b/.changeset/dull-rabbits-glow.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Avoid double-registering of exported components

--- a/app/components/primer/alpha/segmented_control.ts
+++ b/app/components/primer/alpha/segmented_control.ts
@@ -1,7 +1,7 @@
 import {controller, targets} from '@github/catalyst'
 
 @controller
-export class SegmentedControlElement extends HTMLElement {
+class SegmentedControlElement extends HTMLElement {
   @targets items: HTMLElement[]
 
   connectedCallback() {

--- a/app/components/primer/beta/x_banner.ts
+++ b/app/components/primer/beta/x_banner.ts
@@ -1,7 +1,7 @@
 import {controller, target} from '@github/catalyst'
 
 @controller
-export class XBannerElement extends HTMLElement {
+class XBannerElement extends HTMLElement {
   @target root: HTMLElement
   @target titleText: HTMLElement
 


### PR DESCRIPTION
As mentioned at #1450 exporting a component can cause errors when used as an npm package.  In the latest release two components `SegmentedControlElement` and  `XBannerElement` perform the export and I'm receiving the same error reported in #1440.

The code contains a fix with the same approach used by @camertron 

/cc @jonrohan  
