### PR TITLE
Fixing TabNav double render of extra content

### DIFF
--- a/.changeset/late-lions-prove.md
+++ b/.changeset/late-lions-prove.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fixing TabNav double render of extra content

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tmp/
 
 # Simplecov folder
 coverage/
+demo/public/assets/

--- a/app/components/primer/alpha/tab_nav.rb
+++ b/app/components/primer/alpha/tab_nav.rb
@@ -124,6 +124,13 @@ module Primer
 
         aria_label_for_page_nav(label)
       end
+
+      def before_render
+        # Eagerly evaluate content to avoid https://github.com/primer/view_components/issues/1790
+        content
+
+        super
+      end
     end
   end
 end

--- a/test/components/alpha/tab_nav_test.rb
+++ b/test/components/alpha/tab_nav_test.rb
@@ -104,4 +104,22 @@ class PrimerAlphaTabNavTest < Minitest::Test
       refute_selector("ul.tabnav-tabs.tabnav")
     end
   end
+
+  def test_does_not_double_render_extra_content_in_production
+    # rubocop:disable Rails/Inquiry
+    Rails.stub(:env, "production".inquiry) do
+      # Since we've forced ourselves into the prod environment and there's no secret key base
+      # configured for prod, we have to fake it by setting the appropriate environment variable.
+      with_env("SECRET_KEY_BASE" => "abc123") do
+        render_inline(Primer::Alpha::TabNav.new(label: "label")) do |component|
+          component.with_tab(selected: true) { "Tab 1" }
+          component.with_tab { "Tab 2" }
+          component.with_extra { "extra" }
+        end
+      end
+    end
+    # rubocop:enable Rails/Inquiry
+
+    assert_text("extra", count: 1)
+  end
 end


### PR DESCRIPTION
### Description

This does the same as https://github.com/primer/view_components/pull/1818 but for `TabNav`

Fixes https://github.com/github/primer/issues/1820

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
