### PR TITLE
Allow consumers to set ActionList item content's tag

### DIFF
--- a/.changeset/chilled-mugs-play.md
+++ b/.changeset/chilled-mugs-play.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow consumers to set ActionList item content's tag

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -212,12 +212,14 @@ module Primer
             SIZE_MAPPINGS[@size]
           )
 
-          if @href && !@disabled
-            @content_arguments[:tag] = :a
-            @content_arguments[:href] = @href
-          else
-            @content_arguments[:tag] = :button
-            @content_arguments[:onclick] = on_click if on_click
+          unless @content_arguments[:tag]
+            if @href && !@disabled
+              @content_arguments[:tag] = :a
+              @content_arguments[:href] = @href
+            else
+              @content_arguments[:tag] = :button
+              @content_arguments[:onclick] = on_click if on_click
+            end
           end
 
           @description_wrapper_arguments = {

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -109,6 +109,14 @@ module Primer
           { type: :item, href: "/item3" }
         ]
       end
+
+      def test_allows_custom_item_tag
+        render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |component|
+          component.with_item(label: "Item 1", content_arguments: { tag: :"clipboard-copy" })
+        end
+
+        assert_selector "clipboard-copy.ActionListContent"
+      end
     end
   end
 end


### PR DESCRIPTION
### Description

Currently `ActionList` overwrites the tag. This PR only sets the tag if none has been provided in `content_arguments`.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews
