### PR TITLE
Update Banner link in nav after #1579

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -24,7 +24,7 @@
   - title: AvatarStack
     url: "/components/beta/avatarstack"
   - title: Banner
-    url: "/components/beta/banner"
+    url: "/components/alpha/banner"
   - title: Blankslate
     url: "/components/beta/blankslate"
   - title: BorderBox


### PR DESCRIPTION
Banner was moved to alpha in https://github.com/primer/view_components/pull/1579, but the nav link still points to beta/banner

Broken link: https://primer.style/view-components/components/beta/banner
Fixed link: https://primer.style/view-components/components/alpha/banner