### PR TITLE
[WIP] Updating component previews for selector test coverage

### DIFF
--- a/.changeset/olive-socks-shout.md
+++ b/.changeset/olive-socks-shout.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+updating various component previews for lookbook to correct minor issues and include more options in the previews

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -54,7 +54,7 @@
   }
 }
 
-/* could not find any use of this selector */
+/* could not find any use of the capped selector */
 .blankslate-capped {
   border-radius: 0 0 var(--primer-borderRadius-medium, 6px) var(--primer-borderRadius-medium, 6px);
 }
@@ -68,8 +68,7 @@
   margin: 0 auto;
 }
 
-/* was .large-format
-** QUESTION: should we deprecate this? */
+/* could not find any use of these large selectors */
 .blankslate-large {
   & img {
     width: 80px;
@@ -88,7 +87,7 @@
   }
 }
 
-/* could not find use of this selector */
+/* could not find use of the clean background selector */
 .blankslate-clean-background {
   border: 0;
 }

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -54,6 +54,7 @@
   }
 }
 
+/* could not find any use of this selector */
 .blankslate-capped {
   border-radius: 0 0 var(--primer-borderRadius-medium, 6px) var(--primer-borderRadius-medium, 6px);
 }
@@ -87,8 +88,7 @@
   }
 }
 
-/* was .clean-background
-** TO DO: deprecate this and use utility instead */
+/* could not find use of this selector */
 .blankslate-clean-background {
   border: 0;
 }

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -9,6 +9,10 @@
     color: var(--color-fg-muted);
   }
 
+  /*
+    the selector for displaying code in a blank slate does not appear to be used.
+    if this is used in dotcom, then the selector should be moved into that repo
+  */
   & code {
     padding: 2px 5px 3px;
     font-size: var(--primer-text-body-size-medium, 14px);

--- a/previews/primer/alpha/action_list_preview.rb
+++ b/previews/primer/alpha/action_list_preview.rb
@@ -21,13 +21,13 @@ module Primer
                  aria: { label: "Action List" }
                )) do |c|
           c.with_heading(title: "Action List")
-          c.with_item(label: "Item one", href: "/") do |item|
+          c.with_item(label: "Item one", href: "#") do |item|
             item.with_leading_visual_icon(icon: :gear)
           end
-          c.with_item(label: "Item two", href: "/") do |item|
+          c.with_item(label: "Item two", href: "#") do |item|
             item.with_leading_visual_icon(icon: :star)
           end
-          c.with_item(label: "Item three", href: "/") do |item|
+          c.with_item(label: "Item three", href: "#") do |item|
             item.with_leading_visual_icon(icon: :heart)
           end
         end
@@ -50,13 +50,13 @@ module Primer
                  aria: { label: "Action List" }
                )) do |c|
           c.with_heading(title: "Action List")
-          c.with_item(label: "Item one", href: "/") do |item|
+          c.with_item(label: "Item one", href: "#") do |item|
             item.with_leading_visual_icon(icon: :gear)
           end
-          c.with_item(label: "Item two", href: "/") do |item|
+          c.with_item(label: "Item two", href: "#") do |item|
             item.with_leading_visual_icon(icon: :star)
           end
-          c.with_item(label: "Item three", href: "/") do |item|
+          c.with_item(label: "Item three", href: "#") do |item|
             item.with_leading_visual_icon(icon: :heart)
           end
         end
@@ -79,12 +79,12 @@ module Primer
                  aria: { label: "Action List" }
                )) do |c|
           c.with_heading(title: "Action List")
-          c.with_item(label: "Leading SVG visual", href: "/") do |item|
+          c.with_item(label: "Leading SVG visual", href: "#") do |item|
             item.with_leading_visual_svg do
               '<path d="M8 16a2 2 0 001.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 008 16z"></path><path fill-rule="evenodd" d="M8 1.5A3.5 3.5 0 004.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.018.018 0 00-.003.01l.001.006c0 .002.002.004.004.006a.017.017 0 00.006.004l.007.001h10.964l.007-.001a.016.016 0 00.006-.004.016.016 0 00.004-.006l.001-.007a.017.017 0 00-.003-.01l-1.703-2.554a1.75 1.75 0 01-.294-.97V5A3.5 3.5 0 008 1.5zM3 5a5 5 0 0110 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.518 1.518 0 0113.482 13H2.518a1.518 1.518 0 01-1.263-2.36l1.703-2.554A.25.25 0 003 7.947V5z"></path>'.html_safe
             end
           end
-          c.with_item(label: "Custom content", href: "/") do |item|
+          c.with_item(label: "Custom content", href: "#") do |item|
             item.with_leading_visual_content do
               '<span style="width: 16px; height: 16px; display: block; text-align: center; line-height: 16px">A</span>'.html_safe
             end
@@ -218,7 +218,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/")
+          c.with_item(label: "Default item", href: "#")
         end
       end
 
@@ -227,7 +227,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/", size: :large)
+          c.with_item(label: "Default item", href: "#", size: :large)
         end
       end
 
@@ -236,7 +236,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/", size: :xlarge)
+          c.with_item(label: "Default item", href: "#", size: :xlarge)
         end
       end
 
@@ -245,7 +245,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Item with leading visual", href: "/") do |item|
+          c.with_item(label: "Item with leading visual", href: "#") do |item|
             item.with_leading_visual_icon(icon: :star)
           end
         end
@@ -256,7 +256,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Item with trailing visual", href: "/") do |item|
+          c.with_item(label: "Item with trailing visual", href: "#") do |item|
             item.with_trailing_visual_icon(icon: :star)
           end
         end
@@ -267,7 +267,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Item with trailing visual", href: "/") do |item|
+          c.with_item(label: "Item with trailing visual", href: "#") do |item|
             item.with_leading_visual_icon(icon: :heart)
             item.with_trailing_visual_icon(icon: :star)
           end
@@ -279,7 +279,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/") do |item|
+          c.with_item(label: "Default item", href: "#") do |item|
             item.with_description.with_content("This is a description")
           end
         end
@@ -290,7 +290,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/", description_scheme: :inline) do |item|
+          c.with_item(label: "Default item", href: "#", description_scheme: :inline) do |item|
             item.with_description.with_content("This is a description")
           end
         end
@@ -301,7 +301,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/") do |item|
+          c.with_item(label: "Default item", href: "#") do |item|
             item.with_trailing_action(show_on_hover: false, icon: "plus", "aria-label": "Button tooltip", size: :medium)
           end
         end
@@ -312,7 +312,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Default item", href: "/") do |item|
+          c.with_item(label: "Default item", href: "#") do |item|
             item.with_trailing_action(show_on_hover: true, icon: "plus", "aria-label": "Button tooltip", size: :medium)
           end
         end
@@ -323,7 +323,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Danger item", href: "/", scheme: :danger)
+          c.with_item(label: "Danger item", href: "#", scheme: :danger)
         end
       end
 
@@ -332,7 +332,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Disabled item", href: "/", disabled: true)
+          c.with_item(label: "Disabled item", href: "#", disabled: true)
         end
       end
 
@@ -341,7 +341,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "This is a very long string of text that will wrap if it runs out of horizontal space", href: "/")
+          c.with_item(label: "This is a very long string of text that will wrap if it runs out of horizontal space", href: "#")
         end
       end
 
@@ -350,7 +350,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "This is a very long string of text that will truncate if it runs out of horizontal space", href: "/", truncate_label: true)
+          c.with_item(label: "This is a very long string of text that will truncate if it runs out of horizontal space", href: "#", truncate_label: true)
         end
       end
 
@@ -359,7 +359,7 @@ module Primer
         render(Primer::Alpha::ActionList.new(
                  aria: { label: "List heading" }
                )) do |c|
-          c.with_item(label: "Active item", href: "/", active: true)
+          c.with_item(label: "Active item", href: "#", active: true)
         end
       end
     end

--- a/previews/primer/beta/blankslate_preview.rb
+++ b/previews/primer/beta/blankslate_preview.rb
@@ -101,6 +101,53 @@ module Primer
           c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
         end
       end
+
+      # @!group Spacing
+      #
+      # @label Not Narrow or Spacious
+      def spacing_not_narrow_or_spacious
+        render Primer::Beta::Blankslate.new(narrow: false, spacious: false, border: true) do |c|
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_primary_action(href: "#").with_content("Fix issue")
+          c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
+        end
+      end
+
+      # @label Narrow, not Spacious
+      def spacing_narrow_not_spacious
+        render Primer::Beta::Blankslate.new(narrow: true, spacious: false, border: true) do |c|
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_primary_action(href: "#").with_content("Fix issue")
+          c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
+        end
+      end
+
+      # @label Not Narrow, Spacious
+      def spacing_not_narrow_and_spacious
+        render Primer::Beta::Blankslate.new(narrow: false, spacious: true, border: true) do |c|
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_primary_action(href: "#").with_content("Fix issue")
+          c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
+        end
+      end
+
+      # @label Narrow and Spacious
+      def spacing_narrow_and_spacious
+        render Primer::Beta::Blankslate.new(narrow: true, spacious: true, border: true) do |c|
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_primary_action(href: "#").with_content("Fix issue")
+          c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
+        end
+      end
+      # @!endgroup
     end
   end
 end

--- a/previews/primer/beta/blankslate_preview.rb
+++ b/previews/primer/beta/blankslate_preview.rb
@@ -11,8 +11,8 @@ module Primer
       # @param border [Boolean] toggle
       def playground(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("Title")
-          c.description { "Description" }
+          c.with_heading(tag: :h2).with_content("Title")
+          c.with_description { "Description" }
         end
       end
 
@@ -23,8 +23,8 @@ module Primer
       # @param border [Boolean] toggle
       def default(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("Title")
-          c.description { "Description" }
+          c.with_heading(tag: :h2).with_content("Title")
+          c.with_description { "Description" }
         end
       end
 
@@ -33,8 +33,8 @@ module Primer
       # @param border [Boolean] toggle
       def with_icon(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.visual_icon(icon: :shield)
-          c.heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
         end
       end
 
@@ -43,8 +43,8 @@ module Primer
       # @param border [Boolean] toggle
       def with_image(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("Millions of teams trust GitHub to keep their work safe")
-          c.visual_image(src: Primer::ExampleImage::BASE64_SRC, alt: "Security - secure vault")
+          c.with_heading(tag: :h2).with_content("Millions of teams trust GitHub to keep their work safe")
+          c.with_visual_image(src: Primer::ExampleImage::BASE64_SRC, alt: "Security - secure vault")
         end
       end
 
@@ -53,9 +53,9 @@ module Primer
       # @param border [Boolean] toggle
       def loading(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("Mirroring your repository")
-          c.description { "We’re currently mirroring this repository. It should take anywhere from a few minutes to a couple of hours depending on the size of the repository." }
-          c.visual_spinner(size: :large)
+          c.with_heading(tag: :h2).with_content("Mirroring your repository")
+          c.with_description { "We’re currently mirroring this repository. It should take anywhere from a few minutes to a couple of hours depending on the size of the repository." }
+          c.with_visual_spinner(size: :large)
         end
       end
 
@@ -64,8 +64,8 @@ module Primer
       # @param border [Boolean] toggle
       def description(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
-          c.description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
         end
       end
 
@@ -74,8 +74,8 @@ module Primer
       # @param border [Boolean] toggle
       def primary_action(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
-          c.primary_action(href: "#").with_content("Fix issue")
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_primary_action(href: "#").with_content("Fix issue")
         end
       end
 
@@ -84,8 +84,8 @@ module Primer
       # @param border [Boolean] toggle
       def secondary_action(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
-          c.secondary_action(href: "#").with_content("Fix issue")
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_secondary_action(href: "#").with_content("Fix issue")
         end
       end
 
@@ -94,11 +94,11 @@ module Primer
       # @param border [Boolean] toggle
       def full(narrow: false, spacious: false, border: false)
         render Primer::Beta::Blankslate.new(narrow: narrow, spacious: spacious, border: border) do |c|
-          c.visual_icon(icon: :shield)
-          c.heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
-          c.description { "Millions of teams trust GitHub to keep their work safe" }
-          c.primary_action(href: "#").with_content("Fix issue")
-          c.secondary_action(href: "#").with_content("Learn more about vulnerabilities")
+          c.with_visual_icon(icon: :shield)
+          c.with_heading(tag: :h2).with_content("It looks like we have discovered a vulnerability")
+          c.with_description { "Millions of teams trust GitHub to keep their work safe" }
+          c.with_primary_action(href: "#").with_content("Fix issue")
+          c.with_secondary_action(href: "#").with_content("Learn more about vulnerabilities")
         end
       end
     end

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -14,7 +14,7 @@ class ComponentSpecificSelectorsTest < Minitest::Test
   include Primer::RenderPreview
 
   IGNORED_SELECTORS = {
-    :global => [/^\d/, ":"],
+    :global => [/^\d/, ":", /\[.*\]/],
     Primer::Alpha::ActionList => [/^to/],
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -25,7 +25,7 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::ActionList => [/^to/],
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
-    Primer::Beta::Blankslate => ["code", ".blankslate-capped", ".blankslate-clean-background"],
+    Primer::Beta::Blankslate => ["code", ".blankslate-capped", ".blankslate-clean-background", ".blankslate-large"],
     Primer::Beta::Button => ["summary.Button"],
     Primer::Beta::Counter => ["Counter .octicon"]
   }.freeze

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -25,6 +25,7 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::ActionList => [/^to/],
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
+    Primer::Beta::Blankslate => ["code"],
     Primer::Beta::Button => ["summary.Button"],
     Primer::Beta::Counter => ["Counter .octicon"]
   }.freeze

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -25,7 +25,7 @@ class ComponentSpecificSelectorsTest < Minitest::Test
     Primer::Alpha::ActionList => [/^to/],
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],
-    Primer::Beta::Blankslate => ["code"],
+    Primer::Beta::Blankslate => ["code", ".blankslate-capped", ".blankslate-clean-background"],
     Primer::Beta::Button => ["summary.Button"],
     Primer::Beta::Counter => ["Counter .octicon"]
   }.freeze

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -14,7 +14,14 @@ class ComponentSpecificSelectorsTest < Minitest::Test
   include Primer::RenderPreview
 
   IGNORED_SELECTORS = {
-    :global => [/^\d/, ":", /\[.*\]/],
+    :global => [
+      # selectors that start with a number
+      /^\d/,
+      # pseudo selectors, like :hover
+      ":",
+      # attribute selectors, like [aria-label="foo"]
+      /\[.*\]/
+    ],
     Primer::Alpha::ActionList => [/^to/],
     Primer::Alpha::Banner => [".Banner .Banner-close"],
     Primer::Alpha::SegmentedControl => [".Button-withTooltip"],


### PR DESCRIPTION
⚠️ WIP: DO NOT REVIEW ⚠️ 

### Description

this PR updates various component previews for lookbook, to add coverage for component specific selector tests. updated components include:

- [ ] `Primer::Alpha::ActionList`
- [x] `Primer::Beta::BlankSlate`
- [ ] `Primer::Beta::Label`
- [ ] `Primer::Beta::Button`

also includes a few other fixes, like correcting the links used in `ActionList` to point to `#` instead of `/`, preventing the lookbook previews from loading the lookbook site inside of itself when clicked. 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
