### PR TITLE
Associate title with dialog

### DIFF
--- a/.changeset/poor-lizards-clean.md
+++ b/.changeset/poor-lizards-clean.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Associate title with dialog

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -126,32 +126,37 @@ module Primer
       )
         @system_arguments = deny_tag_argument(**system_arguments)
 
-        @system_arguments[:tag] = "modal-dialog"
-        @system_arguments[:role] = "dialog"
-        @system_arguments[:id] = id
-        @system_arguments[:aria] = { modal: true }
-        @system_arguments[:classes] = class_names(
-          "Overlay",
-          "Overlay-whenNarrow",
-          SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)],
-          "Overlay--motion-scaleFade",
-          system_arguments[:classes]
-        )
-        @backdrop_classes = class_names(
-          POSITION_MAPPINGS[fetch_or_fallback(POSITION_OPTIONS, position, DEFAULT_POSITION)],
-          POSITION_NARROW_MAPPINGS[fetch_or_fallback(POSITION_NARROW_MAPPINGS, position_narrow, DEFAULT_POSITION_NARROW)]
-        )
-
         @id = id.to_s
         @title = title
+        @subtitle = subtitle
+        @size = size
         @position = position
         @position_narrow = position_narrow
         @visually_hide_title = visually_hide_title
 
-        @subtitle = subtitle
-
-        @system_arguments[:aria] ||= {}
-        @system_arguments[:aria][:describedby] ||= "#{@id}-description"
+        @system_arguments[:tag] = "modal-dialog"
+        @system_arguments[:role] = "dialog"
+        @system_arguments[:id] = @id
+        @system_arguments[:aria] = { modal: true }
+        @system_arguments[:aria] = merge_aria(
+          @system_arguments, {
+            aria: {
+              disabled: true,
+              describedby: "#{@id}-title #{@id}-description"
+            }
+          }
+        )
+        @system_arguments[:classes] = class_names(
+          "Overlay",
+          "Overlay-whenNarrow",
+          SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, @size, DEFAULT_SIZE)],
+          "Overlay--motion-scaleFade",
+          system_arguments[:classes]
+        )
+        @backdrop_classes = class_names(
+          POSITION_MAPPINGS[fetch_or_fallback(POSITION_OPTIONS, @position, DEFAULT_POSITION)],
+          POSITION_NARROW_MAPPINGS[fetch_or_fallback(POSITION_NARROW_MAPPINGS, @position_narrow, DEFAULT_POSITION_NARROW)]
+        )
       end
 
       def before_render

--- a/app/components/primer/alpha/dialog/header.html.erb
+++ b/app/components/primer/alpha/dialog/header.html.erb
@@ -1,7 +1,9 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
   <div class="Overlay-headerContentWrap">
     <div class="Overlay-titleWrap">
-      <h1 class="Overlay-title <% if @visually_hide_title || content.present? %>sr-only<% end %>"><%= @title %></h1>
+      <h1 class="Overlay-title <% if @visually_hide_title || content.present? %>sr-only<% end %>" id="<%= @id %>-title">
+        <%= @title %>
+      </h1>
       <% if content.present? %>
         <%= content %>
       <% elsif @subtitle.present? %>

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -50,12 +50,13 @@ class PrimerAlphaDialogTest < Minitest::Test
     assert_selector("modal-dialog[id^='dialog-']")
   end
 
-  def test_renders_subtitle_with_describedby
+  def test_renders_title_and_subtitle_with_describedby
     render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog", subtitle: "Subtitle")) do |component|
       component.with_body { "content" }
     end
 
-    assert_selector("modal-dialog[id='my-dialog'][aria-describedby='my-dialog-description']") do
+    assert_selector("modal-dialog[id='my-dialog'][aria-describedby='my-dialog-title my-dialog-description']") do
+      assert_selector("h1[id='my-dialog-title']", text: "Title")
       assert_selector("h2[id='my-dialog-description']", text: "Subtitle")
     end
   end


### PR DESCRIPTION
### Description

Today @neall and I encountered an Axe violation saying our `Primer::Alpha::Dialog` didn't have any text describing it. Digging into the code we discovered that, while the subtitle's ID is added to `aria-describedby`, the title's ID is not.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
~- [ ] Added/updated previews~
