### PR TITLE
Add icon button to overlay show

### DIFF
--- a/.changeset/fast-turtles-pull.md
+++ b/.changeset/fast-turtles-pull.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add aria attributes to Overlay show_button

--- a/.changeset/fresh-nails-rescue.md
+++ b/.changeset/fresh-nails-rescue.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow for IconButtons in overlay show_button

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -74,10 +74,7 @@ module Primer
         )
         system_arguments[:id] = show_button_id
         system_arguments["popovertoggletarget"] = overlay_id
-        system_arguments[:aria] = (system_arguments[:aria] || {}).merge({
-          "controls": overlay_id,
-          "haspopup": "true"
-        })
+        system_arguments[:aria] = (system_arguments[:aria] || {}).merge({ controls: overlay_id, haspopup: "true" })
         if system_arguments[:icon]
           Primer::Beta::IconButton.new(**system_arguments)
         else
@@ -205,7 +202,6 @@ module Primer
       def show_button_id
         "overlay-show-#{overlay_id}"
       end
-
     end
   end
 end

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -68,15 +68,15 @@ module Primer
       # Optional button to open the Overlay.
       #
       # @param system_arguments [Hash] The same arguments as <%= link_to_component(Primer::ButtonComponent) %>.
-      renders_one :show_button, lambda { |**system_arguments|
+      renders_one :show_button, lambda { |icon: nil, **system_arguments|
         system_arguments[:classes] = class_names(
           system_arguments[:classes]
         )
         system_arguments[:id] = show_button_id
         system_arguments["popovertoggletarget"] = overlay_id
         system_arguments[:aria] = (system_arguments[:aria] || {}).merge({ controls: overlay_id, haspopup: "true" })
-        if system_arguments[:icon]
-          Primer::Beta::IconButton.new(**system_arguments)
+        if icon.present?
+          Primer::Beta::IconButton.new(icon: icon, **system_arguments)
         else
           Primer::Beta::Button.new(**system_arguments)
         end

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -72,10 +72,12 @@ module Primer
         system_arguments[:classes] = class_names(
           system_arguments[:classes]
         )
-        system_arguments[:id] = "overlay-show-#{@system_arguments[:id]}"
-        system_arguments["popovertoggletarget"] = @system_arguments[:id]
-        system_arguments[:data] = (system_arguments[:data] || {}).merge({ "show-dialog-id": @system_arguments[:id] })
-        Primer::Beta::Button.new(**system_arguments)
+        system_arguments[:id] = show_button_id
+        system_arguments["popovertoggletarget"] = overlay_id
+        system_arguments[:aria] = (system_arguments[:aria] || {}).merge({
+          "controls": overlay_id,
+          "haspopup": "true"
+        })
       }
 
       # Header content.
@@ -188,6 +190,17 @@ module Primer
         with_header unless header?
         with_body unless body?
       end
+
+      private
+
+      def overlay_id
+        @system_arguments[:id]
+      end
+
+      def show_button_id
+        "overlay-show-#{overlay_id}"
+      end
+
     end
   end
 end

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -78,6 +78,11 @@ module Primer
           "controls": overlay_id,
           "haspopup": "true"
         })
+        if system_arguments[:icon]
+          Primer::Beta::IconButton.new(**system_arguments)
+        else
+          Primer::Beta::Button.new(**system_arguments)
+        end
       }
 
       # Header content.

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -20,7 +20,8 @@ module Primer
       # @param header_size [Symbol] select [medium, large]
       # @param button_text [String] text
       # @param body_text [String] text
-      def playground(title: "Test Overlay", subtitle: nil, role: :dialog, size: :auto, padding: :normal, anchor_align: :center, anchor_offset: :normal, anchor_side: :outside_bottom, allow_out_of_bounds: false, visually_hide_title: false, header_size: :medium, button_text: "Show Overlay", body_text: "")
+      # @param icon [Symbol] octicon
+      def playground(title: "Test Overlay", subtitle: nil, role: :dialog, size: :auto, padding: :normal, anchor_align: :center, anchor_offset: :normal, anchor_side: :outside_bottom, allow_out_of_bounds: false, visually_hide_title: false, header_size: :medium, button_text: "Show Overlay", body_text: "", icon: :none)
         render(Primer::Alpha::Overlay.new(
                  title: title,
                  subtitle: subtitle,
@@ -34,7 +35,11 @@ module Primer
                  visually_hide_title: visually_hide_title,
                )) do |d|
           d.with_header(title: title, size: header_size)
-          d.with_show_button { button_text }
+          if icon.present? and icon != :none
+            d.with_show_button(icon: icon, "aria-label": icon.to_s)
+          else
+            d.with_show_button { button_text }
+          end
           d.with_body { body_text }
         end
       end

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -42,7 +42,6 @@ class PrimerAlphaOverlayTest < Minitest::Test
     assert_selector("[popovertoggletarget]")
   end
 
-
   def test_raises_on_missing_title
     error = assert_raises(ArgumentError) do
       render_inline(Primer::Alpha::Overlay.new(role: :dialog))

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -33,6 +33,16 @@ class PrimerAlphaOverlayTest < Minitest::Test
     assert_selector("[popovertoggletarget]")
   end
 
+  def test_renders_show_icon_button
+    render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
+      component.with_body { "Hello" }
+      component.with_show_button(icon: :star, "aria-label": "Star")
+    end
+
+    assert_selector("[popovertoggletarget]")
+  end
+
+
   def test_raises_on_missing_title
     error = assert_raises(ArgumentError) do
       render_inline(Primer::Alpha::Overlay.new(role: :dialog))


### PR DESCRIPTION
### Description

This adds some aria attributes to the show_button on Overlay.

It also allows for IconButtons to be rendered if an Icon is supplied.

Refs #1830 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
