### PR TITLE
Fix issue in TabPanels causing extra content to render twice

### DIFF
--- a/.changeset/flat-cups-press.md
+++ b/.changeset/flat-cups-press.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix issue in TabPanels causing extra content to render twice

--- a/app/components/primer/alpha/tab_panels.rb
+++ b/app/components/primer/alpha/tab_panels.rb
@@ -77,6 +77,13 @@ module Primer
         @body_arguments[:role] = :tablist
         @body_arguments[:"aria-label"] = label
       end
+
+      def before_render
+        # Eagerly evaluate content to avoid https://github.com/primer/view_components/issues/1790
+        content
+
+        super
+      end
     end
   end
 end

--- a/test/components/alpha/tab_panels_test.rb
+++ b/test/components/alpha/tab_panels_test.rb
@@ -87,6 +87,7 @@ class PrimerAlphaTabPanelsTest < Minitest::Test
   end
 
   def test_does_not_double_render_extra_content_in_production
+    # rubocop:disable Rails/Inquiry
     Rails.stub(:env, "production".inquiry) do
       # Since we've forced ourselves into the prod environment and there's no secret key base
       # configured for prod, we have to fake it by setting the appropriate environment variable.
@@ -100,6 +101,7 @@ class PrimerAlphaTabPanelsTest < Minitest::Test
         end
       end
     end
+    # rubocop:enable Rails/Inquiry
 
     assert_text("extra", count: 1)
   end

--- a/test/components/alpha/tab_panels_test.rb
+++ b/test/components/alpha/tab_panels_test.rb
@@ -85,4 +85,22 @@ class PrimerAlphaTabPanelsTest < Minitest::Test
       assert_text("extra")
     end
   end
+
+  def test_does_not_double_render_extra_content_in_production
+    Rails.stub(:env, "production".inquiry) do
+      # Since we've forced ourselves into the prod environment and there's no secret key base
+      # configured for prod, we have to fake it by setting the appropriate environment variable.
+      with_env("SECRET_KEY_BASE" => "abc123") do
+        render_inline(Primer::Alpha::TabPanels.new(label: "label")) do |component|
+          component.with_tab(selected: true, id: "tab-1") do |tab|
+            tab.with_panel { "Panel 1" }
+            tab.with_text { "Tab 1" }
+          end
+          component.with_extra(align: :right) { "extra" }
+        end
+      end
+    end
+
+    assert_text("extra", count: 1)
+  end
 end

--- a/test/test_helpers/component_test_helpers.rb
+++ b/test/test_helpers/component_test_helpers.rb
@@ -48,6 +48,14 @@ module Primer
       Primer::Classify::Utilities.validate_class_names = old_value
     end
 
+    def with_env(env)
+      old_env = ENV.to_hash
+      ENV.replace(old_env.merge(env))
+      yield
+    ensure
+      ENV.replace(old_env)
+    end
+
     def assert_component_state(component, state)
       assert_equal component.status, Primer::Component::STATUSES[state]
     end


### PR DESCRIPTION
### Description

The `TabPanels` component appears to double-render the `extra` slot in certain scenarios. It happens only when:

1. The `extra` slot setter is called with `align: :right`, eg:

    ```ruby
    render(Primer::Alpha::TabPanels.new) do |component|
      component.with_extra(align: :right) { "Foo" }
    end
    ```
1. In production environments.

In development, the `validate_single_selected_tab` method  calls the `tabs` slot getter, which causes view_component to eagerly evaluate `TabPanel`'s content. Doing so calls the `extra` slot setter _before_ the component is rendered, which correctly sets the `@align` instance variable to `:right`.

In production, `TabPanel`'s content is not eagerly evaluated, and the `extra` slot setter is called _during_ render instead. Since `@align` is set to `:left` in the constructor, `<%= extra if @align == :left %>` emits the `extra` content. Eventually the `extra` slot setter is called, which sets `@align` to `:right` and causes `<%= extra if @align == :right %>` to emit the `extra` content a second time.

This PR eagerly evaluates slots by calling `content` in `before_render`.

Fixes #1790 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
~- [ ] Added/updated previews~
