### PR TITLE
Fix a test that fails in non-UTC TZs

### DIFF
--- a/test/components/primer/beta/relative_time_test.rb
+++ b/test/components/primer/beta/relative_time_test.rb
@@ -16,7 +16,7 @@ class PrimerBetaRelativeTimeTest < Minitest::Test
   end
 
   def test_component_accepts_time_date_format
-    datetime = Time.new(2022, 12, 6, 11, 14, 46).utc
+    datetime = Time.utc(2022, 12, 6, 11, 14, 46)
     render_inline(Primer::Beta::RelativeTime.new(datetime: datetime))
     assert_selector("relative-time", text: "December 6, 2022 11:14")
   end


### PR DESCRIPTION
### Description

This test was passing in CI (which must be in UTC), but when run on developer machines in other time zones it would fail.

To fix it, we changed the test from making a Time object and converting to UTC to have it make a Time object in UTC from the beginning.

### Merge checklist

- [x] Added/updated tests
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews~
