### PR TITLE
Action list allow content label

### DIFF
--- a/.changeset/gorgeous-zoos-exercise.md
+++ b/.changeset/gorgeous-zoos-exercise.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+ActionList item and divider content

--- a/app/components/primer/alpha/action_list/divider.rb
+++ b/app/components/primer/alpha/action_list/divider.rb
@@ -27,7 +27,7 @@ module Primer
         end
 
         def call
-          render(Primer::BaseComponent.new(**@system_arguments)) { "" }
+          render(Primer::BaseComponent.new(**@system_arguments)) { content }
         end
       end
     end

--- a/app/components/primer/alpha/action_list/item.html.erb
+++ b/app/components/primer/alpha/action_list/item.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <%= render(Primer::ConditionalWrapper.new(condition: description?, tag: :span, **@description_wrapper_arguments)) do %>
       <%= render(Primer::BaseComponent.new(tag: :span, **@label_arguments)) do %>
-        <%= @label %>
+        <%= @label || content %>
       <% end %>
       <% if description? %>
         <span class="ActionListItem-description">

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -130,7 +130,7 @@ module Primer
 
         # @param list [Primer::Alpha::ActionList] The list that contains this item. Used internally.
         # @param parent [Primer::Alpha::ActionList::Item] This item's parent item. `nil` if this item is at the root. Used internally.
-        # @param label [String] Item label.
+        # @param label [String] Item label. If no label is provided, content is used.
         # @param label_classes [String] CSS classes that will be added to the label.
         # @param label_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the label.
         # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or button tag.
@@ -147,7 +147,7 @@ module Primer
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(
           list:,
-          label:,
+          label: nil,
           label_classes: nil,
           label_arguments: {},
           content_arguments: {},


### PR DESCRIPTION
### Description

I'm currently working on updating `ActionMenu` (an experimental component in dotcom) to use the `ActionList` component instead of HTML + action list classes. So what's changed?

1. **Allow content to be used as the label**. In my efforts to improve the accessibility of `ActionList` (and `NavList`), I recently added a required `label:` argument. Labels used to be specified via content. Unfortunately numerous places in dotcom specify non-trivial content in `ActionMenu` items, meaning `ActionList` items have to support content again too.
2. **Allow dividers to contain content**. In the original `ActionList` designs, dividers can either be horizontal lines or text. This PR makes the latter possible.

### Integration

> Does this change require any updates to code in production?

No