### PR TITLE
Disable `is()` selector

### DIFF
--- a/.changeset/cuddly-scissors-impress.md
+++ b/.changeset/cuddly-scissors-impress.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Disable `is()` selector

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -16,7 +16,7 @@ module.exports = {
         'nesting-rules': true,
         'focus-visible-pseudo-class': false,
         'logical-properties-and-values': false,
-        'is-pseudo-class': false,
+        'is-pseudo-class': true,
         'custom-media-queries':  {
           importFrom: [
             path.join(__dirname, './node_modules/@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css')

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -13,10 +13,9 @@ module.exports = {
       stage: 2,
       // https://preset-env.cssdb.org/features/#stage-2
       features: {
-        'nesting-rules': true,
+        'nesting-rules': { noIsPseudoSelector: true },
         'focus-visible-pseudo-class': false,
         'logical-properties-and-values': false,
-        'is-pseudo-class': true,
         'custom-media-queries':  {
           importFrom: [
             path.join(__dirname, './node_modules/@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css')

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'nesting-rules': true,
         'focus-visible-pseudo-class': false,
         'logical-properties-and-values': false,
+        'is-pseudo-class': false,
         'custom-media-queries':  {
           importFrom: [
             path.join(__dirname, './node_modules/@primer/primitives/tokens-v2-private/css/tokens/functional/size/viewport.css')


### PR DESCRIPTION
### Description

This disables the `is()` selector for now. It seems to be causing issues with `@csstools/postcss-is-pseudo-class`. See https://github.com/primer/css/issues/2349.

```diff
- :is(.Truncate > .Truncate-text) + .Truncate-text {
+ .Truncate > .Truncate-text + .Truncate-text {
      margin-left: var(--primer-control-small-gap, 4px);
  }
```

Verified in [unpkg.com/.../truncate.css](https://unpkg.com/browse/@primer/view-components@0.0.0-20221221025524/app/components/primer/beta/truncate.css)

### Source

Example from [truncate.pcss](https://github.com/primer/view_components/blob/3cea518c521631ac5e40e857c0eb87d863409a0d/app/components/primer/beta/truncate.pcss)

```pcss
.Truncate {
  display: inline-flex;
  min-width: 0;
  max-width: 100%;

  & > .Truncate-text {
    min-width: 1ch;
    max-width: fit-content;
    overflow: hidden;
    text-overflow: ellipsis;
    white-space: nowrap;

    & + .Truncate-text {
      margin-left: var(--primer-control-small-gap, 4px);
    }

    &.Truncate-text--primary {
      flex-basis: 200%;
    }

    &.Truncate-text--expandable:hover,
    &.Truncate-text--expandable:focus,
    &.Truncate-text--expandable:active {
      max-width: 100% !important;
      flex-shrink: 0;
      cursor: pointer;
    }
  }
}
```

### Compiled

```css
.Truncate {
  display: inline-flex;
  min-width: 0;
  max-width: 100%;
}

.Truncate > .Truncate-text {
  min-width: 1ch;
  max-width: -moz-fit-content;
  max-width: fit-content;
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
}

.Truncate > .Truncate-text + .Truncate-text {
  margin-left: var(--primer-control-small-gap, 4px);
}

.Truncate > .Truncate-text.Truncate-text--primary {
  flex-basis: 200%;
}

.Truncate > .Truncate-text.Truncate-text--expandable:hover,
.Truncate > .Truncate-text.Truncate-text--expandable:focus,
.Truncate > .Truncate-text.Truncate-text--expandable:active {
  max-width: 100% !important;
}

.Truncate > .Truncate-text.Truncate-text--expandable:hover,
.Truncate > .Truncate-text.Truncate-text--expandable:focus,
.Truncate > .Truncate-text.Truncate-text--expandable:active {
  flex-shrink: 0;
  cursor: pointer;
}
```

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
