### PR TITLE
Fix frozen string test failure in framework tests

### DIFF
--- a/test/system/test_case.rb
+++ b/test/system/test_case.rb
@@ -27,7 +27,7 @@ module System
       component_name = component_name.gsub(/^Beta|^Alpha/, "") if match
       component_uri = component_name.underscore
 
-      url = "/rails/view_components/primer/#{status_path}#{component_uri}/#{preview_name}"
+      url = +"/rails/view_components/primer/#{status_path}#{component_uri}/#{preview_name}"
       query_string = params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join("&")
       url << "?#{query_string}" if query_string.present?
 


### PR DESCRIPTION
### Description

The framework test suite has been [failing recently](https://github.com/ViewComponent/view_component/actions/runs/3380954180/jobs/5614440769) because PVC code attempts to append to a frozen string. Weirdly the PVC test suite did not catch this. It only appears to happen under ruby 2.7, the ruby version the framework uses in CI.

### Integration

> Does this change require any updates to code in production?

No, changes are test-only.

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
