### PR TITLE
PVC Deprecations and configurable auto-correct

### DIFF
--- a/.changeset/neat-fireants-bake.md
+++ b/.changeset/neat-fireants-bake.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Converting deprecations list to a .yml file, and updating all code around deprecations to use this new structure

--- a/app/components/primer/beta/popover.pcss
+++ b/app/components/primer/beta/popover.pcss
@@ -67,7 +67,7 @@
   }
 }
 
-/* Top & Bottom: Right-oriented carets */
+/* Top and Bottom: Right-oriented carets */
 .Popover-message--top-right,
 .Popover-message--bottom-right {
   right: -9px;
@@ -88,7 +88,7 @@
   }
 }
 
-/* Top & Bottom: Left-oriented carets */
+/* Top and Bottom: Left-oriented carets */
 .Popover-message--top-left,
 .Popover-message--bottom-left {
   left: -9px;
@@ -105,7 +105,7 @@
   }
 }
 
-/* Right- & Left-oriented carets */
+/* Right- and Left-oriented carets */
 .Popover-message--right,
 .Popover-message--right-top,
 .Popover-message--right-bottom,
@@ -159,7 +159,7 @@
   }
 }
 
-/* Right & Left: Top-oriented carets */
+/* Right and Left: Top-oriented carets */
 .Popover-message--right-top,
 .Popover-message--left-top {
   &::before,
@@ -168,7 +168,7 @@
   }
 }
 
-/* Right & Left: Bottom-oriented carets */
+/* Right and Left: Bottom-oriented carets */
 .Popover-message--right-bottom,
 .Popover-message--left-bottom {
   &::before,

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -18,6 +18,10 @@ module Primer
 
     INVALID_ARIA_LABEL_TAGS = [:div, :span, :p].freeze
 
+    def self.deprecated?
+      status == :deprecated
+    end
+
     private
 
     def raise_on_invalid_options?

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -18,6 +18,10 @@ module Primer
         end
       end
 
+      def deprecated_components
+        deprecations.keys.sort
+      end
+
       def deprecated?(component_name)
         # if the component is registered, it is deprecated
         deprecations.key?(component_name)

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'yaml'
+require "yaml"
 
 module Primer
   # :nodoc:
@@ -52,9 +52,6 @@ module Primer
     end
 
     # auto-load PVC's deprecations
-    begin
-      config_path = File.expand_path("deprecations.yml", __dir__)
-      self.register(config_path)
-    end
+    register(File.expand_path("deprecations.yml", __dir__))
   end
 end

--- a/lib/primer/deprecations.rb
+++ b/lib/primer/deprecations.rb
@@ -12,7 +12,6 @@ module Primer
           component = dep["component"]
           deprecations[component] = {
             autocorrect: dep["autocorrect"],
-            guide: dep["guide"],
             replacement: dep["replacement"]
           }
         end
@@ -39,13 +38,6 @@ module Primer
         return false if dep.nil?
 
         dep[:autocorrect]
-      end
-
-      def guide(component_name)
-        dep = deprecations[component_name]
-        return nil if dep.nil?
-
-        dep[:guide]
       end
 
       private

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -97,7 +97,7 @@ deprecations:
     replacement: "Primer::Box"
   component: "Primer::DropdownMenuComponent"
     autocorrect: false
-    guide: "https://primer.style/view-components/migration"
+    replacement: "Primer::Beta::Dropdown"
   component: "Primer::Dropdown"
     autocorrect: true
     replacement: "Primer::Alpha::Dropdown"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -5,7 +5,6 @@
 # - component: [string]
 #   autocorrect: [boolean] 
 #   replacement: [string] 
-#   guide: [string]
 #
 # Field Descriptions
 # ------------------
@@ -26,55 +25,22 @@
 #   - Default: nil
 #   - The full ruby class of the new component, if any, that replaces the now deprecated component
 #
-# guide:
-#   - Optional
-#   - Type: string
-#   - Default: nil
-#   - A url that contains instructions on how to migrate from the deprecated component to the new component
-#
 # Examples
 # --------
 # Please note that these examples are somewhat contrived, even if they match up to actual PVC components. They
 # should be read as documentation only, and are not expected to be live. See the live configuration below the
 # examples for the real list of deprecations.
 #
-# 1. An autocorrectable deprecation without a migration guide
+# 1. An autocorrectable deprecation
 #
 #   component: "Primer::LabelComponent"
 #     autocorrect: true
 #     replacement: "Primer::Beta::Label
 #
-# 2. An autocorrectable deprecation with a migration guide to provide more information about the changes
-#
-#   component: "Primer::LabelComponent"
-#     autocorrect: true
-#     replacement: "Primer::Beta::Label
-#     guide: "https://primer.style/view-components/migration/label_component"
-#
-# 3. A non-autocorrectable deprecation, with a replacement component and migration guide
+# 2. A non-autocorrectable deprecation (no direct replacement component)
 #
 #   component: "Primer::ButtonComponent"
 #     autocorrect: false
-#     replacement: "Primer::Beta::Button"
-#     guide: "https://primer.style/view-components/migration/button_component"
-#
-# 4. A non-autocorrectable deprecation, without a replacement component, and with a guide to alternatives
-#
-#   component: "Primer::DropdownMenuComponent"
-#     autocorrect: false
-#     guide: "https://primer.style/view-components/migration/dropdown_menu_alternatives"
-#
-# 5. A non-autocorrectable deprecation, without a replacement component, and without a guide to alternatives
-#    !!!WARNING!!!
-#    THIS IS NOT RECOMMENDED. It will provide a deprecation warning with no guidance. This is
-#    not a good user experience. Please provide either a guide or a replacement component.
-#
-#   component: "Primer::BlankslateComponent"
-#     autocorrect: false
-#   
-#   or
-#
-#   component: "Primer::BlankslateComponent"
 
 deprecations:
   - component: "Primer::LabelComponent"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -1,0 +1,93 @@
+# Primer ViewComponents Deprecation Configuration
+# 
+# Schema
+# ------
+# component: [string/class] # Required. The full ruby class being deprecated
+#   autocorrect: [boolean] # Optional. Whether or not this deprecations can be autocorrected with `erblint -a`. default: false
+#   replacement: [string/class] # Optional. The full ruby class of the new component, if any, that replaces the now deprecated component. default: nil
+#   guide: [string/url]. Optional # Optional. A url that contains instructions on how to migrate from the deprecated component to the new component. default: nil
+#
+# Examples
+# --------
+# Please note that these examples are somewhat contrived, even if they match up to actual PVC components. They
+# should be read as documentation only, and are not expected to be live. See the live configuration below the
+# examples for the real list of deprecations.
+#
+# 1. An autocorrectable deprecation without a migration guide.
+#
+#   component: "Primer::LabelComponent"
+#     autocorrect: true
+#     replacement: "Primer::Beta::Label
+#
+# 2. An autocorrectable deprecation with a migration guide to provide more information about the changes.
+#
+#   component: "Primer::LabelComponent"
+#     autocorrect: true
+#     replacement: "Primer::Beta::Label
+#     guide: "https://primer.style/view-components/migration/label_component"
+#
+# 3. A non-autocorrectable deprecation, with a replacement component and migration guide.
+#
+#   component: "Primer::ButtonComponent"
+#     autocorrect: false
+#     replacement: "Primer::Beta::Button"
+#     guide: "https://primer.style/view-components/migration/button_component"
+#
+# 4. A non-autocorrectable deprecation, without a replacement component, and with a guide to alternatives.
+#
+#   component: "Primer::DropdownMenuComponent"
+#     autocorrect: false
+#     guide: "https://primer.style/view-components/migration/dropdown_menu_alternatives"
+#
+# 5. A non-autocorrectable deprecation, without a replacement component, and without a guide to alternatives.
+#   !!!WARNING!!!
+#     THIS IS NOT RECOMMENDED. It will provide a deprecation warning with no guidance. This is
+#     not a good user experience. Please provide either a guide or a replacement component.
+#
+#   component: "Primer::BlankslateComponent"
+#     autocorrect: false
+#   
+#   or
+#
+#   component: "Primer::BlankslateComponent"
+
+deprecations:
+  component: "Primer::LabelComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Label"
+  component: "Primer::LinkComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Link"
+  component: "Primer::Alpha::AutoComplete"
+    autocorrect: true
+    replacement: "Primer::Beta::AutoComplete"
+  component: "Primer::Alpha::AutoComplete::Item"
+    autocorrect: true
+    replacement: "Primer::Beta::AutoComplete::Item"
+  component: "Primer::BlankslateComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Blankslate"
+  component: "Primer::BoxComponent"
+    autocorrect: true
+    replacement: "Primer::Box"
+  component: "Primer::DropdownMenuComponent"
+    autocorrect: false
+    guide: "https://primer.style/view-components/migration"
+  component: "Primer::Dropdown"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown"
+  component: "Primer::Dropdown::Menu"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown::Menu"
+  component: "Primer::Dropdown::Menu::Item"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown::Menu::Item"
+  component: "Primer::IconButton"
+    autocorrect: true
+    replacement: "Primer::Beta::IconButton"
+  component: "Primer::Tooltip"
+    autocorrect: true
+    replacement: "Primer::Alpha::Tooltip"
+  component: "Primer::PopoverComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Popover"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -2,7 +2,7 @@
 # 
 # Schema
 # ------
-# component: [string]
+# - component: [string]
 #   autocorrect: [boolean] 
 #   replacement: [string] 
 #   guide: [string]
@@ -77,42 +77,42 @@
 #   component: "Primer::BlankslateComponent"
 
 deprecations:
-  component: "Primer::LabelComponent"
+  - component: "Primer::LabelComponent"
     autocorrect: true
     replacement: "Primer::Beta::Label"
-  component: "Primer::LinkComponent"
+  - component: "Primer::LinkComponent"
     autocorrect: true
     replacement: "Primer::Beta::Link"
-  component: "Primer::Alpha::AutoComplete"
+  - component: "Primer::Alpha::AutoComplete"
     autocorrect: true
     replacement: "Primer::Beta::AutoComplete"
-  component: "Primer::Alpha::AutoComplete::Item"
+  - component: "Primer::Alpha::AutoComplete::Item"
     autocorrect: true
     replacement: "Primer::Beta::AutoComplete::Item"
-  component: "Primer::BlankslateComponent"
+  - component: "Primer::BlankslateComponent"
     autocorrect: true
     replacement: "Primer::Beta::Blankslate"
-  component: "Primer::BoxComponent"
+  - component: "Primer::BoxComponent"
     autocorrect: true
     replacement: "Primer::Box"
-  component: "Primer::DropdownMenuComponent"
+  - component: "Primer::DropdownMenuComponent"
     autocorrect: false
     replacement: "Primer::Beta::Dropdown"
-  component: "Primer::Dropdown"
+  - component: "Primer::Dropdown"
     autocorrect: true
     replacement: "Primer::Alpha::Dropdown"
-  component: "Primer::Dropdown::Menu"
+  - component: "Primer::Dropdown::Menu"
     autocorrect: true
     replacement: "Primer::Alpha::Dropdown::Menu"
-  component: "Primer::Dropdown::Menu::Item"
+  - component: "Primer::Dropdown::Menu::Item"
     autocorrect: true
     replacement: "Primer::Alpha::Dropdown::Menu::Item"
-  component: "Primer::IconButton"
+  - component: "Primer::IconButton"
     autocorrect: true
     replacement: "Primer::Beta::IconButton"
-  component: "Primer::Tooltip"
+  - component: "Primer::Tooltip"
     autocorrect: true
     replacement: "Primer::Alpha::Tooltip"
-  component: "Primer::PopoverComponent"
+  - component: "Primer::PopoverComponent"
     autocorrect: true
     replacement: "Primer::Beta::Popover"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -2,10 +2,35 @@
 # 
 # Schema
 # ------
-# component: [string/class] # Required. The full ruby class being deprecated
-#   autocorrect: [boolean] # Optional. Whether or not this deprecations can be autocorrected with `erblint -a`. default: false
-#   replacement: [string/class] # Optional. The full ruby class of the new component, if any, that replaces the now deprecated component. default: nil
-#   guide: [string/url]. Optional # Optional. A url that contains instructions on how to migrate from the deprecated component to the new component. default: nil
+# component: [string]
+#   autocorrect: [boolean] 
+#   replacement: [string] 
+#   guide: [string]
+#
+# Field Descriptions
+# ------------------
+# component:
+#   - Required
+#   - Type: string
+#   - The full ruby class of the deprecated component
+#
+# autocorrect:
+#   - Optional
+#   - Type: boolean
+#   - Default: false
+#   - Whether or not this deprecations can be autocorrected with `erblint -a`
+#
+# replacement:
+#   - Optional
+#   - Type: string
+#   - Default: nil
+#   - The full ruby class of the new component, if any, that replaces the now deprecated component
+#
+# guide:
+#   - Optional
+#   - Type: string
+#   - Default: nil
+#   - A url that contains instructions on how to migrate from the deprecated component to the new component
 #
 # Examples
 # --------
@@ -13,36 +38,36 @@
 # should be read as documentation only, and are not expected to be live. See the live configuration below the
 # examples for the real list of deprecations.
 #
-# 1. An autocorrectable deprecation without a migration guide.
+# 1. An autocorrectable deprecation without a migration guide
 #
 #   component: "Primer::LabelComponent"
 #     autocorrect: true
 #     replacement: "Primer::Beta::Label
 #
-# 2. An autocorrectable deprecation with a migration guide to provide more information about the changes.
+# 2. An autocorrectable deprecation with a migration guide to provide more information about the changes
 #
 #   component: "Primer::LabelComponent"
 #     autocorrect: true
 #     replacement: "Primer::Beta::Label
 #     guide: "https://primer.style/view-components/migration/label_component"
 #
-# 3. A non-autocorrectable deprecation, with a replacement component and migration guide.
+# 3. A non-autocorrectable deprecation, with a replacement component and migration guide
 #
 #   component: "Primer::ButtonComponent"
 #     autocorrect: false
 #     replacement: "Primer::Beta::Button"
 #     guide: "https://primer.style/view-components/migration/button_component"
 #
-# 4. A non-autocorrectable deprecation, without a replacement component, and with a guide to alternatives.
+# 4. A non-autocorrectable deprecation, without a replacement component, and with a guide to alternatives
 #
 #   component: "Primer::DropdownMenuComponent"
 #     autocorrect: false
 #     guide: "https://primer.style/view-components/migration/dropdown_menu_alternatives"
 #
-# 5. A non-autocorrectable deprecation, without a replacement component, and without a guide to alternatives.
-#   !!!WARNING!!!
-#     THIS IS NOT RECOMMENDED. It will provide a deprecation warning with no guidance. This is
-#     not a good user experience. Please provide either a guide or a replacement component.
+# 5. A non-autocorrectable deprecation, without a replacement component, and without a guide to alternatives
+#    !!!WARNING!!!
+#    THIS IS NOT RECOMMENDED. It will provide a deprecation warning with no guidance. This is
+#    not a good user experience. Please provide either a guide or a replacement component.
 #
 #   component: "Primer::BlankslateComponent"
 #     autocorrect: false

--- a/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
+++ b/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
@@ -11,8 +11,8 @@ module ERBLint
           message = "#{component} has been deprecated and should not be used."
 
           if Primer::Deprecations.correctable?(component)
-            suggested_component = Primer::Deprecations.suggested_component(component)
-            message += " Try #{suggested_component} instead."
+            replacement = Primer::Deprecations.replacement(component)
+            message += " Try #{replacement} instead."
           end
 
           message

--- a/lib/rubocop/cop/primer/component_name_migration.rb
+++ b/lib/rubocop/cop/primer/component_name_migration.rb
@@ -26,8 +26,8 @@ module RuboCop
             component_name = node.const_name
             return unless ::Primer::Deprecations.correctable?(component_name)
 
-            suggested_component = ::Primer::Deprecations.suggested_component(component_name)
-            corrector.replace(node, suggested_component) if suggested_component.present?
+            replacement = ::Primer::Deprecations.replacement(component_name)
+            corrector.replace(node, replacement) if replacement.present?
           end
         end
       end

--- a/script/setup
+++ b/script/setup
@@ -15,5 +15,8 @@ pushd docs
 npm install
 popd
 
+# Build assets so tests can be run correctly
+script/build-assets
+
 # Initial build of docs content
 bundle exec rake docs:build

--- a/script/setup
+++ b/script/setup
@@ -15,8 +15,5 @@ pushd docs
 npm install
 popd
 
-# Build assets so tests can be run correctly
-script/build-assets
-
 # Initial build of docs content
 bundle exec rake docs:build

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -181,7 +181,7 @@ class PrimerComponentTest < Minitest::Test
 
   def test_deprecated_components_by_status_match_list
     deprecated_by_status = Primer::ViewComponents::STATUSES.select { |_, value| value == "deprecated" }.keys.sort
-    deprecated_by_list = ::Primer::Deprecations::DEPRECATED_COMPONENTS.keys.sort
+    deprecated_by_list = ::Primer::Deprecations.deprecated_components
 
     assert_empty(deprecated_by_status - deprecated_by_list, "Please make sure that components are officially deprecated by setting the `status :deprecated` within the component file.\nMake sure to provide an alternative component for each deprecated component in Primer::Deprecations::DEPRECATED_COMPONENTS (lib/primer/deprecations.rb). If there is no alternative to suggest, set the value to nil.")
   end

--- a/test/lib/deprecations_test.rb
+++ b/test/lib/deprecations_test.rb
@@ -3,7 +3,13 @@
 require "lib/test_helper"
 
 class DeprecationsTest < Minitest::Test
-  def test_default_deprecations
-    assert Primer::Deprecations.deprecated?("Primer::BlankslateComponent")
+  def test_default_deprecations_are_loaded
+    component = "Primer::BlankslateComponent"
+    replacement = "Primer::Beta::Blankslate"
+
+    assert Primer::Deprecations.deprecated?(component)
+    assert Primer::Deprecations.correctable?(component)
+    assert_equal Primer::Deprecations.replacement(component), replacement
+    assert_nil Primer::Deprecations.guide(component)
   end
 end

--- a/test/lib/deprecations_test.rb
+++ b/test/lib/deprecations_test.rb
@@ -1,8 +1,13 @@
 # frozen_string_literal: true
 
 require "lib/test_helper"
+Dir["app/components/**/*.rb"].each { |file| require_relative "../../#{file}" }
 
 class DeprecationsTest < Minitest::Test
+  def setup
+    @deprecated_components = Primer::Deprecations.deprecated_components
+  end
+
   def test_default_deprecations_are_loaded
     component = "Primer::BlankslateComponent"
     replacement = "Primer::Beta::Blankslate"
@@ -11,5 +16,22 @@ class DeprecationsTest < Minitest::Test
     assert Primer::Deprecations.correctable?(component)
     assert_equal Primer::Deprecations.replacement(component), replacement
     assert_nil Primer::Deprecations.guide(component)
+  end
+
+  # ensure all components that has `status: :deprecated` are listed in the
+  # component deprecations configuration file
+  Primer::Component.descendants.each do |component_class|
+    class_test_name = component_class.name.downcase.gsub("::", "_")
+    define_method("test_ensure_#{class_test_name}_is_properly_deprecated") do
+      if component_class.deprecated?
+        assert @deprecated_components.include?(component_class.name), missing_deprecation_message(component_class)
+      end
+    end
+  end
+
+  private
+
+  def missing_deprecation_message(component_class)
+    "PVC Component '#{component_class.name}' has a `status` of `:deprected`, but is not listed in the deprecations.yml file. Please update the deprecations configuration in `lib/primer/deprecations.yml`"
   end
 end

--- a/test/lib/deprecations_test.rb
+++ b/test/lib/deprecations_test.rb
@@ -23,7 +23,7 @@ class DeprecationsTest < Minitest::Test
   Primer::Component.descendants.each do |component_class|
     class_test_name = component_class.name.downcase.gsub("::", "_")
     define_method("test_ensure_#{class_test_name}_is_properly_deprecated") do
-      if component_class.deprecated?
+      if component_class.deprecated? # rubocop:disable Style/IfUnlessModifier
         assert @deprecated_components.include?(component_class.name), missing_deprecation_message(component_class)
       end
     end

--- a/test/lib/deprecations_test.rb
+++ b/test/lib/deprecations_test.rb
@@ -15,7 +15,6 @@ class DeprecationsTest < Minitest::Test
     assert Primer::Deprecations.deprecated?(component)
     assert Primer::Deprecations.correctable?(component)
     assert_equal Primer::Deprecations.replacement(component), replacement
-    assert_nil Primer::Deprecations.guide(component)
   end
 
   # ensure all components that has `status: :deprecated` are listed in the

--- a/test/lib/deprecations_test.rb
+++ b/test/lib/deprecations_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class DeprecationsTest < Minitest::Test
+  def test_default_deprecations
+    assert Primer::Deprecations.deprecated?("Primer::BlankslateComponent")
+  end
+end

--- a/test/lib/rubocop/component_name_migration_test.rb
+++ b/test/lib/rubocop/component_name_migration_test.rb
@@ -16,16 +16,13 @@ class RubocopComponentNameMigrationTest < CopTestCase
   end
 
   def test_using_deprecated_class
-    original_list = Primer::Deprecations::DEPRECATED_COMPONENTS
-    Primer::Deprecations.const_set("DEPRECATED_COMPONENTS", { "Primer::TestComponent" => "Primer::Beta::Test" })
+    original_list = Primer::Deprecations.deprecated_components
 
     investigate(cop, <<-RUBY)
-      Primer::TestComponent.new
+      Primer::BlankslateComponent.new
     RUBY
 
     assert_equal 1, cop.offenses.count
-    assert_equal "Primer::Beta::Test.new", cop.offenses.first.corrector.rewrite.strip
-  ensure
-    Primer::Deprecations.const_set("DEPRECATED_COMPONENTS", original_list)
+    assert_equal "Primer::Beta::Blankslate.new", cop.offenses.first.corrector.rewrite.strip
   end
 end

--- a/test/lib/rubocop/component_name_migration_test.rb
+++ b/test/lib/rubocop/component_name_migration_test.rb
@@ -16,8 +16,6 @@ class RubocopComponentNameMigrationTest < CopTestCase
   end
 
   def test_using_deprecated_class
-    original_list = Primer::Deprecations.deprecated_components
-
     investigate(cop, <<-RUBY)
       Primer::BlankslateComponent.new
     RUBY


### PR DESCRIPTION
⚠️ WORK IN PROGRESS ⚠️ 

### Description

As a first step to [improving the deprecation architecture in PVC](https://github.com/github/primer/discussions/1515), this PR moves away from a hard coded hash of what components are deprecated, in favor of a `deprecations.yml` file.

By providing the deprecation configuration as a yaml file, opportunities are opened for other applications to use this deprecation system. For example, an experimental component in dotcom may be marked as deprecated in favor of an alpha or beta version. Rather than forcing the component to be moved into PVC, a separate yaml file with deprecations can be registered in addition to the built in file.

This also prepares PVC for additional architectural changes with deprecations. This will include the addition of a "guide" setting for deprecations, to ensure developers using PVC have the information they need for migrating components that are not auto-correctable.

### Changes

* created `lib/deprecations/deprecations.yml` to replace the hard coded list of deprecations
* test the basics of the yml configuration
* test to ensure all components with `status: :deprecated` are represented in `deprecations.yml`
* added `script/build-assets` to the `script/setup` file, to ensure test can be run immediately after setup
* updated all the code that relies on the deprecations
* edited popover.pcss to remove `&` from commented, preventing test failures

### Integration

> Does this change require any updates to code in production?

none

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews
