### PR TITLE
Fix width of text fields and multi inputs

### DIFF
--- a/.changeset/tough-bats-refuse.md
+++ b/.changeset/tough-bats-refuse.md
@@ -2,4 +2,4 @@
 '@primer/view-components': patch
 ---
 
-Fix width of text fields
+Fix widths of text fields and multi inputs.

--- a/.changeset/tough-bats-refuse.md
+++ b/.changeset/tough-bats-refuse.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix width of text fields

--- a/app/forms/select_form.rb
+++ b/app/forms/select_form.rb
@@ -2,8 +2,8 @@
 
 # :nodoc:
 class SelectForm < ApplicationForm
-  form do |check_form|
-    check_form.select_list(name: "cities", label: "Cool cities", caption: "Select your favorite!", include_blank: true) do |city_list|
+  form do |select_form|
+    select_form.select_list(name: "cities", label: "Cool cities", caption: "Select your favorite!", include_blank: true) do |city_list|
       city_list.option(label: "Lopez Island", value: "lopez_island")
       city_list.option(label: "Bellevue", value: "bellevue")
       city_list.option(label: "Seattle", value: "seattle")

--- a/lib/primer/forms/form_control.html.erb
+++ b/lib/primer/forms/form_control.html.erb
@@ -1,5 +1,5 @@
 <% if @input.form_control? %>
-  <%= content_tag(:div, **@form_group_arguments) do %>
+  <%= content_tag(@tag, **@form_group_arguments) do %>
     <% if @input.label %>
       <%= builder.label(@input.name, **@input.label_arguments) do %>
         <%= @input.label %>

--- a/lib/primer/forms/form_control.rb
+++ b/lib/primer/forms/form_control.rb
@@ -6,12 +6,15 @@ module Primer
     class FormControl < BaseComponent
       delegate :builder, :form, to: :@input
 
-      def initialize(input:, tag: :div)
+      def initialize(input:, tag: :div, **system_arguments)
         @input = input
         @tag = tag
         @input.add_label_classes("FormControl-label")
         @form_group_arguments = {
+          **system_arguments,
           class: class_names(
+            system_arguments[:class],
+            system_arguments[:classes],
             "FormControl",
             "width-full",
             "FormControl--fullWidth" => @input.full_width?

--- a/lib/primer/forms/form_control.rb
+++ b/lib/primer/forms/form_control.rb
@@ -6,8 +6,9 @@ module Primer
     class FormControl < BaseComponent
       delegate :builder, :form, to: :@input
 
-      def initialize(input:)
+      def initialize(input:, tag: :div)
         @input = input
+        @tag = tag
         @input.add_label_classes("FormControl-label")
         @form_group_arguments = {
           class: class_names(

--- a/lib/primer/forms/multi.html.erb
+++ b/lib/primer/forms/multi.html.erb
@@ -1,9 +1,7 @@
-<%= content_tag(:div, **@input.input_arguments) do %>
-  <%= render(FormControl.new(input: @input)) do %>
-    <primer-multi-input data-name="<%= @input.name %>">
-      <% @input.inputs.each do |child_input| %>
-        <%= render(child_input.to_component) %>
-      <% end %>
-    </primer-multi-input>
-  <% end %>
+<%= render(FormControl.new(input: @input, **@input.input_arguments)) do %>
+  <primer-multi-input data-name="<%= @input.name %>">
+    <% @input.inputs.each do |child_input| %>
+      <%= render(child_input.to_component) %>
+    <% end %>
+  </primer-multi-input>
 <% end %>

--- a/lib/primer/forms/text_field.html.erb
+++ b/lib/primer/forms/text_field.html.erb
@@ -1,19 +1,17 @@
-<primer-text-field>
-  <%= render(FormControl.new(input: @input)) do %>
-    <%= content_tag(:div, **@field_wrap_arguments) do %>
-      <% if @input.leading_visual %>
-        <span class="FormControl-input-leadingVisualWrap">
-          <%= render(Primer::Beta::Octicon.new(**@input.leading_visual)) %>
-        </span>
-      <% end %>
-      <%= render Primer::ConditionalWrapper.new(condition: @input.auto_check_src, tag: "auto-check", csrf: auto_check_authenticity_token, src: @input.auto_check_src) do %>
-        <%= builder.text_field(@input.name, **@input.input_arguments) %>
-      <% end %>
-      <% if @input.show_clear_button? %>
-        <button type="button" id="<%= @input.clear_button_id %>" class="FormControl-input-trailingAction" aria-label="Clear" data-action="click:primer-text-field#clearContents">
-          <%= render(Primer::Beta::Octicon.new(icon: :"x-circle-fill")) %>
-        </button>
-      <% end %>
+<%= render(FormControl.new(input: @input, tag: :"primer-text-field")) do %>
+  <%= content_tag(:div, **@field_wrap_arguments) do %>
+    <% if @input.leading_visual %>
+      <span class="FormControl-input-leadingVisualWrap">
+        <%= render(Primer::Beta::Octicon.new(**@input.leading_visual)) %>
+      </span>
+    <% end %>
+    <%= render Primer::ConditionalWrapper.new(condition: @input.auto_check_src, tag: "auto-check", csrf: auto_check_authenticity_token, src: @input.auto_check_src) do %>
+      <%= builder.text_field(@input.name, **@input.input_arguments) %>
+    <% end %>
+    <% if @input.show_clear_button? %>
+      <button type="button" id="<%= @input.clear_button_id %>" class="FormControl-input-trailingAction" aria-label="Clear" data-action="click:primer-text-field#clearContents">
+        <%= render(Primer::Beta::Octicon.new(icon: :"x-circle-fill")) %>
+      </button>
     <% end %>
   <% end %>
-</primer-text-field>
+<% end %>

--- a/test/lib/primer/forms/forms_test.rb
+++ b/test/lib/primer/forms/forms_test.rb
@@ -275,4 +275,10 @@ class Primer::Forms::FormsTest < Minitest::Test
     assert_selector "input[name=enabled]"
     assert_selector ".my-test-caption"
   end
+
+  def test_text_field_custom_element_is_form_control
+    render_preview :single_text_field_form
+
+    assert_selector "primer-text-field.FormControl"
+  end
 end

--- a/test/lib/primer/forms/forms_test.rb
+++ b/test/lib/primer/forms/forms_test.rb
@@ -281,4 +281,10 @@ class Primer::Forms::FormsTest < Minitest::Test
 
     assert_selector "primer-text-field.FormControl"
   end
+
+  def test_siblings_are_form_controls_when_including_a_multi_input
+    render_preview :multi_input_form
+
+    assert_selector ".FormControl-radio-group-wrap + .FormControl"
+  end
 end


### PR DESCRIPTION
### Description

We have a few forms in dotcom right now that look kinda funky:

<img width="683" alt="Screenshot of the billing upgrade form. Some fields look fine but the city, zip, state, and country fields are all unequal in width, which is jarring to the eye" src="https://user-images.githubusercontent.com/575280/227358230-c5d8e362-ea26-4553-94bd-16bd31942d8a.png">

### Text inputs

A recent PR wrapped text inputs in the `<primer-text-field>` custom element, which has no styling. The framework expects all inputs to be wrapped with the `FormControl` class, which sets some necessary `flex-*` rules. This PR ensures this class is attached to `<primer-text-field>` and not one if its children.

### Multi inputs

Multi inputs suffer from the same problem, although the `<primer-multi-input>` custom element has been around for a bit longer.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
