### PR TITLE
Use a bash script to check for changesets

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,11 +29,12 @@ jobs:
   check-for-changeset:
     name: Check for changeset
     runs-on: ubuntu-latest
+    env:
+      SKIP_LABEL: "skip changelog"
+    if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
     steps:
       - uses: actions/checkout@v3
-      - name: "Check for changeset"
-        uses: brettcannon/check-for-changed-files@v1
         with:
-          file-pattern: ".changeset/*.md"
-          skip-label: "skip changelog"
-          failure-message: "No changeset found. If these changes should not result in a new version, apply the ${skip-label} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ"
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: "Check for changeset"
+        run: script/check-for-changeset

--- a/script/check-for-changeset
+++ b/script/check-for-changeset
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+DEEPEN_LENGTH=${DEEPEN_LENGTH:-10}
+MAX_DEPTH=${MAX_DEPTH:-300}
+
+depth=0
+
+# Fetch the base ref, i.e. main
+git fetch --no-tags --progress --depth=1 origin "+refs/heads/$GITHUB_BASE_REF:refs/heads/$GITHUB_BASE_REF"
+
+# Keep fetching more commits until a merge base can be found
+while [ -z "$(git merge-base "$GITHUB_BASE_REF" "origin/$GITHUB_HEAD_REF")" ]; do
+  git fetch --no-tags -q --deepen="$DEEPEN_LENGTH" origin "$GITHUB_BASE_REF" "$GITHUB_HEAD_REF" > /dev/null
+  depth=$(( depth + $DEEPEN_LENGTH ))
+
+  # Make sure we don't end up in an infinite loop
+  if [[ "$depth" -ge "$MAX_DEPTH" ]]; then
+    echo "Could not find merge base, max depth exceeded."
+    exit 1
+  fi
+done
+
+# Check for added .md files in the .changeset directory
+git diff --name-only origin/${GITHUB_BASE_REF}...origin/${GITHUB_HEAD_REF} | grep '.changeset/.*.md' > /dev/null || (
+  exit_code=$?
+  echo "No changeset found. If these changes should not result in a new version, apply the ${SKIP_LABEL} label to this pull request. If these changes should result in a version bump, please add a changeset https://git.io/J6QvQ"
+  exit "${exit_code}"
+)


### PR DESCRIPTION
### Description

I'm seeing the Triage / Check for changeset job fail from time to time. The brettcannon/check-for-changed-files action we're using makes requests to the GitHub API to find the list of changed files and occasionally runs into a rate limit. I thought we could probably achieve the same thing with some regular 'ol git commands. How hard could it be? As it turns out, quite difficult. The script I added does the following:

1. Fetches `main` (or whatever the base branch is)
2. Fetches HEAD commits until git can find a merge base between the base branch and HEAD.
3. Examines the diff and `grep`s for .md files in the .changeset directory.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
