### PR TITLE
Removing deprecated Primer::ClipboardCopy component and clipboard_copy.rb file

### DIFF
--- a/.changeset/beige-penguins-think.md
+++ b/.changeset/beige-penguins-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Removing deprecated Primer::ClipboardCopy component and clipboard_copy.rb file

--- a/app/components/primer/clipboard_copy.rb
+++ b/app/components/primer/clipboard_copy.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Primer
-  class ClipboardCopy < Primer::Beta::ClipboardCopy
-    status :deprecated
-  end
-end

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -26,10 +26,6 @@ deprecations:
     replacement: "Primer::Beta::Button"
     guide: "https://primer.style/view-components/guides/primer_button_component"
 
-  - component: "Primer::ClipboardCopy"
-    autocorrect: true
-    replacement: "Primer::Beta::ClipboardCopy"
-
   - component: "Primer::DropdownMenuComponent"
     autocorrect: false
     replacement: "Primer::Beta::Dropdown"

--- a/static/audited_at.json
+++ b/static/audited_at.json
@@ -75,7 +75,6 @@
   "Primer::Box": "",
   "Primer::BoxComponent": "",
   "Primer::ButtonComponent": "",
-  "Primer::ClipboardCopy": "",
   "Primer::ConditionalWrapper": "",
   "Primer::Content": "",
   "Primer::Dropdown": "",

--- a/static/constants.json
+++ b/static/constants.json
@@ -1031,8 +1031,6 @@
       "medium"
     ]
   },
-  "Primer::ClipboardCopy": {
-  },
   "Primer::ConditionalWrapper": {
   },
   "Primer::Content": {

--- a/static/statuses.json
+++ b/static/statuses.json
@@ -75,7 +75,6 @@
   "Primer::Box": "stable",
   "Primer::BoxComponent": "deprecated",
   "Primer::ButtonComponent": "deprecated",
-  "Primer::ClipboardCopy": "deprecated",
   "Primer::ConditionalWrapper": "alpha",
   "Primer::Content": "stable",
   "Primer::Dropdown": "deprecated",

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -121,7 +121,6 @@ class PrimerComponentTest < Minitest::Test
       "Primer::OcticonComponent",
       "Primer::Markdown",
       "Primer::MenuComponent",
-      "Primer::ClipboardCopy",
       "Primer::LabelComponent",
       "Primer::LinkComponent",
       "Primer::Alpha::ActionList::Heading",


### PR DESCRIPTION
### Description

Follow up to https://github.com/primer/view_components/issues/676

The `Primer::ClipboardCopy` is no longer used in dotcom. This removes the alias from the codebase. I've left in place the linter rules in case it helps others migrating.

### Integration

> Does this change require any updates to code in production?

Double check no one added `Primer::ClipboardCopy` back.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
