### PR TITLE
Refactor the component manifest; rename YARD -> Yard

### DIFF
--- a/lib/primer/yard.rb
+++ b/lib/primer/yard.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Primer
+  module Yard
+    autoload :Backend,              "primer/yard/backend"
+    autoload :ComponentManifest,    "primer/yard/component_manifest"
+    autoload :ComponentRef,         "primer/yard/component_ref"
+    autoload :DocsHelper,           "primer/yard/docs_helper"
+    autoload :LegacyGatsbyBackend,  "primer/yard/legacy_gatsby_backend"
+    autoload :Registry,             "primer/yard/registry"
+    autoload :RendersManyHandler,   "primer/yard/renders_many_handler"
+    autoload :RendersOneHandler,    "primer/yard/renders_one_handler"
+  end
+end

--- a/lib/primer/yard/backend.rb
+++ b/lib/primer/yard/backend.rb
@@ -2,26 +2,12 @@
 
 # :nocov:
 module Primer
-  module YARD
+  module Yard
     # Shared functionality for generating documentation from YARD comments.
     class Backend
       include DocsHelper
 
       private
-
-      def pretty_default_value(tag, component)
-        params = tag.object.parameters.find { |param| [tag.name.to_s, "#{tag.name}:"].include?(param[0]) }
-        default = tag.defaults&.first || params&.second
-
-        return "N/A" unless default
-
-        constant_name = "#{component.name}::#{default}"
-        constant_value = default.safe_constantize || constant_name.safe_constantize
-
-        return pretty_value(default) if constant_value.nil?
-
-        pretty_value(constant_value)
-      end
 
       def view_context
         @view_context ||= begin

--- a/lib/primer/yard/component_manifest.rb
+++ b/lib/primer/yard/component_manifest.rb
@@ -2,7 +2,7 @@
 
 # :nocov:
 module Primer
-  module YARD
+  module Yard
     # The set of documented components (and associated metadata).
     class ComponentManifest
       COMPONENTS = {
@@ -80,39 +80,49 @@ module Primer
         Primer::Alpha::TextField => { form_component: true }
       }.freeze
 
+      include Enumerable
+
+      def initialize(components)
+        @components = components
+      end
+
+      def each
+        return to_enum(__method__) unless block_given?
+
+        @components.each do |klass|
+          yield self.class.ref_for(klass)
+        end
+      end
+
+      def where(**attrs)
+        self.class.where(@components, **attrs)
+      end
+
       class << self
-        def each(&block)
-          COMPONENTS.keys.each(&block)
+        def where(components = COMPONENTS, **desired_attrs)
+          new(
+            components.each_with_object([]) do |(klass, component_attrs), memo|
+              matches = desired_attrs.all? do |name, desired_value|
+                component_attrs.fetch(name, ComponentRef::ATTR_DEFAULTS[name]) == desired_value
+              end
+
+              memo << klass if matches
+            end
+          )
         end
 
-        def components_with_docs
-          @components_with_docs ||= COMPONENTS.keys
+        def all
+          new(COMPONENTS.keys)
         end
 
-        def all_components
-          @all_components ||= Primer::Component.descendants - [Primer::BaseComponent]
+        def ref_for(klass)
+          ref_cache[klass] ||= ComponentRef.new(klass, COMPONENTS[klass])
         end
 
-        def components_without_docs
-          @components_without_docs ||= all_components - components_with_docs
-        end
+        private
 
-        def components_with_examples
-          @components_with_examples ||= COMPONENTS.keys.select do |c|
-            COMPONENTS[c].fetch(:examples, true)
-          end
-        end
-
-        def components_requiring_js
-          @components_requiring_js ||= COMPONENTS.keys.select do |c|
-            COMPONENTS[c].fetch(:js, false)
-          end
-        end
-
-        def form_components
-          @form_components ||= COMPONENTS.keys.select do |c|
-            COMPONENTS[c].fetch(:form_component, false)
-          end
+        def ref_cache
+          @ref_cache ||= {}
         end
       end
     end

--- a/lib/primer/yard/component_ref.rb
+++ b/lib/primer/yard/component_ref.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# :nocov:
+module Primer
+  module Yard
+    # :nodoc:
+    class ComponentRef
+      ATTR_DEFAULTS = {
+        js: false,
+        examples: true,
+        published: true,
+        form_component: false
+      }.freeze
+
+      attr_reader :klass, :attrs
+
+      def initialize(klass, attrs)
+        @klass = klass
+        @attrs = attrs
+      end
+
+      def requires_js?
+        @attrs.fetch(:js, ATTR_DEFAULTS[:js])
+      end
+
+      def should_have_examples?
+        @attrs.fetch(:examples, ATTR_DEFAULTS[:examples])
+      end
+
+      def published?
+        @attrs.fetch(:published, ATTR_DEFAULTS[:published])
+      end
+
+      def form_component?
+        @attrs.fetch(:form_component, ATTR_DEFAULTS[:form_component])
+      end
+    end
+  end
+end
+# :nocov:

--- a/lib/primer/yard/docs_helper.rb
+++ b/lib/primer/yard/docs_helper.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 # :nocov:
-
 module Primer
-  module YARD
+  module Yard
     # Helper methods to use for yard documentation
     module DocsHelper
       def one_of(enumerable, lower: false, sort: true)
@@ -66,6 +65,20 @@ module Primer
         [m[:status]&.downcase, m[:name].gsub("::", ""), m[:name]]
       end
 
+      def pretty_default_value(tag, component)
+        params = tag.object.parameters.find { |param| [tag.name.to_s, "#{tag.name}:"].include?(param[0]) }
+        default = tag.defaults&.first || params&.second
+
+        return "N/A" unless default
+
+        constant_name = "#{component.name}::#{default}"
+        constant_value = default.safe_constantize || constant_name.safe_constantize
+
+        return pretty_value(default) if constant_value.nil?
+
+        pretty_value(constant_value)
+      end
+
       def pretty_value(val)
         case val
         when nil
@@ -79,3 +92,4 @@ module Primer
     end
   end
 end
+# :nocov:

--- a/lib/primer/yard/registry.rb
+++ b/lib/primer/yard/registry.rb
@@ -2,12 +2,10 @@
 
 # :nocov:
 
-require "primer/view_components"
-require "primer/yard/docs_helper"
 require "view_component/test_helpers"
 
 module Primer
-  module YARD
+  module Yard
     # A wrapper around a YARD class reference that provides convenience methods
     # for extracting component parameters, accessibility status, etc.
     class RegistryEntry
@@ -62,8 +60,9 @@ module Primer
       def public_methods
         # Returns: only public methods that belong to this class (i.e. no inherited methods)
         # excluding the constructor
-        @public_methods ||=
-          docs.meths.reject { |mtd| mtd.tag(:private) || mtd.name == :initialize }
+        @public_methods ||= docs.meths.reject do |mtd|
+          mtd.tag(:private) || mtd.name == :initialize
+        end
       end
 
       def title
@@ -89,20 +88,6 @@ module Primer
       def a11y_reviewed?
         metadata[:a11y_reviewed]
       end
-
-      def requires_js?
-        manifest.components_requiring_js.include?(component)
-      end
-
-      def includes_examples?
-        manifest.components_with_examples.include?(component)
-      end
-
-      private
-
-      def manifest
-        Primer::YARD::ComponentManifest
-      end
     end
 
     # Wrapper around an instance of YARD::Registry that provides easy access to component
@@ -111,11 +96,11 @@ module Primer
       class << self
         include ViewComponent::TestHelpers
         include Primer::ViewHelper
-        include Primer::YARD::DocsHelper
+        include Primer::Yard::DocsHelper
 
         def make
           registry = ::YARD::RegistryStore.new
-          registry.load!(".yardoc")
+          registry.load!(File.expand_path(File.join("..", "..", "..", ".yardoc"), __dir__))
 
           new(registry)
         end

--- a/lib/primer/yard/renders_many_handler.rb
+++ b/lib/primer/yard/renders_many_handler.rb
@@ -2,7 +2,7 @@
 
 # :nocov:
 module Primer
-  module YARD
+  module Yard
     # YARD Handler to parse `renders_many` calls.
     class RendersManyHandler < ::YARD::Handlers::Ruby::Base
       handles method_call(:renders_many)

--- a/lib/primer/yard/renders_one_handler.rb
+++ b/lib/primer/yard/renders_one_handler.rb
@@ -2,7 +2,7 @@
 
 # :nocov:
 module Primer
-  module YARD
+  module Yard
     # YARD Handler to parse `renders_one` calls.
     class RendersOneHandler < ::YARD::Handlers::Ruby::Base
       handles method_call(:renders_one)

--- a/test/lib/yard/docs_helper_test.rb
+++ b/test/lib/yard/docs_helper_test.rb
@@ -3,7 +3,7 @@
 require "lib/test_helper"
 
 class YardDocsHelperTest < Minitest::Test
-  include Primer::YARD::DocsHelper
+  include Primer::Yard::DocsHelper
 
   def test_sorts_one_of
     assert_equal "One of `one` or `two`.", one_of(%w[one two])


### PR DESCRIPTION
### Description

This PR accomplishes the following:

1. Sets up autoloading for the `YARD`/`Yard` namespace.
2. Renames the `YARD` namespace to `Yard` to make Zeitwerk happy.
3. Refactors `Primer::Yard::ComponentManifest` to have a query-like interface, so `ComponentManifest.components_requiring_js` becomes `ComponentManifest.where(js: true)`. The new interface also returns instances of `ComponentManifest` instead of arrays of component classes, so stuff like this is now possible: `ComponentManifest.where(js: true).each { |ref| ref.published? }` etc etc.
4. Changes `Backend` classes to accept component manifests so the set of components can be customized outside the backend's context (i.e. like we're doing in docs.rake).

### Integration

> Does this change require any updates to code in production?

Nope!

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
