### PR TITLE
Fix underline of `UnderlineNav` being cut off

### DIFF
--- a/.changeset/afraid-walls-carry.md
+++ b/.changeset/afraid-walls-carry.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix underline of UnderlineNav being cut off when followed by a flash banner

--- a/app/components/primer/alpha/underline_nav.pcss
+++ b/app/components/primer/alpha/underline_nav.pcss
@@ -87,6 +87,7 @@
     /* current/selected underline */
     &::after {
       position: absolute;
+      z-index: 1; /* raise above full-width flash banner */
       right: 50%;
       bottom: calc(50% - 25px); /* 48px total height / 2 (24px) + 1px */
       width: 100%;


### PR DESCRIPTION
### Description

This fixes the orange underline of the `UnderlineNav` being cut off to only `1px` height when followed by a full-width flash banner. The reason is that full-width flash banners have a `margin-top: -1px`. So raising the underline with `z-index: 1` makes sure the `2px` height is visible.

Before | After
--- | ---
<img width="246" alt="Screen Shot 2023-03-02 at 16 19 28" src="https://user-images.githubusercontent.com/378023/222358710-5331580f-9212-49ce-89e2-93a47490fa52.png"> | <img width="222" alt="Screen Shot 2023-03-02 at 16 20 42" src="https://user-images.githubusercontent.com/378023/222358720-53261119-0916-44f9-9855-676e5d082c15.png">

Closes https://github.com/github/primer/issues/1524

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] ~~Added/updated tests~~
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews~~
