### PR TITLE
migration guide for `Primer::DropdownMenuComponent` to `Primer::Beta::Dropdown`

### DIFF
--- a/.changeset/modern-frogs-eat.md
+++ b/.changeset/modern-frogs-eat.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add a migration guide for moving from Primer::DropdownMenuComponent to Primer::Beta::Dropdown

--- a/docs/content/guides/primer_dropdown_menu_component.md
+++ b/docs/content/guides/primer_dropdown_menu_component.md
@@ -14,17 +14,18 @@ of the Primer Dropdown.
 
 | From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
 |--------------------------------------|------------------------------|-------|
-| `direction` | n/a          | moved to `menu` slot, below                                |
-| `scheme`    | n/a          | moved to `menu` slot, below                                |
-| `header`    | n/a          | moved to `menu` slot, below                                |
-| n/a         | `overlay`    | color of the menu overlay: `:default`, `:dark`, or `:none` |
-| n/a         | `with_caret` | whether or not a caret should be displayed on the button   |
+| `direction` | n/a          | Moved to `menu` slot, below                                |
+| `scheme`    | n/a          | Moved to `menu` slot, below                                |
+| `header`    | n/a          | Moved to `menu` slot, below                                |
+| n/a         | `overlay`    | Color of the menu overlay: `:default`, `:dark`, or `:none` |
+| n/a         | `with_caret` | Whether or not a caret should be displayed on the button   |
 
 The remaining arguments have stayed the same. 
 
 Please see the following documentation for complete descriptions and examples.
 
-* [`Primer::Alpha::Dropdown` component](https://primer.style/view-components/components/alpha/dropdown)
+* [Deprecated `Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu)
+* [Updated `Primer::Alpha::Dropdown` component](https://primer.style/view-components/components/alpha/dropdown)
 * [`Primer::Alpha::Dropdown` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/alpha/dropdown/default)
 
 ## Slot Names
@@ -33,8 +34,8 @@ The following slots have changed with the newer Primer Dropdown.
 
 | From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
 |--------------------------------------|------------------------------|-------|
-| n/a | `menu`   | see the "Arguments for `menu` slot" section, below |
-| n/a | `button` | the button to display for the dropdown action      |
+| n/a | `menu`   | Required context menu for the dropdown. See the "Arguments for `menu` slot" section, below |
+| n/a | `button` | The [`Primer::Beta::Button`](https://primer.style/view-components/components/beta/button) to display for the dropdown action |
 
 The remaining slot names have stayed the same.
 

--- a/docs/content/guides/primer_dropdown_menu_component.md
+++ b/docs/content/guides/primer_dropdown_menu_component.md
@@ -4,7 +4,7 @@ title: Moving Away From `Primer::DropdownMenuComponent`
 
 This guide will show you how to upgrade from the now deprecated
 [`Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu)
-to the latest [`Primer::Beta::Dropdown`](https://primer.style/view-components/components/beta/dropdown)
+to the latest [`Primer::Alpha::Dropdown`](https://primer.style/view-components/components/alpha/dropdown)
 component.
 
 ## Arguments
@@ -12,7 +12,7 @@ component.
 The following arguments for the component initializer have changed between the deprecated and newer versions
 of the Primer Dropdown.
 
-| From `Primer::DropdownMenuComponent` | To `Primer::Beta::Dropdown` | Notes |
+| From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
 |--------------------------------------|-----------------------------|-------|
 | | | |
 
@@ -26,7 +26,7 @@ more description here
 
 The following slots have changed with the newer Primer Dropdown.
 
-| From `Primer::DropdownMenuComponent` | To `Primer::Beta::Dropdown` | Notes |
+| From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
 |--------------------------------------|-----------------------------|-------|
 | | | |
 

--- a/docs/content/guides/primer_dropdown_menu_component.md
+++ b/docs/content/guides/primer_dropdown_menu_component.md
@@ -20,7 +20,7 @@ of the Primer Dropdown.
 | n/a         | `overlay`    | Color of the menu overlay: `:default`, `:dark`, or `:none` |
 | n/a         | `with_caret` | Whether or not a caret should be displayed on the button   |
 
-The remaining arguments have stayed the same. 
+The remaining arguments have stayed the same.
 
 Please see the following documentation for complete descriptions and examples.
 
@@ -52,4 +52,3 @@ The following arguments are available with the `menu` named slot in Primer Dropd
 | `system_arguments` | [System arguments](https://primer.style/view-components/system-arguments)    |
 
 [&larr; Back to migration guides](https://primer.style/view-components/migration)
-

--- a/docs/content/guides/primer_dropdown_menu_component.md
+++ b/docs/content/guides/primer_dropdown_menu_component.md
@@ -13,24 +13,42 @@ The following arguments for the component initializer have changed between the d
 of the Primer Dropdown.
 
 | From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
-|--------------------------------------|-----------------------------|-------|
-| | | |
+|--------------------------------------|------------------------------|-------|
+| `direction` | n/a          | moved to `menu` slot, below                                |
+| `scheme`    | n/a          | moved to `menu` slot, below                                |
+| `header`    | n/a          | moved to `menu` slot, below                                |
+| n/a         | `overlay`    | color of the menu overlay: `:default`, `:dark`, or `:none` |
+| n/a         | `with_caret` | whether or not a caret should be displayed on the button   |
 
-The remaining arguments have stayed the same.
+The remaining arguments have stayed the same. 
 
-more description here
+Please see the following documentation for complete descriptions and examples.
 
-* link to other components and config here
+* [`Primer::Alpha::Dropdown` component](https://primer.style/view-components/components/alpha/dropdown)
+* [`Primer::Alpha::Dropdown` Lookbook examples](https://primer.style/view-components/lookbook/inspect/primer/alpha/dropdown/default)
 
 ## Slot Names
 
 The following slots have changed with the newer Primer Dropdown.
 
 | From `Primer::DropdownMenuComponent` | To `Primer::Alpha::Dropdown` | Notes |
-|--------------------------------------|-----------------------------|-------|
-| | | |
+|--------------------------------------|------------------------------|-------|
+| n/a | `menu`   | see the "Arguments for `menu` slot" section, below |
+| n/a | `button` | the button to display for the dropdown action      |
 
 The remaining slot names have stayed the same.
+
+### Arguments for `menu` slot
+
+The following arguments are available with the `menu` named slot in Primer Dropdown.
+
+| Argument    | Description |
+|-------------|-------------|
+| `as`               | when `as` is `:list`, wraps the menu in a `<ul>` with a `<li>` for each item |
+| `direction`        | relative position to show dropdown, when button is clicked                   |
+| `header`           | optional string to display as the header                                     |
+| `scheme`           | pass `:dark` for dark mode theming                                           |
+| `system_arguments` | [System arguments](https://primer.style/view-components/system-arguments)    |
 
 [&larr; Back to migration guides](https://primer.style/view-components/migration)
 

--- a/docs/content/guides/primer_dropdown_menu_component.md
+++ b/docs/content/guides/primer_dropdown_menu_component.md
@@ -1,0 +1,36 @@
+---
+title: Moving Away From `Primer::DropdownMenuComponent`
+---
+
+This guide will show you how to upgrade from the now deprecated
+[`Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu)
+to the latest [`Primer::Beta::Dropdown`](https://primer.style/view-components/components/beta/dropdown)
+component.
+
+## Arguments
+
+The following arguments for the component initializer have changed between the deprecated and newer versions
+of the Primer Dropdown.
+
+| From `Primer::DropdownMenuComponent` | To `Primer::Beta::Dropdown` | Notes |
+|--------------------------------------|-----------------------------|-------|
+| | | |
+
+The remaining arguments have stayed the same.
+
+more description here
+
+* link to other components and config here
+
+## Slot Names
+
+The following slots have changed with the newer Primer Dropdown.
+
+| From `Primer::DropdownMenuComponent` | To `Primer::Beta::Dropdown` | Notes |
+|--------------------------------------|-----------------------------|-------|
+| | | |
+
+The remaining slot names have stayed the same.
+
+[&larr; Back to migration guides](https://primer.style/view-components/migration)
+

--- a/docs/content/migration.md
+++ b/docs/content/migration.md
@@ -28,4 +28,4 @@ components.
 | Deprecated Component | Replacement Component | Guide |
 |----------------------|-----------------------|-------|
 | [`Primer::ButtonComponent`](https://primer.style/view-components/components/button) | [`Primer::Beta::Button`](https://primer.style/view-components/components/beta/button) | [Upgrade to Primer::Beta::Button](https://primer.style/view-components/guides/primer_button_component) |
-| [`Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu) | [`Primer::Beta::Dropdown`](https://primer.style/view-components/components/beta/dropdown) | [Upgrade to Primer::Beta::Dropdown](https://primer.style/view-components/guides/primer_dropdown_menu_component) |
+| [`Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu) | [`Primer::Alpha::Dropdown`](https://primer.style/view-components/components/alpha/dropdown) | [Upgrade to Primer::Alpha::Dropdown](https://primer.style/view-components/guides/primer_dropdown_menu_component) |

--- a/docs/content/migration.md
+++ b/docs/content/migration.md
@@ -28,3 +28,4 @@ components.
 | Deprecated Component | Replacement Component | Guide |
 |----------------------|-----------------------|-------|
 | [`Primer::ButtonComponent`](https://primer.style/view-components/components/button) | [`Primer::Beta::Button`](https://primer.style/view-components/components/beta/button) | [Upgrade to Primer::Beta::Button](https://primer.style/view-components/guides/primer_button_component) |
+| [`Primer::DropdownMenuComponent`](https://primer.style/view-components/components/dropdownmenu) | [`Primer::Beta::Dropdown`](https://primer.style/view-components/components/beta/dropdown) | [Upgrade to Primer::Beta::Dropdown](https://primer.style/view-components/guides/primer_dropdown_menu_component) |

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -119,10 +119,18 @@
     url: "/components/alpha/underlinepanels"
 - title: Deprecated Components
   children:
-  - title: Button
+  - title: BlankslateComponent
+    url: "/components/blankslate"
+  - title: BoxComponent
+    url: "/components/box"
+  - title: ButtonComponent
     url: "/components/button"
-  - title: DropdownMenu
+  - title: DropdownMenuComponent
     url: "/components/dropdownmenu"
+  - title: IconButton
+    url: "/components/iconbutton"
+  - title: Tooltip
+    url: "/components/tooltip"
 - title: Architecture decisions
   children:
   - title: Developing and publishing client-side behaviours

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -51,8 +51,6 @@
     url: "/components/alpha/dialog"
   - title: Dropdown
     url: "/components/alpha/dropdown"
-  - title: DropdownMenu
-    url: "/components/dropdownmenu"
   - title: Flash
     url: "/components/beta/flash"
   - title: Heading
@@ -119,6 +117,12 @@
     url: "/components/alpha/underlinenav"
   - title: UnderlinePanels
     url: "/components/alpha/underlinepanels"
+- title: Deprecated Components
+  children:
+  - title: Button
+    url: "/components/button"
+  - title: DropdownMenu
+    url: "/components/dropdownmenu"
 - title: Architecture decisions
   children:
   - title: Developing and publishing client-side behaviours

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -26,7 +26,7 @@ deprecations:
   - component: "Primer::DropdownMenuComponent"
     autocorrect: false
     replacement: "Primer::Beta::Dropdown"
-    guide: "https://primer.style/view-components/migration"
+    guide: "https://primer.style/view-components/guides/primer_dropdown_menu_component"
   - component: "Primer::Dropdown"
     autocorrect: true
     replacement: "Primer::Alpha::Dropdown"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -5,47 +5,60 @@
 # See 'docs/contributors/deprecations.md' for information on configuration options.
 
 deprecations:
-  - component: "Primer::LabelComponent"
-    autocorrect: true
-    replacement: "Primer::Beta::Label"
-  - component: "Primer::LinkComponent"
-    autocorrect: true
-    replacement: "Primer::Beta::Link"
   - component: "Primer::Alpha::AutoComplete"
     autocorrect: true
     replacement: "Primer::Beta::AutoComplete"
+
   - component: "Primer::Alpha::AutoComplete::Item"
     autocorrect: true
     replacement: "Primer::Beta::AutoComplete::Item"
+
   - component: "Primer::BlankslateComponent"
     autocorrect: true
     replacement: "Primer::Beta::Blankslate"
+
   - component: "Primer::BoxComponent"
     autocorrect: true
     replacement: "Primer::Box"
-  - component: "Primer::DropdownMenuComponent"
-    autocorrect: false
-    replacement: "Primer::Beta::Dropdown"
-    guide: "https://primer.style/view-components/guides/primer_dropdown_menu_component"
-  - component: "Primer::Dropdown"
-    autocorrect: true
-    replacement: "Primer::Alpha::Dropdown"
-  - component: "Primer::Dropdown::Menu"
-    autocorrect: true
-    replacement: "Primer::Alpha::Dropdown::Menu"
-  - component: "Primer::Dropdown::Menu::Item"
-    autocorrect: true
-    replacement: "Primer::Alpha::Dropdown::Menu::Item"
-  - component: "Primer::IconButton"
-    autocorrect: true
-    replacement: "Primer::Beta::IconButton"
-  - component: "Primer::Tooltip"
-    autocorrect: true
-    replacement: "Primer::Alpha::Tooltip"
-  - component: "Primer::PopoverComponent"
-    autocorrect: true
-    replacement: "Primer::Beta::Popover"
+
   - component: "Primer::ButtonComponent"
     autocorrect: false
     replacement: "Primer::Beta::Button"
     guide: "https://primer.style/view-components/guides/primer_button_component"
+
+  - component: "Primer::DropdownMenuComponent"
+    autocorrect: false
+    replacement: "Primer::Beta::Dropdown"
+    guide: "https://primer.style/view-components/guides/primer_dropdown_menu_component"
+
+  - component: "Primer::Dropdown"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown"
+
+  - component: "Primer::Dropdown::Menu"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown::Menu"
+
+  - component: "Primer::Dropdown::Menu::Item"
+    autocorrect: true
+    replacement: "Primer::Alpha::Dropdown::Menu::Item"
+
+  - component: "Primer::IconButton"
+    autocorrect: true
+    replacement: "Primer::Beta::IconButton"
+
+  - component: "Primer::LabelComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Label"
+
+  - component: "Primer::LinkComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Link"
+
+  - component: "Primer::PopoverComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::Popover"
+
+  - component: "Primer::Tooltip"
+    autocorrect: true
+    replacement: "Primer::Alpha::Tooltip"


### PR DESCRIPTION
### Description

Adds a migration guide for moving from `Primer::DropdownMenuComponent` to `Primer::Beta::Dropdown`. 

Adds a new "Deprecated Components" section to the site navigation, with links to existing documentation for deprecated components. Note that not all deprecated components have previous documentation, so not all of them show up in the nav

Organizes the `lib/primer/deprecations.yml` file so it's now alphabetized, and a bit easier to read with spacing between components

### Screenshots

migration guide listing page:
<img width="2032" alt="image" src="https://user-images.githubusercontent.com/75190/205707232-639ed3fd-bec8-4ff7-8f03-88893da2cbe0.png">

migration guide:
<img width="912" alt="image" src="https://user-images.githubusercontent.com/75190/205715041-d22c0c34-dcfb-45c2-8056-a0c17c683e6d.png">

new `Deprecated Components` menu nav:
<img width="282" alt="image" src="https://user-images.githubusercontent.com/75190/205714697-cba7e9fb-0026-4bc2-81cf-976df2de1dad.png">

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews
