### PR TITLE
Correctly deprecate `Primer::TimelineItemComponent::BadgeComponent` in favor of `Primer::Beta::TimelineItem::Badge`

### DIFF
--- a/.changeset/little-ducks-fix.md
+++ b/.changeset/little-ducks-fix.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Correctly deprecate `Primer::TimelineItemComponent::BadgeComponent` in favor of `Primer::Beta::TimelineItem::Badge`

--- a/app/components/primer/beta/timeline_item.rb
+++ b/app/components/primer/beta/timeline_item.rb
@@ -65,7 +65,9 @@ module Primer
 
       # This component is part of `Primer::Beta::TimelineItem` and should not be
       # used as a standalone component.
-      class BadgeComponent < Primer::Component
+      class Badge < Primer::Component
+        status :beta
+
         def initialize(icon: nil, **system_arguments)
           @icon = icon
 

--- a/app/components/primer/beta/timeline_item.rb
+++ b/app/components/primer/beta/timeline_item.rb
@@ -22,7 +22,7 @@ module Primer
       #
       # @param icon [String] Name of <%= link_to_octicons %> to use.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_one :badge, "BadgeComponent"
+      renders_one :badge, "Badge"
 
       # Body to be rendered to the left of the Badge.
       #

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 module Primer
+  # nodoc
   class TimelineItemComponent < Primer::Beta::TimelineItem
     status :deprecated
 
+    # nodoc
     class BadgeComponent < Primer::Component
       status :deprecated
     end

--- a/app/components/primer/timeline_item_component.rb
+++ b/app/components/primer/timeline_item_component.rb
@@ -3,5 +3,9 @@
 module Primer
   class TimelineItemComponent < Primer::Beta::TimelineItem
     status :deprecated
+
+    class BadgeComponent < Primer::Component
+      status :deprecated
+    end
   end
 end

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -379,6 +379,7 @@ GEM
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -113,6 +113,10 @@ deprecations:
     autocorrect: true
     replacement: "Primer::Beta::TimelineItem"
 
+  - component: "Primer::TimelineItemComponent::BadgeComponent"
+    autocorrect: true
+    replacement: "Primer::Beta::TimelineItem::Badge"
+
   - component: "Primer::Tooltip"
     autocorrect: true
     replacement: "Primer::Alpha::Tooltip"

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -68,7 +68,7 @@
   "Primer::Beta::Subhead": "",
   "Primer::Beta::Text": "",
   "Primer::Beta::TimelineItem": "",
-  "Primer::Beta::TimelineItem::BadgeComponent": "",
+  "Primer::Beta::TimelineItem::Badge": "",
   "Primer::Beta::Truncate": "",
   "Primer::Beta::Truncate::TruncateText": "",
   "Primer::BlankslateComponent": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -978,7 +978,7 @@
     "DEFAULT_TAG": "span"
   },
   "Primer::Beta::TimelineItem": {
-    "BadgeComponent": "Primer::Beta::TimelineItem::Badge"
+    "Badge": "Primer::Beta::TimelineItem::Badge"
   },
   "Primer::Beta::TimelineItem::Badge": {
   },

--- a/static/constants.json
+++ b/static/constants.json
@@ -978,9 +978,9 @@
     "DEFAULT_TAG": "span"
   },
   "Primer::Beta::TimelineItem": {
-    "BadgeComponent": "Primer::Beta::TimelineItem::BadgeComponent"
+    "BadgeComponent": "Primer::Beta::TimelineItem::Badge"
   },
-  "Primer::Beta::TimelineItem::BadgeComponent": {
+  "Primer::Beta::TimelineItem::Badge": {
   },
   "Primer::Beta::Truncate": {
     "TruncateText": "Primer::Beta::Truncate::TruncateText"

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -68,7 +68,7 @@
   "Primer::Beta::Subhead": "beta",
   "Primer::Beta::Text": "beta",
   "Primer::Beta::TimelineItem": "beta",
-  "Primer::Beta::TimelineItem::BadgeComponent": "alpha",
+  "Primer::Beta::TimelineItem::Badge": "alpha",
   "Primer::Beta::Truncate": "beta",
   "Primer::Beta::Truncate::TruncateText": "alpha",
   "Primer::BlankslateComponent": "deprecated",

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -68,7 +68,7 @@
   "Primer::Beta::Subhead": "beta",
   "Primer::Beta::Text": "beta",
   "Primer::Beta::TimelineItem": "beta",
-  "Primer::Beta::TimelineItem::Badge": "alpha",
+  "Primer::Beta::TimelineItem::Badge": "beta",
   "Primer::Beta::Truncate": "beta",
   "Primer::Beta::Truncate::TruncateText": "alpha",
   "Primer::BlankslateComponent": "deprecated",


### PR DESCRIPTION
### Description

Correctly deprecate `Primer::TimelineItemComponent::BadgeComponent` in favor of `Primer::Beta::TimelineItem::Badge`

### Integration

> Does this change require any updates to code in production?

No immediate changes, though deprecated components need to be cleaned up

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews
