### PR TITLE
Remove duplicate `aria-label` in `CloseButton`

### DIFF
--- a/.changeset/tidy-months-relax.md
+++ b/.changeset/tidy-months-relax.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Update CloseButton to work with more aria-label types

--- a/app/components/primer/beta/close_button.rb
+++ b/app/components/primer/beta/close_button.rb
@@ -28,7 +28,7 @@ module Primer
           "close-button",
           system_arguments[:classes]
         )
-        @system_arguments[:"aria-label"] ||= "Close"
+        @system_arguments[:"aria-label"] = aria("label", system_arguments) || "Close"
       end
 
       def call

--- a/test/components/beta/close_button_test.rb
+++ b/test/components/beta/close_button_test.rb
@@ -44,8 +44,22 @@ class PrimerBetaCloseButtonTest < Minitest::Test
   end
 
   def test_can_override_aria_label
+    # Test with nested hash style `aria-label`
     render_inline(Primer::Beta::CloseButton.new(aria: { label: "Label" }))
+    assert_selector("button[type='button'][aria-label='Label'].close-button")
+
+    # Ensure the default `aria-label` is not in the generated HTML
+    #
+    # Note: Must use `refute_includes` instead of `refute_selector`. If there
+    # are duplicate attributes on a given element, Capybara will ignore the second one.
+    # So if we use `refute_selector` the test will pass even if there is a duplicate
+    # `aria-label` in the generated HTML.
+    refute_includes @rendered_content, 'aria-label="Close"'
+
+    # Test with String style `aria-label`
+    render_inline(Primer::Beta::CloseButton.new("aria-label": "Label"))
 
     assert_selector("button[type='button'][aria-label='Label'].close-button")
+    refute_includes @rendered_content, 'aria-label="Close"'
   end
 end


### PR DESCRIPTION
### Description

The `CloseButton` had an issue where using `aria: { label: "foo" }` would result in multiple `aria-label` attributes in the generated HTML.

This fixes the issue by using the `aria` helper method that will check for nested hash keys or a String aria-label

### Integration

> Does this change require any updates to code in production?

No. This should work as-is

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
