### PR TITLE
Document `TextField`'s `auto_check_src` argument

### DIFF
--- a/.changeset/loud-students-switch.md
+++ b/.changeset/loud-students-switch.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Document TextField's auto_check_src argument

--- a/app/components/primer/alpha/text_field.rb
+++ b/app/components/primer/alpha/text_field.rb
@@ -98,6 +98,7 @@ module Primer
       # @param leading_visual [Hash] Renders a leading visual icon before the text field's cursor. The hash will be passed to Primer's [Octicon component](https://primer.style/view-components/components/octicon).
       # @param validation_message [String] A validation message to display beneath the input. Implicitly sets `invalid` to `true`.
       # @param label_arguments [Hash] System arugments passed to the Rails builder's `#label` method. These arguments will appear as HTML attributes on the `<label>` tag.
+      # @param auto_check_src [String] When provided, makes a request to the given URL whenever the contents of the text field changes. If the server responds with a non-2xx status code, the response body is used as the validation message.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       # @param block [Proc] Unused.
     end

--- a/previews/primer/alpha/text_field_preview.rb
+++ b/previews/primer/alpha/text_field_preview.rb
@@ -144,6 +144,20 @@ module Primer
       end
       #
       # @!endgroup
+
+      # @!group Auto check
+      #
+      # @label Auto check request ok
+      def with_auto_check_ok
+        render(Primer::Alpha::TextField.new(auto_check_src: URLHelpers.example_check_ok_path, name: "my-text-field", label: "My text field"))
+      end
+
+      # @label Auto check request error
+      def with_auto_check_error
+        render(Primer::Alpha::TextField.new(auto_check_src: URLHelpers.example_check_error_path, name: "my-text-field", label: "My text field"))
+      end
+      #
+      # @!endgroup
     end
   end
 end


### PR DESCRIPTION
### Description

We added this a while ago but neglected to document it 😅 

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
- [x] Added/updated documentation~
- [x] Added/updated previews
