### PR TITLE
Lookbook form assets

### DIFF
--- a/demo/app/views/lookbook/panels/_assets.html.erb
+++ b/demo/app/views/lookbook/panels/_assets.html.erb
@@ -31,11 +31,10 @@
       <div class="asset-preview">
         <header class="asset-header">
           <%= icon :file, size: 3.5, class: "asset-icon" %>
-          <h4 class="asset-title font-mono"><%= asset.basename %></h4>
+          <h4 class="asset-title font-mono"><%= asset[:path].relative_path_from(Primer::ViewComponents.root) %></h4>
         </header>
         <div class="asset-contents">
-          <% extension = asset.extname %>
-          <%= code language: extension == ".css" ? :css : :js, line_numbers: true do %><%== File.read(asset) %><% end %>
+          <%= code language: asset[:language], line_numbers: true do %><%== File.read(asset[:path]) %><% end %>
         </div>
       </div>
     <% end %>

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -55,7 +55,7 @@ module Demo
           assets += data.examples.each_with_object([]) do |rendered_example, memo|
             form_constants = rendered_example.source.match(/([\w:]+Form)\.new/)&.captures || []
             form_constants.each do |form_constant|
-              path, _ = Kernel.const_source_location(form_constant)
+              path, = Kernel.const_source_location(form_constant)
               memo << { path: Pathname(path), language: :ruby }
 
               const = Kernel.const_get(form_constant)

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -7,6 +7,7 @@ require "action_view/railtie"
 require "active_model/railtie"
 require "sprockets/railtie"
 require "view_component"
+require "primer/view_components"
 require "primer/view_components/engine"
 
 # Require the gems listed in Gemfile, including any gems
@@ -43,10 +44,32 @@ module Demo
         label: "Assets",
         partial: "lookbook/panels/assets",
         locals: lambda do |data|
-          assets = data.preview.components.map do |component|
-            asset_files = Dir[Rails.root.join("../", "#{component.full_path.to_s.chomp('.rb')}.{css,ts}")]
-            asset_files.map { |path| Pathname.new path }
-          end.flatten.compact
+          assets = data.preview.components.flat_map do |component|
+            asset_files = Dir[Primer::ViewComponents.root.join("app", "components", "#{component.relative_file_path.to_s.chomp('.rb')}.{css,ts}")]
+            asset_files.map do |path_str|
+              path = Pathname(path_str)
+              { path: path, language: path.extname == ".ts" ? :js : :css }
+            end
+          end
+
+          assets += data.examples.each_with_object([]) do |rendered_example, memo|
+            form_constants = rendered_example.source.match(/([\w:]+Form)\.new/)&.captures || []
+            form_constants.each do |form_constant|
+              path, _ = Kernel.const_source_location(form_constant)
+              memo << { path: Pathname(path), language: :ruby }
+
+              const = Kernel.const_get(form_constant)
+              next unless const.template_root_path
+
+              Dir[File.join(const.template_root_path, "*_caption.html.erb")].each do |template_caption_path|
+                memo << { path: Pathname(template_caption_path), language: :erb }
+              end
+
+              after_content_path = Pathname(File.join(const.template_root_path, "after_content.html.erb"))
+              memo << { path: after_content_path, language: :erb } if after_content_path.exist?
+            end
+          end
+
           { assets: assets }
         end
       }

--- a/lib/primer/view_components.rb
+++ b/lib/primer/view_components.rb
@@ -54,5 +54,10 @@ module Primer
     def self.read(stats)
       File.read(File.join(DEFAULT_STATIC_PATH, FILE_NAMES[stats]))
     end
+
+    # primer/view_components root directory.
+    def self.root
+      Pathname(File.expand_path(File.join("..", ".."), __dir__))
+    end
   end
 end

--- a/test/lib/primer/view_components_test.rb
+++ b/test/lib/primer/view_components_test.rb
@@ -27,4 +27,8 @@ class Primer::ViewComponentsTest < Minitest::Test
 
     assert_equal JSON.pretty_generate(Primer::ViewComponents.generate_audited_at), Primer::ViewComponents.read(:audited_at).chomp
   end
+
+  def test_root
+    assert Primer::ViewComponents.root.join("app", "components", "primer", "base_component.rb").exist?
+  end
 end


### PR DESCRIPTION
### Description

Form previews aren't super helpful because they only show the template used to render them. For example:

```erb
<%= primer_form_with(url: "/foo") do |f| %>
  <%= render(AfterContentForm.new(f)) %>
<% end %>
```

This PR updates the "assets" panel in Lookbook to include:

1. The form class.
2. Any caption templates (eg. field_name_caption.html.erb).
3. The contents of after_content.html.erb, if it exists.

![image](https://user-images.githubusercontent.com/575280/214394654-7751c054-4e24-4c60-9bab-3e7a53fe75db.png)

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
- [x] Added/updated previews
