### PR TITLE
Change hook in engine to hook ActionController::Base only for form helpers

### DIFF
--- a/.changeset/blue-zoos-design.md
+++ b/.changeset/blue-zoos-design.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Changes lifecycle event to trigger from :action_controller_base children instead of :action_controller

--- a/lib/primer/view_components/engine.rb
+++ b/lib/primer/view_components/engine.rb
@@ -43,7 +43,7 @@ module Primer
       end
 
       initializer "primer.forms.helpers" do
-        ActiveSupport.on_load :action_controller do
+        ActiveSupport.on_load :action_controller_base do
           require "primer/form_helper"
           helper Primer::FormHelper
 


### PR DESCRIPTION
### Description

Triggers lifecycle event for :action_controller_base children instead of :action_controller. Since :action_controller includes both API and Base children primer mixins would fail for ActionController::API children since they lacked the helper method.

### Integration

> Does this change require any updates to code in production?
Yes
