### PR TITLE
Make Overlay header optional, ensure labelledby/label are always present

### DIFF
--- a/.changeset/chilly-olives-smash.md
+++ b/.changeset/chilly-olives-smash.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Make Overlay headings optional

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -89,7 +89,7 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :header, lambda { |divider: false, size: :medium, visually_hide_title: @visually_hide_title, **system_arguments|
         Primer::Alpha::Overlay::Header.new(
-          id: @id,
+          id: title_id,
           title: @title,
           subtitle: @subtitle,
           size: size,
@@ -185,11 +185,14 @@ module Primer
 
         @system_arguments[:popover] = popover
         @system_arguments[:aria] ||= {}
-        @system_arguments[:aria][:describedby] ||= "#{@id}-description"
       end
 
       def before_render
-        with_header unless header?
+        if header?
+          @system_arguments[:aria][:labelledby] ||= title_id
+        else
+          @system_arguments[:aria][:label] = @title
+        end
         with_body unless body?
       end
 
@@ -197,6 +200,10 @@ module Primer
 
       def overlay_id
         @system_arguments[:id]
+      end
+
+      def title_id
+        "overlay-title-#{overlay_id}"
       end
 
       def show_button_id

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -1,11 +1,11 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <div class="Overlay-headerContentWrap">
     <div class="Overlay-titleWrap">
-      <h1 class="Overlay-title <% if @visually_hide_title || content.present? %>sr-only<% end %>"><%= @title %></h1>
+      <h1 id="<%= @id %>" class="Overlay-title <% if @visually_hide_title || content.present? %>sr-only<% end %>"><%= @title %></h1>
       <% if content.present? %>
         <%= content %>
       <% elsif @subtitle.present? %>
-        <h2 id="<%= @id %>-description" class="Overlay-description"><%= @subtitle %></h2>
+        <h2 class="Overlay-description"><%= @subtitle %></h2>
       <% end %>
     </div>
     <div class="Overlay-actionWrap">

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -77,6 +77,32 @@ module Primer
         end
       end
 
+      # @label Menu No Header
+      #
+      # @param title [String] text
+      # @param size [Symbol] select [auto, small, medium, medium_portrait, large, xlarge]
+      # @param padding [Symbol] select [normal, condensed, none]
+      # @param anchor_align [Symbol] select [start, center, end]
+      # @param anchor_side [Symbol] select [inside_top, inside_bottom, inside_left, inside_right, inside_center, outside_top, outside_bottom, outside_left, outside_right]
+      # @param allow_out_of_bounds [Boolean] toggle
+      #
+      # @param button_text [String] text
+      # @param body_text [String] text
+      def menu_no_header(title: "Test Overlay", size: :auto, padding: :normal, anchor_align: :center, anchor_side: :outside_bottom, allow_out_of_bounds: false, button_text: "Show Overlay Menu", body_text: "This is a menu")
+        render(Primer::Alpha::Overlay.new(
+                 title: "Menu",
+                 role: :menu,
+                 size: size,
+                 padding: padding,
+                 anchor_align: anchor_align,
+                 anchor_side: anchor_side,
+                 allow_out_of_bounds: allow_out_of_bounds,
+               )) do |d|
+          d.with_show_button { button_text }
+          d.with_body { body_text }
+        end
+      end
+
       # @label Middle Of Page
       #
       # @param title [String] text

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -32,10 +32,10 @@ module Primer
                  anchor_offset: anchor_offset,
                  anchor_side: anchor_side,
                  allow_out_of_bounds: allow_out_of_bounds,
-                 visually_hide_title: visually_hide_title,
+                 visually_hide_title: visually_hide_title
                )) do |d|
           d.with_header(title: title, size: header_size)
-          if icon.present? and icon != :none
+          if icon.present? && (icon != :none)
             d.with_show_button(icon: icon, "aria-label": icon.to_s)
           else
             d.with_show_button { button_text }
@@ -69,7 +69,7 @@ module Primer
                  anchor_align: anchor_align,
                  anchor_side: anchor_side,
                  allow_out_of_bounds: allow_out_of_bounds,
-                 visually_hide_title: visually_hide_title,
+                 visually_hide_title: visually_hide_title
                )) do |d|
           d.with_header(title: title, size: header_size)
           d.with_show_button { button_text }
@@ -79,7 +79,6 @@ module Primer
 
       # @label Menu No Header
       #
-      # @param title [String] text
       # @param size [Symbol] select [auto, small, medium, medium_portrait, large, xlarge]
       # @param padding [Symbol] select [normal, condensed, none]
       # @param anchor_align [Symbol] select [start, center, end]
@@ -88,7 +87,7 @@ module Primer
       #
       # @param button_text [String] text
       # @param body_text [String] text
-      def menu_no_header(title: "Test Overlay", size: :auto, padding: :normal, anchor_align: :center, anchor_side: :outside_bottom, allow_out_of_bounds: false, button_text: "Show Overlay Menu", body_text: "This is a menu")
+      def menu_no_header(size: :auto, padding: :normal, anchor_align: :center, anchor_side: :outside_bottom, allow_out_of_bounds: false, button_text: "Show Overlay Menu", body_text: "This is a menu")
         render(Primer::Alpha::Overlay.new(
                  title: "Menu",
                  role: :menu,
@@ -96,7 +95,7 @@ module Primer
                  padding: padding,
                  anchor_align: anchor_align,
                  anchor_side: anchor_side,
-                 allow_out_of_bounds: allow_out_of_bounds,
+                 allow_out_of_bounds: allow_out_of_bounds
                )) do |d|
           d.with_show_button { button_text }
           d.with_body { body_text }

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -7,7 +7,7 @@ class PrimerAlphaOverlayTest < Minitest::Test
 
   def test_renders_title_and_body
     render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
-      component.with_header {}
+      component.with_header
       component.with_body { "Hello" }
     end
 

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -7,11 +7,23 @@ class PrimerAlphaOverlayTest < Minitest::Test
 
   def test_renders_title_and_body
     render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
+      component.with_header {}
       component.with_body { "Hello" }
     end
 
     assert_selector("anchored-position[role='dialog']") do
       assert_selector("h1", text: "Title")
+      assert_selector(".Overlay-body", text: "Hello")
+    end
+  end
+
+  def test_does_not_render_header_if_omitted
+    render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
+      component.with_body { "Hello" }
+    end
+
+    assert_selector("anchored-position[role='dialog'][aria-label='Title']") do
+      refute_selector("h1", text: "Title")
       assert_selector(".Overlay-body", text: "Hello")
     end
   end
@@ -74,16 +86,6 @@ class PrimerAlphaOverlayTest < Minitest::Test
     end
 
     assert_selector("anchored-position[id^='overlay-']")
-  end
-
-  def test_renders_subtitle_with_describedby
-    render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog, id: "my-dialog", subtitle: "Subtitle")) do |component|
-      component.with_body { "content" }
-    end
-
-    assert_selector("anchored-position[id='my-dialog'][aria-describedby='my-dialog-description']") do
-      assert_selector("h2[id='my-dialog-description']", text: "Subtitle")
-    end
   end
 
   def test_body_padding


### PR DESCRIPTION
### Description

This PR allows for Overlays to have optional headings, but always ensures that the `aria-label` or `aria-labelledby` fields are present.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
