### PR TITLE
Allow form field names to end in "?"

### DIFF
--- a/.changeset/old-beds-mate.md
+++ b/.changeset/old-beds-mate.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow form field names to end in "?"

--- a/app/forms/name_with_question_mark_form.rb
+++ b/app/forms/name_with_question_mark_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# :nodoc:
+class NameWithQuestionMarkForm < ApplicationForm
+  form do |name_with_question_mark_form|
+    name_with_question_mark_form.check_box(
+      name: :enabled?,
+      label: "Enabled"
+    )
+  end
+end

--- a/app/forms/name_with_question_mark_form/enabled_caption.html.erb
+++ b/app/forms/name_with_question_mark_form/enabled_caption.html.erb
@@ -1,0 +1,1 @@
+<p class="my-test-caption">The caption for Enabled?</p>

--- a/lib/primer/forms/base.rb
+++ b/lib/primer/forms/base.rb
@@ -44,11 +44,15 @@ module Primer
         end
 
         def caption_template?(field_name)
-          fields_with_caption_templates.include?(field_name)
+          fields_with_caption_templates.include?(sanitize_field_name_for_template_path(field_name))
         end
 
         def fields_with_caption_templates
           @fields_with_caption_templates ||= []
+        end
+
+        def sanitize_field_name_for_template_path(field_name)
+          field_name.to_s.delete_suffix("?").to_sym
         end
 
         private
@@ -115,8 +119,8 @@ module Primer
         self.class.after_content?(*args)
       end
 
-      def render_caption_template(name)
-        send(:"render_#{name}_caption")
+      def render_caption_template(field_name)
+        send(:"render_#{self.class.sanitize_field_name_for_template_path(field_name)}_caption")
       end
 
       def perform_render(&_block)

--- a/previews/primer/forms/forms_preview.rb
+++ b/previews/primer/forms/forms_preview.rb
@@ -34,6 +34,8 @@ module Primer
       def invalid_form; end
 
       def multi_input_form; end
+
+      def name_with_question_mark_form; end
     end
   end
 end

--- a/previews/primer/forms/forms_preview/name_with_question_mark_form.html.erb
+++ b/previews/primer/forms/forms_preview/name_with_question_mark_form.html.erb
@@ -1,0 +1,3 @@
+<%= primer_form_with(url: "/foo") do |f| %>
+  <%= render(NameWithQuestionMarkForm.new(f)) %>
+<% end %>

--- a/test/lib/primer/forms/forms_test.rb
+++ b/test/lib/primer/forms/forms_test.rb
@@ -315,4 +315,11 @@ class Primer::Forms::FormsTest < Minitest::Test
 
     assert_includes error.message, "please pass an instance of Primer::Forms::Builder"
   end
+
+  def test_renders_field_name_with_question_mark_caption_template
+    render_preview :name_with_question_mark_form
+
+    assert_selector "input[name=enabled]"
+    assert_selector ".my-test-caption"
+  end
 end


### PR DESCRIPTION
### Description

Rails will allow input names that end in a question mark and call the appropriate method on the model to (for example) decide if a checkbox should start off as "checked". This change ensures we can still find a caption template associated with a field named with a question mark, but not have to embed a question mark in the template file name.

### Integration

No changes in production. (Prod doesn't use this feature yet.)

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [x] Added/updated previews
