### PR TITLE
Update `dropdown` hover text color

### DIFF
--- a/.changeset/good-games-try.md
+++ b/.changeset/good-games-try.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update `dropdown` hover text color

--- a/app/components/primer/dropdown.pcss
+++ b/app/components/primer/dropdown.pcss
@@ -89,7 +89,7 @@
       opacity: 1;
     }
 
-    & [class*='color-text-'] {
+    & [class*='color-fg-'] {
       color: inherit !important;
     }
 


### PR DESCRIPTION
### Description

This is a port from https://github.com/primer/css/pull/2310 and updates the selector from `color-text-` to `color-fg-`.

The `color-text-` prefix was used for an older version but got replaced by [`color-fg-`](https://primer.style/css/utilities/colors/) in the meantime.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
