### PR TITLE
Adding label styling to the `ActionList::Item` component

### DIFF
--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -156,6 +156,7 @@ module Primer
           active: false,
           on_click: nil,
           id: self.class.generate_id,
+          label_style: nil,
           **system_arguments
         )
           @list = list
@@ -192,7 +193,8 @@ module Primer
               label_classes,
               "ActionListItem-label",
               "ActionListItem-label--truncate" => @truncate_label
-            )
+            ),
+            style: label_style
           }
 
           @content_arguments[:id] = @id

--- a/previews/primer/alpha/action_list_preview.rb
+++ b/previews/primer/alpha/action_list_preview.rb
@@ -362,6 +362,18 @@ module Primer
           component.with_item(label: "Active item", href: "/", active: true)
         end
       end
+
+      # @label Item [label styled]
+      def item_label_styled
+        render(Primer::Alpha::ActionList.new(
+                 aria: { label: "List heading" }
+               )) do |component|
+          component.with_heading(title: "Action List")
+          component.with_item(label: "Styled item", href: "/", label_style: "font-size:20px;font-weight:bold") do |item|
+            item.with_leading_visual_icon(icon: :star)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

This is a relatively small change to the API, which simply adds the styling change for the `ActionList::Item` label. This is sometimes needed when we needed when we need to override some styling on certain elements.

Closes #1811 (if the issue is accepted)

### Integration

> Does this change require any updates to code in production?

No.

### Merge checklist

- [ ] Added/updated tests - I would require some help for this actually
- [x] Added/updated documentation
- [x] Added/updated previews
