### PR TITLE
SegmentedControl: Don't update selected state on links

### DIFF
--- a/.changeset/honest-worms-breathe.md
+++ b/.changeset/honest-worms-breathe.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+SegmentedControl: Don't update selected state on links

--- a/app/components/primer/alpha/segmented_control/item.rb
+++ b/app/components/primer/alpha/segmented_control/item.rb
@@ -19,7 +19,7 @@ module Primer
           @selected = selected
 
           @system_arguments = system_arguments
-          @system_arguments[:"data-action"] = "click:segmented-control#select"
+          @system_arguments[:"data-action"] = "click:segmented-control#select" if system_arguments[:href].nil?
           @system_arguments[:"aria-current"] = selected
           @system_arguments[:scheme] = :invisible
         end

--- a/test/components/primer/alpha/segmented_control_test.rb
+++ b/test/components/primer/alpha/segmented_control_test.rb
@@ -51,6 +51,16 @@ module Primer
         assert_selector("segmented-control ul.SegmentedControl.SegmentedControl--fullWidth")
       end
 
+      def test_doesnt_use_control_click_with_href
+        render_inline(Primer::Alpha::SegmentedControl.new) do |c|
+          c.with_item(icon: :zap, label: "Item 1", selected: true) { "Item 1" }
+          c.with_item(tag: :a, href: "#", icon: :zap, label: "Item 2") { "Item 2" }
+        end
+
+        assert_selector("button[data-action=\"click:segmented-control#select\"]", count: 1)
+        assert_selector("a[data-action=\"click:segmented-control#select\"]", count: 0)
+      end
+
       def test_doesnt_render_with_too_many_items
         error = assert_raises(ArgumentError) do
           render_inline(Primer::Alpha::SegmentedControl.new) do |c|


### PR DESCRIPTION
### Description

This updates the SegmentedControl component to not change selected state when clicking on an item rendered as a link. This is because the browser will take care of loading and updating, changing the selected state before it's finished loaded breaks that cognitive connection.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
