### PR TITLE
Fix toggle switch form templates

### DIFF
--- a/.changeset/slow-sheep-boil.md
+++ b/.changeset/slow-sheep-boil.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow toggle-switch forms to use caption templates.

--- a/app/forms/example_toggle_switch_form.rb
+++ b/app/forms/example_toggle_switch_form.rb
@@ -3,6 +3,6 @@
 # :nodoc:
 class ExampleToggleSwitchForm < Primer::Forms::ToggleSwitchForm
   def initialize(**system_arguments)
-    super(name: :example_field, label: "Example", caption: "This is an example toggle switch.", **system_arguments)
+    super(name: :example_field, label: "Example", **system_arguments)
   end
 end

--- a/lib/primer/forms/toggle_switch_form.rb
+++ b/lib/primer/forms/toggle_switch_form.rb
@@ -32,8 +32,10 @@ module Primer
     #
     class ToggleSwitchForm < Primer::Forms::Base
       # Define the form on subclasses so render(Subclass.new) works as expected.
-      def self.inherited(base)
-        base.form do |toggle_switch_form|
+      # (this is called directly on this class, but also on classes
+      # that inherit from this class)
+      def self.define_form_on(klass)
+        klass.form do |toggle_switch_form|
           input = Dsl::ToggleSwitchInput.new(
             builder: toggle_switch_form.builder, form: self, **@system_arguments
           )
@@ -42,8 +44,13 @@ module Primer
         end
       end
 
+      def self.inherited(base)
+        super
+        define_form_on(base)
+      end
+
       # Define the form on self so render(ToggleSwitchForm.new) works as expected.
-      inherited(self)
+      define_form_on(self)
 
       # Override to avoid accepting a builder argument. We create our own builder
       # on render. See the implementation of render_in below.

--- a/test/lib/primer/forms/toggle_switch_form_test.rb
+++ b/test/lib/primer/forms/toggle_switch_form_test.rb
@@ -10,6 +10,7 @@ class Primer::Forms::ToggleSwitchFormTest < Minitest::Test
     render_inline(ExampleToggleSwitchForm.new(csrf: bogus_csrf, src: "/toggle_switch"))
 
     assert_selector "toggle-switch[src='/toggle_switch'][csrf='#{bogus_csrf}']"
+    assert_selector "em", text: "favorite"
   end
 
   def test_can_render_without_subclass


### PR DESCRIPTION
### Description

The `ToggleSwitchForm` is unique in that we expect developers to use it directly sometimes but also inherit from it. When we implement the `inherited` method on `ToggleSwitchForm` we also need to call `super` to allow that same method on `Primer::Forms::Base` to do its magic as well (in this case, finding related caption templates).

### Integration

This type of caption isn't used in production yet (we figured out we needed it while implementing an updated settings form).

### Merge checklist

- [x] Added/updated tests
- ~[ ] Added/updated documentation~ n/a
- [x] Added/updated previews
