### PR TITLE
Move `dropdown` styles to PVC

### DIFF
--- a/.changeset/twelve-dancers-retire.md
+++ b/.changeset/twelve-dancers-retire.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move `dropdown` styles to PVC

--- a/app/components/primer/dropdown.pcss
+++ b/app/components/primer/dropdown.pcss
@@ -1,0 +1,270 @@
+.dropdown {
+  position: relative;
+}
+
+.dropdown-caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  vertical-align: middle;
+  content: '';
+  border-style: $border-style;
+  // stylelint-disable-next-line primer/borders
+  border-width: $spacer-1 $spacer-1 0;
+  border-right-color: transparent;
+  border-bottom-color: transparent;
+  border-left-color: transparent;
+}
+
+// Requires a positioning class (e.g., `.dropdown-menu-w`) to determine which
+// way the menu should render from the element triggering it.
+
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  width: 160px;
+  padding-top: $spacer-1;
+  padding-bottom: $spacer-1;
+  // stylelint-disable-next-line primer/spacing
+  margin-top: 2px;
+  list-style: none;
+  background-color: var(--color-canvas-overlay);
+  background-clip: padding-box;
+  border: $border-width $border-style var(--color-border-default);
+  border-radius: $border-radius;
+  box-shadow: var(--color-shadow-large);
+
+  &::before,
+  &::after {
+    position: absolute;
+    display: inline-block;
+    content: '';
+  }
+
+  // caret border
+  &::before {
+    // stylelint-disable-next-line primer/borders
+    border: $spacer-2 $border-style transparent;
+    border-bottom-color: var(--color-border-default);
+  }
+
+  // caret background (should match dropdown background)
+  &::after {
+    // stylelint-disable-next-line primer/borders
+    border: 7px $border-style transparent;
+    border-bottom-color: var(--color-canvas-overlay);
+  }
+
+  // stylelint-disable-next-line selector-max-type
+  > ul {
+    list-style: none;
+  }
+}
+
+.dropdown-menu-no-overflow {
+  width: auto;
+
+  .dropdown-item {
+    padding: $spacer-1 $spacer-3;
+    overflow: visible;
+    text-overflow: inherit;
+  }
+}
+
+// Dropdown items (can be links or buttons)
+.dropdown-item {
+  display: block;
+  padding: $spacer-1 $spacer-2 $spacer-1 $spacer-3;
+  overflow: hidden;
+  color: var(--color-fg-default);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    color: var(--color-fg-on-emphasis);
+    text-decoration: none;
+    background-color: var(--color-accent-emphasis);
+
+    > .octicon {
+      color: inherit;
+      opacity: 1;
+    }
+
+    [class*='color-text-'] {
+      color: inherit !important;
+    }
+
+    > .Label {
+      color: inherit !important;
+      border-color: currentColor;
+    }
+  }
+
+  &.btn-link {
+    width: 100%;
+    text-align: left;
+  }
+}
+
+.dropdown-signout {
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+}
+
+.dropdown-divider {
+  display: block;
+  height: 0;
+  margin: $spacer-2 0;
+  border-top: $border-width $border-style var(--color-border-default);
+}
+
+.dropdown-header {
+  padding: $spacer-1 $spacer-3;
+  font-size: $h6-size;
+  color: var(--color-fg-muted);
+}
+
+.dropdown-item[aria-checked='false'] .octicon-check {
+  display: none;
+}
+
+// Directional classes
+//
+// Move the menu and the caret attached to it. Requires at least one of these on
+// the `.dropdown-menu` element.
+
+.dropdown-menu-w {
+  top: 0;
+  right: 100%;
+  left: auto;
+  width: auto;
+  margin-top: 0;
+  margin-right: $spacer-2;
+
+  &::before {
+    top: 10px;
+    right: -$spacer-3;
+    left: auto;
+    border-color: transparent;
+    border-left-color: var(--color-border-default);
+  }
+
+  &::after {
+    top: 11px;
+    right: -14px;
+    left: auto;
+    border-color: transparent;
+    border-left-color: var(--color-canvas-overlay);
+  }
+}
+
+.dropdown-menu-e {
+  top: 0;
+  left: 100%;
+  width: auto;
+  margin-top: 0;
+  margin-left: $spacer-2;
+
+  &::before {
+    top: 10px;
+    left: -$spacer-3;
+    border-color: transparent;
+    border-right-color: var(--color-border-default);
+  }
+
+  &::after {
+    top: 11px;
+    left: -14px;
+    border-color: transparent;
+    border-right-color: var(--color-canvas-overlay);
+  }
+}
+
+.dropdown-menu-ne {
+  top: auto;
+  bottom: 100%;
+  left: 0;
+  // stylelint-disable-next-line primer/spacing
+  margin-bottom: 3px;
+
+  &::before,
+  &::after {
+    top: auto;
+    right: auto;
+  }
+
+  &::before {
+    bottom: -$spacer-2;
+    left: 9px;
+    // stylelint-disable-next-line primer/borders
+    border-top: $spacer-2 $border-style var(--color-border-default);
+    // stylelint-disable-next-line primer/borders
+    border-right: $spacer-2 $border-style transparent;
+    border-bottom: 0;
+    // stylelint-disable-next-line primer/borders
+    border-left: $spacer-2 $border-style transparent;
+  }
+
+  &::after {
+    bottom: -7px;
+    left: 10px;
+    // stylelint-disable-next-line primer/borders
+    border-top: 7px $border-style var(--color-canvas-overlay);
+    // stylelint-disable-next-line primer/borders
+    border-right: 7px $border-style transparent;
+    border-bottom: 0;
+    // stylelint-disable-next-line primer/borders
+    border-left: 7px $border-style transparent;
+  }
+}
+
+.dropdown-menu-s {
+  right: 50%;
+  left: auto;
+  transform: translateX(50%);
+
+  &::before {
+    top: -$spacer-3;
+    right: 50%;
+    transform: translateX(50%);
+  }
+
+  &::after {
+    top: -14px;
+    right: 50%;
+    transform: translateX(50%);
+  }
+}
+
+.dropdown-menu-sw {
+  right: 0;
+  left: auto;
+
+  &::before {
+    top: -$spacer-3;
+    right: 9px;
+    left: auto;
+  }
+
+  &::after {
+    top: -14px;
+    right: 10px;
+    left: auto;
+  }
+}
+
+.dropdown-menu-se {
+  &::before {
+    top: -$spacer-3;
+    left: 9px;
+  }
+
+  &::after {
+    top: -14px;
+    left: 10px;
+  }
+}

--- a/app/components/primer/dropdown.pcss
+++ b/app/components/primer/dropdown.pcss
@@ -1,3 +1,5 @@
+/* dropdown */
+
 .dropdown {
   position: relative;
 }
@@ -8,16 +10,15 @@
   height: 0;
   vertical-align: middle;
   content: '';
-  border-style: $border-style;
-  // stylelint-disable-next-line primer/borders
-  border-width: $spacer-1 $spacer-1 0;
+  border-style: solid;
+  border-width: var(--primer-borderWidth-thicker, 4px) var(--primer-borderWidth-thicker, 4px) 0;
   border-right-color: transparent;
   border-bottom-color: transparent;
   border-left-color: transparent;
 }
 
-// Requires a positioning class (e.g., `.dropdown-menu-w`) to determine which
-// way the menu should render from the element triggering it.
+/* Requires a positioning class (e.g., `.dropdown-menu-w`) to determine which
+** way the menu should render from the element triggering it. */
 
 .dropdown-menu {
   position: absolute;
@@ -25,15 +26,14 @@
   left: 0;
   z-index: 100;
   width: 160px;
-  padding-top: $spacer-1;
-  padding-bottom: $spacer-1;
-  // stylelint-disable-next-line primer/spacing
+  padding-top: var(--primer-control-small-paddingBlock, 4px);
+  padding-bottom: var(--primer-control-small-paddingBlock, 4px);
   margin-top: 2px;
   list-style: none;
   background-color: var(--color-canvas-overlay);
   background-clip: padding-box;
-  border: $border-width $border-style var(--color-border-default);
-  border-radius: $border-radius;
+  border: var(--primer-borderWidth-thin, 1px) solid var(--color-border-default);
+  border-radius: var(--primer-borderRadius-medium, 6px);
   box-shadow: var(--color-shadow-large);
 
   &::before,
@@ -43,22 +43,19 @@
     content: '';
   }
 
-  // caret border
+  /* caret border */
   &::before {
-    // stylelint-disable-next-line primer/borders
-    border: $spacer-2 $border-style transparent;
+    border: 8px solid transparent;
     border-bottom-color: var(--color-border-default);
   }
 
-  // caret background (should match dropdown background)
+  /* caret background (should match dropdown background) */
   &::after {
-    // stylelint-disable-next-line primer/borders
-    border: 7px $border-style transparent;
+    border: 7px solid transparent;
     border-bottom-color: var(--color-canvas-overlay);
   }
 
-  // stylelint-disable-next-line selector-max-type
-  > ul {
+  & > ul {
     list-style: none;
   }
 }
@@ -66,17 +63,17 @@
 .dropdown-menu-no-overflow {
   width: auto;
 
-  .dropdown-item {
-    padding: $spacer-1 $spacer-3;
+  & .dropdown-item {
+    padding: var(--primer-control-small-paddingBlock, 4px) var(--primer-control-medium-paddingInline-spacious, 16px);
     overflow: visible;
     text-overflow: inherit;
   }
 }
 
-// Dropdown items (can be links or buttons)
+/* Dropdown items (can be links or buttons) */
 .dropdown-item {
   display: block;
-  padding: $spacer-1 $spacer-2 $spacer-1 $spacer-3;
+  padding: var(--primer-control-small-paddingBlock, 4px) var(--primer-control-medium-paddingInline-condensed, 8px) var(--primer-control-small-paddingBlock, 4px) var(--primer-control-medium-paddingInline-spacious, 16px);
   overflow: hidden;
   color: var(--color-fg-default);
   text-overflow: ellipsis;
@@ -87,18 +84,18 @@
     text-decoration: none;
     background-color: var(--color-accent-emphasis);
 
-    > .octicon {
+    & > .octicon {
       color: inherit;
       opacity: 1;
     }
 
-    [class*='color-text-'] {
+    & [class*='color-text-'] {
       color: inherit !important;
     }
 
-    > .Label {
+    & > .Label {
       color: inherit !important;
-      border-color: currentColor;
+      border-color: currentcolor;
     }
   }
 
@@ -118,13 +115,13 @@
 .dropdown-divider {
   display: block;
   height: 0;
-  margin: $spacer-2 0;
-  border-top: $border-width $border-style var(--color-border-default);
+  margin: var(--primer-stack-gap-condensed, 8px) 0;
+  border-top: var(--primer-borderWidth-thin, 1px) solid var(--color-border-default);
 }
 
 .dropdown-header {
-  padding: $spacer-1 $spacer-3;
-  font-size: $h6-size;
+  padding: var(--primer-control-small-paddingBlock, 4px) var(--primer-control-medium-paddingInline-spacious, 16px);
+  font-size: var(--primer-text-body-size-small, 12px);
   color: var(--color-fg-muted);
 }
 
@@ -132,10 +129,10 @@
   display: none;
 }
 
-// Directional classes
-//
-// Move the menu and the caret attached to it. Requires at least one of these on
-// the `.dropdown-menu` element.
+/* Directional classes
+**
+** Move the menu and the caret attached to it. Requires at least one of these on
+** the `.dropdown-menu` element. */
 
 .dropdown-menu-w {
   top: 0;
@@ -143,11 +140,11 @@
   left: auto;
   width: auto;
   margin-top: 0;
-  margin-right: $spacer-2;
+  margin-right: 8px;
 
   &::before {
     top: 10px;
-    right: -$spacer-3;
+    right: -16px;
     left: auto;
     border-color: transparent;
     border-left-color: var(--color-border-default);
@@ -167,11 +164,11 @@
   left: 100%;
   width: auto;
   margin-top: 0;
-  margin-left: $spacer-2;
+  margin-left: 8px;
 
   &::before {
     top: 10px;
-    left: -$spacer-3;
+    left: -16px;
     border-color: transparent;
     border-right-color: var(--color-border-default);
   }
@@ -188,7 +185,6 @@
   top: auto;
   bottom: 100%;
   left: 0;
-  // stylelint-disable-next-line primer/spacing
   margin-bottom: 3px;
 
   &::before,
@@ -198,27 +194,21 @@
   }
 
   &::before {
-    bottom: -$spacer-2;
+    bottom: -8px;
     left: 9px;
-    // stylelint-disable-next-line primer/borders
-    border-top: $spacer-2 $border-style var(--color-border-default);
-    // stylelint-disable-next-line primer/borders
-    border-right: $spacer-2 $border-style transparent;
+    border-top: 8px solid var(--color-border-default);
+    border-right: 8px solid transparent;
     border-bottom: 0;
-    // stylelint-disable-next-line primer/borders
-    border-left: $spacer-2 $border-style transparent;
+    border-left: 8px solid transparent;
   }
 
   &::after {
     bottom: -7px;
     left: 10px;
-    // stylelint-disable-next-line primer/borders
-    border-top: 7px $border-style var(--color-canvas-overlay);
-    // stylelint-disable-next-line primer/borders
-    border-right: 7px $border-style transparent;
+    border-top: 7px solid var(--color-canvas-overlay);
+    border-right: 7px solid transparent;
     border-bottom: 0;
-    // stylelint-disable-next-line primer/borders
-    border-left: 7px $border-style transparent;
+    border-left: 7px solid transparent;
   }
 }
 
@@ -228,7 +218,7 @@
   transform: translateX(50%);
 
   &::before {
-    top: -$spacer-3;
+    top: -16px;
     right: 50%;
     transform: translateX(50%);
   }
@@ -245,7 +235,7 @@
   left: auto;
 
   &::before {
-    top: -$spacer-3;
+    top: -16px;
     right: 9px;
     left: auto;
   }
@@ -259,7 +249,7 @@
 
 .dropdown-menu-se {
   &::before {
-    top: -$spacer-3;
+    top: -16px;
     left: 9px;
   }
 

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -10,6 +10,7 @@
 @import "./beta/blankslate.pcss";
 @import "./beta/progress_bar.pcss";
 @import "./beta/truncate.pcss";
+@import "./dropdown.pcss";
 @import "./state_component.pcss";
 @import "./subhead_component.pcss";
 @import "./truncate.pcss";

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -19,7 +19,6 @@
  *= require @primer/css/dist/autocomplete.css
  *= require @primer/css/dist/avatars.css
  *= require @primer/css/dist/branch-name.css
- *= require @primer/css/dist/dropdown.css
  *= require @primer/css/dist/header.css
  *= require @primer/css/dist/loaders.css
  *= require @primer/css/dist/markdown.css


### PR DESCRIPTION
### Description

This is part of [#1342](https://github.com/github/primer/issues/1342) and adds the [`dropdown`](https://github.com/primer/css/blob/5a0b9b2939c1428430d249aeeb9adb0ba8bc18ce/src/dropdown/dropdown.scss) styles from PCSS. There should be no visual changes.

### Integration

> Does this change require any updates to code in production?

Yes, the following line can be removed on [dotcom](https://github.com/github/github/blob/e009ce8f20d5700a7f4a581e3c7953951469bf9c/app/assets/stylesheets/bundles/primer/index.scss#L127):

```diff
- @import '@primer/css/dropdown/dropdown.scss';
```

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
- [x] Visual regression test

Before | After
--- | ---
![Screen Shot 2022-11-11 at 17 18 43](https://user-images.githubusercontent.com/378023/201299195-e34e5646-6ea5-4002-8d72-56d619bf698f.png) | ![Screen Shot 2022-11-11 at 17 18 50](https://user-images.githubusercontent.com/378023/201299220-040c72cc-d854-4982-933e-ff0175188609.png)
