### PR TITLE
Fix beta button tooltip compatibility with display :block

### DIFF
--- a/.changeset/red-crews-worry.md
+++ b/.changeset/red-crews-worry.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix beta button tooltip compatibility with display :block

--- a/app/components/primer/beta/button.html.erb
+++ b/app/components/primer/beta/button.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::ConditionalWrapper.new(condition: tooltip.present?, tag: :div, classes: "Button-withTooltip") do -%>
+<%= render Primer::ConditionalWrapper.new(condition: tooltip.present?, tag: :div, display: (:block if @block), classes: "Button-withTooltip") do -%>
   <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
     <span class="<%= @align_content_classes %>">
       <% if leading_visual %>

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -144,6 +144,7 @@ module Primer
         **system_arguments
       )
         @scheme = scheme
+        @block = block
 
         @system_arguments = system_arguments
 
@@ -162,7 +163,7 @@ module Primer
           SCHEME_MAPPINGS[fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)],
           SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)],
           "Button",
-          "Button--fullWidth" => block
+          "Button--fullWidth" => @block
         )
       end
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "demo",
       "version": "0.1.0",
       "dependencies": {
         "@primer/css": "^20.8.2",
@@ -566,8 +567,6 @@
       "version": "8.11.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -582,9 +581,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -3552,13 +3549,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -3569,9 +3567,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -15,108 +15,108 @@
     url: "/status"
 - title: Components
   children:
-    - title: AutoComplete
-      url: '/components/beta/autocomplete'
-    - title: AutoCompleteItem
-      url: '/components/beta/autocompleteitem'
-    - title: Avatar
-      url: '/components/beta/avatar'
-    - title: AvatarStack
-      url: '/components/beta/avatarstack'
-    - title: Banner
-      url: '/components/alpha/banner'
-    - title: Blankslate
-      url: '/components/beta/blankslate'
-    - title: BorderBox
-      url: '/components/beta/borderbox'
-    - title: Box
-      url: '/components/box'
-    - title: Breadcrumbs
-      url: '/components/beta/breadcrumbs'
-    - title: Button
-      url: '/components/beta/button'
-    - title: ButtonGroup
-      url: '/components/beta/buttongroup'
-    - title: ButtonMarketing
-      url: '/components/alpha/buttonmarketing'
-    - title: ClipboardCopy
-      url: '/components/beta/clipboardcopy'
-    - title: CloseButton
-      url: '/components/beta/closebutton'
-    - title: Counter
-      url: '/components/beta/counter'
-    - title: Details
-      url: '/components/beta/details'
-    - title: Dialog
-      url: '/components/alpha/dialog'
-    - title: Dropdown
-      url: '/components/alpha/dropdown'
-    - title: Flash
-      url: '/components/beta/flash'
-    - title: Heading
-      url: '/components/beta/heading'
-    - title: HiddenTextExpander
-      url: '/components/alpha/hiddentextexpander'
-    - title: IconButton
-      url: '/components/beta/iconbutton'
-    - title: Image
-      url: '/components/alpha/image'
-    - title: ImageCrop
-      url: '/components/alpha/imagecrop'
-    - title: Label
-      url: '/components/beta/label'
-    - title: Layout
-      url: '/components/alpha/layout'
-    - title: Link
-      url: '/components/beta/link'
-    - title: Markdown
-      url: '/components/beta/markdown'
-    - title: Menu
-      url: '/components/alpha/menu'
-    - title: NavList
-      url: '/components/alpha/navlist'
-    - title: Octicon
-      url: '/components/beta/octicon'
-    - title: OcticonSymbols
-      url: '/components/alpha/octiconsymbols'
-    - title: Overlay
-      url: '/components/alpha/overlay'
-    - title: Popover
-      url: '/components/beta/popover'
-    - title: ProgressBar
-      url: '/components/beta/progressbar'
-    - title: RelativeTime
-      url: '/components/beta/relativetime'
-    - title: SegmentedControl
-      url: '/components/alpha/segmentedcontrol'
-    - title: Spinner
-      url: '/components/beta/spinner'
-    - title: State
-      url: '/components/beta/state'
-    - title: Subhead
-      url: '/components/beta/subhead'
-    - title: TabContainer
-      url: '/components/alpha/tabcontainer'
-    - title: TabNav
-      url: '/components/alpha/tabnav'
-    - title: TabPanels
-      url: '/components/alpha/tabpanels'
-    - title: Text
-      url: '/components/beta/text'
-    - title: TextField
-      url: '/components/alpha/textfield'
-    - title: TimelineItem
-      url: '/components/beta/timelineitem'
-    - title: ToggleSwitch
-      url: '/components/alpha/toggleswitch'
-    - title: Tooltip
-      url: '/components/alpha/tooltip'
-    - title: Truncate
-      url: '/components/beta/truncate'
-    - title: UnderlineNav
-      url: '/components/alpha/underlinenav'
-    - title: UnderlinePanels
-      url: '/components/alpha/underlinepanels'
+  - title: AutoComplete
+    url: "/components/beta/autocomplete"
+  - title: AutoCompleteItem
+    url: "/components/beta/autocompleteitem"
+  - title: Avatar
+    url: "/components/beta/avatar"
+  - title: AvatarStack
+    url: "/components/beta/avatarstack"
+  - title: Banner
+    url: "/components/alpha/banner"
+  - title: Blankslate
+    url: "/components/beta/blankslate"
+  - title: BorderBox
+    url: "/components/beta/borderbox"
+  - title: Box
+    url: "/components/box"
+  - title: Breadcrumbs
+    url: "/components/beta/breadcrumbs"
+  - title: Button
+    url: "/components/beta/button"
+  - title: ButtonGroup
+    url: "/components/beta/buttongroup"
+  - title: ButtonMarketing
+    url: "/components/alpha/buttonmarketing"
+  - title: ClipboardCopy
+    url: "/components/beta/clipboardcopy"
+  - title: CloseButton
+    url: "/components/beta/closebutton"
+  - title: Counter
+    url: "/components/beta/counter"
+  - title: Details
+    url: "/components/beta/details"
+  - title: Dialog
+    url: "/components/alpha/dialog"
+  - title: Dropdown
+    url: "/components/alpha/dropdown"
+  - title: Flash
+    url: "/components/beta/flash"
+  - title: Heading
+    url: "/components/beta/heading"
+  - title: HiddenTextExpander
+    url: "/components/alpha/hiddentextexpander"
+  - title: IconButton
+    url: "/components/beta/iconbutton"
+  - title: Image
+    url: "/components/alpha/image"
+  - title: ImageCrop
+    url: "/components/alpha/imagecrop"
+  - title: Label
+    url: "/components/beta/label"
+  - title: Layout
+    url: "/components/alpha/layout"
+  - title: Link
+    url: "/components/beta/link"
+  - title: Markdown
+    url: "/components/beta/markdown"
+  - title: Menu
+    url: "/components/alpha/menu"
+  - title: NavList
+    url: "/components/alpha/navlist"
+  - title: Octicon
+    url: "/components/beta/octicon"
+  - title: OcticonSymbols
+    url: "/components/alpha/octiconsymbols"
+  - title: Overlay
+    url: "/components/alpha/overlay"
+  - title: Popover
+    url: "/components/beta/popover"
+  - title: ProgressBar
+    url: "/components/beta/progressbar"
+  - title: RelativeTime
+    url: "/components/beta/relativetime"
+  - title: SegmentedControl
+    url: "/components/alpha/segmentedcontrol"
+  - title: Spinner
+    url: "/components/beta/spinner"
+  - title: State
+    url: "/components/beta/state"
+  - title: Subhead
+    url: "/components/beta/subhead"
+  - title: TabContainer
+    url: "/components/alpha/tabcontainer"
+  - title: TabNav
+    url: "/components/alpha/tabnav"
+  - title: TabPanels
+    url: "/components/alpha/tabpanels"
+  - title: Text
+    url: "/components/beta/text"
+  - title: TextField
+    url: "/components/alpha/textfield"
+  - title: TimelineItem
+    url: "/components/beta/timelineitem"
+  - title: ToggleSwitch
+    url: "/components/alpha/toggleswitch"
+  - title: Tooltip
+    url: "/components/alpha/tooltip"
+  - title: Truncate
+    url: "/components/beta/truncate"
+  - title: UnderlineNav
+    url: "/components/alpha/underlinenav"
+  - title: UnderlinePanels
+    url: "/components/alpha/underlinepanels"
 - title: Deprecated Components
   children:
   - title: BlankslateComponent


### PR DESCRIPTION
### Description

Addresses a bug in which a beta Button with a tooltip does not fully respect the block parameter. This was because a tooltipped button is wrapped in a div that inherits its display width, the fix was to also add display: :block to that wrapper when appropriate.

### Integration

> Does this change require any updates to code in production?

Yes

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
