### PR TITLE
Attach behavior to TextField's clear button

### DIFF
--- a/.changeset/flat-starfishes-teach.md
+++ b/.changeset/flat-starfishes-teach.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Attach behavior to TextField's clear button

--- a/lib/primer/forms/dsl/text_field_input.rb
+++ b/lib/primer/forms/dsl/text_field_input.rb
@@ -32,7 +32,7 @@ module Primer
 
           super(**system_arguments)
 
-          add_input_data(:target, "primer-text-field.inputElement") if auto_check_src.present?
+          add_input_data(:target, "primer-text-field.inputElement")
           add_input_classes("FormControl-inset") if inset?
           add_input_classes("FormControl-monospace") if monospace?
         end

--- a/lib/primer/forms/primer_text_field.ts
+++ b/lib/primer/forms/primer_text_field.ts
@@ -1,7 +1,9 @@
 import '@github/auto-check-element'
 import {controller, target} from '@github/catalyst'
 
+// eslint-disable-next-line custom-elements/expose-class-on-global
 @controller
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
 class PrimerTextFieldElement extends HTMLElement {
   @target inputElement: HTMLInputElement
   @target validationElement: HTMLElement
@@ -15,16 +17,17 @@ class PrimerTextFieldElement extends HTMLElement {
 
     this.inputElement.addEventListener(
       'auto-check-success',
-      () => { this.clearError() },
+      () => {
+        this.clearError()
+      },
       {signal}
     )
 
     this.inputElement.addEventListener(
       'auto-check-error',
-      (event: any) => {
-        event.detail.response.text().then(
-          (error_message: string) => { this.setError(error_message) }
-        )
+      async (event: any) => {
+        const errorMessage = await event.detail.response.text()
+        this.setError(errorMessage)
       },
       {signal}
     )
@@ -34,14 +37,19 @@ class PrimerTextFieldElement extends HTMLElement {
     this.#abortController?.abort()
   }
 
+  clearContents() {
+    this.inputElement.value = ''
+    this.inputElement.focus()
+  }
+
   clearError(): void {
     this.inputElement.removeAttribute('invalid')
     this.validationElement.hidden = true
-    this.validationMessageElement.innerText = ''
+    this.validationMessageElement.textContent = ''
   }
 
   setError(message: string): void {
-    this.validationMessageElement.innerText = message
+    this.validationMessageElement.textContent = message
     this.validationElement.hidden = false
     this.inputElement.setAttribute('invalid', 'true')
   }

--- a/lib/primer/forms/text_field.html.erb
+++ b/lib/primer/forms/text_field.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::ConditionalWrapper.new(condition: @input.auto_check_src, tag: "primer-text-field") do %>
+<primer-text-field>
   <%= render(FormControl.new(input: @input)) do %>
     <%= content_tag(:div, **@field_wrap_arguments) do %>
       <% if @input.leading_visual %>
@@ -10,10 +10,10 @@
         <%= builder.text_field(@input.name, **@input.input_arguments) %>
       <% end %>
       <% if @input.show_clear_button? %>
-        <button type="button" id="<%= @input.clear_button_id %>" class="FormControl-input-trailingAction" aria-label="Clear">
+        <button type="button" id="<%= @input.clear_button_id %>" class="FormControl-input-trailingAction" aria-label="Clear" data-action="click:primer-text-field#clearContents">
           <%= render(Primer::Beta::Octicon.new(icon: :"x-circle-fill")) %>
         </button>
       <% end %>
     <% end %>
   <% end %>
-<% end %>
+</primer-text-field>

--- a/test/system/alpha/text_field_test.rb
+++ b/test/system/alpha/text_field_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "system/test_case"
+
+module Alpha
+  class IntegrationTextFieldTest < System::TestCase
+    def test_clear_button
+      visit_preview(:show_clear_button)
+
+      find("input[type=text]").fill_in(with: "foobar")
+      assert_equal find("input[type=text]").value, "foobar"
+
+      find("button").click
+      assert_equal find("input[type=text]").value, ""
+    end
+
+    def test_auto_check_error
+      visit_preview(:with_auto_check_error)
+
+      assert_selector ".FormControl-inlineValidation", visible: :hidden, text: ""
+
+      find("input[type=text]").fill_in(with: "foobar")
+
+      assert_selector ".FormControl-inlineValidation", text: "Error! Error!"
+    end
+  end
+end


### PR DESCRIPTION
### Description

`TextField` components come with a clear button that currently requires consumers of the library to attach behavior on their own. Historically this has been because `TextField`s were not wrapped with a custom element and thus had no convenient place to add javascript behavior. However since @neall and I worked on adding auto-check capabilities to `TextField`, we now have such a custom element and can add behavior to the clear button.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews
