### PR TITLE
Setting up custom media queries

### DIFF
--- a/app/components/primer/alpha/auto_complete.pcss
+++ b/app/components/primer/alpha/auto_complete.pcss
@@ -16,7 +16,7 @@
 }
 
 /* Switch to stacked at smaller viewport */
-@media (max-width: 543.98px) {
+@media (--primer-viewportRange-narrow-viewport) {
   .autocomplete-label-inline {
     display: block;
     margin-bottom: 6px;

--- a/app/components/primer/alpha/banner.pcss
+++ b/app/components/primer/alpha/banner.pcss
@@ -14,7 +14,7 @@
   grid-template-rows: min-content;
 
   /* `sm` breakpoint variantion */
-  @media (max-width: 543.98px) {
+  @media (--primer-viewportRange-narrow-viewport) {
     grid-template-areas:
       'visual message close'
       '. actions actions';
@@ -115,8 +115,7 @@
     border-radius: 0;
   }
 
-  /* --primer-viewportRange-narrowLandscape */
-  @media (max-width: 767.98px) {
+  @media (--primer-viewportRange-narrowLandscape) {
     &.Banner--full-whenNarrow {
       margin-top: calc(var(--primer-borderWidth-thin, max(1px, 0.0625rem)) * -1);
       border-right: 0;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -14,7 +14,12 @@ module.exports = {
       // https://preset-env.cssdb.org/features/#stage-2
       features: {
         'nesting-rules': true,
-        'focus-visible-pseudo-class': false
+        'focus-visible-pseudo-class': false,
+        'custom-media-queries':  {
+          importFrom: [
+            path.join(__dirname, './node_modules/@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css')
+          ]
+        },
       }
     }),
     process.env.CI === 'true' ? require('cssnano') : null


### PR DESCRIPTION
### Description

This pulls in the `custom-media` [queries from primitives](https://unpkg.com/browse/@primer/primitives@7.8.3/tokens-v2-private/css/tokens/functional/size/viewport.css) into our postcss config.

Turns out the plugin was already included we just needed to tell it where the queries were https://preset-env.cssdb.org/features/#custom-media-queries

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
