### PR TITLE
Allow ActionList dividers to be added manually

### DIFF
--- a/.changeset/selfish-glasses-count.md
+++ b/.changeset/selfish-glasses-count.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow ActionList dividers to be added manually

--- a/app/components/primer/alpha/action_list.html.erb
+++ b/app/components/primer/alpha/action_list.html.erb
@@ -8,7 +8,7 @@
       <% if index > 0 && @show_dividers && !item.is_a?(Divider) && !items[index - 1].is_a?(Divider) %>
         <%= render(Primer::Alpha::ActionList::Divider.new) %>
       <% end %>
-      <%= render(item) %>
+      <%= item %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/primer/alpha/action_list.html.erb
+++ b/app/components/primer/alpha/action_list.html.erb
@@ -4,10 +4,11 @@
   <% end %>
   <%= render(Primer::BaseComponent.new(tag: :ul, **@system_arguments)) do %>
     <% items.each_with_index do |item, index| %>
-      <% if index > 0 && @show_dividers %>
+      <%# the conditions here make sure two dividers are never rendered one after the other %>
+      <% if index > 0 && @show_dividers && !item.is_a?(Divider) && !items[index - 1].is_a?(Divider) %>
         <%= render(Primer::Alpha::ActionList::Divider.new) %>
       <% end %>
-      <%= item %>
+      <%= render(item) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -39,28 +39,23 @@ module Primer
         Heading.new(list_id: @id, **system_arguments)
       }
 
-      # Adds an item to the list.
+      # Items.
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      def with_item(**system_arguments)
-        @items << build_item(**system_arguments).tap do |item|
-          yield item if block_given?
-
+      renders_many :items, lambda { |**system_arguments|
+        build_item(**system_arguments).tap do |item|
           will_add_item(item)
         end
-      end
+      }
 
       # Adds a divider to the list of items.
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
-      def with_divider(**system_arguments)
-        @items << ActionList::Divider.new(**system_arguments).tap do |divider|
-          yield divider if block_given?
-        end
+      def with_divider(**system_arguments, &block)
+        # This is a giant hack that should be removed when :items can be converted into a polymorphic slot.
+        # This feature needs to land in view_component first: https://github.com/ViewComponent/view_component/pull/1652
+        set_slot(:items, { renderable: Divider, collection: true }, **system_arguments, &block)
       end
-
-      # Returns the current list of items.
-      attr_reader :items
 
       # @param role [Boolean] ARIA role describing the function of the list. listbox and menu are a common values.
       # @param item_classes [String] Additional CSS classes to attach to items.
@@ -74,7 +69,6 @@ module Primer
         show_dividers: false,
         **system_arguments
       )
-        @items = []
         @id = self.class.generate_id
 
         @system_arguments = system_arguments

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -90,12 +90,13 @@ module Primer
       # @private
       def before_render
         aria_label = aria(:label, @system_arguments)
+        aria_labelledby = aria(:labelledby, @system_arguments)
 
         if heading.present?
           @system_arguments[:"aria-labelledby"] = @id
           raise ArgumentError, "An aria-label should not be provided if a heading is present" if aria_label.present?
-        elsif aria_label.blank?
-          raise ArgumentError, "An aria-label or heading must be provided"
+        elsif aria_label.blank? && aria_labelledby.blank?
+          raise ArgumentError, "An aria-label, aria-labelledby, or heading must be provided"
         end
       end
 

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -39,14 +39,28 @@ module Primer
         Heading.new(list_id: @id, **system_arguments)
       }
 
-      # Items.
+      # Adds an item to the list.
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      renders_many :items, lambda { |**system_arguments|
-        build_item(**system_arguments).tap do |item|
+      def with_item(**system_arguments)
+        @items << build_item(**system_arguments).tap do |item|
+          yield item if block_given?
+
           will_add_item(item)
         end
-      }
+      end
+
+      # Adds a divider to the list of items.
+      #
+      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
+      def with_divider(**system_arguments)
+        @items << ActionList::Divider.new(**system_arguments).tap do |divider|
+          yield divider if block_given?
+        end
+      end
+
+      # Returns the current list of items.
+      attr_reader :items
 
       # @param role [Boolean] ARIA role describing the function of the list. listbox and menu are a common values.
       # @param item_classes [String] Additional CSS classes to attach to items.
@@ -60,6 +74,7 @@ module Primer
         show_dividers: false,
         **system_arguments
       )
+        @items = []
         @id = self.class.generate_id
 
         @system_arguments = system_arguments

--- a/app/components/primer/alpha/action_list/divider.rb
+++ b/app/components/primer/alpha/action_list/divider.rb
@@ -16,8 +16,8 @@ module Primer
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(scheme: DEFAULT_SCHEME, **system_arguments)
           @system_arguments = system_arguments
-          @system_arguments[:tag] = :div
-          @system_arguments[:role] = :separator
+          @system_arguments[:tag] = :li
+          @system_arguments[:role] = :presentation
           @system_arguments[:'aria-hidden'] = true
           @scheme = fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)
           @system_arguments[:classes] = class_names(

--- a/previews/primer/alpha/action_list_preview.rb
+++ b/previews/primer/alpha/action_list_preview.rb
@@ -89,6 +89,39 @@ module Primer
         end
       end
 
+      # @label With manual dividers
+      #
+      # @param role text
+      # @param scheme [Symbol] select [full, inset]
+      # @param show_dividers toggle
+      def with_manual_dividers(
+        role: Primer::Alpha::ActionList::DEFAULT_ROLE,
+        scheme: Primer::Alpha::ActionList::DEFAULT_SCHEME,
+        show_dividers: false
+      )
+        render(Primer::Alpha::ActionList.new(
+          role: role,
+          scheme: scheme,
+          show_dividers: show_dividers
+        )) do |component|
+          component.with_heading(title: "Action List")
+          component.with_item(label: "Item one", href: "/") do |item|
+            item.with_leading_visual_icon(icon: :gear)
+          end
+          component.with_divider
+          component.with_item(label: "Item two", href: "/") do |item|
+            item.with_leading_visual_icon(icon: :star)
+          end
+          component.with_item(label: "Item three", href: "/") do |item|
+            item.with_leading_visual_icon(icon: :heart)
+          end
+          component.with_divider
+          component.with_item(label: "Item four", href: "/") do |item|
+            item.with_leading_visual_icon(icon: :bug)
+          end
+        end
+      end
+
       # @label Divider
       #
       # @param scheme [Symbol] select [subtle, filled]

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -89,6 +89,32 @@ module Primer
 
         assert_match(/This component has a fixed tag/, error.message)
       end
+
+      def test_manual_dividers
+        render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |component|
+          component.with_item(label: "Item 1", href: "/item1")
+          component.with_item(label: "Item 2", href: "/item2")
+          component.with_divider
+          component.with_item(label: "Item 3", href: "/item3")
+        end
+
+        list_items = page.find_css("ul.ActionListWrap li").map do |list_item|
+          classes = list_item["class"].split
+
+          if classes.include?("ActionListItem")
+            { type: :item, href: list_item.css("a").first["href"] }
+          elsif classes.include?("ActionList-sectionDivider")
+            { type: :divider }
+          end
+        end
+
+        assert_equal list_items, [
+          { type: :item, href: "/item1" },
+          { type: :item, href: "/item2" },
+          { type: :divider },
+          { type: :item, href: "/item3" }
+        ]
+      end
     end
   end
 end

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -12,7 +12,7 @@ module Primer
           render_inline(Primer::Alpha::ActionList.new)
         end
 
-        assert_includes(error.message, "label or heading must be provided")
+        assert_includes(error.message, "aria-label, aria-labelledby, or heading must be provided")
       end
 
       def test_active_item


### PR DESCRIPTION
### Description

Dividers in an `ActionList` can currently only be added by passing `show_dividers: true`, which will add a divider between each list item:

<img width="176" alt="image" src="https://user-images.githubusercontent.com/575280/223927445-0e498aa0-0bbc-4422-8eb4-e3b14740d06b.png">

I'm working on integrating `ActionList` inside `ActionMenu` (currently an experimental component in dotcom) that needs to be able to insert dividers manually at user-defined positions within the list. This PR introduces the `#with_divider` method which offers such functionality. Here's an example:

<img width="170" alt="image" src="https://user-images.githubusercontent.com/575280/223928236-b255e839-9410-48ab-9a32-ac6753f87874.png">

### Why not use polymorphic slots?

This is a use-case tailor-made for polymorphic slots, but using them would necessitate a painful API change. Fortunately custom polymorphic slot names are [on the horizon](https://github.com/ViewComponent/view_component/pull/1652), but until then I've added a bit of a hacky workaround in the form of a `#with_divider` method that appends to the existing `items` slot using ViewComponent's private `#set_slot` method.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews
