### PR TITLE
Improve `Counter` colors when nested in `Button`

### DIFF
--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -95,6 +95,11 @@ summary.Button {
 .Button-visual {
   display: flex;
   pointer-events: none; /* allow click handler to work, avoiding visuals */
+
+  & .Counter {
+    color: inherit;
+    background-color: var(--color-btn-counter-bg);
+  }
 }
 
 .Button-label {


### PR DESCRIPTION
### Description

Improves the `.Counter` when nested in a `.Button`.

Before | After
--- | ---
![Screen Shot 2022-12-15 at 16 33 23](https://user-images.githubusercontent.com/378023/207803632-98b806ef-1c7b-48a5-964c-6c97cb2bd5af.png) | ![Screen Shot 2022-12-15 at 16 45 08](https://user-images.githubusercontent.com/378023/207803641-9210889c-483c-4286-9d6f-fd3c58e7de7d.png)
![Screen Shot 2022-12-15 at 16 33 59](https://user-images.githubusercontent.com/378023/207803699-79542bf4-5492-476e-8f3a-c866ec9f5a12.png) | ![Screen Shot 2022-12-15 at 16 46 07](https://user-images.githubusercontent.com/378023/207803703-42952778-1e60-4dfe-be19-a5d5f795d4b9.png)

Reported in [Slack](https://github.slack.com/archives/CSGAVNZ19/p1671034123423419).

### What should reviewers focus on?

Note that `dark_high_contrast` still needs fixing:

![Screen Shot 2022-12-15 at 16 59 11](https://user-images.githubusercontent.com/378023/207805457-12267bb4-18d8-4d10-8c6e-db22b4a89ede.png)

- Either by adding a new `--color-btn-counter-fg` variable that is light
- Or updating `--color-btn-counter-bg` to be light

I added an issue in Primitives: TBD

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
