### PR TITLE
Update contributing guidelines regarding changesets

### DIFF
--- a/.changeset/strong-radios-promise.md
+++ b/.changeset/strong-radios-promise.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Correct contributing guidelines

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -115,7 +115,7 @@ To minimize the number of restarts, we recommend checking the component in Lookb
 0. Make sure the tests pass on your machine
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
-0. 1. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes
+0. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes if needed
 0. Push to your fork and [submit a pull request](https://github.com/primer/view_components/compare)
 0. Pat yourself on the back and wait for your pull request to be reviewed and merged.
 

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -115,7 +115,7 @@ To minimize the number of restarts, we recommend checking the component in Lookb
 0. Make sure the tests pass on your machine
 0. Create a new branch: `git checkout -b my-branch-name`
 0. Make your change, add tests, and make sure the tests still pass
-0. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading
+0. 1. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes
 0. Push to your fork and [submit a pull request](https://github.com/primer/view_components/compare)
 0. Pat yourself on the back and wait for your pull request to be reviewed and merged.
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -14,7 +14,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 1. [Fork](https://github.com/primer/view_components/fork) and clone the repository
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass
-1. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes
+1. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes if needed
 1. Push to your fork and [submit a pull request](https://github.com/primer/view_components/compare)
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged, after merging it will be included in the next release
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -14,7 +14,7 @@ Please note that this project is released with a [Contributor Code of Conduct](h
 1. [Fork](https://github.com/primer/view_components/fork) and clone the repository
 1. Create a new branch: `git switch -n your-username/your-feature`
 1. Make your change, add tests, and make sure all the tests still pass
-1. Add an entry to the top of `CHANGELOG.md` for your change under the appropriate heading
+1. Add a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) for your changes
 1. Push to your fork and [submit a pull request](https://github.com/primer/view_components/compare)
 1. Pat yourself on the back and wait for your pull request to be reviewed and merged, after merging it will be included in the next release
 


### PR DESCRIPTION
### Description

The project uses changesets rather than having contributors manually update the CHANGELOG.md file.

This branch updates the contributing guidelines to encourage people to add changesets using the provided documentation in https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md.

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
