### PR TITLE
Remove extra space between flash icon and message

### DIFF
--- a/.changeset/eighty-cars-guess.md
+++ b/.changeset/eighty-cars-guess.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove extra space between flash icon and message

--- a/app/components/primer/beta/flash.html.erb
+++ b/app/components/primer/beta/flash.html.erb
@@ -1,6 +1,5 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <%= primer_octicon @icon if @icon %>
-  <%= content %>
+  <%= primer_octicon @icon if @icon %><%= content %>
   <% if @dismissible %>
     <button class="flash-close js-flash-close" type="button" aria-label="Close">
       <%= primer_octicon "x" %>


### PR DESCRIPTION
### Description

Flash banners have an extra space between the icon and message text, probably because of HTML's very confusing whitespace collapsing rules.

<img width="329" alt="image" src="https://user-images.githubusercontent.com/575280/220791846-05c59485-55f6-4113-9f99-14898e7a136c.png">

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
