### PR TITLE
upgrade @oddbird/popover-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@github/mini-throttle": "^2.1.0",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.0.9",
+        "@oddbird/popover-polyfill": "^0.0.10",
         "@primer/behaviors": "^1.2.0"
       },
       "devDependencies": {
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.0.9.tgz",
-      "integrity": "sha512-D/l63YW0hNWSxTMx5V9LWme4BliyrsSJ5IDAjtIU+/kRMy3jBl7an72+e8usPdihpyFkeM5ynUOOKJ00nq4pDA=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.0.10.tgz",
+      "integrity": "sha512-jkfX/35EsxDe9ruTx3He59FyE+y5WDF5S4YJ7TABj0c8egHV2FLeADavknvr12CnSu0QTybv9ufKfPJDsYZYNw=="
     },
     "node_modules/@playwright/test": {
       "version": "1.27.1",
@@ -10048,9 +10048,9 @@
       }
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.0.9.tgz",
-      "integrity": "sha512-D/l63YW0hNWSxTMx5V9LWme4BliyrsSJ5IDAjtIU+/kRMy3jBl7an72+e8usPdihpyFkeM5ynUOOKJ00nq4pDA=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.0.10.tgz",
+      "integrity": "sha512-jkfX/35EsxDe9ruTx3He59FyE+y5WDF5S4YJ7TABj0c8egHV2FLeADavknvr12CnSu0QTybv9ufKfPJDsYZYNw=="
     },
     "@playwright/test": {
       "version": "1.27.1",

--- a/package.json
+++ b/package.json
@@ -53,15 +53,15 @@
     "@github/mini-throttle": "^2.1.0",
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
-    "@oddbird/popover-polyfill": "^0.0.9",
+    "@oddbird/popover-polyfill": "^0.0.10",
     "@primer/behaviors": "^1.2.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.24.1",
     "@github/browserslist-config": "^1.0.0",
-    "@github/prettier-config": "0.0.4",
     "@github/markdownlint-github": "^0.2.2",
+    "@github/prettier-config": "0.0.4",
     "@playwright/test": "^1.27.1",
     "@primer/css": "20.4.7",
     "@primer/primitives": "^7.11.1",


### PR DESCRIPTION
### Description

Upgrade @oddbird/popover-polyfill to the latest version, which includes support for `aria-expanded`.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
