### PR TITLE
Remove redundant system_argument in dialog component

### DIFF
--- a/.changeset/neat-wasps-agree.md
+++ b/.changeset/neat-wasps-agree.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove redundant data-show-dialog-id system_argument in dialog component

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -54,7 +54,6 @@ module Primer
           system_arguments[:classes]
         )
         system_arguments[:id] = "dialog-show-#{@system_arguments[:id]}"
-        system_arguments["data-show-dialog-id"] = @system_arguments[:id]
         system_arguments[:data] = (system_arguments[:data] || {}).merge({ "show-dialog-id": @system_arguments[:id] })
         Primer::ButtonComponent.new(**system_arguments)
       }


### PR DESCRIPTION
### Description

This PR removes the redundant `data-show-dialog-id` system argument from the dialog component as per this Slack thread https://github.slack.com/archives/CSGAVNZ19/p1667339039401439 (staff only).

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
