### PR TITLE
Fix regression causing check boxes to always render enabled

### DIFF
--- a/.changeset/two-clocks-share.md
+++ b/.changeset/two-clocks-share.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix regression causing check boxes to always render enabled

--- a/lib/primer/forms/dsl/check_box_group_input.rb
+++ b/lib/primer/forms/dsl/check_box_group_input.rb
@@ -32,11 +32,11 @@ module Primer
         def check_box(**system_arguments, &block)
           args = {
             name: @name,
-            **system_arguments,
             builder: @builder,
             form: @form,
             scheme: scheme,
-            disabled: disabled?
+            disabled: disabled?,
+            **system_arguments
           }
 
           @check_boxes << CheckBoxInput.new(**args, &block)

--- a/test/lib/primer/forms/checkbox_group_input_test.rb
+++ b/test/lib/primer/forms/checkbox_group_input_test.rb
@@ -23,4 +23,40 @@ class Primer::Forms::CheckboxGroupInputTest < Minitest::Test
     assert_selector "fieldset", visible: :hidden
     assert_selector ".FormControl-checkbox-wrap", visible: :hidden
   end
+
+  class DisabledCheckboxGroupForm < ApplicationForm
+    form do |check_form|
+      check_form.check_box_group(label: "Foobar", disabled: true) do |check_group|
+        check_group.check_box(name: :foo, label: "Foo")
+      end
+    end
+  end
+
+  def test_disabled_checkbox_group_disables_constituent_checkboxes
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(DisabledCheckboxGroupForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl-checkbox-wrap input[disabled]"
+  end
+
+  class DisabledCheckboxInGroupForm < ApplicationForm
+    form do |check_form|
+      check_form.check_box_group(label: "Foobar") do |check_group|
+        check_group.check_box(name: :foo, label: "Foo", disabled: true)
+      end
+    end
+  end
+
+  def test_checkbox_can_be_individually_disabled_in_group
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(DisabledCheckboxInGroupForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl-checkbox-wrap input[disabled]"
+  end
 end

--- a/test/lib/primer/forms/radio_button_group_input_test.rb
+++ b/test/lib/primer/forms/radio_button_group_input_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::RadioButtonGroupInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  class HiddenRadioGroupForm < ApplicationForm
+    form do |radio_form|
+      radio_form.radio_button_group(name: :foobar, label: "Foobar", hidden: true) do |radio_group|
+        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
+      end
+    end
+  end
+
+  def test_hidden_radio_button_group
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(HiddenRadioGroupForm.new(f))
+      end
+    end
+
+    assert_selector "fieldset", visible: :hidden
+    assert_selector ".FormControl-radio-wrap", visible: :hidden
+  end
+
+  class DisabledRadioGroupForm < ApplicationForm
+    form do |radio_form|
+      radio_form.radio_button_group(name: :foobar, label: "Foobar", disabled: true) do |radio_group|
+        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
+      end
+    end
+  end
+
+  def test_disabled_radio_group_disables_constituent_radios
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(DisabledRadioGroupForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl-radio-wrap input[disabled]"
+  end
+
+  class DisabledRadioInGroupForm < ApplicationForm
+    form do |radio_form|
+      radio_form.radio_button_group(name: :foobar, label: "Foobar") do |radio_group|
+        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo", disabled: true)
+      end
+    end
+  end
+
+  def test_radio_can_be_individually_disabled_in_group
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render(DisabledRadioInGroupForm.new(f))
+      end
+    end
+
+    assert_selector ".FormControl-radio-wrap input[disabled]"
+  end
+end


### PR DESCRIPTION
### Description

In https://github.com/primer/view_components/pull/1821 I accidentally made it so check boxes rendered as part of a group can't be disabled. This PR fixes the issue.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
