### PR TITLE
Move `flash` styles to PVC

### DIFF
--- a/.changeset/famous-maps-joke.md
+++ b/.changeset/famous-maps-joke.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move `flash` styles to PVC

--- a/app/components/primer/beta/flash.pcss
+++ b/app/components/primer/beta/flash.pcss
@@ -8,12 +8,18 @@
   border-width: var(--primer-borderWidth-thin, 1px);
   border-radius: var(--primer-borderRadius-medium, 6px);
 
-  & p:last-child {
-    margin-bottom: 0;
-  }
+  /* Default color */
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
+  border-color: var(--color-accent-muted);
 
   & .octicon {
+    color: var(--color-accent-fg);
     margin-right: var(--base-size-12, 12px);
+  }
+
+  & p:last-child {
+    margin-bottom: 0;
   }
 }
 
@@ -71,16 +77,6 @@
 
 
 /* Color variations */
-
-.flash:not(.Banner) {
-  color: var(--color-fg-default);
-  background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
-  border-color: var(--color-accent-muted);
-
-  & .octicon {
-    color: var(--color-accent-fg);
-  }
-}
 
 .flash-warn:not(.Banner) {
   color: var(--color-fg-default);

--- a/app/components/primer/beta/flash.pcss
+++ b/app/components/primer/beta/flash.pcss
@@ -1,38 +1,36 @@
-// stylelint-disable selector-max-type, no-duplicate-selectors
+/* flash */
 
-// Default flash
+/* Default flash */
 .flash:not(.Banner) {
   position: relative;
-  // stylelint-disable-next-line primer/spacing
-  padding: 20px $spacer-3;
-  border-style: $border-style;
-  border-width: $border-width;
-  border-radius: $border-radius;
+  padding: var(--base-size-20, 20px) var(--primer-control-medium-paddingInline-spacious, 16px);
+  border-style: solid;
+  border-width: var(--primer-borderWidth-thin, 1px);
+  border-radius: var(--primer-borderRadius-medium, 6px);
 
-  p:last-child {
+  & p:last-child {
     margin-bottom: 0;
   }
 
-  .octicon {
-    // stylelint-disable-next-line primer/spacing
-    margin-right: 12px;
+  & .octicon {
+    margin-right: var(--base-size-12, 12px);
   }
 }
 
-// Contain the flash messages
+/* Contain the flash messages */
 .flash-messages {
-  margin-bottom: $spacer-4;
+  margin-bottom: var(--primer-stack-gap-spacious, 24px);
 }
 
-// Close button
+/* Close button */
 .flash-close:not(.Banner-close) {
   float: right;
-  padding: $spacer-3;
-  margin: -$spacer-3;
+  padding: var(--primer-control-medium-paddingInline-spacious, 16px);
+  margin: calc(var(--primer-control-medium-paddingInline-spacious, 16px) * -1);
   text-align: center;
   cursor: pointer;
 
-  // Undo `<button>` styles
+  /* Undo `<button>` styles */
   background: none;
   border: 0;
   appearance: none;
@@ -45,43 +43,41 @@
     opacity: 0.5;
   }
 
-  .octicon {
+  & .octicon {
     margin-right: 0;
   }
 }
 
-// Action button
+/* Action button */
 .flash-action:not(.Banner-actions) {
   float: right;
-  // stylelint-disable-next-line primer/spacing
   margin-top: -3px;
-  margin-left: $spacer-4;
+  margin-left: var(--primer-stack-gap-spacious, 24px);
   background-clip: padding-box;
 
   &.btn .octicon {
-    margin-right: $spacer-1;
+    margin-right: var(--primer-control-small-gap, 4px);
     color: var(--color-fg-muted);
   }
 
   &.btn-primary {
     background-clip: border-box;
 
-    .octicon {
+    & .octicon {
       color: inherit;
     }
   }
 }
 
-//
-// Color variations
-//
+
+/* Color variations */
 
 .flash:not(.Banner) {
   color: var(--color-fg-default);
   background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
   border-color: var(--color-accent-muted);
 
-  .octicon {
+  & .octicon {
     color: var(--color-accent-fg);
   }
 }
@@ -91,7 +87,7 @@
   background-image: linear-gradient(var(--color-attention-subtle), var(--color-attention-subtle));
   border-color: var(--color-attention-muted);
 
-  .octicon {
+  & .octicon {
     color: var(--color-attention-fg);
   }
 }
@@ -101,7 +97,7 @@
   background-image: linear-gradient(var(--color-danger-subtle), var(--color-danger-subtle));
   border-color: var(--color-danger-muted);
 
-  .octicon {
+  & .octicon {
     color: var(--color-danger-fg);
   }
 }
@@ -111,23 +107,20 @@
   background-image: linear-gradient(var(--color-success-subtle), var(--color-success-subtle));
   border-color: var(--color-success-muted);
 
-  .octicon {
+  & .octicon {
     color: var(--color-success-fg);
   }
 }
 
-//
-// Layout variations
-//
+/* Layout variations */
 
 .flash-full:not(.Banner) {
-  // stylelint-disable-next-line primer/spacing
-  margin-top: -1px;
-  border-width: $border-width 0;
+  margin-top: calc(var(--primer-borderWidth-thin, 1px) * -1);
+  border-width: var(--primer-borderWidth-thin, 1px) 0;
   border-radius: 0;
 }
 
-// A banner rendered at the top of the page.
+/* A banner rendered at the top of the page. */
 .flash-banner {
   position: fixed;
   top: 0;
@@ -139,17 +132,16 @@
   border-radius: 0;
 }
 
-// Makes sure the background is opaque to cover any content underneath
+/* Makes sure the background is opaque to cover any content underneath */
 .flash-full,
 .flash-banner {
   background-color: var(--color-canvas-default);
 }
 
-// FIXME deprecate this
+/* FIXME deprecate this */
 .warning {
-  padding: $em-spacer-5;
-  // stylelint-disable-next-line primer/spacing
+  padding: 0.5em;
   margin-bottom: 0.8em;
-  font-weight: $font-weight-bold;
+  font-weight: var(--base-text-weight-semibold, 600);
   background-color: var(--color-attention-subtle);
 }

--- a/app/components/primer/beta/flash.pcss
+++ b/app/components/primer/beta/flash.pcss
@@ -1,0 +1,155 @@
+// stylelint-disable selector-max-type, no-duplicate-selectors
+
+// Default flash
+.flash:not(.Banner) {
+  position: relative;
+  // stylelint-disable-next-line primer/spacing
+  padding: 20px $spacer-3;
+  border-style: $border-style;
+  border-width: $border-width;
+  border-radius: $border-radius;
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+
+  .octicon {
+    // stylelint-disable-next-line primer/spacing
+    margin-right: 12px;
+  }
+}
+
+// Contain the flash messages
+.flash-messages {
+  margin-bottom: $spacer-4;
+}
+
+// Close button
+.flash-close:not(.Banner-close) {
+  float: right;
+  padding: $spacer-3;
+  margin: -$spacer-3;
+  text-align: center;
+  cursor: pointer;
+
+  // Undo `<button>` styles
+  background: none;
+  border: 0;
+  appearance: none;
+
+  &:hover {
+    opacity: 0.7;
+  }
+
+  &:active {
+    opacity: 0.5;
+  }
+
+  .octicon {
+    margin-right: 0;
+  }
+}
+
+// Action button
+.flash-action:not(.Banner-actions) {
+  float: right;
+  // stylelint-disable-next-line primer/spacing
+  margin-top: -3px;
+  margin-left: $spacer-4;
+  background-clip: padding-box;
+
+  &.btn .octicon {
+    margin-right: $spacer-1;
+    color: var(--color-fg-muted);
+  }
+
+  &.btn-primary {
+    background-clip: border-box;
+
+    .octicon {
+      color: inherit;
+    }
+  }
+}
+
+//
+// Color variations
+//
+
+.flash:not(.Banner) {
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-accent-subtle), var(--color-accent-subtle));
+  border-color: var(--color-accent-muted);
+
+  .octicon {
+    color: var(--color-accent-fg);
+  }
+}
+
+.flash-warn:not(.Banner) {
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-attention-subtle), var(--color-attention-subtle));
+  border-color: var(--color-attention-muted);
+
+  .octicon {
+    color: var(--color-attention-fg);
+  }
+}
+
+.flash-error:not(.Banner) {
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-danger-subtle), var(--color-danger-subtle));
+  border-color: var(--color-danger-muted);
+
+  .octicon {
+    color: var(--color-danger-fg);
+  }
+}
+
+.flash-success:not(.Banner) {
+  color: var(--color-fg-default);
+  background-image: linear-gradient(var(--color-success-subtle), var(--color-success-subtle));
+  border-color: var(--color-success-muted);
+
+  .octicon {
+    color: var(--color-success-fg);
+  }
+}
+
+//
+// Layout variations
+//
+
+.flash-full:not(.Banner) {
+  // stylelint-disable-next-line primer/spacing
+  margin-top: -1px;
+  border-width: $border-width 0;
+  border-radius: 0;
+}
+
+// A banner rendered at the top of the page.
+.flash-banner {
+  position: fixed;
+  top: 0;
+  z-index: 90;
+  width: 100%;
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+}
+
+// Makes sure the background is opaque to cover any content underneath
+.flash-full,
+.flash-banner {
+  background-color: var(--color-canvas-default);
+}
+
+// FIXME deprecate this
+.warning {
+  padding: $em-spacer-5;
+  // stylelint-disable-next-line primer/spacing
+  margin-bottom: 0.8em;
+  font-weight: $font-weight-bold;
+  background-color: var(--color-attention-subtle);
+}

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -6,6 +6,7 @@
 @import "./beta/breadcrumbs.pcss";
 @import "./beta/button.pcss";
 @import "./beta/counter.pcss";
+@import "./beta/flash.pcss";
 @import "./beta/label.pcss";
 @import "./beta/blankslate.pcss";
 @import "./beta/progress_bar.pcss";

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -15,7 +15,6 @@
  *= require @primer/css/dist/tooltips.css
  *= require @primer/css/dist/overlay.css
  *= require @primer/css/dist/utilities.css
- *= require @primer/css/dist/alerts.css
  *= require @primer/css/dist/autocomplete.css
  *= require @primer/css/dist/avatars.css
  *= require @primer/css/dist/branch-name.css


### PR DESCRIPTION
### Description

This is part of [#1342](https://github.com/github/primer/issues/1342) and adds the [`flash`](https://github.com/primer/css/blob/5a0b9b2939c1428430d249aeeb9adb0ba8bc18ce/src/alerts/flash.scss) styles from PCSS. There should be no visual changes.

### Integration

> Does this change require any updates to code in production?

Yes, the following line can be removed on [dotcom](https://github.com/github/github/blob/e009ce8f20d5700a7f4a581e3c7953951469bf9c/app/assets/stylesheets/bundles/primer/index.scss#L108):

```diff
- @import '@primer/css/alerts/flash.scss';
```

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
- [x] Visual regression test

Before | After
--- | ---
![Screen Shot 2022-11-11 at 18 48 00](https://user-images.githubusercontent.com/378023/201314767-bd5fafe0-a4eb-4dda-9a5f-ea134a11da3b.png) | ![Screen Shot 2022-11-11 at 18 48 07](https://user-images.githubusercontent.com/378023/201314778-00956ba1-9e9e-4302-8f43-594ccbb46c6b.png)
![Screen Shot 2022-11-11 at 18 50 19](https://user-images.githubusercontent.com/378023/201314784-ad858a8e-17de-4f4b-b2f7-c637a8174e60.png) | ![Screen Shot 2022-11-11 at 18 50 26](https://user-images.githubusercontent.com/378023/201314786-3cef6468-ec8e-4f3b-8de3-01a3ea537e43.png)
