### PR TITLE
Fix issue causing NavList parents to be selected

### DIFF
--- a/.changeset/rare-ghosts-train.md
+++ b/.changeset/rare-ghosts-train.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix issue causing NavList parents to appear selected

--- a/app/components/primer/alpha/nav_list.rb
+++ b/app/components/primer/alpha/nav_list.rb
@@ -67,7 +67,7 @@ module Primer
       #   <%= render(Primer::Alpha::NavList.new(selected_item_id: :email_notifications)) do |component| %>
       #     <% component.with_section(aria: { label: "Account settings" }) do |section| %>
       #       <% section.with_heading(title: "Account Settings") %>
-      #       <% section.with_item(label: "Notification settings", selected_by_ids: :notifications) do |item| %>
+      #       <% section.with_item(label: "Notification settings") do |item| %>
       #         <% item.with_leading_visual_icon(icon: :bell) %>
       #         <% item.with_item(label: "Email", selected_by_ids: :email_notifications, href: "/account/notifications/email") do |subitem| %>
       #           <% subitem.with_trailing_visual_icon(icon: :mail) %>
@@ -76,7 +76,7 @@ module Primer
       #           <% subitem.with_trailing_visual_icon(icon: :"device-mobile") %>
       #         <% end %>
       #       <% end %>
-      #       <% section.with_item(label: "Messages", selected_by_ids: :messages) do |item| %>
+      #       <% section.with_item(label: "Messages") do |item| %>
       #         <% item.with_leading_visual_icon(icon: :bookmark) %>
       #         <% item.with_item(label: "Inbox", href: "/account/messages/inbox") do |subitem| %>
       #           <% subitem.with_trailing_visual_counter(count: 10) %>

--- a/app/components/primer/alpha/nav_list.ts
+++ b/app/components/primer/alpha/nav_list.ts
@@ -162,6 +162,10 @@ export class NavListElement extends HTMLElement {
   #findSelectedNavItemById(itemId: string): HTMLElement | null {
     // First we compare the selected link to data-item-id for each nav item
     for (const navItem of this.items) {
+      if (navItem.classList.contains('ActionListItem--hasSubItem')) {
+        continue
+      }
+
       const keys = navItem.getAttribute('data-item-id')?.split(' ') || []
 
       if (keys.includes(itemId)) {

--- a/app/components/primer/alpha/nav_list/item.rb
+++ b/app/components/primer/alpha/nav_list/item.rb
@@ -101,6 +101,9 @@ module Primer
         # the parent and bypass the problem entirely. Maybe not the most OO approach,
         # but it works.
         def item_active?(item)
+          # parent items cannot be active
+          return false if item.items.any?
+
           if item.selected_by_ids.present?
             item.selected_by_ids.include?(@selected_item_id)
           elsif item.href

--- a/app/components/primer/alpha/nav_list/item.rb
+++ b/app/components/primer/alpha/nav_list/item.rb
@@ -53,7 +53,7 @@ module Primer
         end
 
         def active?
-          item_active?(self)
+          item_active?(self) && items.empty?
         end
 
         # Cause this item to show its list of sub items when rendered.
@@ -74,6 +74,8 @@ module Primer
           super
 
           raise "Cannot render a trailing action for an item with subitems" if items.present? && trailing_action.present?
+
+          raise "Cannot pass `selected_by_ids:` for an item with subitems, since parent items cannot be selected" if items.present? && @selected_by_ids.present?
 
           return if items.blank?
 
@@ -101,9 +103,6 @@ module Primer
         # the parent and bypass the problem entirely. Maybe not the most OO approach,
         # but it works.
         def item_active?(item)
-          # parent items cannot be active
-          return false if item.items.any?
-
           if item.selected_by_ids.present?
             item.selected_by_ids.include?(@selected_item_id)
           elsif item.href

--- a/test/components/alpha/nav_list_test.rb
+++ b/test/components/alpha/nav_list_test.rb
@@ -128,6 +128,20 @@ module Primer
 
         assert_equal "Cannot render a trailing action for an item with subitems", error.message
       end
+
+      def test_errors_when_passing_selected_by_ids_to_parent
+        error = assert_raises(RuntimeError) do
+          render_inline(Primer::Alpha::NavList.new) do |component|
+            component.with_section(aria: { label: "List" }) do |section|
+              section.with_item(label: "Level 1", href: "/level1", selected_by_ids: :foo) do |item|
+                item.with_item(label: "Level 2", href: "/level2")
+              end
+            end
+          end
+        end
+
+        assert_equal "Cannot pass `selected_by_ids:` for an item with subitems, since parent items cannot be selected", error.message
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

I recently landed [a change](https://github.com/primer/view_components/pull/1822) that added a JavaScript API to `NavList` for selecting items by their ID or href. Unfortunately I ran into an issue integrating it with dotcom:

<img width="338" alt="A NavList section showing an active parent item. The entire item, including sub items, appears to be selected, which is nonsensical." src="https://user-images.githubusercontent.com/575280/220776718-2c395129-893c-4d02-9cf9-63a335a9ab28.png">

It turns out dotcom mistakenly passes `selected_by_ids:` to some parent items. The new JavaScript API searches through each item element trying to find the one with the right ID. It will select the first one it finds, which in the example above means the parent item. While parent items are themselves items, they are not selectable. The solution was to make sure to never select a parent item, and to raise an error if parent items are passed the `selected_by_ids` argument.

### Integration

> Does this change require any updates to code in production?

Yes. `selected_by_ids` will need to be removed from any call to `NavList::Section#with_item`. Fortunately there should only be a few places we're doing this.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
