### PR TITLE
Remove duplicate `id` argument from IconButton example

### DIFF
--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -27,7 +27,7 @@ module Primer
 
       # @example Default
       #
-      #   <%= render(Primer::Beta::IconButton.new(icon: :search, "aria-label": "Search", id: "search-button", id: "search-button")) %>
+      #   <%= render(Primer::Beta::IconButton.new(icon: :search, "aria-label": "Search", id: "search-button")) %>
       #
       # @example Schemes
       #


### PR DESCRIPTION
### Description

The IconButton docs have an example with a duplicate `id` argument for the default variant.

https://primer.style/view-components/components/beta/iconbutton#default

### Integration

> Does this change require any updates to code in production?

No
