### PR TITLE
Move `Truncate` styles to PVC

### DIFF
--- a/.changeset/slow-grapes-dance.md
+++ b/.changeset/slow-grapes-dance.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move `Truncate` styles to PVC

--- a/app/components/primer/beta/truncate.pcss
+++ b/app/components/primer/beta/truncate.pcss
@@ -1,0 +1,29 @@
+.Truncate {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+
+  > .Truncate-text {
+    min-width: 1ch;
+    max-width: fit-content;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    + .Truncate-text {
+      margin-left: $spacer-1;
+    }
+
+    &.Truncate-text--primary {
+      flex-basis: 200%;
+    }
+
+    &.Truncate-text--expandable:hover,
+    &.Truncate-text--expandable:focus,
+    &.Truncate-text--expandable:active {
+      max-width: 100% !important;
+      flex-shrink: 0;
+      cursor: pointer;
+    }
+  }
+}

--- a/app/components/primer/beta/truncate.pcss
+++ b/app/components/primer/beta/truncate.pcss
@@ -1,17 +1,19 @@
+/* Truncate */
+
 .Truncate {
   display: inline-flex;
   min-width: 0;
   max-width: 100%;
 
-  > .Truncate-text {
+  & > .Truncate-text {
     min-width: 1ch;
     max-width: fit-content;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    + .Truncate-text {
-      margin-left: $spacer-1;
+    & + .Truncate-text {
+      margin-left: var(--primer-control-small-gap, 4px);
     }
 
     &.Truncate-text--primary {

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -4,3 +4,5 @@
 @import './alpha/segmented_control.pcss';
 @import "./beta/button.pcss";
 @import "./beta/progress_bar.pcss";
+@import "./beta/truncate.pcss";
+@import "./truncate.pcss";

--- a/app/components/primer/truncate.pcss
+++ b/app/components/primer/truncate.pcss
@@ -1,0 +1,31 @@
+// Truncate
+//
+// css-truncate will shorten text with an ellipsis.
+
+.css-truncate {
+
+  // css-truncate-auto will shorten text with an ellipsis when overflowing
+  &.css-truncate-overflow,
+  .css-truncate-overflow,
+  &.css-truncate-target,
+  .css-truncate-target {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  // css-truncate-target will shorten text with an ellipsis and a max width
+  &.css-truncate-target,
+  .css-truncate-target {
+    display: inline-block;
+    max-width: 125px;
+    vertical-align: top;
+  }
+
+  &.expandable.zeroclipboard-is-hover .css-truncate-target,
+  &.expandable.zeroclipboard-is-hover.css-truncate-target,
+  &.expandable:hover .css-truncate-target,
+  &.expandable:hover.css-truncate-target {
+    max-width: 10000px !important;
+  }
+}

--- a/app/components/primer/truncate.pcss
+++ b/app/components/primer/truncate.pcss
@@ -1,22 +1,21 @@
-// Truncate
-//
-// css-truncate will shorten text with an ellipsis.
+/* CSS truncate */
+
+/* css-truncate will shorten text with an ellipsis. */
 
 .css-truncate {
-
-  // css-truncate-auto will shorten text with an ellipsis when overflowing
+  /* css-truncate-overflow will shorten text with an ellipsis when overflowing */
   &.css-truncate-overflow,
-  .css-truncate-overflow,
+  & .css-truncate-overflow,
   &.css-truncate-target,
-  .css-truncate-target {
+  & .css-truncate-target {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  // css-truncate-target will shorten text with an ellipsis and a max width
+  /* css-truncate-target will shorten text with an ellipsis and a max width */
   &.css-truncate-target,
-  .css-truncate-target {
+  & .css-truncate-target {
     display: inline-block;
     max-width: 125px;
     vertical-align: top;

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -14,7 +14,6 @@
  *= require @primer/css/dist/navigation.css
  *= require @primer/css/dist/pagination.css
  *= require @primer/css/dist/tooltips.css
- *= require @primer/css/dist/truncate.css
  *= require @primer/css/dist/overlay.css
  *= require @primer/css/dist/utilities.css
  *= require @primer/css/dist/alerts.css


### PR DESCRIPTION
### Description

This is part of [#1342](https://github.com/github/primer/issues/1342) and adds the [`Truncate` + `css-truncate`](https://github.com/primer/css/blob/5a0b9b2939c1428430d249aeeb9adb0ba8bc18ce/src/truncate/truncate.scss) styles from PCSS. There should be no visual changes.

### Integration

> Does this change require any updates to code in production?

Yes, the following line can be removed on [dotcom](https://github.com/github/github/blob/e009ce8f20d5700a7f4a581e3c7953951469bf9c/app/assets/stylesheets/bundles/primer/index.scss#L86):

```diff
- @import '@primer/css/truncate/truncate.scss';
```

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
- [x] Visual regression test

Before | After
--- | ---
![Screen Shot 2022-11-10 at 10 58 45](https://user-images.githubusercontent.com/378023/200984076-3848d9e7-6700-4896-b364-49aab4c65614.png) | ![Screen Shot 2022-11-10 at 10 58 52](https://user-images.githubusercontent.com/378023/200984079-3a1cfbd8-577a-43f1-b84d-7fcb200fe066.png)
