### PR TITLE
Adding aria labeled by and described by check to SegmentedControl component

### DIFF
--- a/.changeset/swift-shirts-press.md
+++ b/.changeset/swift-shirts-press.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Adding aria labeled by and described by check to SegmentedControl component

--- a/.changeset/swift-shirts-press.md
+++ b/.changeset/swift-shirts-press.md
@@ -2,4 +2,4 @@
 "@primer/view-components": patch
 ---
 
-Adding aria labeled by and described by check to SegmentedControl component
+Adding aria labeled by and described by check to SegmentedControl component. Marking as accessibility reviewed

--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -5,6 +5,7 @@ module Primer
     # Use a segmented control to let users select an option from a short list and immediately apply the selection
     class SegmentedControl < Primer::Component
       status :alpha
+      audited_at "2023-02-01"
 
       FULL_WIDTH_DEFAULT = false
       HIDE_LABELS_DEFAULT = false

--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -61,6 +61,30 @@ module Primer
       #     <%= component.with_item(label: "Blame", icon: :people) %>
       #   <% end %>
       #
+      # @example With subheading and description
+      #   <%= render(Primer::Beta::Subhead.new) do |component| %>
+      #     <% component.with_heading(id: "scLabel-vert") { "File view" } %>
+      #     <% component.with_description(id: "scCaption-vert") { "Change the way the file is viewed" } %>
+      #     <% component.with_actions do %>
+      #       <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-vert", "aria-describedby": "scCaption-vert")) do |component| %>
+      #         <% component.with_item(label: "Preview", selected: true) %>
+      #         <% component.with_item(label: "Raw") %>
+      #         <% component.with_item(label: "Blame") %>
+      #       <% end %>
+      #     <% end %>
+      #   <% end %>
+      #
+      # @example With Label and caption
+      #   <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
+      #     <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
+      #     <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
+      #       <% component.with_item(label: "Preview", selected: true) %>
+      #       <% component.with_item(label: "Raw") %>
+      #       <% component.with_item(label: "Blame") %>
+      #     <% end %>
+      #     <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
+      #   <% end %>
+      #
       # @param hide_labels [Boolean] Whether to hide the labels and only show the icons
       # @param full_width [Boolean] If the component should be full width
       # @param size [Symbol] <%= one_of(Primer::Beta::Button::SIZE_OPTIONS) %>
@@ -79,6 +103,8 @@ module Primer
           "SegmentedControl--iconOnly": hide_labels,
           "SegmentedControl--fullWidth": full_width
         )
+
+        validate_aria_labeled
       end
 
       def render?

--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -28,7 +28,18 @@ module Primer
         )
       }
 
-      # @example With subheading and description
+      # @example With a label above and caption below
+      #   <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
+      #     <%= render(Primer::BaseComponent.new(tag: "span", id: "scLabel-horiz")) { "File view" } %>
+      #     <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
+      #       <% component.with_item(label: "Preview", selected: true) %>
+      #       <% component.with_item(label: "Raw") %>
+      #       <% component.with_item(label: "Blame") %>
+      #     <% end %>
+      #     <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
+      #   <% end %>
+      #
+      # @example With a label and caption on the left
       #   <%= render(Primer::Beta::Subhead.new) do |component| %>
       #     <% component.with_heading(id: "scLabel-vert") { "File view" } %>
       #     <% component.with_description(id: "scCaption-vert") { "Change the way the file is viewed" } %>
@@ -39,17 +50,6 @@ module Primer
       #         <% component.with_item(label: "Blame") %>
       #       <% end %>
       #     <% end %>
-      #   <% end %>
-      #
-      # @example With Label and caption
-      #   <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
-      #     <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
-      #     <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
-      #       <% component.with_item(label: "Preview", selected: true) %>
-      #       <% component.with_item(label: "Raw") %>
-      #       <% component.with_item(label: "Blame") %>
-      #     <% end %>
-      #     <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
       #   <% end %>
       #
       # @example Basic usage

--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -3,6 +3,9 @@
 module Primer
   module Alpha
     # Use a segmented control to let users select an option from a short list and immediately apply the selection
+    # @accessibility
+    #   A `SegmentedControl` should not be used in a form as a replacement for something like a radio group or select.
+    #   See the [Accessibility section](https://primer.style/design/components/segmented-control#accessibility) of the SegmentedControl interface guidelines for more details.
     class SegmentedControl < Primer::Component
       status :alpha
       audited_at "2023-02-01"
@@ -25,6 +28,30 @@ module Primer
         )
       }
 
+      # @example With subheading and description
+      #   <%= render(Primer::Beta::Subhead.new) do |component| %>
+      #     <% component.with_heading(id: "scLabel-vert") { "File view" } %>
+      #     <% component.with_description(id: "scCaption-vert") { "Change the way the file is viewed" } %>
+      #     <% component.with_actions do %>
+      #       <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-vert", "aria-describedby": "scCaption-vert")) do |component| %>
+      #         <% component.with_item(label: "Preview", selected: true) %>
+      #         <% component.with_item(label: "Raw") %>
+      #         <% component.with_item(label: "Blame") %>
+      #       <% end %>
+      #     <% end %>
+      #   <% end %>
+      #
+      # @example With Label and caption
+      #   <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
+      #     <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
+      #     <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
+      #       <% component.with_item(label: "Preview", selected: true) %>
+      #       <% component.with_item(label: "Raw") %>
+      #       <% component.with_item(label: "Blame") %>
+      #     <% end %>
+      #     <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
+      #   <% end %>
+      #
       # @example Basic usage
       #
       #   <%= render(Primer::Alpha::SegmentedControl.new("aria-label": "File view")) do |component| %>
@@ -60,30 +87,6 @@ module Primer
       #     <%= component.with_item(label: "Preview", icon: :eye, selected: true) %>
       #     <%= component.with_item(label: "Raw", icon: :"file-code") %>
       #     <%= component.with_item(label: "Blame", icon: :people) %>
-      #   <% end %>
-      #
-      # @example With subheading and description
-      #   <%= render(Primer::Beta::Subhead.new) do |component| %>
-      #     <% component.with_heading(id: "scLabel-vert") { "File view" } %>
-      #     <% component.with_description(id: "scCaption-vert") { "Change the way the file is viewed" } %>
-      #     <% component.with_actions do %>
-      #       <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-vert", "aria-describedby": "scCaption-vert")) do |component| %>
-      #         <% component.with_item(label: "Preview", selected: true) %>
-      #         <% component.with_item(label: "Raw") %>
-      #         <% component.with_item(label: "Blame") %>
-      #       <% end %>
-      #     <% end %>
-      #   <% end %>
-      #
-      # @example With Label and caption
-      #   <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
-      #     <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
-      #     <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
-      #       <% component.with_item(label: "Preview", selected: true) %>
-      #       <% component.with_item(label: "Raw") %>
-      #       <% component.with_item(label: "Blame") %>
-      #     <% end %>
-      #     <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
       #   <% end %>
       #
       # @param hide_labels [Boolean] Whether to hide the labels and only show the icons

--- a/app/components/primer/alpha/segmented_control.rb
+++ b/app/components/primer/alpha/segmented_control.rb
@@ -104,7 +104,7 @@ module Primer
           "SegmentedControl--fullWidth": full_width
         )
 
-        validate_aria_labeled
+        validate_aria_label
       end
 
       def render?

--- a/app/components/primer/alpha/segmented_control/item.rb
+++ b/app/components/primer/alpha/segmented_control/item.rb
@@ -7,6 +7,7 @@ module Primer
       # It wraps the Button and IconButton components to provide the correct styles
       class Item < Primer::BaseComponent
         status :alpha
+        audited_at "2023-02-01"
 
         # @param label [String] The label to use
         # @param selected [Boolean] Whether the item is selected

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -134,12 +134,12 @@ module Primer
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
-    # | `font_family` | Symbol | Font weight. <%= one_of([:mono]) %> |
+    # | `font_family` | Symbol | Font family. <%= one_of([:mono]) %> |
     # | `font_size` | String, Integer, Symbol | <%= one_of(["00", 0, 1, 2, 3, 4, 5, 6, :small, :normal]) %> |
-    # | `font_style` | Symbol | Font weight. <%= one_of([:italic]) %> |
+    # | `font_style` | Symbol | Font style. <%= one_of([:italic]) %> |
     # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold, :emphasized]) %> |
     # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
-    # | `text_transform` | Symbol | Text alignment. <%= one_of([:uppercase]) %> |
+    # | `text_transform` | Symbol | Text transformation. <%= one_of([:uppercase]) %> |
     # | `underline` | Boolean | Whether text should be underlined. |
     # | `word_break` | Symbol | Whether to break words on line breaks. <%= one_of(Primer::Classify::Utilities.mappings(:word_break)) %> |
     #

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -55,6 +55,13 @@ module Primer
       raise ArgumentError, "`aria-label` is required." if aria_label.nil? && !Rails.env.production?
     end
 
+    def validate_aria_labeled
+      return if Rails.env.production?
+
+      aria_label = aria("label", @system_arguments) || aria("labelledby", @system_arguments) || aria("describedby", @system_arguments)
+      raise ArgumentError, "`aria-label`, `aria-labelledby` or `aria-describedby` is required." if aria_label.nil?
+    end
+
     def silence_deprecations?
       Rails.application.config.primer_view_components.silence_deprecations
     end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -52,14 +52,8 @@ module Primer
 
     def validate_aria_label
       aria_label = aria("label", @system_arguments)
-      raise ArgumentError, "`aria-label` is required." if aria_label.nil? && !Rails.env.production?
-    end
-
-    def validate_aria_labeled
-      return if Rails.env.production?
-
-      aria_label = aria("label", @system_arguments) || aria("labelledby", @system_arguments) || aria("describedby", @system_arguments)
-      raise ArgumentError, "`aria-label`, `aria-labelledby` or `aria-describedby` is required." if aria_label.nil?
+      aria_labelledby = aria("labelledby", @system_arguments)
+      raise ArgumentError, "`aria-label` or `aria-labelledby` is required." if (aria_label.nil? || aria_labelledby.nil?) && !Rails.env.production?
     end
 
     def silence_deprecations?

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -53,7 +53,7 @@ module Primer
     def validate_aria_label
       aria_label = aria("label", @system_arguments)
       aria_labelledby = aria("labelledby", @system_arguments)
-      raise ArgumentError, "`aria-label` or `aria-labelledby` is required." if (aria_label.nil? || aria_labelledby.nil?) && !Rails.env.production?
+      raise ArgumentError, "`aria-label` or `aria-labelledby` is required." if aria_label.nil? && aria_labelledby.nil? && !Rails.env.production?
     end
 
     def silence_deprecations?

--- a/previews/primer/alpha/segmented_control_preview.rb
+++ b/previews/primer/alpha/segmented_control_preview.rb
@@ -159,6 +159,12 @@ module Primer
         end
       end
       # @!endgroup
+
+      # @!group With aria labeled headings
+      def with_subhead_actions; end
+
+      def with_label_and_caption; end
+      # @!endgroup
     end
   end
 end

--- a/previews/primer/alpha/segmented_control_preview.rb
+++ b/previews/primer/alpha/segmented_control_preview.rb
@@ -152,7 +152,7 @@ module Primer
       # NOTE: this preview uses a group to force it's display below the other groups
       # @!group With link as tag
       def with_link_as_tag
-        render(Primer::Alpha::SegmentedControl.new) do |component|
+        render(Primer::Alpha::SegmentedControl.new("aria-label": "File view")) do |component|
           component.with_item(tag: :a, href: "#", label: "Preview", icon: :eye, selected: true)
           component.with_item(tag: :a, href: "#", label: "Raw", icon: :"file-code")
           component.with_item(tag: :a, href: "#", label: "Blame", icon: :people)

--- a/previews/primer/alpha/segmented_control_preview/with_label_and_caption.html.erb
+++ b/previews/primer/alpha/segmented_control_preview/with_label_and_caption.html.erb
@@ -1,0 +1,9 @@
+<%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
+  <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
+  <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
+    <% component.with_item(label: "Preview", selected: true) %>
+    <% component.with_item(label: "Raw") %>
+    <% component.with_item(label: "Blame") %>
+  <% end %>
+  <%= render(Primer::Beta::Text.new(font_size: :small, mt: 1, color: :muted, id: "scCaption-horiz")) { "Change the way the file is viewed" } %>
+<% end %>

--- a/previews/primer/alpha/segmented_control_preview/with_label_and_caption.html.erb
+++ b/previews/primer/alpha/segmented_control_preview/with_label_and_caption.html.erb
@@ -1,5 +1,5 @@
 <%= render(Primer::Box.new(display: :flex, direction: :column)) do %>
-  <%= render(Primer::BaseComponent.new(tag: "label", id: "scLabel-horiz")) { "File view" } %>
+  <%= render(Primer::BaseComponent.new(tag: "span", id: "scLabel-horiz")) { "File view" } %>
   <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-horiz", "aria-describedby": "scCaption-horiz")) do |component| %>
     <% component.with_item(label: "Preview", selected: true) %>
     <% component.with_item(label: "Raw") %>

--- a/previews/primer/alpha/segmented_control_preview/with_subhead_actions.html.erb
+++ b/previews/primer/alpha/segmented_control_preview/with_subhead_actions.html.erb
@@ -1,0 +1,11 @@
+<%= render(Primer::Beta::Subhead.new) do |component| %>
+  <% component.with_heading(id: "scLabel-vert") { "File view" } %>
+  <% component.with_description(id: "scCaption-vert") { "Change the way the file is viewed" } %>
+  <% component.with_actions do %>
+    <%= render(Primer::Alpha::SegmentedControl.new("aria-labelledby": "scLabel-vert", "aria-describedby": "scCaption-vert")) do |component| %>
+      <% component.with_item(label: "Preview", selected: true) %>
+      <% component.with_item(label: "Raw") %>
+      <% component.with_item(label: "Blame") %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/components/alpha/hellip_button_test.rb
+++ b/test/components/alpha/hellip_button_test.rb
@@ -40,7 +40,7 @@ class PrimerAlphaHellipButtonTest < Minitest::Test
       render_inline(Primer::Alpha::HellipButton.new)
     end
 
-    assert_equal("`aria-label` is required.", err.message)
+    assert_equal("`aria-label` or `aria-labelledby` is required.", err.message)
   end
 
   def test_does_not_render_content

--- a/test/components/alpha/hidden_text_expander_test.rb
+++ b/test/components/alpha/hidden_text_expander_test.rb
@@ -46,7 +46,7 @@ class PrimerAlphaHiddenTextExpanderTest < Minitest::Test
       render_inline(Primer::Alpha::HiddenTextExpander.new)
     end
 
-    assert_equal("`aria-label` is required.", err.message)
+    assert_equal("`aria-label` or `aria-labelledby` is required.", err.message)
   end
 
   def test_does_not_render_content

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -12,6 +12,7 @@ class PrimerComponentTest < Minitest::Test
     [Primer::Beta::IconButton, { icon: :star, "aria-label": "Star" }],
     [Primer::Beta::Button, {}],
     [Primer::Alpha::SegmentedControl, {
+      "aria-label": "File view",
       full_width: false
     }, proc { |component|
       component.with_item(label: "Button", selected: true)

--- a/test/components/icon_button_test.rb
+++ b/test/components/icon_button_test.rb
@@ -53,7 +53,7 @@ class PrimerIconButtonTest < Minitest::Test
       render_inline(Primer::IconButton.new(icon: :star))
     end
 
-    assert_equal("`aria-label` is required.", err.message)
+    assert_equal("`aria-label` or `aria-labelledby` is required.", err.message)
   end
 
   def test_does_not_raise_if_aria_label_is_provided_as_an_object

--- a/test/components/primer/alpha/segmented_control_test.rb
+++ b/test/components/primer/alpha/segmented_control_test.rb
@@ -97,7 +97,7 @@ module Primer
           render_inline(Primer::Alpha::SegmentedControl.new)
         end
 
-        assert_equal("`aria-label`, `aria-labelledby` or `aria-describedby` is required.", err.message)
+        assert_equal("`aria-label` or `aria-labelledby` is required.", err.message)
       end
     end
   end

--- a/test/components/primer/alpha/segmented_control_test.rb
+++ b/test/components/primer/alpha/segmented_control_test.rb
@@ -52,7 +52,7 @@ module Primer
       end
 
       def test_doesnt_use_control_click_with_href
-        render_inline(Primer::Alpha::SegmentedControl.new) do |component|
+        render_inline(Primer::Alpha::SegmentedControl.new("aria-label": "File view")) do |component|
           component.with_item(icon: :zap, label: "Item 1", selected: true) { "Item 1" }
           component.with_item(tag: :a, href: "#", icon: :zap, label: "Item 2") { "Item 2" }
         end
@@ -63,7 +63,7 @@ module Primer
 
       def test_doesnt_render_with_too_many_items
         error = assert_raises(ArgumentError) do
-          render_inline(Primer::Alpha::SegmentedControl.new) do |component|
+          render_inline(Primer::Alpha::SegmentedControl.new("aria-label": "File view")) do |component|
             component.with_item(label: "Item 1", selected: true) { "Item 1" }
             component.with_item(label: "Item 2") { "Item 2" }
             component.with_item(label: "Item 3") { "Item 3" }
@@ -78,7 +78,7 @@ module Primer
 
       def test_doesnt_render_with_too_many_icon_items
         error = assert_raises(ArgumentError) do
-          render_inline(Primer::Alpha::SegmentedControl.new(hide_labels: true)) do |component|
+          render_inline(Primer::Alpha::SegmentedControl.new(hide_labels: true, "aria-label": "File view")) do |component|
             component.with_item(icon: :zap, label: "Item 1", selected: true) { "Item 1" }
             component.with_item(icon: :zap, label: "Item 2") { "Item 2" }
             component.with_item(icon: :zap, label: "Item 3") { "Item 3" }
@@ -90,6 +90,14 @@ module Primer
         end
 
         assert_equal(error.message, "A segmented control should have 2–5 choices with text labels, or up to 6 icon-only buttons.")
+      end
+
+      def test_raises_if_no_aria_label_is_provided
+        err = assert_raises ArgumentError do
+          render_inline(Primer::Alpha::SegmentedControl.new)
+        end
+
+        assert_equal("`aria-label`, `aria-labelledby` or `aria-describedby` is required.", err.message)
       end
     end
   end


### PR DESCRIPTION
### Description

This adds examples of including Subhead and Label components with the control to demonstrate proper labeling. I also added a new check that will make sure a component has at least one of `aria-label, aria-labeledby, aria-describedby`

Closes # https://github.com/github/primer/issues/1149

### Integration

> Does this change require any updates to code in production?

We should check the existing uses of SegmentedControl to make sure they are using an aria-label

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
