### PR TITLE
Allow form inputs to be hidden

### DIFF
--- a/.changeset/gorgeous-pans-work.md
+++ b/.changeset/gorgeous-pans-work.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow form inputs to be hidden

--- a/lib/primer/forms/check_box.html.erb
+++ b/lib/primer/forms/check_box.html.erb
@@ -1,4 +1,4 @@
-<div class="FormControl-checkbox-wrap">
+<%= content_tag(:div, class: "FormControl-checkbox-wrap", hidden: @input.hidden?) do %>
   <%= builder.check_box(@input.name, @input.input_arguments, checked_value, unchecked_value) %>
   <span class="FormControl-checkbox-labelWrap">
     <%= builder.label(@input.name, **@input.label_arguments) do %>
@@ -6,7 +6,7 @@
     <% end %>
     <%= render(Caption.new(input: @input)) %>
   </span>
-</div>
+<% end %>
 <% if @input.nested_form_block %>
   <%= content_tag(:div, nested_form_arguments) do %>
     <%= render(@input.nested_form_block.call(builder)) %>

--- a/lib/primer/forms/check_box.rb
+++ b/lib/primer/forms/check_box.rb
@@ -20,7 +20,7 @@ module Primer
       def nested_form_arguments
         return @nested_form_arguments if defined?(@nested_form_arguments)
 
-        @nested_form_arguments = { **@input.nested_form_arguments }
+        @nested_form_arguments = { **@input.nested_form_arguments, hidden: @input.hidden? }
         @nested_form_arguments[:class] = class_names(
           @nested_form_arguments[:class],
           @nested_form_arguments.delete(:classes),

--- a/lib/primer/forms/check_box_group.html.erb
+++ b/lib/primer/forms/check_box_group.html.erb
@@ -1,4 +1,4 @@
-<fieldset>
+<%= content_tag(:fieldset, hidden: @input.hidden?) do %>
   <% if @input.label %>
     <%= content_tag(:legend, **@input.label_arguments) do %>
       <%= @input.label %>
@@ -9,4 +9,4 @@
       <%= render(check_box.to_component) %>
     <% end %>
   <% end %>
-</fieldset>
+<% end %>

--- a/lib/primer/forms/dsl/text_field_input.rb
+++ b/lib/primer/forms/dsl/text_field_input.rb
@@ -31,13 +31,6 @@ module Primer
 
           add_input_classes("FormControl-inset") if inset?
           add_input_classes("FormControl-monospace") if monospace?
-
-          @field_wrap_classes = class_names(
-            "FormControl-input-wrap",
-            Primer::Forms::Dsl::Input::SIZE_MAPPINGS[size],
-            "FormControl-input-wrap--trailingAction": show_clear_button?,
-            "FormControl-input-wrap--leadingVisual": leading_visual?
-          )
         end
 
         alias show_clear_button? show_clear_button

--- a/lib/primer/forms/radio_button.html.erb
+++ b/lib/primer/forms/radio_button.html.erb
@@ -1,4 +1,4 @@
-<div class="FormControl-radio-wrap">
+<%= content_tag(:div, class: "FormControl-radio-wrap", hidden: @input.hidden?) do %>
   <%= builder.radio_button(@input.name, @input.value, **@input.input_arguments) %>
   <span class="FormControl-radio-labelWrap">
     <%= builder.label(@input.name, value: @input.value, **@input.label_arguments) do %>
@@ -6,7 +6,7 @@
     <% end %>
     <%= render(Caption.new(input: @input)) %>
   </span>
-</div>
+<% end %>
 <% if @input.nested_form_block %>
   <%= content_tag(:div, nested_form_arguments) do %>
     <%= render(@input.nested_form_block.call(builder)) %>

--- a/lib/primer/forms/radio_button.rb
+++ b/lib/primer/forms/radio_button.rb
@@ -15,7 +15,7 @@ module Primer
       def nested_form_arguments
         return @nested_form_arguments if defined?(@nested_form_arguments)
 
-        @nested_form_arguments = { **@input.nested_form_arguments }
+        @nested_form_arguments = { **@input.nested_form_arguments, hidden: @input.hidden? }
         @nested_form_arguments[:class] = class_names(
           @nested_form_arguments[:class],
           @nested_form_arguments.delete(:classes),

--- a/lib/primer/forms/radio_button_group.html.erb
+++ b/lib/primer/forms/radio_button_group.html.erb
@@ -1,4 +1,4 @@
-<fieldset>
+<%= content_tag(:fieldset, hidden: @input.hidden?) do %>
   <% if @input.label %>
     <%= content_tag(:legend, **@input.label_arguments) do %>
       <%= @input.label %>
@@ -9,4 +9,4 @@
       <%= render(radio_button.to_component) %>
     <% end %>
   <% end %>
-</fieldset>
+<% end %>

--- a/lib/primer/forms/select_list.html.erb
+++ b/lib/primer/forms/select_list.html.erb
@@ -1,5 +1,5 @@
 <%= render(FormControl.new(input: @input)) do %>
-  <%= content_tag(:div, class: @field_wrap_classes) do %>
+  <%= content_tag(:div, **@field_wrap_arguments) do %>
     <%= builder.select(@input.name, options, @input.select_arguments, **@input.input_arguments) %>
   <% end %>
 <% end %>

--- a/lib/primer/forms/select_list.rb
+++ b/lib/primer/forms/select_list.rb
@@ -13,7 +13,10 @@ module Primer
           "FormControl--medium"
         )
 
-        @field_wrap_classes = class_names("FormControl-select-wrap")
+        @field_wrap_arguments = {
+          class: "FormControl-select-wrap",
+          hidden: @input.hidden?
+        }
       end
 
       def options

--- a/lib/primer/forms/text_area.html.erb
+++ b/lib/primer/forms/text_area.html.erb
@@ -1,5 +1,5 @@
 <%= render(FormControl.new(input: @input)) do %>
-  <%= content_tag(:div, class: @field_wrap_classes) do %>
+  <%= content_tag(:div, **@field_wrap_arguments) do %>
     <%= builder.text_area(@input.name, **@input.input_arguments) %>
   <% end %>
 <% end %>

--- a/lib/primer/forms/text_area.rb
+++ b/lib/primer/forms/text_area.rb
@@ -9,7 +9,11 @@ module Primer
       def initialize(input:)
         @input = input
         @input.add_input_classes("FormControl-input", "FormControl--medium")
-        @field_wrap_classes = class_names("FormControl-input-wrap")
+
+        @field_wrap_arguments = {
+          class: class_names("FormControl-input-wrap"),
+          hidden: @input.hidden?
+        }
       end
     end
   end

--- a/lib/primer/forms/text_field.html.erb
+++ b/lib/primer/forms/text_field.html.erb
@@ -1,6 +1,6 @@
 <%= render(FormControl.new(input: @input)) do %>
   <% if @input.leading_visual || @input.show_clear_button? %>
-    <%= content_tag(:div, class: @input.field_wrap_classes) do %>
+    <%= content_tag(:div, **@field_wrap_arguments) do %>
       <% if @input.leading_visual %>
         <span class="FormControl-input-leadingVisualWrap">
           <%= render(Primer::OcticonComponent.new(**@input.leading_visual)) %>

--- a/lib/primer/forms/text_field.rb
+++ b/lib/primer/forms/text_field.rb
@@ -8,6 +8,17 @@ module Primer
 
       def initialize(input:)
         @input = input
+
+        @field_wrap_arguments = {
+          class: class_names(
+            "FormControl-input-wrap",
+            Primer::Forms::Dsl::Input::SIZE_MAPPINGS[@input.size],
+            "FormControl-input-wrap--trailingAction": @input.show_clear_button?,
+            "FormControl-input-wrap--leadingVisual": @input.leading_visual?
+          ),
+
+          hidden: @input.hidden?
+        }
       end
     end
   end

--- a/test/lib/primer/forms/checkbox_group_input_test.rb
+++ b/test/lib/primer/forms/checkbox_group_input_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::CheckboxGroupInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenCheckboxGroupForm < ApplicationForm
+    form do |check_form|
+      check_form.check_box_group(label: "Foobar", hidden: true) do |check_group|
+        check_group.check_box(name: :foo, label: "Foo")
+      end
+    end
+  end
+
+  def test_hidden_checkbox_group
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenCheckboxGroupForm.new(f))
+      end
+    end
+
+    assert_selector "fieldset", visible: false
+    assert_selector ".FormControl-checkbox-wrap", visible: false
+  end
+end

--- a/test/lib/primer/forms/checkbox_input_test.rb
+++ b/test/lib/primer/forms/checkbox_input_test.rb
@@ -7,7 +7,7 @@ class Primer::Forms::CheckboxInputTest < Minitest::Test
 
   class BadCheckboxesForm < ApplicationForm
     form do |check_form|
-      check_form.check_box(name: "alpha", label: "Alpha", scheme: :array)
+      check_form.check_box(name: :alpha, label: "Alpha", scheme: :array)
     end
   end
 
@@ -21,5 +21,21 @@ class Primer::Forms::CheckboxInputTest < Minitest::Test
     end
 
     assert_includes error.message, "Check box needs an explicit value if scheme is array"
+  end
+
+  class HiddenCheckboxForm < ApplicationForm
+    form do |check_form|
+      check_form.check_box(name: :foo, label: "Foo", hidden: true)
+    end
+  end
+
+  def test_hidden_checkbox
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenCheckboxForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl-checkbox-wrap", visible: false
   end
 end

--- a/test/lib/primer/forms/radio_button_input_test.rb
+++ b/test/lib/primer/forms/radio_button_input_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::RadioButtonInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenRadioButtonForm < ApplicationForm
+    form do |radio_form|
+      radio_form.radio_button_group(name: :foos, label: "Foos") do |radio_group|
+        radio_group.radio_button(name: :foo, label: "Foo", value: "foo", hidden: true)
+      end
+    end
+  end
+
+  def test_hidden_radio_button
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenRadioButtonForm.new(f))
+      end
+    end
+
+    assert_selector "fieldset"
+    assert_selector ".FormControl-radio-wrap", visible: false
+  end
+
+  class HiddenRadioButtonGroupForm < ApplicationForm
+    form do |radio_form|
+      radio_form.radio_button_group(name: :foos, label: "Foos", hidden: true) do |radio_group|
+        radio_group.radio_button(name: :foo, label: "Foo", value: "foo")
+      end
+    end
+  end
+
+  def test_hidden_radio_button_group
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenRadioButtonGroupForm.new(f))
+      end
+    end
+
+    assert_selector "fieldset", visible: false
+    assert_selector ".FormControl-radio-wrap", visible: false
+  end
+end

--- a/test/lib/primer/forms/select_list_input_test.rb
+++ b/test/lib/primer/forms/select_list_input_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::SelectListInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenSelectListForm < ApplicationForm
+    form do |select_list_form|
+      select_list_form.select_list(name: :foo, label: "Foo") do |list|
+        list.option(label: "Foo", value: "foo")
+      end
+    end
+  end
+
+  def test_hidden_select_list
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenSelectListForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl", visible: false
+  end
+end

--- a/test/lib/primer/forms/text_area_input_test.rb
+++ b/test/lib/primer/forms/text_area_input_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::TextAreaInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenTextAreaForm < ApplicationForm
+    form do |text_field_form|
+      text_field_form.text_area(name: :foo, label: "Foo")
+    end
+  end
+
+  def test_hidden_text_area
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenTextAreaForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl", visible: false
+  end
+end

--- a/test/lib/primer/forms/text_field_input_test.rb
+++ b/test/lib/primer/forms/text_field_input_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::TextFieldInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenTextFieldForm < ApplicationForm
+    form do |text_field_form|
+      text_field_form.text_field(name: :foo, label: "Foo")
+    end
+  end
+
+  def test_hidden_text_field
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenTextFieldForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl", visible: false
+  end
+end


### PR DESCRIPTION
### Description

The forms framework supports a `hidden` attribute that is passed to the underlying Rails builder. Passing `hidden: true` will result in the `<input>` itself being hidden on the page, but does not account for any accompanying labels, validation messages, nested forms, etc, i.e. decorations added by `FormControl` and friends. This PR ensures all related markup is hidden along with the input.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [x] Added/updated previews
