### PR TITLE
Add `RuboCop::Cop::Primer::TestSelector` to encourage use of the `test_selector` argument

### DIFF
--- a/.changeset/lemon-years-peel.md
+++ b/.changeset/lemon-years-peel.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add RuboCop::Cop::Primer::TestSelector to encourage use of the test_selector argument

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,3 +82,6 @@ Primer/DeprecatedLabelVariants:
   Enabled: true
   Exclude:
     - "test/**/*"
+
+Primer/TestSelector:
+  Enabled: true

--- a/lib/rubocop/config/default.yml
+++ b/lib/rubocop/config/default.yml
@@ -15,3 +15,6 @@ Primer/DeprecatedArguments:
 
 Primer/DeprecatedComponents:
   Enabled: true
+
+Primer/TestSelector:
+  Enabled: true

--- a/lib/rubocop/cop/primer/test_selector.rb
+++ b/lib/rubocop/cop/primer/test_selector.rb
@@ -11,11 +11,11 @@ module RuboCop
       #
       # Bad:
       #
-      # Component.new(data: { "test-selector": "the-component" })
+      # Primer::BaseComponent.new(data: { "test-selector": "the-component" })
       #
       # Good:
       #
-      # Component.new(test_selector: "the-component")
+      # Primer::BaseComponent.new(test_selector: "the-component")
       class TestSelector < BaseCop
         INVALID_MESSAGE = <<~STR
           Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.

--- a/lib/rubocop/cop/primer/test_selector.rb
+++ b/lib/rubocop/cop/primer/test_selector.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rubocop"
+
+# :nocov:
+module RuboCop
+  module Cop
+    module Primer
+      # Prefer the `test_selector` argument over manually generating
+      # a `data-test-selector` attribute.
+      #
+      # Bad:
+      #
+      # Component.new(data: { "test-selector": "the-component" })
+      #
+      # Good:
+      #
+      # Component.new(test_selector: "the-component")
+      class TestSelector < BaseCop
+        INVALID_MESSAGE = <<~STR
+          Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.
+        STR
+
+        def on_send(node)
+          return unless valid_node?(node)
+          return unless node.arguments?
+
+          kwargs = node.arguments.last
+          return unless kwargs.type == :hash
+
+          data_arg = kwargs.pairs.find { |kwarg| kwarg.key.value == :data }
+          return if data_arg.nil?
+          return unless data_arg.value.type == :hash
+
+          hash = data_arg.child_nodes.find { |arg| arg.type == :hash }
+          return unless hash
+
+          test_selector = hash.pairs.find do |pair|
+            pair.key.value == :"test-selector" || pair.key.value == "test-selector"
+          end
+          return unless test_selector
+
+          add_offense(data_arg, message: INVALID_MESSAGE)
+        end
+      end
+    end
+  end
+end

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "lib/cop_test_case"
+
+class RubocopTestSelectorTest < CopTestCase
+  def cop_class
+    RuboCop::Cop::Primer::TestSelector
+  end
+
+  def test_non_primer_component
+    investigate(cop, <<-RUBY)
+      Component.new(data: { "test-selector": "the-component" })
+    RUBY
+
+    assert_empty cop.offenses
+  end
+
+  def test_primer_component
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new(data: { "test-selector": "the-component" })
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
+end

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -23,4 +23,12 @@ class RubocopTestSelectorTest < CopTestCase
     assert_equal 1, cop.offenses.count
     assert_equal "Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
   end
+
+  def test_non_primer_view_helper
+    investigate(cop, <<-RUBY)
+      octicon(data: { "test-selector": "the-component" })
+    RUBY
+
+    assert_empty cop.offenses
+  end
 end

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -57,4 +57,12 @@ class RubocopTestSelectorTest < CopTestCase
 
     assert_empty cop.offenses
   end
+
+  def test_data_with_no_test_selector
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new(data: { "some-other" => "data-thing" })
+    RUBY
+
+    assert_empty cop.offenses
+  end
 end

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -26,7 +26,7 @@ class RubocopTestSelectorTest < CopTestCase
 
   def test_non_primer_view_helper
     investigate(cop, <<-RUBY)
-      octicon(data: { "test-selector": "the-component" })
+      octicon(data: { "test-selector": "the-octicon" })
     RUBY
 
     assert_empty cop.offenses

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -31,4 +31,13 @@ class RubocopTestSelectorTest < CopTestCase
 
     assert_empty cop.offenses
   end
+
+  def test_primer_view_helper
+    investigate(cop, <<-RUBY)
+      primer_octicon(data: { "test-selector": "the-octicon" })
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
 end

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -15,9 +15,18 @@ class RubocopTestSelectorTest < CopTestCase
     assert_empty cop.offenses
   end
 
-  def test_primer_component
+  def test_primer_component_with_symbol_key
     investigate(cop, <<-RUBY)
       Primer::BaseComponent.new(data: { "test-selector": "the-component" })
+    RUBY
+
+    assert_equal 1, cop.offenses.count
+    assert_equal "Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
+  end
+
+  def test_primer_component_with_string_key
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new(data: { "test-selector" => "the-component" })
     RUBY
 
     assert_equal 1, cop.offenses.count

--- a/test/lib/rubocop/test_selector_test.rb
+++ b/test/lib/rubocop/test_selector_test.rb
@@ -40,4 +40,12 @@ class RubocopTestSelectorTest < CopTestCase
     assert_equal 1, cop.offenses.count
     assert_equal "Prefer the `test_selector` argument over manually generating a `data-test-selector` attribute: https://primer.style/view-components/system-arguments.\n", cop.offenses.first.message
   end
+
+  def test_no_test_selector
+    investigate(cop, <<-RUBY)
+      Primer::BaseComponent.new
+    RUBY
+
+    assert_empty cop.offenses
+  end
 end


### PR DESCRIPTION
### Description

This branch adds `RuboCop::Cop::Primer::TestSelector`, which aims to prevent people doing this:

```rb
Primer::BaseComponent.new(data: { "test-selector": "the-component" })
```

And instead encourage this:

```rb
Primer::BaseComponent.new(test_selector: "the-component")
```

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
