### PR TITLE
Update previews and get CSS coverage to pass

### DIFF
--- a/previews/primer/beta/flash_preview.rb
+++ b/previews/primer/beta/flash_preview.rb
@@ -18,15 +18,52 @@ module Primer
 
       # @label Default
       #
-      # @param full toggle
-      # @param spacious toggle
-      # @param dismissible toggle
-      # @param icon [Symbol] select [alert, check, info, people]
-      # @param scheme [Symbol] select [default, warning, danger, success]
-      # @param content text
-      def default(full: false, spacious: false, dismissible: false, icon: :people, scheme: Primer::Beta::Flash::DEFAULT_SCHEME, content: "This is a flash message!")
-        render(Primer::Beta::Flash.new(full: full, spacious: spacious, dismissible: dismissible, icon: icon, scheme: scheme)) { content }
+      def default
+        render(Primer::Beta::Flash.new) { "This is a flash message!" }
       end
+
+      # @!group Color Schemes
+      #
+      # @label Default
+      def color_scheme_default
+        render(Primer::Beta::Flash.new) { "This is a flash message!" }
+      end
+
+      # @label Warning
+      def color_scheme_warning
+        render(Primer::Beta::Flash.new(scheme: :warning)) { "This is a warning flash message!" }
+      end
+
+      # @label Danger
+      def color_scheme_danger
+        render(Primer::Beta::Flash.new(scheme: :danger)) { "This is a danger flash message!" }
+      end
+
+      # @label Success
+      def color_scheme_success
+        render(Primer::Beta::Flash.new(scheme: :success)) { "This is a success flash message!" }
+      end
+      #
+      # @!endgroup
+
+      # @!group More options
+      #
+      # @label Full width
+      def options_full
+        render(Primer::Beta::Flash.new(full: true)) { "This is a full width flash message!" }
+      end
+
+      # @label Dismissible
+      def options_dismissible
+        render(Primer::Beta::Flash.new(dismissible: true)) { "This is a dismissible flash message!" }
+      end
+
+      # @label With icon
+      def options_with_icon
+        render(Primer::Beta::Flash.new(icon: :info)) { "This is a flash message with an icon!" }
+      end
+      #
+      # @!endgroup
     end
   end
 end

--- a/previews/primer/dropdown_preview.rb
+++ b/previews/primer/dropdown_preview.rb
@@ -21,25 +21,20 @@ module Primer
       end
     end
 
-    # @label Default Options
+    # @label Default
     #
-    # @param with_caret [Boolean] toggle
-    # @param overlay [Symbol] select [none, default, dark]
-    def default(overlay: :default, with_caret: false)
-      render(Primer::Dropdown.new(overlay: overlay, with_caret: with_caret)) do |c|
+    def default
+      render(Primer::Dropdown.new) do |c|
         c.with_button { "Dropdown" }
-
-        c.with_menu(header: "Header") do |m|
+        c.with_menu do |m|
           m.with_item { "Item 1" }
           m.with_item { "Item 2" }
-          m.with_item(divider: true)
           m.with_item { "Item 3" }
-          m.with_item { "Item 4" }
         end
       end
     end
 
-    # @label Menu Options
+    # @label Menu
     #
     # @param as [Symbol] select [list, default]
     # @param direction [Symbol] select [se, sw, w, e, ne, s]
@@ -53,5 +48,161 @@ module Primer
         m.with_item { "Item 4" }
       end
     end
+
+    # @!group Direction
+    #
+    # @label Direction e
+    def direction_e
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :e) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Direction ne
+    def direction_ne
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :ne) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Direction s
+    def direction_s
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :s) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Direction se
+    def direction_se
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :se) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Direction sw
+    def direction_sw
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :sw) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Direction w
+    def direction_w
+      render(Primer::Dropdown.new(display: :inline_block)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(direction: :w) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+    #
+    # @!endgroup
+
+    # @!group Options
+    #
+    # @label With caret
+    def options_with_caret
+      render(Primer::Dropdown.new(with_caret: true)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label With header
+    def options_with_header
+      render(Primer::Dropdown.new) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(header: "Header") do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label With dividers
+    def options_with_dividers
+      render(Primer::Dropdown.new) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item(divider: true)
+          m.with_item { "Item 3" }
+          m.with_item { "Item 4" }
+          m.with_item(divider: true)
+          m.with_item { "Item 5" }
+        end
+      end
+    end
+
+    # @label As list
+    def options_as_list
+      render(Primer::Dropdown.new) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu(as: :list) do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Overlay none
+    def options_overlay_none
+      render(Primer::Dropdown.new(overlay: :none)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+
+    # @label Overlay dark
+    def options_overlay_dark
+      render(Primer::Dropdown.new(overlay: :dark)) do |c|
+        c.with_button { "Dropdown" }
+        c.with_menu do |m|
+          m.with_item { "Item 1" }
+          m.with_item { "Item 2" }
+          m.with_item { "Item 3" }
+        end
+      end
+    end
+    #
+    # @!endgroup
   end
 end

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -14,8 +14,18 @@ class ComponentSpecificSelectorsTest < Minitest::Test
   include Primer::RenderPreview
 
   IGNORED_SELECTORS = {
-    :global => [/^\d/, ":", /\[.*\]/],
-    Primer::Alpha::ActionList => [/^to/],
+    :global => [/^\d/, ":", /\[.*\]/, /^to/, /^from/],
+    Primer::Alpha::ActionList => [
+      ".ActionListWrap--inset",
+      ".ActionListItem.ActionListItem--hasSubItem > .ActionListContent",
+      ".ActionListItem.ActionListItem--danger .ActionListItem-visual",
+      ".ActionListContent.ActionListContent--blockDescription .ActionListItem-visual",
+      ".ActionListItem-action--leading",
+      ".ActionListItem-action--trailing",
+      ".ActionListItem-action",
+      ".ActionListItem--subItem > .ActionListContent > .ActionListItem-label",
+      ".ActionList-sectionDivider--filled"
+    ],
     Primer::Alpha::Banner => [
       ".Banner .Banner-close"
     ],

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -43,6 +43,11 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".blankslate-large p",
       ".blankslate-capped",
       ".blankslate-clean-background"
+    ],
+    Primer::Beta::Flash => [
+      ".flash-messages",
+      ".flash-banner",
+      ".warning"
     ]
   }.freeze
 

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -23,7 +23,15 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".Button-withTooltip"
     ],
     Primer::Beta::Button => [
-      "summary.Button"
+      "summary.Button",
+      ".Button-content--alignStart",
+      ".Button--small",
+      ".Button--small .Button-label",
+      ".Button--large",
+      ".Button--large .Button-label",
+      ".Button--iconOnly",
+      ".Button--iconOnly.Button--small",
+      ".Button--iconOnly.Button--large"
     ],
     Primer::Beta::Counter => [
       "Counter .octicon"

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -48,6 +48,13 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".flash-messages",
       ".flash-banner",
       ".warning"
+    ],
+    Primer::Dropdown => [
+      ".dropdown-caret",
+      ".dropdown-menu-no-overflow",
+      ".dropdown-menu-no-overflow .dropdown-item",
+      ".dropdown-item.btn-link",
+      ".dropdown-signout"
     ]
   }.freeze
 


### PR DESCRIPTION
### Description

This is a follow-up to https://github.com/primer/view_components/pull/1602 and adds some more previews and ignores some selectors for:

- [x] `flash`
- [x] `dropdown`

To make the "CSS coverage" pass I also added the remaining selectors to `IGNORED_SELECTORS` for:

- [x] `ActionList`
- [x] `Button`

We can take a closer look once we move the styles from Primer CSS. But might be good to have `main` not fail for too long.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
- [x] Added/updated previews
