### PR TITLE
Use URL helpers in previews that interact with the server-side

### DIFF
--- a/.changeset/rude-toes-play.md
+++ b/.changeset/rude-toes-play.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use URL helpers in previews that interact with the server-side

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     get "/", to: redirect("/lookbook/")
   end
 
-  scope path: Rails.env.production? ? "/view-components" : "/" do
+  scope path: Rails.env.production? ? "/view-components/rails-app/" : "/" do
     get "/auto_complete", to: "auto_complete_test#index", as: :autocomplete_index
     resources :toggle_switch, only: [:create]
     resources :nav_list_items, only: [:index]

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   end
 
   scope path: Rails.env.production? ? "/view-components" : "/" do
-    get "/auto_complete", to: "auto_complete_test#index"
+    get "/auto_complete", to: "auto_complete_test#index", as: :autocomplete_index
     resources :toggle_switch, only: [:create]
     resources :nav_list_items, only: [:index]
 

--- a/previews/primer/alpha/auto_complete_preview.rb
+++ b/previews/primer/alpha/auto_complete_preview.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../url_helpers"
+
 module Primer
   module Alpha
     # @label AutoComplete
@@ -12,7 +14,18 @@ module Primer
       # @param is_clearable toggle
       def playground(label_text: "Select a fruit", is_label_visible: true, is_label_inline: false, with_icon: false, is_clearable: false)
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: label_text, input_id: "input-id", list_id: "test-id", src: "/auto_complete?version=alpha", is_label_visible: is_label_visible, is_label_inline: is_label_inline, with_icon: with_icon, is_clearable: is_clearable))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: label_text,
+            input_id: "input-id",
+            list_id: "test-id",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            is_label_visible: is_label_visible,
+            is_label_inline: is_label_inline,
+            with_icon: with_icon,
+            is_clearable: is_clearable
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 
@@ -24,7 +37,18 @@ module Primer
       # @param is_clearable toggle
       def default(label_text: "Select a fruit", is_label_visible: true, is_label_inline: false, with_icon: false, is_clearable: false)
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: label_text, input_id: "input-id", list_id: "test-id", src: "/auto_complete?version=alpha", is_label_visible: is_label_visible, is_label_inline: is_label_inline, with_icon: with_icon, is_clearable: is_clearable))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: label_text,
+            input_id: "input-id",
+            list_id: "test-id",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            is_label_visible: is_label_visible,
+            is_label_inline: is_label_inline,
+            with_icon: with_icon,
+            is_clearable: is_clearable
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 
@@ -33,28 +57,60 @@ module Primer
       # @label AutoComplete with non-visible label
       def with_non_visible_label
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id-1", list_id: "test-id-1", src: "/auto_complete?version=alpha", is_label_visible: false))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: "Select a fruit",
+            input_id: "input-id-1",
+            list_id: "test-id-1",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            is_label_visible: false
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 
       # @label AutoComplete with inline label
       def with_inline_label
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id-2", list_id: "test-id-2", src: "/auto_complete?version=alpha", is_label_inline: true))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: "Select a fruit",
+            input_id: "input-id-2",
+            list_id: "test-id-2",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            is_label_inline: true
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 
       # @label AutoComplete with search icon
       def with_icon
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id-3", list_id: "test-id-3", src: "/auto_complete?version=alpha", with_icon: true))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: "Select a fruit",
+            input_id: "input-id-3",
+            list_id: "test-id-3",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            with_icon: true
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 
       # @label AutoComplete with clear button
       def with_clear_button
         # rubocop:disable Primer/ComponentNameMigration
-        render(Primer::Alpha::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id-4", list_id: "test-id-4", src: "/auto_complete?version=alpha", is_clearable: true))
+        render(
+          Primer::Alpha::AutoComplete.new(
+            label_text: "Select a fruit",
+            input_id: "input-id-4",
+            list_id: "test-id-4",
+            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            is_clearable: true
+          )
+        )
         # rubocop:enable Primer/ComponentNameMigration
       end
 

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -1,40 +1,39 @@
 # frozen_string_literal: true
 
+require_relative "../url_helpers"
+
 module Primer
   module Alpha
     # @label Toggle Switch
     class ToggleSwitchPreview < ViewComponent::Preview
       include ActionView::Helpers::FormTagHelper
 
-      # use send to avoid yard warning
-      send :include, Rails.application.routes.url_helpers
-
       def playground
-        render(ToggleSwitch.new(src: toggle_switch_index_path))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path))
       end
 
       def default
-        render(ToggleSwitch.new(src: toggle_switch_index_path))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path))
       end
 
       def checked
-        render(ToggleSwitch.new(src: toggle_switch_index_path, checked: true))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, checked: true))
       end
 
       def disabled
-        render(ToggleSwitch.new(src: toggle_switch_index_path, enabled: false))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, enabled: false))
       end
 
       def checked_disabled
-        render(ToggleSwitch.new(src: toggle_switch_index_path, checked: true, enabled: false))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, checked: true, enabled: false))
       end
 
       def small
-        render(ToggleSwitch.new(src: toggle_switch_index_path, size: :small))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, size: :small))
       end
 
       def with_status_label_position_end
-        render(ToggleSwitch.new(src: toggle_switch_index_path, status_label_position: :end))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, status_label_position: :end))
       end
 
       def with_a_bad_src
@@ -46,17 +45,11 @@ module Primer
       end
 
       def with_csrf_token
-        render(ToggleSwitch.new(src: toggle_switch_index_path, csrf_token: "let_me_in"))
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, csrf_token: "let_me_in"))
       end
 
       def with_bad_csrf_token
-        render(ToggleSwitch.new(src: toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
-      end
-
-      private
-
-      # necessary to support URL helpers
-      def controller
+        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
       end
     end
   end

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -6,32 +6,35 @@ module Primer
     class ToggleSwitchPreview < ViewComponent::Preview
       include ActionView::Helpers::FormTagHelper
 
+      # use send to avoid yard warning
+      send :include, Rails.application.routes.url_helpers
+
       def playground
-        render(ToggleSwitch.new(src: "/toggle_switch"))
+        render(ToggleSwitch.new(src: toggle_switch_index_path))
       end
 
       def default
-        render(ToggleSwitch.new(src: "/toggle_switch"))
+        render(ToggleSwitch.new(src: toggle_switch_index_path))
       end
 
       def checked
-        render(ToggleSwitch.new(src: "/toggle_switch", checked: true))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, checked: true))
       end
 
       def disabled
-        render(ToggleSwitch.new(src: "/toggle_switch", enabled: false))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, enabled: false))
       end
 
       def checked_disabled
-        render(ToggleSwitch.new(src: "/toggle_switch", checked: true, enabled: false))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, checked: true, enabled: false))
       end
 
       def small
-        render(ToggleSwitch.new(src: "/toggle_switch", size: :small))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, size: :small))
       end
 
       def with_status_label_position_end
-        render(ToggleSwitch.new(src: "/toggle_switch", status_label_position: :end))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, status_label_position: :end))
       end
 
       def with_a_bad_src
@@ -43,11 +46,17 @@ module Primer
       end
 
       def with_csrf_token
-        render(ToggleSwitch.new(src: "/toggle_switch", csrf_token: "let_me_in"))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, csrf_token: "let_me_in"))
       end
 
       def with_bad_csrf_token
-        render(ToggleSwitch.new(src: "/toggle_switch", csrf_token: "i_am_a_criminal"))
+        render(ToggleSwitch.new(src: toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
+      end
+
+      private
+
+      # necessary to support URL helpers
+      def controller
       end
     end
   end

--- a/previews/primer/beta/auto_complete_preview.rb
+++ b/previews/primer/beta/auto_complete_preview.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../url_helpers"
+
 module Primer
   module Beta
     # @label AutoComplete
@@ -19,7 +21,7 @@ module Primer
       # @param inset toggle
       # @param monospace toggle
       def playground(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -39,7 +41,7 @@ module Primer
       # @param inset toggle
       # @param monospace toggle
       def default(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -85,7 +87,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def leading_visual(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -103,7 +105,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def trailing_action(label_text: "Select a fruit", show_clear_button: true, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @label Full width
@@ -119,7 +121,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def full_width(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: true, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -137,7 +139,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def visually_hide_label(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: true, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -156,7 +158,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def small(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :small, full_width: false, disabled: false, invalid: false, input_id: "input-id-1", list_id: "list-id-1", input_name: "input-id-1")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -173,7 +175,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def medium(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id-2", list_id: "list-id-2", input_name: "input-id-2")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -190,7 +192,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def large(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :large, full_width: false, disabled: false, invalid: false, input_id: "input-id-3", list_id: "list-id-3", input_name: "input-id-3")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
@@ -210,7 +212,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def leading_visual_in_results(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete?visual=leading", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path(visual: "leading"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @label Trailing visual in results
@@ -226,39 +228,39 @@ module Primer
       # @param list_id text
       # @param input_name text
       def trailing_visual_in_results(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: "/auto_complete?visual=trailing", show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path(visual: "trailing"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @hidden
       def with_non_visible_label
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", visually_hide_label: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, visually_hide_label: true))
       end
 
       # @hidden
       def with_icon
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete")) do |c|
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path)) do |c|
           c.leading_visual_icon(icon: :search)
         end
       end
 
       # @hidden
       def show_clear_button
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", show_clear_button: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: true))
       end
 
       # @hidden
       def size_small
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", show_clear_button: false, size: :small))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, size: :small))
       end
 
       # @hidden
       def monospace
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", show_clear_button: false, monospace: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, monospace: true))
       end
 
       # @hidden
       def inset
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: "/auto_complete", show_clear_button: false, inset: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, inset: true))
       end
     end
   end

--- a/previews/primer/beta/auto_complete_preview/with_submit_button.html.erb
+++ b/previews/primer/beta/auto_complete_preview/with_submit_button.html.erb
@@ -4,7 +4,7 @@
             label_text: label_text,
             input_id: input_id,
             list_id: list_id,
-            src: "/auto_complete",
+            src: autocomplete_index_path,
             show_clear_button: show_clear_button,
             visually_hide_label: visually_hide_label,
             placeholder: placeholder,

--- a/previews/primer/url_helpers.rb
+++ b/previews/primer/url_helpers.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Primer
+  module URLHelpers
+    class << self
+      # use send to avoid yard warning
+      send :include, Rails.application.routes.url_helpers
+
+      private
+
+      def controller
+      end
+    end
+  end
+end

--- a/test/components/preview_test.rb
+++ b/test/components/preview_test.rb
@@ -4,7 +4,7 @@ require "components/test_helper"
 
 class PreviewTest < Minitest::Test
   def setup
-    @previews = Dir.glob("previews/**/*.rb").reject { |f| f.include?("forms_preview.rb") || f.include?("/docs/") }
+    @previews = Dir.glob("previews/**/*_preview.rb").reject { |f| f.end_with?("forms_preview.rb") || f.include?("/docs/") }
   end
 
   def test_previews_exist


### PR DESCRIPTION
### Description

Some of our previews don't work in the prod Lookbook because the URLs are hard-coded and only work in dev.

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [x] Added/updated previews
