### PR TITLE
Adding :auto to size options to Dialog component

### DIFF
--- a/.changeset/selfish-countries-vanish.md
+++ b/.changeset/selfish-countries-vanish.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Adding `:auto` to size option to Dialog component

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -27,7 +27,8 @@ module Primer
         :medium_portrait => "Overlay--size-medium-portrait",
         DEFAULT_SIZE => "Overlay--size-medium",
         :large => "Overlay--size-large",
-        :xlarge => "Overlay--size-xlarge"
+        :xlarge => "Overlay--size-xlarge",
+        :auto => "Overlay--size-auto"
       }.freeze
       SIZE_OPTIONS = SIZE_MAPPINGS.keys
 


### PR DESCRIPTION
### Description

I think it's possible we're missing more than just auto? I saw a few other sizes in the css that didn't seem to be in the component. eg. [Overlay--size-full](https://github.com/primer/view_components/blob/a8b8e95ab1116548a116124aa2dc25eb98d19768/app/components/primer/alpha/dialog.pcss#L32)

[Slack thread](https://github.slack.com/archives/CSGAVNZ19/p1672933074645839)

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
