### PR TITLE
Add `severity` setting to ERBLint rules

### DIFF
--- a/.changeset/spotty-items-yell.md
+++ b/.changeset/spotty-items-yell.md
@@ -2,4 +2,4 @@
 '@primer/view-components': patch
 ---
 
-adding a custom erblint schema to allow `severity` in linter configuration
+Adding a custom erblint schema to allow `severity` in linter configuration

--- a/.changeset/spotty-items-yell.md
+++ b/.changeset/spotty-items-yell.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+adding a custom erblint schema to allow `severity` in linter configuration

--- a/lib/primer/view_components/linters/deprecated_components_counter.rb
+++ b/lib/primer/view_components/linters/deprecated_components_counter.rb
@@ -50,6 +50,10 @@ module ERBLint
           end
         end
       end
+
+      def severity
+        @config.severity
+      end
     end
   end
 end

--- a/lib/primer/view_components/linters/deprecated_components_counter.rb
+++ b/lib/primer/view_components/linters/deprecated_components_counter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "helpers/deprecated_components_helpers"
+require_relative "severity_schema"
+
 require "erblint-github/linters/custom_helpers"
 
 module ERBLint
@@ -10,6 +12,8 @@ module ERBLint
       include CustomHelpers
       include ERBLint::LinterRegistry
       include Helpers::DeprecatedComponentsHelpers
+
+      self.config_schema = SeveritySchema
 
       def run(processed_source)
         processed_source.ast.descendants(:erb).each do |erb_node|

--- a/lib/primer/view_components/linters/deprecated_components_counter.rb
+++ b/lib/primer/view_components/linters/deprecated_components_counter.rb
@@ -27,7 +27,9 @@ module ERBLint
 
             add_offense(
               erb_node.loc,
-              message(component)
+              message(component),
+              nil,
+              @config.severity
             )
           end
         end

--- a/lib/primer/view_components/linters/deprecated_components_counter.rb
+++ b/lib/primer/view_components/linters/deprecated_components_counter.rb
@@ -25,12 +25,7 @@ module ERBLint
           deprecated_components.each do |component|
             next unless code.include?(component)
 
-            add_offense(
-              erb_node.loc,
-              message(component),
-              nil,
-              @config.severity
-            )
+            add_offense(erb_node.loc, message(component))
           end
         end
 
@@ -51,8 +46,14 @@ module ERBLint
         end
       end
 
-      def severity
-        @config.severity
+      # this override is necessary because of the github/erblint-github `CustomHelpers`
+      # module. `counter_correct?` is provided by this module, and calls `add_offense`
+      # directly. there is no simple way to modify this without updating the gem and
+      # creating what would likely be an API that is non-standard and/or difficult to use
+      #
+      # https://github.com/github/erblint-github/blob/main/lib/erblint-github/linters/custom_helpers.rb
+      def add_offense(source_range, message, context = nil, severity = nil)
+        super(source_range, message, context, severity || @config.severity)
       end
     end
   end

--- a/lib/primer/view_components/linters/severity_schema.rb
+++ b/lib/primer/view_components/linters/severity_schema.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "erb_lint/utils/severity_levels"
+
+module ERBLint
+  module Linters
+    class SeveritySchema < LinterConfig
+      property :severity, accepts: ERBLint::Utils::SeverityLevels::SEVERITY_NAMES, default: :fatal, reader: :severity
+    end
+  end
+end

--- a/lib/primer/view_components/linters/severity_schema.rb
+++ b/lib/primer/view_components/linters/severity_schema.rb
@@ -5,7 +5,10 @@ require "erb_lint/utils/severity_levels"
 module ERBLint
   module Linters
     class SeveritySchema < LinterConfig
-      property :severity, accepts: ERBLint::Utils::SeverityLevels::SEVERITY_NAMES, default: :fatal, reader: :severity
+      # SEVERITY_NAMES :info, :refactor, :convention, :warning, :error, :fatal
+      # see https://github.com/Shopify/erb-lint/blob/main/lib/erb_lint/utils/severity_levels.rb
+
+      property :severity, accepts: ERBLint::Utils::SeverityLevels::SEVERITY_NAMES, default: nil, reader: :severity
     end
   end
 end

--- a/test/lib/erblint/deprecated_components_counter_test.rb
+++ b/test/lib/erblint/deprecated_components_counter_test.rb
@@ -3,6 +3,15 @@
 require "lib/erblint_test_case"
 
 class DeprecatedComponentsCounterTest < ErblintTestCase
+  def test_severity_level
+    @file = <<~ERB
+      <%= render Primer::BlankslateComponent.new %>
+    ERB
+    @linter.run(processed_source)
+
+    assert_equal :info, @linter.offenses[0].severity
+  end
+
   def test_warns_about_deprecated_primer_component
     @file = <<~ERB
       <%= render Primer::BlankslateComponent.new %>

--- a/test/lib/erblint/deprecated_components_counter_test.rb
+++ b/test/lib/erblint/deprecated_components_counter_test.rb
@@ -10,6 +10,7 @@ class DeprecatedComponentsCounterTest < ErblintTestCase
     @linter.run(processed_source)
 
     assert_nil @linter.offenses[0].severity
+    assert_nil @linter.offenses[1].severity
   end
 
   def test_setting_severity_level
@@ -20,6 +21,7 @@ class DeprecatedComponentsCounterTest < ErblintTestCase
     linter.run(processed_source)
 
     assert_equal :info, linter.offenses[0].severity
+    assert_equal :info, linter.offenses[1].severity
   end
 
   def test_warns_about_deprecated_primer_component

--- a/test/lib/erblint/deprecated_components_counter_test.rb
+++ b/test/lib/erblint/deprecated_components_counter_test.rb
@@ -3,7 +3,16 @@
 require "lib/erblint_test_case"
 
 class DeprecatedComponentsCounterTest < ErblintTestCase
-  def test_severity_level
+  def test_default_severity_level
+    @file = <<~ERB
+      <%= render Primer::BlankslateComponent.new %>
+    ERB
+    @linter.run(processed_source)
+
+    assert_nil @linter.offenses[0].severity
+  end
+
+  def test_setting_severity_level
     @file = <<~ERB
       <%= render Primer::BlankslateComponent.new %>
     ERB

--- a/test/lib/erblint/deprecated_components_counter_test.rb
+++ b/test/lib/erblint/deprecated_components_counter_test.rb
@@ -7,9 +7,10 @@ class DeprecatedComponentsCounterTest < ErblintTestCase
     @file = <<~ERB
       <%= render Primer::BlankslateComponent.new %>
     ERB
-    @linter.run(processed_source)
+    linter = linter_with_severity(:info)
+    linter.run(processed_source)
 
-    assert_equal :info, @linter.offenses[0].severity
+    assert_equal :info, linter.offenses[0].severity
   end
 
   def test_warns_about_deprecated_primer_component

--- a/test/lib/erblint_test_case.rb
+++ b/test/lib/erblint_test_case.rb
@@ -57,6 +57,13 @@ class ErblintTestCase < Minitest::Test
     end
   end
 
+  def linter_with_severity(severity)
+    return unless linter_class
+
+    config_with_severity = linter_class.config_schema.new({ severity: severity })
+    linter_class.new(file_loader, config_with_severity)
+  end
+
   def linter_with_override
     linter_class&.new(file_loader, linter_class.config_schema.new(override_ignores_if_correctable: true))
   end


### PR DESCRIPTION
### Description

This PR adds the ability to set a `severity` level in our custom ERBLint rules, through the use of the new `SeveritySchema` linter schema. The goal is to provide a configuration option for linters, allowing us to set the failure severity in a project's `erb-lint.yml` file. This will help us with cleaning up the deprecated components counter failures in dotcom, by allowing us to re-enable that rules but only warn about the failures, giving us time to clean up the issues in smaller PRs

For this PR, only the `DeprecatetdComponentsCounter` linter is using the new severity schema. Tests for the `DeprecatetdComponentsCounter` have been updated to ensure the severity is used as expected.

### Integration

> Does this change require any updates to code in production?

No change required, as the new setting is optional. Once we are ready, the following configuration in dotcom's `erb-lint.yml` file needs to be made:

```diff
  DeprecatedComponentsCounter:
-   enabled: false
+   enabled: true
+   severity: :info
```

### Setting the Severity

The options for `severity` in ERBLint come [from ERBLint::Utils::SeverityLevels in ERBLint](https://github.com/Shopify/erb-lint/blob/main/lib/erb_lint/utils/severity_levels.rb), and include the following:

* `:info`
* `:refactor`
* `:convention`
* `:warning`
* `:error`
* `:fatal`

**NOTE:** With all other settings defaulted, only the `:info` severity appears to ignore the failures. setting this to `:warning` or any other level (including the default / removing the setting) causes it to treat linting issues as failures. This is possible to change by updating the `github-lint` step to include the following command-line option for ERBLint, however:

```
--fail-level SEVERITY        Minimum severity for exit with error code
```

For example: `bin/bundle exec erblint --fail-severity :error` should allow `severity: :warning` to still pass the CI step, while allowing `:error` and `:fatal` to fail the step. Without further testing, though, it's unknown how the default `nil` severity would behave.


### Proof of Concept in dotcom

Using this branch, I ran two examples of erblint on dotcom. the first was with the severity set to `:warning` and the second set to `:info`, using [this proof of concept PR in dotcom](https://github.com/github/github/pull/248219)

* 🔴 `severity: :warning` https://janky.githubapp.com/71857737/output
* ✅ `severity: :info` https://janky.githubapp.com/71860174/output

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
