### PR TITLE
Add the primer_fields_for helper

### DIFF
--- a/.changeset/lemon-pillows-hug.md
+++ b/.changeset/lemon-pillows-hug.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add the primer_fields_for helper

--- a/app/helpers/primer/form_helper.rb
+++ b/app/helpers/primer/form_helper.rb
@@ -7,5 +7,17 @@ module Primer
     def primer_form_with(**kwargs, &block)
       form_with(**kwargs, skip_default_ids: false, builder: Primer::Forms::Builder, &block)
     end
+
+    def primer_fields_for(record_name, record_object = nil, options = {}, &block)
+      fields_for(
+        record_name,
+        record_object,
+        options.merge(
+          skip_default_ids: false,
+          builder: Primer::Forms::Builder
+        ),
+        &block
+      )
+    end
   end
 end

--- a/test/lib/primer/forms/form_helper_test.rb
+++ b/test/lib/primer/forms/form_helper_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::FormHelperTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class DeepThought
+    if Rails::VERSION::STRING < "7.0"
+      include ActiveModel::Model
+    else
+      include ActiveModel::API
+    end
+
+    include ActiveModel::Validations
+
+    attr_reader :ultimate_answer
+
+    def initialize(ultimate_answer)
+      @ultimate_answer = ultimate_answer
+    end
+
+    validates :ultimate_answer, numericality: { greater_than: 41, less_than: 43 }
+  end
+
+  def test_includes_activemodel_validation_messages
+    model = DeepThought.new(41)
+    model.valid? # populate validation error messages
+
+    render_in_view_context do
+      primer_form_with(model: model, url: "/foo") do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl" do
+      assert_selector ".FormControl-inlineValidation", text: "Ultimate answer must be greater than 41" do
+        assert_selector ".octicon-alert-fill"
+      end
+    end
+  end
+
+  def test_names_inputs_correctly_when_rendered_against_an_activemodel
+    model = DeepThought.new(42)
+
+    render_in_view_context do
+      primer_form_with(model: model, url: "/foo") do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    text_field = page.find_all("input[type=text]").first
+    assert_equal text_field["name"], "primer_forms_form_helper_test_deep_thought[ultimate_answer]"
+  end
+
+  def test_the_input_is_described_by_the_validation_message
+    model = DeepThought.new(41)
+    model.valid? # populate validation error messages
+
+    render_in_view_context do
+      primer_form_with(model: model, url: "/foo") do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    validation_id = page.find_all(".FormControl-inlineValidation").first["id"]
+    described_by = page.find_all("input[type='text']").first["aria-describedby"]
+    assert described_by.split.include?(validation_id)
+  end
+
+  def test_primer_fields_for
+    model = DeepThought.new(42)
+
+    render_in_view_context do
+      primer_fields_for(:deep_thought, model) do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    refute_selector "form" # does not render a <form> tag
+    assert_selector "input[name='deep_thought[ultimate_answer]']"
+  end
+end

--- a/test/lib/primer/forms/forms_test.rb
+++ b/test/lib/primer/forms/forms_test.rb
@@ -6,24 +6,6 @@ require_relative "form_test_component"
 class Primer::Forms::FormsTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class DeepThought
-    if Rails::VERSION::STRING < "7.0"
-      include ActiveModel::Model
-    else
-      include ActiveModel::API
-    end
-
-    include ActiveModel::Validations
-
-    attr_reader :ultimate_answer
-
-    def initialize(ultimate_answer)
-      @ultimate_answer = ultimate_answer
-    end
-
-    validates :ultimate_answer, numericality: { greater_than: 41, less_than: 43 }
-  end
-
   def test_renders_correct_form_structure
     render_preview :single_text_field_form
 
@@ -70,51 +52,6 @@ class Primer::Forms::FormsTest < Minitest::Test
 
     caption_id = page.find_all(".FormControl-caption").first["id"]
     assert_selector "input[aria-describedby='#{caption_id}']"
-  end
-
-  def test_includes_activemodel_validation_messages
-    model = DeepThought.new(41)
-    model.valid? # populate validation error messages
-
-    render_in_view_context do
-      primer_form_with(model: model, url: "/foo") do |f|
-        render(SingleTextFieldForm.new(f))
-      end
-    end
-
-    assert_selector ".FormControl" do
-      assert_selector ".FormControl-inlineValidation", text: "Ultimate answer must be greater than 41" do
-        assert_selector ".octicon-alert-fill"
-      end
-    end
-  end
-
-  def test_names_inputs_correctly_when_rendered_against_an_activemodel
-    model = DeepThought.new(42)
-
-    render_in_view_context do
-      primer_form_with(model: model, url: "/foo") do |f|
-        render(SingleTextFieldForm.new(f))
-      end
-    end
-
-    text_field = page.find_all("input[type=text]").first
-    assert_equal text_field["name"], "primer_forms_forms_test_deep_thought[ultimate_answer]"
-  end
-
-  def test_the_input_is_described_by_the_validation_message
-    model = DeepThought.new(41)
-    model.valid? # populate validation error messages
-
-    render_in_view_context do
-      primer_form_with(model: model, url: "/foo") do |f|
-        render(SingleTextFieldForm.new(f))
-      end
-    end
-
-    validation_id = page.find_all(".FormControl-inlineValidation").first["id"]
-    described_by = page.find_all("input[type='text']").first["aria-describedby"]
-    assert described_by.split.include?(validation_id)
   end
 
   def test_renders_the_caption_template_when_present


### PR DESCRIPTION
### Description

Rails features several ways to create a form builder. The most common are via `form_for` and it's newer counterpart `form_with`. Primer contains a handy `primer_form_with` that should be used instead of the originals when rendering forms created using the Primer forms framework.

If you don't want to emit a `<form>` tag, Rails also provides `fields_for`, which accepts many of the same arguments as `form_for` and `form_with`. This PR introduces a companion `primer_fields_for` method for rendering only the fields defined by a form object.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
