### PR TITLE
Move `TimelineItem` styles to PVC

### DIFF
--- a/.changeset/six-ways-sin.md
+++ b/.changeset/six-ways-sin.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move `TimelineItem` styles to PVC

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -12,4 +12,5 @@
 @import "./beta/truncate.pcss";
 @import "./state_component.pcss";
 @import "./subhead_component.pcss";
+@import "./timeline_item_component.pcss";
 @import "./truncate.pcss";

--- a/app/components/primer/timeline_item_component.pcss
+++ b/app/components/primer/timeline_item_component.pcss
@@ -1,0 +1,94 @@
+.TimelineItem {
+  position: relative;
+  display: flex;
+  padding: $spacer-3 0;
+  margin-left: $spacer-3;
+
+  // The Timeline
+  &::before {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    width: 2px;
+    content: '';
+    background-color: var(--color-border-muted);
+  }
+
+  &:target .TimelineItem-badge {
+    border-color: var(--color-accent-emphasis);
+    // stylelint-disable-next-line primer/box-shadow
+    box-shadow: 0 0 0.2em var(--color-accent-muted);
+  }
+}
+
+.TimelineItem-badge {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: $spacer-5;
+  height: $spacer-5;
+  margin-right: $spacer-2;
+  margin-left: -$spacer-3 + 1;
+  color: var(--color-fg-muted);
+  align-items: center;
+  background-color: var(--color-timeline-badge-bg);
+  // stylelint-disable-next-line primer/borders
+  border: 2px $border-style var(--color-canvas-default);
+  border-radius: 50%;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &--success {
+    color: var(--color-fg-on-emphasis);
+    background-color: var(--color-success-emphasis);
+    border: $border-width $border-style transparent;
+  }
+}
+
+.TimelineItem-body {
+  min-width: 0;
+  max-width: 100%;
+  margin-top: $spacer-1;
+  color: var(--color-fg-muted);
+  flex: auto;
+}
+
+.TimelineItem-avatar {
+  position: absolute;
+  left: -($spacer-6 + $spacer-5);
+  z-index: 1;
+}
+
+.TimelineItem-break {
+  position: relative;
+  z-index: 1;
+  height: $spacer-4;
+  margin: 0;
+  margin-bottom: -$spacer-3;
+  margin-left: -($spacer-6 + $spacer-3);
+  background-color: var(--color-canvas-default);
+  border: 0;
+  // stylelint-disable-next-line primer/borders
+  border-top: 4px $border-style var(--color-border-default);
+}
+
+.TimelineItem--condensed {
+  padding-top: $spacer-1;
+  padding-bottom: 0;
+
+  // TimelineItem--condensed is often grouped. (commits)
+  &:last-child {
+    padding-bottom: $spacer-3;
+  }
+
+  .TimelineItem-badge {
+    height: $spacer-3;
+    margin-top: $spacer-2;
+    margin-bottom: $spacer-2;
+    color: var(--color-fg-muted);
+    background-color: var(--color-canvas-default);
+    border: 0;
+  }
+}

--- a/app/components/primer/timeline_item_component.pcss
+++ b/app/components/primer/timeline_item_component.pcss
@@ -35,7 +35,7 @@
   color: var(--color-fg-muted);
   align-items: center;
   background-color: var(--color-timeline-badge-bg);
-  border: 2px solid var(--color-canvas-default);
+  border: var(--primer-borderWidth-thick, 2px) solid var(--color-canvas-default);
   border-radius: 50%;
   justify-content: center;
   flex-shrink: 0;

--- a/app/components/primer/timeline_item_component.pcss
+++ b/app/components/primer/timeline_item_component.pcss
@@ -1,24 +1,25 @@
+/* TimelineItem */
+
 .TimelineItem {
   position: relative;
   display: flex;
-  padding: $spacer-3 0;
-  margin-left: $spacer-3;
+  padding: var(--primer-stack-padding-normal, 16px) 0;
+  margin-left: var(--primer-stack-gap-normal, 16px);
 
-  // The Timeline
+  /* The Timeline */
   &::before {
     position: absolute;
     top: 0;
     bottom: 0;
     left: 0;
     display: block;
-    width: 2px;
+    width: var(--primer-borderWidth-thick, 2px);
     content: '';
     background-color: var(--color-border-muted);
   }
 
   &:target .TimelineItem-badge {
     border-color: var(--color-accent-emphasis);
-    // stylelint-disable-next-line primer/box-shadow
     box-shadow: 0 0 0.2em var(--color-accent-muted);
   }
 }
@@ -27,66 +28,64 @@
   position: relative;
   z-index: 1;
   display: flex;
-  width: $spacer-5;
-  height: $spacer-5;
-  margin-right: $spacer-2;
-  margin-left: -$spacer-3 + 1;
+  width: var(--primer-control-medium-size, 32px);
+  height: var(--primer-control-medium-size, 32px);
+  margin-right: var(--primer-controlStack-medium-gap-condensed, 8px);
+  margin-left: calc(var(--primer-control-medium-size, 32px) / -2 + 1px);
   color: var(--color-fg-muted);
   align-items: center;
   background-color: var(--color-timeline-badge-bg);
-  // stylelint-disable-next-line primer/borders
-  border: 2px $border-style var(--color-canvas-default);
+  border: 2px solid var(--color-canvas-default);
   border-radius: 50%;
   justify-content: center;
   flex-shrink: 0;
+}
 
-  &--success {
-    color: var(--color-fg-on-emphasis);
-    background-color: var(--color-success-emphasis);
-    border: $border-width $border-style transparent;
-  }
+.TimelineItem-badge--success {
+  color: var(--color-fg-on-emphasis);
+  background-color: var(--color-success-emphasis);
+  border: var(--primer-borderWidth-thin, 1px) solid transparent;
 }
 
 .TimelineItem-body {
   min-width: 0;
   max-width: 100%;
-  margin-top: $spacer-1;
+  margin-top: var(--base-size-4, 4px);
   color: var(--color-fg-muted);
   flex: auto;
 }
 
 .TimelineItem-avatar {
   position: absolute;
-  left: -($spacer-6 + $spacer-5);
+  left: -72px;
   z-index: 1;
 }
 
 .TimelineItem-break {
   position: relative;
   z-index: 1;
-  height: $spacer-4;
+  height: var(--primer-stack-gap-spacious, 24px);
   margin: 0;
-  margin-bottom: -$spacer-3;
-  margin-left: -($spacer-6 + $spacer-3);
+  margin-bottom: calc(var(--primer-stack-gap-normal, 16px) * -1);
+  margin-left: -56px;
   background-color: var(--color-canvas-default);
   border: 0;
-  // stylelint-disable-next-line primer/borders
-  border-top: 4px $border-style var(--color-border-default);
+  border-top: var(--primer-borderWidth-thicker, 4px) solid var(--color-border-default);
 }
 
 .TimelineItem--condensed {
-  padding-top: $spacer-1;
+  padding-top: var(--base-size-4, 4px);
   padding-bottom: 0;
 
-  // TimelineItem--condensed is often grouped. (commits)
+  /* TimelineItem--condensed is often grouped. (commits) */
   &:last-child {
-    padding-bottom: $spacer-3;
+    padding-bottom: var(--primer-stack-gap-normal, 16px);
   }
 
-  .TimelineItem-badge {
-    height: $spacer-3;
-    margin-top: $spacer-2;
-    margin-bottom: $spacer-2;
+  & .TimelineItem-badge {
+    height: var(--base-size-16, 16px);
+    margin-top: var(--base-size-8, 8px);
+    margin-bottom: var(--base-size-8, 8px);
     color: var(--color-fg-muted);
     background-color: var(--color-canvas-default);
     border: 0;

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -25,6 +25,5 @@
  *= require @primer/css/dist/markdown.css
  *= require @primer/css/dist/popover.css
  *= require @primer/css/dist/select-menu.css
- *= require @primer/css/dist/timeline.css
  *= require @primer/css/dist/toasts.css
 */


### PR DESCRIPTION
### Description

This is part of [#1342](https://github.com/github/primer/issues/1342) and adds the [`TimelineItem`](https://github.com/primer/css/blob/5a0b9b2939c1428430d249aeeb9adb0ba8bc18ce/src/timeline/timeline-item.scss) styles from PCSS. There should be no visual changes.

### Integration

> Does this change require any updates to code in production?

Yes, the following line can be removed on [dotcom](https://github.com/github/github/blob/e009ce8f20d5700a7f4a581e3c7953951469bf9c/app/assets/stylesheets/bundles/primer/index.scss#L166):

```diff
- @import '@primer/css/timeline/timeline-item.scss';
```

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
- [x] Visual regression test

Before | After
--- | ---
![Screen Shot 2022-11-11 at 12 33 39](https://user-images.githubusercontent.com/378023/201258514-f45d223e-bdfe-4665-9f0b-156aab77fe13.png) | ![Screen Shot 2022-11-11 at 12 33 46](https://user-images.githubusercontent.com/378023/201258521-744bc3ca-ec1a-4aab-b607-0825e5b59624.png)
