### PR TITLE
Use system arguments instead of utility classes for NavList's "show more" item

### DIFF
--- a/.changeset/tasty-rules-end.md
+++ b/.changeset/tasty-rules-end.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use system arguments instead of utility classes for NavList's "show more" item

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,9 @@ Naming/MethodParameterName:
 Rails/RefuteMethods:
   Enabled: false
 
+Rails/FilePath:
+  EnforcedStyle: arguments
+
 Style/MultipleComparison:
   Enabled: true
   Exclude:

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -128,6 +128,7 @@ module Primer
         # @param parent [Primer::Alpha::ActionList::Item] This item's parent item. `nil` if this item is at the root. Used internally.
         # @param label [String] Item label.
         # @param label_classes [String] CSS classes that will be added to the label.
+        # @param label_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the label.
         # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or button tag.
         # @param truncate_label [Boolean] Truncate label with ellipsis.
         # @param href [String] Link URL.
@@ -144,6 +145,7 @@ module Primer
           list:,
           label:,
           label_classes: nil,
+          label_arguments: {},
           content_arguments: {},
           parent: nil,
           truncate_label: false,
@@ -191,8 +193,10 @@ module Primer
           @system_arguments[:data][:targets] = "#{list_class.custom_element_name}.items"
 
           @label_arguments = {
+            **label_arguments,
             classes: class_names(
               label_classes,
+              label_arguments[:classes],
               "ActionListItem-label",
               "ActionListItem-label--truncate" => @truncate_label
             )

--- a/app/components/primer/alpha/nav_list/section.rb
+++ b/app/components/primer/alpha/nav_list/section.rb
@@ -28,10 +28,10 @@ module Primer
           system_arguments[:data][:action] = "click:nav-list#showMore"
           system_arguments[:data][:"current-page"] = "1"
           system_arguments[:data][:"total-pages"] = pages.to_s
-          system_arguments[:label_classes] = class_names(
-            system_arguments[:label_classes],
-            "color-fg-accent"
-          )
+          system_arguments[:label_arguments] = {
+            **system_arguments[:label_arguments] || {},
+            color: :accent
+          }
 
           component_klass.new(list: self, src: src, **system_arguments)
         }

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
   config.primer_view_components.silence_deprecations = true
-  config.primer_view_components.raise_on_invalid_options = false
+  config.primer_view_components.raise_on_invalid_options = true
 
   config.autoload_paths << Rails.root.join("..", "test", "forms")
   config.view_component.preview_paths << Rails.root.join("..", "test", "previews")

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -422,7 +422,9 @@ class PrimerClassifyTest < Minitest::Test
   end
 
   def test_does_not_raise_error_when_passing_in_a_primer_css_class_otherwise
-    assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
+    with_raise_on_invalid_options(false) do
+      assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
+    end
   end
 
   def test_does_include_leading_trailing_whitespace_in_class


### PR DESCRIPTION
### Description

`NavList` features a special "show more" item for lazy loading additional list items. Unfortunately it uses a Primer utility class instead of the corresponding system argument, and is causing an error in dotcom's Lookbook.

This would have been caught by our test suite except that we have `raise_on_invalid_options` set to `false` in the test environment 🤦 

Closes #1843.

### Integration

> Does this change require any updates to code in production?

No. Should be backwards-compatible.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
~- [ ] Added/updated previews~
