### PR TITLE
Change `ActionList::Item` tag to `button`

### DIFF
--- a/.changeset/hungry-points-kneel.md
+++ b/.changeset/hungry-points-kneel.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use a button tag for ActionList::Items

--- a/.changeset/little-dingos-jam.md
+++ b/.changeset/little-dingos-jam.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Change `ActionList::Item` tag to `button`

--- a/.changeset/little-dingos-jam.md
+++ b/.changeset/little-dingos-jam.md
@@ -1,5 +1,0 @@
----
-"@primer/view-components": patch
----
-
-Change `ActionList::Item` tag to `button`

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -48,7 +48,7 @@ module Primer
             Primer::BaseComponent.new(tag: :svg, width: "16", height: "16", **system_arguments)
           },
           content: lambda { |**system_arguments|
-            Primer::BaseComponent.new(tag: :span, **system_arguments)
+            Primer::BaseComponent.new(tag: :button, **system_arguments)
           }
         }
 
@@ -128,7 +128,7 @@ module Primer
         # @param parent [Primer::Alpha::ActionList::Item] This item's parent item. `nil` if this item is at the root. Used internally.
         # @param label [String] Item label.
         # @param label_classes [String] CSS classes that will be added to the label.
-        # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or span tag.
+        # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or button tag.
         # @param truncate_label [Boolean] Truncate label with ellipsis.
         # @param href [String] Link URL.
         # @param role [String] ARIA role describing the function of the item.
@@ -206,7 +206,7 @@ module Primer
             @content_arguments[:tag] = :a
             @content_arguments[:href] = @href
           else
-            @content_arguments[:tag] = :span
+            @content_arguments[:tag] = :button
             @content_arguments[:onclick] = on_click if on_click
           end
 

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -48,7 +48,7 @@ module Primer
             Primer::BaseComponent.new(tag: :svg, width: "16", height: "16", **system_arguments)
           },
           content: lambda { |**system_arguments|
-            Primer::BaseComponent.new(tag: :button, **system_arguments)
+            Primer::BaseComponent.new(tag: :span, **system_arguments)
           }
         }
 


### PR DESCRIPTION
### Description

To be honest, I'm not entirely sure why it was a `span`. This could be a huge mistake. I'm hoping someone else will know! 🙌 

If this becomes a `button`, it makes it much easier to use for triggering our new `Dialog` component (which is an extremely common use case.)

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
