### PR TITLE
Deleting deprecated Primer::ProgressBarComponent

### DIFF
--- a/.changeset/three-rocks-fail.md
+++ b/.changeset/three-rocks-fail.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Deleting deprecated Primer::ProgressBarComponent in favor of Primer::Beta::ProgressBar

--- a/app/components/primer/progress_bar_component.rb
+++ b/app/components/primer/progress_bar_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class ProgressBarComponent < Primer::Beta::ProgressBar
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -14,8 +14,7 @@ module Primer
       "Primer::BoxComponent" => "Primer::Box",
       "Primer::DropdownMenuComponent" => nil,
       "Primer::IconButton" => "Primer::Beta::IconButton",
-      "Primer::Tooltip" => "Primer::Alpha::Tooltip",
-      "Primer::ProgressBarComponent" => "Primer::Beta::ProgressBar"
+      "Primer::Tooltip" => "Primer::Alpha::Tooltip"
     }.freeze
 
     def self.deprecated?(name)

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -78,7 +78,6 @@
   "Primer::OcticonComponent": "",
   "Primer::OcticonSymbolsComponent": "",
   "Primer::PopoverComponent": "",
-  "Primer::ProgressBarComponent": "",
   "Primer::SpinnerComponent": "",
   "Primer::StateComponent": "",
   "Primer::SubheadComponent": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -899,8 +899,6 @@
     },
     "DEFAULT_HEADING_TAG": "h4"
   },
-  "Primer::ProgressBarComponent": {
-  },
   "Primer::SpinnerComponent": {
     "DEFAULT_SIZE": "medium",
     "DEFAULT_STYLE": "box-sizing: content-box; color: var(--color-icon-primary);",

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -78,7 +78,6 @@
   "Primer::OcticonComponent": "beta",
   "Primer::OcticonSymbolsComponent": "alpha",
   "Primer::PopoverComponent": "beta",
-  "Primer::ProgressBarComponent": "deprecated",
   "Primer::SpinnerComponent": "beta",
   "Primer::StateComponent": "beta",
   "Primer::SubheadComponent": "beta",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -112,7 +112,6 @@ class PrimerComponentTest < Minitest::Test
     ignored_components = [
       "Primer::LabelComponent",
       "Primer::LinkComponent",
-      "Primer::ProgressBarComponent",
       "Primer::Image",
       "Primer::Alpha::ActionList::Heading",
       "Primer::Alpha::ActionList::Item",


### PR DESCRIPTION
### Description

The previously deprecated `ProgressBarComponent` has been completely migrated to `Primer::Beta::ProgressBar` in production. This removes the old class.

### Integration

> Does this change require any updates to code in production?

Double check no [Primer::ProgressBarComponent](https://github.com/search?q=repo%3Agithub%2Fgithub+%22Primer%3A%3AProgressBarComponent%22&type=code) calls were added.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
