### PR TITLE
Creating AUDITED variable to access audited_at static file

### DIFF
--- a/.changeset/wild-beds-tease.md
+++ b/.changeset/wild-beds-tease.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Adding `Primer::ViewComponents::AUDITED` variable to access when a component was last audited. Get's data from the `static/audited_at.json` file.

--- a/lib/primer/view_components/audited.rb
+++ b/lib/primer/view_components/audited.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Primer
+  # :nodoc:
+  module ViewComponents
+    AUDITED = JSON.parse(
+      File.read(
+        File.join(File.dirname(__FILE__), "../../../static/audited_at.json")
+      )
+    ).freeze
+  end
+end

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -57,6 +57,7 @@ module Primer
           autoloader.ignore(Engine.root.join("lib", "primer", "view_components", "linters.rb"))
           autoloader.ignore(Engine.root.join("lib", "primer", "view_components", "linters", "**", "*.rb"))
           autoloader.ignore(Engine.root.join("lib", "primer", "view_components", "statuses.rb"))
+          autoloader.ignore(Engine.root.join("lib", "primer", "view_components", "audited.rb"))
         end
       end
 

--- a/test/lib/audited_test.rb
+++ b/test/lib/audited_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+require "primer/view_components/audited"
+
+class Primer::ViewComponents::AuditedTest < Minitest::Test
+  def test_audited_array_isnt_empty
+    refute_empty Primer::ViewComponents::AUDITED.keys
+  end
+end


### PR DESCRIPTION
### Description

I want to be able to access the `static/audited_at.json` file using the `Primer::ViewComponents::AUDITED` static variable. This was made to be exactly like `Primer::ViewComponents::STATUSES`.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
