### PR TITLE
Don't export PrimerMultiInputElement

### DIFF
--- a/.changeset/dull-rabbits-glow.md
+++ b/.changeset/dull-rabbits-glow.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Avoid double-registering of exported components

--- a/lib/primer/forms/primer_multi_input.ts
+++ b/lib/primer/forms/primer_multi_input.ts
@@ -2,7 +2,7 @@
 import {controller, targets} from '@github/catalyst'
 
 @controller
-export class PrimerMultiInputElement extends HTMLElement {
+class PrimerMultiInputElement extends HTMLElement {
   @targets fields: HTMLInputElement[]
 
   activateField(name: string) {


### PR DESCRIPTION
Exporting a component can cause errors when used as an npm package. Please see #1560

/cc @jonrohan