### PR TITLE
Remove CounterComponet for Counter

### DIFF
--- a/.changeset/chilled-paws-march.md
+++ b/.changeset/chilled-paws-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove the deprecated `Primer::CounterComponet` and use `Primer::Beta::Counter`.

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -63,7 +63,7 @@ module Primer
         #
         # To render a label, call the `with_leading_visual_label` method, which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Label) %>.
         #
-        # To render a counter, call the `with_leading_visual_counter` method, which accepts the arguments accepted by <%= link_to_component(Primer::CounterComponent) %>.
+        # To render a counter, call the `with_leading_visual_counter` method, which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Counter) %>.
         #
         # To render text, call the `with_leading_visual_text` method and pass a block that returns a string. Eg:
         # ```ruby
@@ -72,7 +72,7 @@ module Primer
         renders_one :trailing_visual, types: {
           icon: Primer::OcticonComponent,
           label: Primer::Beta::Label,
-          counter: Primer::CounterComponent,
+          counter: Primer::Beta::Counter,
           text: ->(text) { text }
         }
 

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -58,7 +58,7 @@ module Primer
       renders_one :trailing_visual, types: {
         icon: Primer::OcticonComponent,
         label: Primer::Beta::Label,
-        counter: Primer::CounterComponent
+        counter: Primer::Beta::Counter
       }
 
       # Trailing action appears to the right of the trailing visual.

--- a/app/components/primer/counter_component.rb
+++ b/app/components/primer/counter_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class CounterComponent < Primer::Beta::Counter
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -12,7 +12,6 @@ module Primer
       "Primer::Alpha::AutoComplete::Item" => "Primer::Beta::AutoComplete::Item",
       "Primer::BlankslateComponent" => "Primer::Beta::Blankslate",
       "Primer::BoxComponent" => "Primer::Box",
-      "Primer::CounterComponent" => "Primer::Beta::Counter",
       "Primer::DropdownMenuComponent" => nil,
       "Primer::IconButton" => "Primer::Beta::IconButton",
       "Primer::Tooltip" => "Primer::Alpha::Tooltip",

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -61,7 +61,6 @@
   "Primer::ClipboardCopy": "",
   "Primer::ConditionalWrapper": "",
   "Primer::Content": "",
-  "Primer::CounterComponent": "",
   "Primer::Dropdown": "",
   "Primer::Dropdown::Menu": "",
   "Primer::Dropdown::Menu::Item": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -732,8 +732,6 @@
   },
   "Primer::Content": {
   },
-  "Primer::CounterComponent": {
-  },
   "Primer::Dropdown": {
     "Menu": "Primer::Dropdown::Menu"
   },

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -61,7 +61,6 @@
   "Primer::ClipboardCopy": "beta",
   "Primer::ConditionalWrapper": "alpha",
   "Primer::Content": "stable",
-  "Primer::CounterComponent": "deprecated",
   "Primer::Dropdown": "alpha",
   "Primer::Dropdown::Menu": "alpha",
   "Primer::Dropdown::Menu::Item": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -118,7 +118,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Alpha::ActionList::Item",
       "Primer::Alpha::ActionList::Separator",
       "Primer::Alpha::NavList::Section",
-      "Primer::CounterComponent",
       "Primer::Component",
       "Primer::OcticonsSymbolComponent",
       "Primer::Content",


### PR DESCRIPTION
### Description

With https://github.com/github/github/pull/246687 merging, there will be no more uses of the deprecated `Primer::CounterComponent` namespace. This PR removes it from the codebase.

### Integration

> Does this change require any updates to code in production?

Yes https://github.com/github/github/pull/246687 should be merged first

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
