### PR TITLE
Removing deprecated Primer::BoxComponent and box_component.rb file

### DIFF
--- a/.changeset/curvy-items-fix.md
+++ b/.changeset/curvy-items-fix.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing deprecated box_component.rb file `Primer::BoxComponent`

--- a/app/components/primer/box_component.rb
+++ b/app/components/primer/box_component.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class BoxComponent < Primer::Box
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -17,10 +17,6 @@ deprecations:
     autocorrect: true
     replacement: "Primer::Beta::Blankslate"
 
-  - component: "Primer::BoxComponent"
-    autocorrect: true
-    replacement: "Primer::Box"
-
   - component: "Primer::ButtonComponent"
     autocorrect: false
     replacement: "Primer::Beta::Button"

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -73,7 +73,6 @@
   "Primer::Beta::Truncate::TruncateText": "",
   "Primer::BlankslateComponent": "",
   "Primer::Box": "",
-  "Primer::BoxComponent": "",
   "Primer::ButtonComponent": "",
   "Primer::ClipboardCopy": "",
   "Primer::ConditionalWrapper": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -1000,8 +1000,6 @@
   },
   "Primer::Box": {
   },
-  "Primer::BoxComponent": {
-  },
   "Primer::ButtonComponent": {
     "DEFAULT_SCHEME": "default",
     "DEFAULT_SIZE": "medium",

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -73,7 +73,6 @@
   "Primer::Beta::Truncate::TruncateText": "alpha",
   "Primer::BlankslateComponent": "deprecated",
   "Primer::Box": "stable",
-  "Primer::BoxComponent": "deprecated",
   "Primer::ButtonComponent": "deprecated",
   "Primer::ClipboardCopy": "deprecated",
   "Primer::ConditionalWrapper": "alpha",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -131,7 +131,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Component",
       "Primer::OcticonsSymbolComponent",
       "Primer::Content",
-      "Primer::BoxComponent",
       "Primer::PopoverComponent",
       "Primer::Dropdown",
       "Primer::Dropdown::Menu"


### PR DESCRIPTION
### Description

Follow up to https://github.com/primer/view_components/issues/676

The `Primer::BoxComponent` is no longer used in dotcom. This removes the alias from the codebase. I've left in place the linter rules in case it helps others migrating.

### Integration

> Does this change require any updates to code in production?

Double check no one added `Primer::BoxComponent` back.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
