### PR TITLE
Bump `octicons` to v18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     primer_view_components (0.1.1)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
-      octicons (>= 17.0.0)
+      octicons (>= 18.0.0)
       view_component (> 2.0, < 4.0)
 
 GEM

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency     "actionview", ">= 5.0.0"
   spec.add_runtime_dependency     "activesupport", ">= 5.0.0"
-  spec.add_runtime_dependency     "octicons", ">= 17.0.0"
+  spec.add_runtime_dependency     "octicons", ">= 18.0.0"
   spec.add_runtime_dependency     "view_component", ["> 2.0", "< 4.0"]
 
   spec.add_development_dependency "allocation_stats", "~> 0.1"


### PR DESCRIPTION
### Description

This updates `octicons` to use v18+, so we can use the icons added in https://github.com/primer/octicons/pull/928. This is part of https://github.com/github/discussions/issues/3079.

### Integration

> Does this change require any updates to code in production?

The only breaking change in v18 is changing the following icon names:

- `issue-tracked-by` → `issue-tracks`
- `issue-tracked-in` → `issue-tracked-by`

I don't see those being used anywhere in Dotcom.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
