### PR TITLE
Remove sass variable

### DIFF
--- a/.changeset/lazy-trains-wink.md
+++ b/.changeset/lazy-trains-wink.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix sass variable in layout.pcss

--- a/app/components/primer/alpha/layout.pcss
+++ b/app/components/primer/alpha/layout.pcss
@@ -73,7 +73,7 @@
       background: var(--color-canvas-inset);
       border-color: var(--color-border-default);
       border-style: solid;
-      border-width: $border-width 0;
+      border-width: var(--primer-borderWidth-thin, 1px) 0;
     }
   }
 }

--- a/test/components/component_css_test.rb
+++ b/test/components/component_css_test.rb
@@ -13,8 +13,12 @@ class ComponentCssTest < Minitest::Test
     Dir["app/components/**/*.css"].each do |file|
       css = File.read(file)
 
+      # remove comments
+      css.gsub!(%r{/\*((?!\*/).)*\*/}m, "")
+
       refute(css.include?("@import"), "CSS files should not import other CSS files:\n#{file} contains @import")
       refute(css.include?("&"), "CSS Nesting wasn't compiled correctly:\n#{file} contains &")
+      refute(css.include?("$"), "Sass variable(s) detected:\n#{file} contains $")
     end
   end
 end


### PR DESCRIPTION
### Description

Got some super weird errors in dotcom when attempting to use PVC `main`. Looks like a sass variable snuck through.

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
