### PR TITLE
Update css selector test

### DIFF
--- a/previews/primer/beta/blankslate_preview.rb
+++ b/previews/primer/beta/blankslate_preview.rb
@@ -17,16 +17,40 @@ module Primer
       end
 
       # @label Default options
-      #
-      # @param narrow [Boolean] toggle
-      # @param spacious [Boolean] toggle
-      # @param border [Boolean] toggle
-      def default(narrow: false, spacious: false, border: false)
-        render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
+      def default
+        render Primer::Beta::Blankslate.new do |c|
           c.heading(tag: :h2).with_content("Title")
           c.description { "Description" }
         end
       end
+
+      # @!group Options
+      #
+      # @label Narrow
+      def option_narrow
+        render Primer::Beta::Blankslate.new(narrow: true) do |c|
+          c.heading(tag: :h2).with_content("Title")
+          c.description { "Description" }
+        end
+      end
+
+      # @label Spacious
+      def option_spacious
+        render Primer::Beta::Blankslate.new(spacious: true) do |c|
+          c.heading(tag: :h2).with_content("Title")
+          c.description { "Description" }
+        end
+      end
+
+      # @label Border
+      def option_border
+        render Primer::Beta::Blankslate.new(border: true) do |c|
+          c.heading(tag: :h2).with_content("Title")
+          c.description { "Description" }
+        end
+      end
+      #
+      # @!endgroup
 
       # @param narrow [Boolean] toggle
       # @param spacious [Boolean] toggle

--- a/previews/primer/beta/label_preview.rb
+++ b/previews/primer/beta/label_preview.rb
@@ -4,21 +4,17 @@ module Primer
   module Beta
     # @label Label
     class LabelPreview < ViewComponent::Preview
-      # @label Default Options
-      #
-      # @param size [Symbol] select [medium, large]
-      # @param tag [Symbol] select [span, summary, a, div]
-      # @param inline [Boolean] toggle
-      def default(size: :medium, tag: :span, inline: false)
-        render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
-      end
-
       # @label Playground
       #
       # @param size [Symbol] select [medium, large]
       # @param tag [Symbol] select [span, summary, a, div]
       # @param inline [Boolean] toggle
       def playground(size: :medium, tag: :span, inline: false)
+        render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
+      end
+
+      # @label Default Options
+      def default
         render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
       end
     end

--- a/previews/primer/beta/label_preview.rb
+++ b/previews/primer/beta/label_preview.rb
@@ -15,8 +15,90 @@ module Primer
 
       # @label Default Options
       def default
-        render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
+        render(Primer::Beta::Label.new) { "Label" }
       end
+
+      # @!group Color Schemes
+      #
+      # @label Default
+      def color_scheme_default
+        render(Primer::Beta::Label.new) { "Default" }
+      end
+
+      # @label Primary
+      def color_scheme_primary
+        render(Primer::Beta::Label.new(scheme: :primary)) { "Primary" }
+      end
+
+      # @label Secondary
+      def color_scheme_secondary
+        render(Primer::Beta::Label.new(scheme: :secondary)) { "Secondary" }
+      end
+
+      # @label Accent
+      def color_scheme_accent
+        render(Primer::Beta::Label.new(scheme: :accent)) { "Accent" }
+      end
+
+      # @label Success
+      def color_scheme_success
+        render(Primer::Beta::Label.new(scheme: :success)) { "Success" }
+      end
+
+      # @label Attention
+      def color_scheme_attention
+        render(Primer::Beta::Label.new(scheme: :attention)) { "Attention" }
+      end
+
+      # @label Danger
+      def color_scheme_danger
+        render(Primer::Beta::Label.new(scheme: :danger)) { "Danger" }
+      end
+
+      # @label Severe
+      def color_scheme_severe
+        render(Primer::Beta::Label.new(scheme: :severe)) { "Severe" }
+      end
+
+      # @label Done
+      def color_scheme_done
+        render(Primer::Beta::Label.new(scheme: :done)) { "Done" }
+      end
+
+      # @label Sponsors
+      def color_scheme_sponsors
+        render(Primer::Beta::Label.new(scheme: :sponsors)) { "Sponsors" }
+      end
+      #
+      # @!endgroup
+
+      # @!group Sizes
+      #
+      # @label Default
+      def size_default
+        render(Primer::Beta::Label.new) { "Default" }
+      end
+
+      # @label Large
+      def size_large
+        render(Primer::Beta::Label.new(size: :large)) { "Large" }
+      end
+      #
+      # @!endgroup
+
+      # @!group Inline
+      #
+      # @label Default
+      def inline_default
+        render(Primer::Beta::Label.new) { "Default" }
+      end
+
+      # @label Inline
+      def inline_inline
+        render(Primer::Beta::Label.new(inline: true)) { "Inline" }
+      end
+      #
+      # @!endgroup
     end
   end
 end

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -16,10 +16,18 @@ class ComponentSpecificSelectorsTest < Minitest::Test
   IGNORED_SELECTORS = {
     :global => [/^\d/, ":"],
     Primer::Alpha::ActionList => [/^to/],
-    Primer::Alpha::Banner => [".Banner .Banner-close"],
-    Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
-    Primer::Beta::Button => ["summary.Button"],
-    Primer::Beta::Counter => ["Counter .octicon"],
+    Primer::Alpha::Banner => [
+      ".Banner .Banner-close"
+    ],
+    Primer::Alpha::SegmentedControl => [
+      ".Button-withTooltip"
+    ],
+    Primer::Beta::Button => [
+      "summary.Button"
+    ],
+    Primer::Beta::Counter => [
+      "Counter .octicon"
+    ],
     Primer::Beta::Label => [
       ".labels",
       ".label",

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -20,8 +20,22 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
     Primer::Beta::Button => ["summary.Button"],
     Primer::Beta::Counter => ["Counter .octicon"],
-    Primer::Beta::Label => %w[.labels .label .Label--info .Label--warning .Label--open .Label--closed],
-    Primer::Beta::Blankslate => [".blankslate code", ".blankslate-large img", ".blankslate-large h3", ".blankslate-large p", ".blankslate-capped", ".blankslate-clean-background"]
+    Primer::Beta::Label => [
+      ".labels",
+      ".label",
+      ".Label--info",
+      ".Label--warning",
+      ".Label--open",
+      ".Label--closed"
+    ],
+    Primer::Beta::Blankslate => [
+      ".blankslate code",
+      ".blankslate-large img",
+      ".blankslate-large h3",
+      ".blankslate-large p",
+      ".blankslate-capped",
+      ".blankslate-clean-background"
+    ]
   }.freeze
 
   # these test methods are created dynamically so we can see all failures for

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -19,7 +19,8 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
     Primer::Beta::Button => ["summary.Button"],
-    Primer::Beta::Counter => ["Counter .octicon"]
+    Primer::Beta::Counter => ["Counter .octicon"],
+    Primer::Beta::Label => %w[labels label Label--info Label--warning Label--open Label--closed]
   }.freeze
 
   # these test methods are created dynamically so we can see all failures for

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -20,7 +20,8 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
     Primer::Beta::Button => ["summary.Button"],
     Primer::Beta::Counter => ["Counter .octicon"],
-    Primer::Beta::Label => %w[labels label Label--info Label--warning Label--open Label--closed]
+    Primer::Beta::Label => %w[.labels .label .Label--info .Label--warning .Label--open .Label--closed],
+    Primer::Beta::Blankslate => [".blankslate code", ".blankslate-large img", ".blankslate-large h3", ".blankslate-large p", ".blankslate-capped", ".blankslate-clean-background"]
   }.freeze
 
   # these test methods are created dynamically so we can see all failures for


### PR DESCRIPTION
### Description

This is a follow-up to https://github.com/primer/view_components/pull/1574 and adds updates to:

- [x] Label
- [x] Blankslate

The selectors added to `IGNORED_SELECTORS` are mostly old/deprecated classes that we still need to migrate on dotcom before we can remove them. 

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
- [x] Added/updated previews
