### PR TITLE
Remove preview from lookbook path

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -515,7 +515,7 @@ namespace :docs do
   def lookbook_url(component)
     path = component.name.underscore.gsub("_component", "")
 
-    "https://primer.style/view-components/lookbook/inspect/#{path}_preview/default/"
+    "https://primer.style/view-components/lookbook/inspect/#{path}/default/"
   end
 
   def preview_exists?(component)


### PR DESCRIPTION
### Description

With recent lookbook updates, the `_preview` url was changed. I noticed this broke our lookbook links in doctocat. https://primer.style/view-components/components/beta/borderbox

This pr removes the `_preview` from the rake job.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
