### PR TITLE
Allow `Layout` sidebar to be hidden

### DIFF
--- a/.changeset/funny-nails-turn.md
+++ b/.changeset/funny-nails-turn.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Allow `Layout` sidebar to be hidden

--- a/app/components/primer/alpha/layout.pcss
+++ b/app/components/primer/alpha/layout.pcss
@@ -225,6 +225,22 @@
       }
     }
   }
+
+  /* Sidebar hidden */
+
+  &.Layout--sidebar-hidden {
+    grid-auto-flow: row;
+    grid-gap: 0;
+    grid-template-columns: 1fr;
+
+    & .Layout-sidebar {
+      display: none;
+    }
+
+    & .Layout-main {
+      grid-column: auto;
+    }
+  }
 }
 
 .Layout-divider {


### PR DESCRIPTION
### Description

This adds an option to hide the sidebar of the [`Layout`](https://primer.style/view-components/components/alpha/layout) component. It's upstreaming this [hack](https://github.com/github/github/blob/044416b90e8e99fb9cce0d2f74a75886d2b8852e/app/assets/stylesheets/bundles/global/hx_primer-layout.scss#LL7C12-L7C37) from dotcom.

### TODO

- [x] Add styling
- [ ] Test on dotcom https://github.com/github/github/pull/252416
- [ ] Add argument
- [ ] Add JS to toggle sidebar?
- [ ] Make it accessible. We probably want to use the `hidden` attribute or add `aria-hidden` whenever the sidebar is hidden.
- [ ] Update docs

### Integration

> Does this change require any updates to code in production?

No, but we could remove this [hack](https://github.com/github/github/blob/044416b90e8e99fb9cce0d2f74a75886d2b8852e/app/assets/stylesheets/bundles/global/hx_primer-layout.scss#LL7C12-L7C37).

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
