### PR TITLE
remove animation from overlay

### DIFF
--- a/.changeset/sixty-seas-applaud.md
+++ b/.changeset/sixty-seas-applaud.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove animation from Overlay component

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -165,7 +165,6 @@ module Primer
         @system_arguments[:classes] = class_names(
           "Overlay",
           SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)],
-          "Overlay--motion-scaleFade",
           system_arguments[:classes]
         )
         @system_arguments[:tag] = "anchored-position"


### PR DESCRIPTION
### Description

@langermank and I were debugging as to why Overlay seems to only work properly on my devices... when we figured out that I have `prefers-reduced-motion` set!

In `anchored-position`, the following steps happen:

- `IntersectionObserver` is registered.
- When the user clicks the button, the element is visible.
- `IntersectionObserver` triggers `anchored-position#update()`.
  - If the user has `prefers-reduced-motion` then no animation plays
  - If the user does not have `prefers-reduced-motion` then:
    - The `scaleFade` animation kicks in. It starts at `scale(0.5)` which changes the `BoundingClientRect` of `anchored-position` to be half the size.
    - The animation grows the container to `scale(1)`
    - The animation finishes
- A user with animations enabled observes that the position is "off" (by exactly half the width of the container element)

There are several not-ideal solutions to all of this:

 - `anchored-position` can listen for `animationend` and call `update()`. This will have a "popping" effect as when the animation ends the element will reflow into position
 - The CSS for `scaleFade` can add padding/margin to accommodate for the change in scale, keeping a consistent `BoundingClientRect`. This will be very difficult to achieve in CSS alone.
 - The JS can detect if an animation is occurring via `getAnimations()` and if it is occuring, then call `update()` on each animationframe until the animation has completed. This can be very computationally expensive and may slow down animations as each frame the position will need to be recalculated
 - We remove all animations and ship that (that's this PR!)
 - We change to an animation style that does not change the `BoundingClientRect` - such as a fade-in animation.
