### PR TITLE
Restore old ActionView functionality to unbreak forms

### DIFF
--- a/lib/primer/forms/acts_as_component.rb
+++ b/lib/primer/forms/acts_as_component.rb
@@ -8,12 +8,23 @@ module Primer
     module ActsAsComponent
       # :nodoc:
       module InstanceMethods
-        delegate :render, :content_tag, :output_buffer, :capture, to: :@view_context
+        delegate :render, :content_tag, :output_buffer, to: :@view_context
 
         def render_in(view_context, &block)
           @view_context = view_context
           before_render
           perform_render(&block)
+        end
+
+        # This is necessary to restore the functionality changed by https://github.com/rails/rails/pull/47194.
+        # I would love to remove this at some point, perhaps if we ever decide to replace
+        # ActsAsComponent with view component.
+        def capture(*args, &block)
+          old_buffer = @view_context.output_buffer
+          @view_context.output_buffer = ActionView::OutputBuffer.new
+          @view_context.capture(*args, &block)
+        ensure
+          @view_context.output_buffer = old_buffer
         end
 
         # :nocov:


### PR DESCRIPTION
### Description

A [recent change](https://github.com/rails/rails/pull/47194) to Rails main has broken some of our forms framework code. This PR restores the old functionality for forms only until I can come up with a longer-term fix.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
