### PR TITLE
Use a mouseup mousedown event to guard accidental clicks dismissing dialog

### DIFF
--- a/.changeset/witty-mails-attend.md
+++ b/.changeset/witty-mails-attend.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix bug where clicking inside dialog, but finishing click outside, dismisses dialog

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -112,6 +112,21 @@ module Primer
                                show_divider: show_divider
                              })
       end
+
+      # @label Dialog with text input
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      def with_text_input(title: "Test Dialog", subtitle: nil, button_text: "Show Dialog", show_divider: true)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               button_text: button_text,
+                               show_divider: show_divider
+                             })
+      end
     end
   end
 end

--- a/previews/primer/alpha/dialog_preview/with_text_input.html.erb
+++ b/previews/primer/alpha/dialog_preview/with_text_input.html.erb
@@ -1,0 +1,10 @@
+<%= render(Primer::Alpha::Dialog.new(id: "dialog-one", title: title, subtitle: subtitle, visually_hide_title: false)) do |d| %>
+  <% d.show_button { button_text } %>
+  <% d.body do %>
+    <p>Dialog One!</p>
+
+    <form>
+      <input type="text" value="Some text goes in here">
+    </form>
+  <% end %>
+<% end %>


### PR DESCRIPTION
### Description

From https://github.com/github/primer/issues/1628 (staff only)

> [we] noticed that if a user selects text, drags the cursor outside of the modal and then releases the mouse button, the dialog closes as if they had clicked outside of the dialog.

This fixes the problem by  using a `mousedown` event listener to track that a click starts out on the backdrop, and then registering a onetime mouseup listener to ensure the mouse is still over the backdrop. 

With this pattern we can track click events that happen only where the backdrop was the element initially part of the mousedown and part of the mouseup, this prevents:

- Dismissing the dialog if the click started inside the dialog but ended up on the backdrop
- Dismissing the dialog if the click started on the backdrop but the user intends to "undo" their click and moves the mouse inside the dialog.

Closes https://github.com/github/primer/issues/1628

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
