### PR TITLE
Ensure nested forms can be hidden independently of their radio button or check box

### DIFF
--- a/.changeset/smart-pugs-complain.md
+++ b/.changeset/smart-pugs-complain.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure nested forms can be hidden independently of their radio button or check box

--- a/lib/primer/forms/check_box.rb
+++ b/lib/primer/forms/check_box.rb
@@ -20,7 +20,7 @@ module Primer
       def nested_form_arguments
         return @nested_form_arguments if defined?(@nested_form_arguments)
 
-        @nested_form_arguments = { **@input.nested_form_arguments, hidden: @input.hidden? }
+        @nested_form_arguments = { hidden: @input.hidden?, **@input.nested_form_arguments }
         @nested_form_arguments[:class] = class_names(
           @nested_form_arguments[:class],
           @nested_form_arguments.delete(:classes),

--- a/lib/primer/forms/dsl/input_methods.rb
+++ b/lib/primer/forms/dsl/input_methods.rb
@@ -17,8 +17,8 @@ module Primer
           add_input HiddenInput.new(builder: builder, form: form, **options)
         end
 
-        def check_box(**options)
-          add_input CheckBoxInput.new(builder: builder, form: form, **options)
+        def check_box(**options, &block)
+          add_input CheckBoxInput.new(builder: builder, form: form, **options, &block)
         end
 
         def radio_button_group(**options, &block)

--- a/lib/primer/forms/radio_button.rb
+++ b/lib/primer/forms/radio_button.rb
@@ -15,7 +15,7 @@ module Primer
       def nested_form_arguments
         return @nested_form_arguments if defined?(@nested_form_arguments)
 
-        @nested_form_arguments = { **@input.nested_form_arguments, hidden: @input.hidden? }
+        @nested_form_arguments = { hidden: @input.hidden?, **@input.nested_form_arguments }
         @nested_form_arguments[:class] = class_names(
           @nested_form_arguments[:class],
           @nested_form_arguments.delete(:classes),


### PR DESCRIPTION
### Description

A [recent PR](https://github.com/primer/view_components/pull/1664) modified the forms framework so hiding inputs worked as expected. Unfortunately doing so also broke hiding nested forms. The code in main right now does this:

```ruby
@nested_form_arguments = { **@input.nested_form_arguments, hidden: @input.hidden? }
```

It assumes that, if the input is hidden, the nested form should also be hidden. For the hidden case, this makes sense. If the input is _not_ hidden though, the code above will overwrite the supplied value with `false` and the nested form will always appear.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
