### PR TITLE
Deny tag argument for ActionList headings

### DIFF
--- a/.changeset/seven-tables-applaud.md
+++ b/.changeset/seven-tables-applaud.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Deny tag argument for ActionList headings

--- a/app/components/primer/alpha/action_list/heading.rb
+++ b/app/components/primer/alpha/action_list/heading.rb
@@ -27,7 +27,7 @@ module Primer
 
           @heading_level = heading_level
           @tag = :"h#{heading_level}"
-          @system_arguments = system_arguments
+          @system_arguments = deny_tag_argument(**system_arguments)
           @list_id = list_id
           @title = title
           @subtitle = subtitle

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -87,7 +87,7 @@ module Primer
           end
         end
 
-        assert_match /This component has a fixed tag/, error.message
+        assert_match(/This component has a fixed tag/, error.message)
       end
     end
   end

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -79,6 +79,16 @@ module Primer
 
         assert_selector(".ActionListItem-visual--leading", count: 2)
       end
+
+      def test_heading_denies_tag_argument
+        error = assert_raises ArgumentError do
+          render_inline(Primer::Alpha::ActionList.new(aria: { lable: "List" })) do |component|
+            component.with_heading(title: "Foo", tag: :foo)
+          end
+        end
+
+        assert_match /This component has a fixed tag/, error.message
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

I ran into a case in dotcom today where a `tag: "h2"` option was being passed to an `ActionList` heading, which caused problems. This was easily fixed by passing `heading_level: 2` instead, but the component should disallow passing `tag:`.

### Integration

> Does this change require any updates to code in production?

No, all instances of this should be fixed by the time this PR ships.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
