### PR TITLE
Move `blankslate` styles to PVC

### DIFF
--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -1,0 +1,89 @@
+// stylelint-disable selector-max-type
+.blankslate {
+  position: relative;
+  padding: $spacer-5;
+  text-align: center;
+
+  p {
+    color: var(--color-fg-muted);
+  }
+
+  code {
+    // stylelint-disable-next-line primer/spacing
+    padding: 2px 5px 3px;
+    font-size: $h5-size;
+    background: var(--color-canvas-default);
+    border: $border-width $border-style var(--color-border-muted);
+    border-radius: $border-radius;
+  }
+
+  img {
+    width: 56px;
+    height: 56px;
+  }
+}
+
+.blankslate-icon {
+  margin-right: $spacer-1;
+  margin-bottom: $spacer-2;
+  margin-left: $spacer-1;
+  color: var(--color-fg-muted);
+}
+
+.blankslate-image {
+  margin-bottom: $spacer-3;
+}
+
+.blankslate-heading {
+  margin-bottom: $spacer-1;
+}
+
+.blankslate-action {
+  margin-top: $spacer-3;
+
+  &:first-of-type {
+    margin-top: $spacer-4;
+  }
+
+  &:last-of-type {
+    margin-bottom: $spacer-2;
+  }
+}
+
+.blankslate-capped {
+  border-radius: 0 0 $border-radius $border-radius;
+}
+
+.blankslate-spacious {
+  padding: ($spacer-6 * 2) $spacer-6;
+}
+
+.blankslate-narrow {
+  max-width: 485px;
+  margin: 0 auto;
+}
+
+// was .large-format
+// QUESTION: should we deprecate this?
+.blankslate-large {
+  img {
+    width: 80px;
+    height: 80px;
+  }
+
+  h3 {
+    margin: $spacer-3 0;
+    //font-size: $h3-size; // This doesn't actually make the text larger. Should this be $h2-size?
+    font-size: $h2-size;
+  }
+
+  p {
+    font-size: $h4-size;
+  }
+}
+
+// was .clean-background
+// TO DO: deprecate this and use utility instead
+.blankslate-clean-background {
+  border: 0;
+}

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -1,61 +1,61 @@
-// stylelint-disable selector-max-type
+/* blankslate */
+
 .blankslate {
   position: relative;
-  padding: $spacer-5;
+  padding: var(--base-size-32, 32px);
   text-align: center;
 
-  p {
+  & p {
     color: var(--color-fg-muted);
   }
 
-  code {
-    // stylelint-disable-next-line primer/spacing
+  & code {
     padding: 2px 5px 3px;
-    font-size: $h5-size;
+    font-size: var(--primer-text-body-size-medium, 14px);
     background: var(--color-canvas-default);
-    border: $border-width $border-style var(--color-border-muted);
-    border-radius: $border-radius;
+    border: var(--primer-borderWidth-thin, 1px) solid var(--color-border-muted);
+    border-radius: var(--primer-borderRadius-medium, 6px);
   }
 
-  img {
+  & img {
     width: 56px;
     height: 56px;
   }
 }
 
 .blankslate-icon {
-  margin-right: $spacer-1;
-  margin-bottom: $spacer-2;
-  margin-left: $spacer-1;
+  margin-right: var(--primer-control-small-gap, 4px);
+  margin-bottom: var(--primer-stack-gap-condensed, 8px);
+  margin-left: var(--primer-control-small-gap, 4px);
   color: var(--color-fg-muted);
 }
 
 .blankslate-image {
-  margin-bottom: $spacer-3;
+  margin-bottom: var(--primer-stack-gap-normal, 16px);
 }
 
 .blankslate-heading {
-  margin-bottom: $spacer-1;
+  margin-bottom: var(--base-size-4, 4px);
 }
 
 .blankslate-action {
-  margin-top: $spacer-3;
+  margin-top: var(--primer-stack-gap-normal, 16px);
 
   &:first-of-type {
-    margin-top: $spacer-4;
+    margin-top: var(--primer-stack-gap-spacious, 24px);
   }
 
   &:last-of-type {
-    margin-bottom: $spacer-2;
+    margin-bottom: var(--primer-stack-gap-condensed, 8px);
   }
 }
 
 .blankslate-capped {
-  border-radius: 0 0 $border-radius $border-radius;
+  border-radius: 0 0 var(--primer-borderRadius-medium, 6px) var(--primer-borderRadius-medium, 6px);
 }
 
 .blankslate-spacious {
-  padding: ($spacer-6 * 2) $spacer-6;
+  padding: var(--base-size-80, 80px) var(--base-size-40, 40px);
 }
 
 .blankslate-narrow {
@@ -63,27 +63,28 @@
   margin: 0 auto;
 }
 
-// was .large-format
-// QUESTION: should we deprecate this?
+/* was .large-format
+** QUESTION: should we deprecate this? */
 .blankslate-large {
-  img {
+  & img {
     width: 80px;
     height: 80px;
   }
 
-  h3 {
-    margin: $spacer-3 0;
-    //font-size: $h3-size; // This doesn't actually make the text larger. Should this be $h2-size?
-    font-size: $h2-size;
+  & h3 {
+    margin: var(--primer-stack-gap-normal, 16px) 0;
+
+    /* font-size: $h3-size; // This doesn't actually make the text larger. Should this be $h2-size? */
+    font-size: 24px;
   }
 
-  p {
-    font-size: $h4-size;
+  & p {
+    font-size: var(--primer-text-body-size-large, 16px);
   }
 }
 
-// was .clean-background
-// TO DO: deprecate this and use utility instead
+/* was .clean-background
+** TO DO: deprecate this and use utility instead */
 .blankslate-clean-background {
   border: 0;
 }

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -3,3 +3,4 @@
 @import "./alpha/banner.pcss";
 @import './alpha/segmented_control.pcss';
 @import "./beta/button.pcss";
+@import "./beta/blankslate.pcss";

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -20,7 +20,6 @@
  *= require @primer/css/dist/alerts.css
  *= require @primer/css/dist/autocomplete.css
  *= require @primer/css/dist/avatars.css
- *= require @primer/css/dist/blankslate.css
  *= require @primer/css/dist/branch-name.css
  *= require @primer/css/dist/dropdown.css
  *= require @primer/css/dist/header.css


### PR DESCRIPTION
### Description

This adds the `blankslate` styles from [PCSS](https://github.com/primer/css/blob/5a0b9b2939c1428430d249aeeb9adb0ba8bc18ce/src/blankslate/blankslate.scss).

There should be no visual changes. See this commit https://github.com/primer/view_components/commit/a263494b9ed92c62eec9f6b9df3834ea853b5cdf for the diff of migrating from `.scss` to `.pcss`.

Closes https://github.com/github/primer/issues/1497

### Integration

> Does this change require any updates to code in production?

Yes, [this line](https://github.com/github/github/blob/e009ce8f20d5700a7f4a581e3c7953951469bf9c/app/assets/stylesheets/bundles/primer/index.scss#L121) should be updated on dotcom:

```diff
- @import '@primer/css/blankslate/blankslate.scss';
+ @import '@primer/view-components/app/assets/styles/blankslate.scss';
```

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
- [x] Visual regression test

Before | After
--- | ---
![Screen Shot 2022-11-08 at 15 18 09](https://user-images.githubusercontent.com/378023/200491646-ccf7ea67-f97b-43a4-80a3-c71ed149cd8b.png) | ![Screen Shot 2022-11-08 at 15 18 18](https://user-images.githubusercontent.com/378023/200491652-7f5598c2-95ac-4e11-947c-7aa3460556ab.png)

If you can't spot a difference 👉  good!