### PR TITLE
Generate IDs for HTML in a standard way

### DIFF
--- a/.changeset/brown-tigers-suffer.md
+++ b/.changeset/brown-tigers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Standardize how we generate ids for HTML

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -60,7 +60,7 @@ module Primer
         show_dividers: false,
         **system_arguments
       )
-        @id = "action-list-#{SecureRandom.uuid}"
+        @id = self.class.generate_id
         @role = role
 
         @system_arguments = system_arguments

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -155,7 +155,7 @@ module Primer
           description_scheme: DEFAULT_DESCRIPTION_SCHEME,
           active: false,
           on_click: nil,
-          id: SecureRandom.hex,
+          id: self.class.generate_id,
           **system_arguments
         )
           @list = list

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -121,14 +121,14 @@ module Primer
         position: DEFAULT_POSITION,
         position_narrow: DEFAULT_POSITION_NARROW,
         visually_hide_title: false,
-        id: "dialog-#{(36**3 + rand(36**4)).to_s(36)}",
+        id: self.class.generate_id,
         **system_arguments
       )
         @system_arguments = deny_tag_argument(**system_arguments)
 
         @system_arguments[:tag] = "modal-dialog"
         @system_arguments[:role] = "dialog"
-        @system_arguments[:id] = id.to_s
+        @system_arguments[:id] = id
         @system_arguments[:aria] = { modal: true }
         @system_arguments[:classes] = class_names(
           "Overlay",

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -197,10 +197,6 @@ class ToolTipElement extends HTMLElement {
     this.hiddenFromView = true
     this.#allowUpdatePosition = true
 
-    if (!this.id) {
-      this.id = `tooltip-${Date.now()}-${(Math.random() * 10000).toFixed(0)}`
-    }
-
     if (!this.control) return
 
     this.setAttribute('role', 'tooltip')

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -107,10 +107,11 @@ module Primer
 
         @text = text
         @system_arguments = system_arguments
+        @system_arguments[:id] ||= self.class.generate_id
         @system_arguments[:tag] = :"tool-tip"
         @system_arguments[:for] = for_id
-        system_arguments[:classes] = class_names(
-          system_arguments[:classes],
+        @system_arguments[:classes] = class_names(
+          @system_arguments[:classes],
           "sr-only"
         )
         @system_arguments[:position] = :absolute
@@ -121,6 +122,6 @@ module Primer
       def call
         render(Primer::BaseComponent.new(**@system_arguments)) { @text }
       end
-      end
     end
   end
+end

--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -63,7 +63,7 @@ module Primer
         @wrapper_arguments = wrapper_arguments
         @show_tooltip = show_tooltip
         @system_arguments = system_arguments
-        @system_arguments[:id] ||= "icon-button-#{SecureRandom.hex(4)}"
+        @system_arguments[:id] ||= self.class.generate_id
 
         @system_arguments[:classes] = class_names(
           "Button",

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -22,6 +22,10 @@ module Primer
       status == :deprecated
     end
 
+    def self.generate_id
+      "#{name.demodulize.underscore.dasherize}-#{SecureRandom.uuid}"
+    end
+
     private
 
     def raise_on_invalid_options?

--- a/app/components/primer/icon_button.rb
+++ b/app/components/primer/icon_button.rb
@@ -65,7 +65,7 @@ module Primer
 
       @system_arguments = system_arguments
 
-      @system_arguments[:id] ||= "icon-button-#{SecureRandom.hex(4)}"
+      @system_arguments[:id] ||= self.class.generate_id
 
       @system_arguments[:classes] = class_names(
         "btn-octicon",

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -76,7 +76,7 @@ module Primer
 
           @input_arguments[:invalid] = "true" if invalid?
 
-          base_id = SecureRandom.hex[0..5]
+          base_id = SecureRandom.uuid
 
           @ids = {}.tap do |id_map|
             id_map[:validation] = "validation-#{base_id}" if invalid?


### PR DESCRIPTION
### Description

Tooltips were getting IDs that would occasionally conflict in CI. In order to prevent that, we are standardizing our ID generation to start with the component class name plus a random UUID.

Closes #1751

### Integration

no changes required

### Merge checklist

- ~[ ] Added/updated tests~ N/A
- ~[ ] Added/updated documentation~ N/A
- ~[ ] Added/updated previews~ N/A
