### PR TITLE
Fix condition for including polymorphic slots module

### DIFF
--- a/.changeset/shaggy-apes-listen.md
+++ b/.changeset/shaggy-apes-listen.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix conditional inclusion of polymorphic slots module

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -12,7 +12,7 @@ module Primer
     end
 
     if Module.const_defined?("ViewComponent::PolymorphicSlots") &&
-       ViewComponent::Base < ViewComponent::PolymorphicSlots
+       !(ViewComponent::Base < ViewComponent::PolymorphicSlots)
       include ViewComponent::PolymorphicSlots
     end
 


### PR DESCRIPTION
### Description

A [recent change](https://github.com/primer/view_components/pull/1832) intended to only include `ViewComponent::PolymorphicSlots` if a) the module exists, and b) isn't already included. The second condition mistakenly checks if the module _is_ included instead, which is what this PR fixes.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
