### PR TITLE
Fixing a missed slot migration

### DIFF
--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -101,7 +101,7 @@ module Primer
       #       <% d.with_body do %>
       #         <p>Some content</p>
       #       <% end %>
-      #       <% d.footer do %>
+      #       <% d.with_footer do %>
       #         <%= render(Primer::ButtonComponent.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
       #         <%= render(Primer::ButtonComponent.new(scheme: :primary)) { "Submit" } %>
       #       <% end %>


### PR DESCRIPTION
### Description

Pointed out by @AndrewRPorter in [slack](https://github.slack.com/archives/CGJTTJ738/p1675893239867829), the example isn't rendering the footer. This is because we missed this in the migration.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
