### PR TITLE
Rename URLHelpers to UrlHelpers

### DIFF
--- a/.changeset/kind-ears-approve.md
+++ b/.changeset/kind-ears-approve.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Rename URLHelpers to UrlHelpers to fix console error.

--- a/previews/primer/alpha/auto_complete_preview.rb
+++ b/previews/primer/alpha/auto_complete_preview.rb
@@ -19,7 +19,7 @@ module Primer
             label_text: label_text,
             input_id: "input-id",
             list_id: "test-id",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             is_label_visible: is_label_visible,
             is_label_inline: is_label_inline,
             with_icon: with_icon,
@@ -42,7 +42,7 @@ module Primer
             label_text: label_text,
             input_id: "input-id",
             list_id: "test-id",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             is_label_visible: is_label_visible,
             is_label_inline: is_label_inline,
             with_icon: with_icon,
@@ -62,7 +62,7 @@ module Primer
             label_text: "Select a fruit",
             input_id: "input-id-1",
             list_id: "test-id-1",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             is_label_visible: false
           )
         )
@@ -77,7 +77,7 @@ module Primer
             label_text: "Select a fruit",
             input_id: "input-id-2",
             list_id: "test-id-2",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             is_label_inline: true
           )
         )
@@ -92,7 +92,7 @@ module Primer
             label_text: "Select a fruit",
             input_id: "input-id-3",
             list_id: "test-id-3",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             with_icon: true
           )
         )
@@ -107,7 +107,7 @@ module Primer
             label_text: "Select a fruit",
             input_id: "input-id-4",
             list_id: "test-id-4",
-            src: URLHelpers.autocomplete_index_path(version: "alpha"),
+            src: UrlHelpers.autocomplete_index_path(version: "alpha"),
             is_clearable: true
           )
         )

--- a/previews/primer/alpha/text_field_preview.rb
+++ b/previews/primer/alpha/text_field_preview.rb
@@ -149,12 +149,12 @@ module Primer
       #
       # @label Auto check request ok
       def with_auto_check_ok
-        render(Primer::Alpha::TextField.new(auto_check_src: URLHelpers.example_check_ok_path, name: "my-text-field", label: "My text field"))
+        render(Primer::Alpha::TextField.new(auto_check_src: UrlHelpers.example_check_ok_path, name: "my-text-field", label: "My text field"))
       end
 
       # @label Auto check request error
       def with_auto_check_error
-        render(Primer::Alpha::TextField.new(auto_check_src: URLHelpers.example_check_error_path, name: "my-text-field", label: "My text field"))
+        render(Primer::Alpha::TextField.new(auto_check_src: UrlHelpers.example_check_error_path, name: "my-text-field", label: "My text field"))
       end
       #
       # @!endgroup

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -9,31 +9,31 @@ module Primer
       include ActionView::Helpers::FormTagHelper
 
       def playground
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path))
       end
 
       def default
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path))
       end
 
       def checked
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, checked: true))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, checked: true))
       end
 
       def disabled
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, enabled: false))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, enabled: false))
       end
 
       def checked_disabled
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, checked: true, enabled: false))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, checked: true, enabled: false))
       end
 
       def small
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, size: :small))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, size: :small))
       end
 
       def with_status_label_position_end
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, status_label_position: :end))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, status_label_position: :end))
       end
 
       def with_a_bad_src
@@ -45,11 +45,11 @@ module Primer
       end
 
       def with_csrf_token
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, csrf_token: "let_me_in"))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, csrf_token: "let_me_in"))
       end
 
       def with_bad_csrf_token
-        render(ToggleSwitch.new(src: URLHelpers.toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
+        render(ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
       end
     end
   end

--- a/previews/primer/beta/auto_complete_preview.rb
+++ b/previews/primer/beta/auto_complete_preview.rb
@@ -21,7 +21,7 @@ module Primer
       # @param inset toggle
       # @param monospace toggle
       def playground(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -41,7 +41,7 @@ module Primer
       # @param inset toggle
       # @param monospace toggle
       def default(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id", inset: false, monospace: false)
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name, inset: inset, monospace: monospace)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -87,7 +87,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def leading_visual(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -105,7 +105,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def trailing_action(label_text: "Select a fruit", show_clear_button: true, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @label Full width
@@ -121,7 +121,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def full_width(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: true, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -139,7 +139,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def visually_hide_label(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: true, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -158,7 +158,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def small(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :small, full_width: false, disabled: false, invalid: false, input_id: "input-id-1", list_id: "list-id-1", input_name: "input-id-1")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -175,7 +175,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def medium(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id-2", list_id: "list-id-2", input_name: "input-id-2")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -192,7 +192,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def large(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :large, full_width: false, disabled: false, invalid: false, input_id: "input-id-3", list_id: "list-id-3", input_name: "input-id-3")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path, show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
@@ -212,7 +212,7 @@ module Primer
       # @param list_id text
       # @param input_name text
       def leading_visual_in_results(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path(visual: "leading"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path(visual: "leading"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @label Trailing visual in results
@@ -228,39 +228,39 @@ module Primer
       # @param list_id text
       # @param input_name text
       def trailing_visual_in_results(label_text: "Select a fruit", show_clear_button: false, visually_hide_label: false, placeholder: "Placeholder text", size: :medium, full_width: false, disabled: false, invalid: false, input_id: "input-id", list_id: "list-id", input_name: "input-id")
-        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: URLHelpers.autocomplete_index_path(visual: "trailing"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
+        render(Primer::Beta::AutoComplete.new(label_text: label_text, input_id: input_id, list_id: list_id, src: UrlHelpers.autocomplete_index_path(visual: "trailing"), show_clear_button: show_clear_button, visually_hide_label: visually_hide_label, placeholder: placeholder, size: size, full_width: full_width, disabled: disabled, invalid: invalid, input_name: input_name))
       end
 
       # @hidden
       def with_non_visible_label
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, visually_hide_label: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path, visually_hide_label: true))
       end
 
       # @hidden
       def with_icon
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path)) do |component|
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path)) do |component|
           component.with_leading_visual_icon(icon: :search)
         end
       end
 
       # @hidden
       def show_clear_button
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path, show_clear_button: true))
       end
 
       # @hidden
       def size_small
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, size: :small))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path, show_clear_button: false, size: :small))
       end
 
       # @hidden
       def monospace
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, monospace: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path, show_clear_button: false, monospace: true))
       end
 
       # @hidden
       def inset
-        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: URLHelpers.autocomplete_index_path, show_clear_button: false, inset: true))
+        render(Primer::Beta::AutoComplete.new(label_text: "Select a fruit", input_id: "input-id", list_id: "test-id", src: UrlHelpers.autocomplete_index_path, show_clear_button: false, inset: true))
       end
     end
   end

--- a/previews/primer/url_helpers.rb
+++ b/previews/primer/url_helpers.rb
@@ -2,7 +2,7 @@
 
 module Primer
   # :nodoc:
-  module URLHelpers
+  module UrlHelpers
     class << self
       # use send to avoid yard warning
       send :include, Rails.application.routes.url_helpers


### PR DESCRIPTION
In some environments, we are seeing an error that url_helpers.rb does not define `Primer::UrlHelpers`, I believe due to the capitalization of `URL`. I think it's fine to just name this module as ruby expects unless there are any objections to this style change.