### PR TITLE
Support multiple data-target attributes in `Primer::Alpha::TextField`

### DIFF
--- a/.changeset/fresh-mails-smash.md
+++ b/.changeset/fresh-mails-smash.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Update Primer::Alpha::TextInput to support multiple target attributes

--- a/lib/primer/forms/dsl/text_field_input.rb
+++ b/lib/primer/forms/dsl/text_field_input.rb
@@ -32,7 +32,7 @@ module Primer
 
           super(**system_arguments)
 
-          add_input_data(:target, "primer-text-field.inputElement #{system_arguments.dig(:data, :target) || ""}")
+          add_input_data(:target, "primer-text-field.inputElement #{system_arguments.dig(:data, :target) || ''}")
           add_input_classes("FormControl-inset") if inset?
           add_input_classes("FormControl-monospace") if monospace?
         end

--- a/lib/primer/forms/dsl/text_field_input.rb
+++ b/lib/primer/forms/dsl/text_field_input.rb
@@ -32,7 +32,7 @@ module Primer
 
           super(**system_arguments)
 
-          add_input_data(:target, "primer-text-field.inputElement")
+          add_input_data(:target, "primer-text-field.inputElement #{system_arguments.dig(:data, :target) || ""}")
           add_input_classes("FormControl-inset") if inset?
           add_input_classes("FormControl-monospace") if monospace?
         end

--- a/previews/primer/alpha/text_field_preview.rb
+++ b/previews/primer/alpha/text_field_preview.rb
@@ -167,6 +167,13 @@ module Primer
       end
       #
       # @!endgroup
+
+      # @label With data target attribute
+      def with_data_target
+        render(Primer::Alpha::TextField.new(name: "my-text-field", label: "My text field", data: { target: "custom-component.inputElement" }))
+      end
+      #
+      # @!endgroup
     end
   end
 end

--- a/test/system/alpha/text_field_test.rb
+++ b/test/system/alpha/text_field_test.rb
@@ -23,5 +23,12 @@ module Alpha
 
       assert_selector ".FormControl-inlineValidation", text: "Error! Error!"
     end
+
+    def test_custom_data_target
+      visit_preview(:with_data_target)
+
+      assert_selector "input[data-target*='primer-text-field.inputElement']"
+      assert_selector "input[data-target*='custom-component.inputElement']"
+    end
   end
 end


### PR DESCRIPTION
### Description

This change updates `Primer::Alpha::TextField` to support multiple `data-target` attributes.

Closes https://github.com/primer/view_components/issues/1893

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
