### PR TITLE
Prefer `Primer::Beta::Button` in `ERBLint::Linters::ButtonComponentMigrationCounter`

### DIFF
--- a/.changeset/fluffy-rivers-search.md
+++ b/.changeset/fluffy-rivers-search.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prefer Primer::Beta::Button in ERBLint::Linters::ButtonComponentMigrationCounter

--- a/lib/primer/view_components/linters/button_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/button_component_migration_counter.rb
@@ -18,9 +18,9 @@ module ERBLint
       # CloseButton component has preference when this class is seen in conjunction with `btn`.
       DISALLOWED_CLASSES = %w[close-button].freeze
       CLASSES = %w[btn btn-link].freeze
-      MESSAGE = "We are migrating buttons to use [Primer::ButtonComponent](https://primer.style/view-components/components/button), please try to use that instead of raw HTML."
+      MESSAGE = "We are migrating buttons to use [Primer::Beta::Button](https://primer.style/view-components/components/beta/button), please try to use that instead of raw HTML."
       ARGUMENT_MAPPER = ArgumentMappers::Button
-      COMPONENT = "Primer::ButtonComponent"
+      COMPONENT = "Primer::Beta::Button"
     end
   end
 end

--- a/test/lib/erblint/button_component_migration_counter_test.rb
+++ b/test/lib/erblint/button_component_migration_counter_test.rb
@@ -24,28 +24,28 @@ class ButtonComponentMigrationCounterTest < ErblintTestCase
     @file = "<button class=\"btn btn-sm btn-primary\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(size: :small, scheme: :primary)")
+    assert_includes(offenses.first.message, "render Primer::Beta::Button.new(size: :small, scheme: :primary)")
   end
 
   def test_suggests_how_to_use_the_component_as_link
     @file = "<button class=\"btn-link\">Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(scheme: :link)")
+    assert_includes(offenses.first.message, "render Primer::Beta::Button.new(scheme: :link)")
   end
 
   def test_suggest_when_button_is_disabled
     @file = "<button class=\"btn\" disabled>Button</button>"
     @linter.run(processed_source)
 
-    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(disabled: true)")
+    assert_includes(offenses.first.message, "render Primer::Beta::Button.new(disabled: true)")
   end
 
   def test_suggest_using_the_tag_system_argument
     @file = "<a class=\"btn\">Button</a>"
     @linter.run(processed_source)
 
-    assert_includes(offenses.first.message, "render Primer::ButtonComponent.new(tag: :a)")
+    assert_includes(offenses.first.message, "render Primer::Beta::Button.new(tag: :a)")
   end
 
   def test_autocorrects
@@ -74,19 +74,19 @@ class ButtonComponentMigrationCounterTest < ErblintTestCase
 
     expected = <<~HTML
       <%# erblint:counter ButtonComponentMigrationCounter 1 %>
-      <%= render Primer::ButtonComponent.new(scheme: :primary) do %>
+      <%= render Primer::Beta::Button.new(scheme: :primary) do %>
         button 1
         <button invalid-attr class="btn">
           Can't be autocorrected
         </button>
-        <%= render Primer::ButtonComponent.new(scheme: :danger) do %>
+        <%= render Primer::Beta::Button.new(scheme: :danger) do %>
           button 2
-          <%= render Primer::ButtonComponent.new(scheme: :outline) do %>
+          <%= render Primer::Beta::Button.new(scheme: :outline) do %>
             button 3
             <a>not a button</a>
-            <%= render Primer::ButtonComponent.new(tag: :summary, size: :small) do %>
+            <%= render Primer::Beta::Button.new(tag: :summary, size: :small) do %>
               summary
-              <%= render Primer::ButtonComponent.new(tag: :a, test_selector: "test selector") do %>
+              <%= render Primer::Beta::Button.new(tag: :a, test_selector: "test selector") do %>
                 a
               <% end %>
             <% end %>
@@ -107,7 +107,7 @@ class ButtonComponentMigrationCounterTest < ErblintTestCase
     HTML
 
     expected = <<~HTML
-      <%= render Primer::ButtonComponent.new(href: "href", value: "value", name: "name", tabindex: "tabindex") do %>
+      <%= render Primer::Beta::Button.new(href: "href", value: "value", name: "name", tabindex: "tabindex") do %>
         button
       <% end %>
     HTML


### PR DESCRIPTION
### Description

`ERBLint::Linters::ButtonComponentMigrationCounter` currently asks people to replace raw HTML with `Primer::ButtonComponent`, but `Primer::ButtonComponent` is deprecated, which then results in another linter error asking for `Primer::ButtonComponent` to be replaced with `Primer::Beta::Button`.

It seems to make more sense that `ERBLint::Linters::ButtonComponentMigrationCounter` just prefers `Primer::Beta::Button`?

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
