### PR TITLE
Move `Link` styles to PVC

### DIFF
--- a/.changeset/olive-vans-think.md
+++ b/.changeset/olive-vans-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Move `Link` styles to PVC

--- a/app/components/primer/beta/link.pcss
+++ b/app/components/primer/beta/link.pcss
@@ -1,0 +1,60 @@
+// Links
+
+.Link {
+  color: var(--color-accent-fg);
+
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  &:focus,
+  &:focus-visible {
+    outline-offset: 0;
+  }
+}
+
+.Link--primary {
+  color: var(--color-fg-default) !important;
+
+  &:hover {
+    color: var(--color-accent-fg) !important;
+  }
+}
+
+.Link--secondary {
+  color: var(--color-fg-muted) !important;
+
+  &:hover {
+    color: var(--color-accent-fg) !important;
+  }
+}
+
+.Link--muted {
+  color: var(--color-fg-muted) !important;
+
+  &:hover {
+    color: var(--color-accent-fg) !important;
+    text-decoration: none;
+  }
+}
+
+// Set the link color only on hover
+// Useful when you want only part of a link to turn blue on hover
+.Link--onHover {
+  &:hover {
+    color: var(--color-accent-fg) !important;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}
+
+// When using a color utility class inside of a link class,
+// color should change with link on hover.
+.Link--secondary,
+.Link--primary,
+.Link--muted {
+  &:hover [class*='color-fg'] {
+    color: inherit !important;
+  }
+}

--- a/app/components/primer/beta/link.pcss
+++ b/app/components/primer/beta/link.pcss
@@ -1,4 +1,4 @@
-// Links
+/* Link */
 
 .Link {
   color: var(--color-accent-fg);
@@ -39,8 +39,9 @@
   }
 }
 
-// Set the link color only on hover
-// Useful when you want only part of a link to turn blue on hover
+/* Set the link color only on hover
+** Useful when you want only part of a link to turn blue on hover */
+
 .Link--onHover {
   &:hover {
     color: var(--color-accent-fg) !important;
@@ -49,8 +50,9 @@
   }
 }
 
-// When using a color utility class inside of a link class,
-// color should change with link on hover.
+/* When using a color utility class inside of a link class,
+** color should change with link on hover. */
+
 .Link--secondary,
 .Link--primary,
 .Link--muted {

--- a/app/components/primer/primer.pcss
+++ b/app/components/primer/primer.pcss
@@ -10,6 +10,7 @@
 @import "./beta/counter.pcss";
 @import "./beta/flash.pcss";
 @import "./beta/label.pcss";
+@import "./beta/link.pcss";
 @import "./beta/blankslate.pcss";
 @import "./beta/progress_bar.pcss";
 @import "./beta/truncate.pcss";

--- a/demo/app/assets/stylesheets/application.css
+++ b/demo/app/assets/stylesheets/application.css
@@ -9,7 +9,6 @@
  *= require @primer/css/dist/table-object.css
  *= require @primer/css/dist/forms.css
  *= require @primer/css/dist/layout.css
- *= require @primer/css/dist/links.css
  *= require @primer/css/dist/navigation.css
  *= require @primer/css/dist/pagination.css
  *= require @primer/css/dist/tooltips.css

--- a/previews/primer/beta/link_preview.rb
+++ b/previews/primer/beta/link_preview.rb
@@ -14,14 +14,9 @@ module Primer
         render(Primer::Beta::Link.new(href: "#", tag: tag, scheme: scheme, muted: muted, underline: underline)) { "This is a link!" }
       end
 
-      # @label Default Options
-      #
-      # @param underline [Boolean]
-      # @param muted [Boolean]
-      # @param tag [Symbol] select [a, span]
-      # @param scheme [Symbol] select [default, primary, secondary]
-      def default(tag: :a, scheme: :default, muted: false, underline: true)
-        render(Primer::Beta::Link.new(href: "#", tag: tag, scheme: scheme, muted: muted, underline: underline)) { "This is a link!" }
+      # @label Default
+      def default
+        render(Primer::Beta::Link.new(href: "#")) { "This is a link!" }
       end
 
       # @label With Tooltip
@@ -36,6 +31,35 @@ module Primer
           "Link with tooltip"
         end
       end
+
+      # @!group Options
+      #
+      # @label Default
+      def options_default
+        render(Primer::Beta::Link.new(href: "#")) { "Link" }
+      end
+
+      # @label Primary
+      def options_primary
+        render(Primer::Beta::Link.new(href: "#", scheme: :primary)) { "Link" }
+      end
+
+      # @label Secondary
+      def options_secondary
+        render(Primer::Beta::Link.new(href: "#", scheme: :secondary)) { "Link" }
+      end
+
+      # @label Muted
+      def options_muted
+        render(Primer::Beta::Link.new(href: "#", muted: true)) { "Link" }
+      end
+
+      # @label Without underline
+      def options_underline
+        render(Primer::Beta::Link.new(href: "#", underline: false)) { "Link" }
+      end
+      #
+      # @!endgroup
     end
   end
 end

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -71,6 +71,9 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".Label--open",
       ".Label--closed"
     ],
+    Primer::Beta::Link => [
+      ".Link"
+    ],
     Primer::Beta::Blankslate => [
       ".blankslate code",
       ".blankslate-large img",


### PR DESCRIPTION
### Description

This is part of [#1342](https://github.com/github/primer/issues/1342) and adds the [`Link`](https://github.com/primer/css/blob/c8100be771634093fe3a4d36481fc43c0d966015/src/links/link.scss) styles from PCSS. There should be no visual changes.

### Integration

> Does this change require any updates to code in production?

Yes, the [following line](https://github.com/github/github/blob/0502b0e2d5cf0a758984dcf1200467591d55b88c/app/assets/stylesheets/bundles/primer/index.scss#L66) can be removed on dotcom:

```diff
- @import '@primer/css/links/link.scss';
```

### Merge checklist

- [x] Added/updated tests
- [ ] ~~Added/updated documentation~~
- [x] Added/updated previews
- [x] Visual regression test

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/378023/202636968-e21e4d91-e594-4271-84c8-d1b626f2dfad.png) | ![image](https://user-images.githubusercontent.com/378023/202637008-022f7156-ed7c-4b7c-8862-015a8b65bbb9.png)
