### PR TITLE
Don't export XBannerElement

### DIFF
--- a/.changeset/dull-rabbits-glow.md
+++ b/.changeset/dull-rabbits-glow.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Avoid double-registering of exported components

--- a/app/components/primer/alpha/x_banner.ts
+++ b/app/components/primer/alpha/x_banner.ts
@@ -1,7 +1,7 @@
 import {controller, target} from '@github/catalyst'
 
 @controller
-export class XBannerElement extends HTMLElement {
+class XBannerElement extends HTMLElement {
   @target titleText: HTMLElement
 
   dismiss() {


### PR DESCRIPTION
@camertron for some reason during the promotion from beta to alpha #1579 the export is present again, we should avoid registering the component twice as mentioned in #1560 and #1440.