### PR TITLE
Update component status migrator to migrate from alpha or beta

### DIFF
--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -11,7 +11,7 @@ class ComponentVersion
 
   def initialize(name, status = nil)
     @name = name
-    @status = (status || inferred_component_status).to_sym
+    @status = status || inferred_component_status
 
     raise "Invalid status: #{@status}" unless STATUSES.include?(@status)
   end
@@ -414,12 +414,11 @@ class ComponentStatusMigrator < Thor::Group
 
   private
 
-  def status
-    options[:status].downcase
-  end
-
   def new_version
-    @new_version ||= ComponentVersion.new(name.gsub("Component", ""), status)
+    @new_version ||= ComponentVersion.new(
+      name.gsub("Component", ""),
+      options[:status].downcase.to_sym
+    )
   end
 
   def old_version

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -45,7 +45,7 @@ class ComponentVersion
   end
 
   def static_asset_paths
-    Dir.glob(File.join(base_path, "#{name.underscore}*"))
+    Dir.glob(File.join(base_path, "#{name.underscore}.*"))
   end
 
   def template_path

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -139,8 +139,12 @@ class ComponentStatusMigrator < Thor::Group
     true
   end
 
-  def explain_migration
-    puts "Migrating #{old_version.fully_qualified_class_name} -> #{new_version.fully_qualified_class_name}"
+  def verify_different_statuses
+    if old_version.status == new_version.status
+      raise "#{old_version.name} is already in \"#{old_version.status}\""
+    else
+      puts "Migrating #{old_version.fully_qualified_class_name} -> #{new_version.fully_qualified_class_name}"
+    end
   end
 
   def validate_status

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -125,13 +125,13 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def rename_test_class
-    return nil unless File.exist?(new_version.test_path)
-
-    gsub_file(
-      new_version.test_path,
-      /class .*Test </,
-      "class Primer#{new_version.module_name}#{name_without_suffix.gsub('::', '')}Test <"
-    )
+    if File.exist?(new_version.test_path)
+      gsub_file(
+        new_version.test_path,
+        /class .*Test </,
+        "class Primer#{new_version.module_name}#{new_version.name.gsub('::', '')}Test <"
+      )
+    end
   end
 
   def rename_nav_entry

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -5,13 +5,15 @@ require "active_support/core_ext/string/inflections"
 
 class ComponentVersion
   COMPONENT_PATH = File.join("app", "components", "primer")
-  STATUSES = %w[alpha beta deprecated stable experimental].freeze
+  STATUSES = [:alpha, :beta, :deprecated, :stable, :experimental].freeze
 
   attr_reader :name, :status
 
   def initialize(name, status = nil)
     @name = name
     @status = (status || inferred_status).to_sym
+
+    raise "Invalid status: #{@status}" unless STATUSES.include?(@status)
   end
 
   def module_name
@@ -144,10 +146,6 @@ class ComponentStatusMigrator < Thor::Group
     else
       puts "Migrating #{old_version.fully_qualified_class_name} -> #{new_version.fully_qualified_class_name}"
     end
-  end
-
-  def validate_status
-    raise "Invalid status: #{status}" unless ComponentVersion::STATUSES.include?(status)
   end
 
   def move_controller

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -21,7 +21,7 @@ class ComponentStatusMigrator < Thor::Group
     default: "alpha",
     desc: "Status of the component. Valid values: #{STATUSES.join(', ')}",
     required: true,
-    type: :string,
+    type: :string
   )
 
   def self.source_root
@@ -40,7 +40,7 @@ class ComponentStatusMigrator < Thor::Group
     move_file(
       "controller",
       old_version.controller_path,
-      new_version.controller_path,
+      new_version.controller_path
     )
   end
 
@@ -49,7 +49,7 @@ class ComponentStatusMigrator < Thor::Group
       move_file(
         "template",
         old_version.template_path,
-        new_version.template_path,
+        new_version.template_path
       )
     end
   end
@@ -67,7 +67,7 @@ class ComponentStatusMigrator < Thor::Group
       move_file(
         "test",
         old_version.test_path,
-        new_version.test_path,
+        new_version.test_path
       )
     end
   end
@@ -77,25 +77,25 @@ class ComponentStatusMigrator < Thor::Group
       move_file(
         "preview",
         old_version.preview_path,
-        new_version.preview_path,
+        new_version.preview_path
       )
     end
   end
 
   def add_module_to_component
-    # TODO avoid adding the module twice
-    if !stable?
+    # TODO: avoid adding the module twice
+    unless stable?
       insert_into_file(
         new_version.controller_path,
         "  module #{new_version.class_status}\n",
-        after: "module Primer\n",
+        after: "module Primer\n"
       )
 
       insert_into_file(
         new_version.controller_path,
         "  end\n",
         before: /^end$/,
-        force: true,
+        force: true
       )
     end
   end
@@ -107,14 +107,14 @@ class ComponentStatusMigrator < Thor::Group
     insert_into_file(
       new_version.preview_path,
       "  module #{new_version.class_status}\n",
-      after: "module Primer\n",
+      after: "module Primer\n"
     )
 
     insert_into_file(
       new_version.preview_path,
       "  end\n",
       before: /^end$/,
-      force: true,
+      force: true
     )
   end
 
@@ -146,7 +146,7 @@ class ComponentStatusMigrator < Thor::Group
     gsub_file(
       new_version.test_path,
       /class .*Test </,
-      "class Primer#{new_version.class_status}#{name_without_suffix.gsub('::', '')}Test <",
+      "class Primer#{new_version.class_status}#{name_without_suffix.gsub('::', '')}Test <"
     )
   end
 
@@ -224,6 +224,7 @@ class ComponentStatusMigrator < Thor::Group
     # rubocop will exit with a non-zero code, due to
     # the expected linter failures. this causes thor
     # to stop running the script before it should
+    exit 1 # TODO remove this!
     run("bundle exec rubocop -a; exit 0")
   end
 
@@ -318,9 +319,7 @@ class ComponentVersion
   end
 
   def class_status
-    if status != :stable
-      status.to_s.capitalize
-    end
+    status.to_s.capitalize if status != :stable
   end
 
   def controller_path
@@ -328,21 +327,21 @@ class ComponentVersion
   end
 
   def template_path
-    File.join(base_path, "#{ name.underscore }.html.erb")
+    File.join(base_path, "#{name.underscore}.html.erb")
   end
 
   def test_path
-    File.join("test", "components", status_directory, "#{ name.underscore }_test.rb")
+    File.join("test", "components", status_directory, "#{name.underscore}_test.rb")
   end
 
   def preview_path
     preview_directory = File.join("previews", "primer", status_directory)
-    path_with_component = File.join(preview_directory, "#{ name.underscore }_component_preview.rb")
+    path_with_component = File.join(preview_directory, "#{name.underscore}_component_preview.rb")
 
     if File.exist?(path_with_component)
       path_with_component
     else
-      path_with_component = File.join(preview_directory, "#{ name.underscore }_preview.rb")
+      path_with_component = File.join(preview_directory, "#{name.underscore}_preview.rb")
     end
   end
 
@@ -355,29 +354,25 @@ class ComponentVersion
   def inferred_status
     component_paths = Dir.glob(File.join(COMPONENT_PATH, "**", component_file_name))
 
-    if component_paths.empty?
-      raise("Couldn't find #{ component_file_name } in component directory")
-    end
+    raise("Couldn't find #{component_file_name} in component directory") if component_paths.empty?
 
-    if component_paths.size > 1
-      raise("Found multiple files named #{ component_file_name } in component directory, can't infer version")
-    end
+    raise("Found multiple files named #{component_file_name} in component directory, can't infer version") if component_paths.size > 1
 
     component_path = component_paths.first
     component_directory = File.dirname(component_path)
 
-    if component_directory != COMPONENT_PATH
-      File.split(component_directory).last.to_sym
-    else
+    if component_directory == COMPONENT_PATH
       content = File.read(component_path)
 
-      if content =~ /^\s+status\s+:stable\s*$/
+      if /^\s+status\s+:stable\s*$/.match?(content)
         :stable
-      elsif content =~ /^\s+status\s+:deprecated\s*$/
+      elsif /^\s+status\s+:deprecated\s*$/.match?(content)
         :deprecated
       else
-        raise("Can't infer version of #{ component_path }")
+        raise("Can't infer version of #{component_path}")
       end
+    else
+      File.split(component_directory).last.to_sym
     end
   end
 
@@ -394,6 +389,6 @@ class ComponentVersion
   end
 
   def component_file_name
-    "#{ name.underscore }.rb"
+    "#{name.underscore}.rb"
   end
 end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -337,18 +337,18 @@ class ComponentStatusMigrator < Thor::Group
     cmd = ["grep -rl #{name} ."]
     cmd << exclude_files.map { |f| "--exclude=#{f}" }.join(" ")
     cmd << "--exclude-dir={#{exclude_folders.join(',')}}"
-    cmd << "| xargs #{inline_sed} -e 's/#{old_version.fully_qualified_class_name}/#{new_version.fully_qualified_class_name}/g'"
+    cmd << "| xargs #{replace_class_name_command}"
 
     run(cmd.join(" "))
   end
 
-  def inline_sed
+  def replace_class_name_command
     # GNU and FreeBSD/Mac seds have mutually incompatible syntax for modifying
-    # files inline.
+    # files inline and identifying word boundaries.
     if using_gnu_sed?
-      "sed -i"
+      "sed -i -e 's/#{old_version.fully_qualified_class_name}\\>/#{new_version.fully_qualified_class_name}/g'"
     else
-      "sed -i ''"
+      "sed -i '' -e 's/#{old_version.fully_qualified_class_name}[[:>:]]/#{new_version.fully_qualified_class_name}/g'"
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -269,6 +269,22 @@ class ComponentStatusMigrator < Thor::Group
     )
   end
 
+  def update_component_status
+    if component_has_status_annotation?
+      gsub_file(
+        new_version.controller_path,
+        /^\s+status\s+:#{old_version.status}\s*$/,
+        "status :#{new_version.status}"
+      )
+    else
+      insert_into_file(
+        new_version.controller_path,
+        "status :#{new_version.status}\n\n",
+        after: "class #{new_version.name} < Primer::Component\n"
+      )
+    end
+  end
+
   def rename_preview_label
     return unless File.exist?(new_version.preview_path)
 
@@ -438,6 +454,10 @@ class ComponentStatusMigrator < Thor::Group
 
   def old_version
     @old_version ||= ComponentVersion.new(name)
+  end
+
+  def component_has_status_annotation?
+    File.read(new_version.controller_path).match?(/^\s+status\s+:#{old_version.status}\s*$/)
   end
 
   def move_file(file_type, old_path, new_path)

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -105,11 +105,13 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def remove_suffix_from_preview_class
-    return nil unless File.exist?(new_version.preview_path)
-
-    original_preview_class = /class .*Preview < ViewComponent::Preview/
-    updated_preview_class = "class #{name_without_suffix}Preview < ViewComponent::Preview"
-    gsub_file(new_version.preview_path, original_preview_class, updated_preview_class)
+    if File.exist?(new_version.preview_path)
+      gsub_file(
+        new_version.preview_path,
+        /class .*Preview < ViewComponent::Preview/,
+        "class #{new_version.name}Preview < ViewComponent::Preview"
+      )
+    end
   end
 
   def rename_preview_label

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -21,10 +21,14 @@ class ComponentVersion
   end
 
   def fully_qualified_class_name
+    "Primer::#{qualified_class_name}"
+  end
+
+  def qualified_class_name
     if component_belongs_in_module?
-      "Primer::#{module_name}::#{name}"
+      "#{module_name}::#{name}"
     else
-      "Primer::#{name}"
+      "#{name}"
     end
   end
 
@@ -142,7 +146,7 @@ class ComponentStatusMigrator < Thor::Group
 
   def verify_different_statuses
     if old_version.status == new_version.status
-      raise "#{old_version.name} is already in \"#{old_version.status}\""
+      raise "#{old_version.name} is already \"#{old_version.status}\"!"
     else
       puts "Migrating #{old_version.fully_qualified_class_name} -> #{new_version.fully_qualified_class_name}"
     end
@@ -317,7 +321,7 @@ class ComponentStatusMigrator < Thor::Group
       # frozen_string_literal: true
 
       module Primer
-        class #{name} < #{new_version.fully_qualified_class_name}
+        class #{old_version.qualified_class_name} < #{new_version.qualified_class_name}
           status :deprecated
         end
       end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -91,15 +91,19 @@ class ComponentVersion
     component_directory = File.dirname(component_path)
 
     if component_directory == COMPONENT_PATH
-      content = File.read(component_path)
-
-      if /^\s+status\s+:stable\s*$/.match?(content)
-        :stable
-      else
-        :deprecated
-      end
+      infer_status_from_code(component_path)
     else
       File.split(component_directory).last.to_sym
+    end
+  end
+
+  def infer_status_from_source(path)
+    content = File.read(path)
+
+    if /^\s+status\s+:stable\s*$/.match?(content)
+      :stable
+    else
+      :deprecated
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "active_support/core_ext/string/inflections"
 
 # :nodoc:
 class ComponentVersion

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -227,7 +227,7 @@ class ComponentStatusMigrator < Thor::Group
       copy_file(old_path, new_path)
       remove_file(old_path)
     else
-      puts "Nothing moved. #{file_type.capitalize} file not found: #{new_path}"
+      puts "Nothing moved. #{file_type.capitalize} file not found: #{old_path}"
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "thor"
+require "fileutils"
 require "active_support/core_ext/string/inflections"
 
 # Migrates components to their new namespace.
@@ -55,6 +56,13 @@ class ComponentStatusMigrator < Thor::Group
         old_version.template_path,
         new_version.template_path
       )
+    end
+  end
+
+  def move_assets
+    old_version.static_asset_paths.each do |static_asset_path|
+      puts "Moving #{static_asset_path} -> #{new_version.base_path}"
+      FileUtils.mv(static_asset_path, new_version.base_path)
     end
   end
 
@@ -346,6 +354,14 @@ class ComponentVersion
     File.join(base_path, component_file_name)
   end
 
+  def base_path
+    File.join(COMPONENT_PATH, status_directory)
+  end
+
+  def static_asset_paths
+    Dir.glob(File.join(base_path, "#{name.underscore}*"))
+  end
+
   def template_path
     File.join(base_path, "#{name.underscore}.html.erb")
   end
@@ -404,10 +420,6 @@ class ComponentVersion
     else
       File.split(component_directory).last.to_sym
     end
-  end
-
-  def base_path
-    File.join(COMPONENT_PATH, status_directory)
   end
 
   def component_file_name

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -83,52 +83,13 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def add_module_to_component
-    if old_version.component_belongs_in_module?
-      gsub_file(
-        new_version.controller_path,
-        /^  module #{old_version.module_name}$\n/,
-        ""
-      )
-
-      gsub_file(
-        new_version.controller_path,
-        "  end\nend\n",
-        "end\n"
-      )
-    end
-
-    if new_version.component_belongs_in_module?
-      insert_into_file(
-        new_version.controller_path,
-        "  module #{new_version.module_name}\n",
-        after: "module Primer\n"
-      )
-
-      insert_into_file(
-        new_version.controller_path,
-        "  end\n",
-        before: /^end$/,
-        force: true
-      )
-    end
+    update_ruby_version_module(new_version.controller_path)
   end
 
   def add_module_to_preview
-    return unless new_version.component_belongs_in_module?
-    return nil unless File.exist?(new_version.preview_path)
-
-    insert_into_file(
-      new_version.preview_path,
-      "  module #{new_version.module_name}\n",
-      after: "module Primer\n"
-    )
-
-    insert_into_file(
-      new_version.preview_path,
-      "  end\n",
-      before: /^end$/,
-      force: true
-    )
+    if File.exist?(new_version.preview_path)
+      update_ruby_version_module(new_version.preview_path)
+    end
   end
 
   def remove_suffix_from_component_class
@@ -293,6 +254,37 @@ class ComponentStatusMigrator < Thor::Group
       remove_file(old_path)
     else
       puts "Nothing moved. #{file_type.capitalize} file not found: #{old_path}"
+    end
+  end
+
+  def update_ruby_version_module(path)
+    if old_version.component_belongs_in_module?
+      gsub_file(
+        path,
+        /^  module #{old_version.module_name}$\n/,
+        ""
+      )
+
+      gsub_file(
+        path,
+        "  end\nend\n",
+        "end\n"
+      )
+    end
+
+    if new_version.component_belongs_in_module?
+      insert_into_file(
+        path,
+        "  module #{new_version.module_name}\n",
+        after: "module Primer\n"
+      )
+
+      insert_into_file(
+        path,
+        "  end\n",
+        before: /^end$/,
+        force: true
+      )
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -30,6 +30,11 @@ class ComponentStatusMigrator < Thor::Group
     raise "Invalid status: #{status}" unless STATUSES.include?(status)
   end
 
+  def check_current_status
+    puts from_status
+    exit
+  end
+
   def move_controller
     move_file("controller", controller_path, controller_path_with_status)
   end
@@ -285,6 +290,27 @@ class ComponentStatusMigrator < Thor::Group
 
   def status
     @status ||= options[:status].downcase
+  end
+
+  def from_status
+    @detected_status ||= STATUSES.detect { |from_status|
+      controller_path = File.join(
+        source_path_for_status(from_status),
+        "#{name.underscore}.rb",
+      )
+
+      File.exists?(controller_path)
+    }
+
+    @detected_status || raise("Couldn't find #{name.underscore}.rb in component directory")
+  end
+
+  def source_path_for_status(from_status)
+    if from_status == "deprecated"
+      File.join("app", "components", "primer")
+    else
+      File.join("app", "components", "primer", from_status)
+    end
   end
 
   def status_url

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -34,7 +34,7 @@ class ComponentVersion
   end
 
   def component_belongs_in_module?
-    [:deprecated, :stable].exclude?(status)
+    ![:deprecated, :stable].include?(status) # rubocop:disable Rails/NegateInclude
   end
 
   def controller_path

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -55,7 +55,11 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def update_css
-    gsub_file(primer_css_file, component_css_import, component_css_import_with_status)
+    gsub_file(
+      primer_css_file,
+      "import \"#{old_version.css_import_path}\"",
+      "import \"#{new_version.css_import_path}\""
+    )
   end
 
   def move_test
@@ -255,16 +259,6 @@ class ComponentStatusMigrator < Thor::Group
     @old_version ||= ComponentVersion.new(name)
   end
 
-  def component_css_import
-    # TODO use relative location
-    @component_css_import ||= "import \"./#{name.underscore}.pcss\""
-  end
-
-  def component_css_import_with_status
-    # TODO use relative location
-    @component_css_import_with_status ||= "import \"./#{status_folder_name}#{name_without_suffix.underscore}.pcss\""
-  end
-
   def move_file(file_type, old_path, new_path)
     if old_path == new_path
       puts "No change needed - #{file_type} file not moved"
@@ -350,6 +344,10 @@ class ComponentVersion
     else
       path_with_component = File.join(preview_directory, "#{ name.underscore }_preview.rb")
     end
+  end
+
+  def css_import_path
+    File.join(".", status_directory, "#{name.underscore}.pcss")
   end
 
   private

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -40,14 +40,6 @@ class ComponentStatusMigrator < Thor::Group
     move_file("template", template_path, template_path_with_status)
   end
 
-  def move_reamining_files
-    Dir["app/components/primer/#{name.underscore}.*"].each do |file_path|
-      file_name = File.basename(file_path)
-      new_path = "#{status_full_path}#{file_name.gsub('_component', '')}"
-      move_file("misc", file_path, new_path)
-    end
-  end
-
   def update_css
     gsub_file(primer_css_file, component_css_import, component_css_import_with_status)
   end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -119,10 +119,14 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def remove_suffix_from_component_class
-    if name == name_without_suffix
+    if old_version.name == new_version.name
       puts "No change needed - component suffix not removed from component class name"
     else
-      gsub_file(new_version.controller_path, "class #{name}", "class #{name_without_suffix}")
+      gsub_file(
+        new_version.controller_path,
+        "class #{old_version.name}",
+        "class #{new_version.name}"
+      )
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -115,9 +115,13 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def rename_preview_label
-    return nil unless File.exist?(new_version.preview_path)
-
-    gsub_file(new_version.preview_path, /# @label #{name}/, "# @label #{name_without_suffix}")
+    if File.exist?(new_version.preview_path)
+      gsub_file(
+        new_version.preview_path,
+        /# @label #{old_version.name}/,
+        "# @label #{new_version.name}",
+      )
+    end
   end
 
   def rename_test_class

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -204,9 +204,10 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def add_to_deprecated_component_configuration
-    content = []
-    content << "  - component: \"Primer::#{name}\"\n"
-    content << "    replacement: \"Primer::#{new_version.module_prefix}#{new_version.name}\"\n"
+    content = [
+      "  - component: \"Primer::#{name}\"\n",
+      "    replacement: \"Primer::#{new_version.module_prefix}#{new_version.name}\"\n"
+    ]
 
     insert_into_file(
       "lib/primer/deprecations.yml",
@@ -218,7 +219,7 @@ class ComponentStatusMigrator < Thor::Group
   def add_to_ignored_component_test
     insert_into_file(
       "test/components/component_test.rb",
-      "\"Primer::#{name}\",\n",
+      "\"Primer::#{old_version.name}\",\n",
       after: "ignored_components = [\n"
     )
   end
@@ -245,12 +246,12 @@ class ComponentStatusMigrator < Thor::Group
     puts "Component Status Migration Completed"
     puts "------------------------------------"
     puts ""
-    puts "Original Component: 'Primer::#{name}'"
+    puts "Original Component: 'Primer::#{old_version.module_prefix}#{old_version.name}'"
     puts "     New Component: 'Primer::#{new_version.module_prefix}#{new_version.name}'"
     puts ""
     puts "IMPORTANT NOTE:"
     puts ""
-    puts "The original component has been marked as deprecated, but needs additional configuration. Please update the entry in 'lib/primer/deprecations.yml'."
+    puts "The original component has been migrated, but may need additional configuration. Please update the entry in 'lib/primer/deprecations.yml'."
     puts ""
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -391,10 +391,8 @@ class ComponentVersion
 
       if /^\s+status\s+:stable\s*$/.match?(content)
         :stable
-      elsif /^\s+status\s+:deprecated\s*$/.match?(content)
-        :deprecated
       else
-        raise("Can't infer version of #{component_path}")
+        :deprecated
       end
     else
       File.split(component_directory).last.to_sym

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -199,7 +199,15 @@ class ComponentStatusMigrator < Thor::Group
     remove_file(old_version.controller_path)
     create_file(
       old_version.controller_path,
-      "# frozen_string_literal: true\n\nmodule Primer\n\tclass #{name} < Primer::#{status_module}#{name_without_suffix}\n\t\tstatus :deprecated\n\tend\nend"
+      <<~DEPRECATED_CLASS
+      # frozen_string_literal: true
+
+      module Primer
+        class #{name} < Primer::#{status_module}#{name_without_suffix}
+          status :deprecated
+        end
+      end
+      DEPRECATED_CLASS
     )
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -93,9 +93,7 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def remove_suffix_from_component_class
-    if old_version.name == new_version.name
-      puts "No change needed - component suffix not removed from component class name"
-    else
+    if old_version.name != new_version.name
       gsub_file(
         new_version.controller_path,
         "class #{old_version.name}",
@@ -154,10 +152,11 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def update_primer_js_imports
-    primer_js = "app/components/primer/primer.ts"
-    original_content = "import './#{name.underscore}'"
-    updated_content = "import './#{status_folder_name}#{name_without_suffix.underscore}'"
-    gsub_file(primer_js, original_content, updated_content)
+    gsub_file(
+      "app/components/primer/primer.ts",
+      "import '#{old_version.primer_js_import_path}'",
+      "import '#{new_version.primer_js_import_path}'"
+    )
   end
 
   def update_all_references
@@ -383,6 +382,10 @@ class ComponentVersion
 
   def css_import_path
     File.join(".", status_directory, "#{name.underscore}.pcss")
+  end
+
+  def primer_js_import_path
+    File.join(".", status_directory, "#{name.underscore}")
   end
 
   def status_directory

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -83,11 +83,24 @@ class ComponentStatusMigrator < Thor::Group
   end
 
   def add_module_to_component
-    # TODO: avoid adding the module twice
-    if !new_version.stable?
+    if old_version.component_belongs_in_module?
+      gsub_file(
+        new_version.controller_path,
+        /^  module #{old_version.module_name}$\n/,
+        ""
+      )
+
+      gsub_file(
+        new_version.controller_path,
+        "  end\nend\n",
+        "end\n"
+      )
+    end
+
+    if new_version.component_belongs_in_module?
       insert_into_file(
         new_version.controller_path,
-        "  module #{new_version.class_status}\n",
+        "  module #{new_version.module_name}\n",
         after: "module Primer\n"
       )
 
@@ -327,7 +340,7 @@ class ComponentVersion
   end
 
   def module_name
-    status.to_s.capitalize if !component_belongs_in_module?
+    status.to_s.capitalize if component_belongs_in_module?
   end
 
   def component_belongs_in_module?

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -56,7 +56,7 @@ class ComponentStatusMigrator < Thor::Group
 
   def update_css
     gsub_file(
-      primer_css_file,
+      "app/components/primer/primer.pcss",
       "import \"#{old_version.css_import_path}\"",
       "import \"#{new_version.css_import_path}\""
     )
@@ -257,6 +257,10 @@ class ComponentStatusMigrator < Thor::Group
 
   private
 
+  def status
+    options[:status].downcase
+  end
+
   def new_version
     @new_version ||= ComponentVersion.new(name.gsub("Component", ""), status)
   end
@@ -304,22 +308,6 @@ class ComponentStatusMigrator < Thor::Group
         before: /^end$/,
         force: true
       )
-    end
-  end
-
-  def status
-    @status ||= options[:status].downcase
-  end
-
-  def primer_css_file
-    "app/components/primer/primer.pcss"
-  end
-
-  def short_name
-    @short_name ||= begin
-      name_with_status = name.gsub(/Primer::|Component/, "")
-      m = name_with_status.match(/(?<status>Beta|Alpha|Deprecated)?(?<_colons>::)?(?<name>.*)/)
-      m[:name].gsub("::", "").downcase
     end
   end
 end

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -136,8 +136,21 @@ class ComponentStatusMigrator < Thor::Group
 
   def rename_nav_entry
     nav_file = "docs/src/@primer/gatsby-theme-doctocat/nav.yml"
-    gsub_file(nav_file, "title: #{name}", "title: #{name_without_suffix}")
-    gsub_file(nav_file, "url: \"/components/#{name_without_suffix.downcase}\"", "url: \"/components/#{status_url}#{name_without_suffix.downcase}\"")
+
+    gsub_file(
+      nav_file,
+      "title: #{old_version.name}",
+      "title: #{new_version.name}",
+    )
+
+    old_path = File.join("/", "components", old_version.status_directory, new_version.name.downcase)
+    new_path = File.join("/", "components", new_version.status_directory, new_version.name.downcase)
+
+    gsub_file(
+      nav_file,
+      "url: \"#{old_path}\"",
+      "url: \"#{new_path}\""
+    )
   end
 
   def update_primer_js_imports
@@ -372,6 +385,14 @@ class ComponentVersion
     File.join(".", status_directory, "#{name.underscore}.pcss")
   end
 
+  def status_directory
+    if component_belongs_in_module?
+      status.to_s
+    else
+      ""
+    end
+  end
+
   private
 
   def inferred_status
@@ -394,14 +415,6 @@ class ComponentVersion
       end
     else
       File.split(component_directory).last.to_sym
-    end
-  end
-
-  def status_directory
-    if component_belongs_in_module?
-      status.to_s
-    else
-      ""
     end
   end
 

--- a/component_status_migrator.thor
+++ b/component_status_migrator.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "fileutils"
 require "active_support/core_ext/string/inflections"
 
 class ComponentVersion
@@ -171,8 +170,11 @@ class ComponentStatusMigrator < Thor::Group
 
   def move_assets
     old_version.static_asset_paths.each do |static_asset_path|
-      puts "Moving #{static_asset_path} -> #{new_version.base_path}"
-      FileUtils.mv(static_asset_path, new_version.base_path)
+      copy_file(
+        static_asset_path,
+        File.join(new_version.base_path, File.basename(static_asset_path))
+      )
+      remove_file(static_asset_path)
     end
   end
 


### PR DESCRIPTION
### Description
The status migrator currently only accepts components defined at the top level of the `app/components/primer`. Since we've moved most of those components into subdirectories, like `alpha/` and `beta/`, we'd like to be able to migrate those, too, so that we can automatically migrate components e.g. `alpha -> beta`.

This involves:

1. Determining the *current* status of the component. This can't just involve checking paths, but needs to involve inspecting the source code of the component for a `status` annotation, since when we migrate components we leave behind a file annotated with `status: :deprecated` representing the previous version of the component.
2. Manipulating the code by editing the module in which the component's defined. For example, `Primer::FooBar -> Primer::Alpha::FooBar` involves adding a `module Alpha` section, which we already do, but `Primer::Alpha::FooBar -> Primer::Beta::FooBar` requires recognizing and modifying that module.

This PR defines a `ComponentVersion` class representing a component and its status. We use that information to construct fully qualified class names and file paths. If a status isn't provided it infers the current version from a combination of file paths and source code.

While there still aren't automated tests for this script, you can try the manual commands to see how it works:

```sh
$ bundle exec thor component_status_migrator ButtonMarketing --status beta
Migrating Primer::Alpha::ButtonMarketing -> Primer::Beta::ButtonMarketing
      create  app/components/primer/beta/button_marketing.rb
      remove  app/components/primer/alpha/button_marketing.rb
      create  app/components/primer/beta/button_marketing.pcss
      remove  app/components/primer/alpha/button_marketing.pcss
        gsub  app/components/primer/primer.pcss
      create  test/components/beta/button_marketing_test.rb
      remove  test/components/alpha/button_marketing_test.rb
      create  previews/primer/beta/button_marketing_preview.rb
      remove  previews/primer/alpha/button_marketing_preview.rb
        gsub  app/components/primer/beta/button_marketing.rb
        gsub  app/components/primer/beta/button_marketing.rb
      insert  app/components/primer/beta/button_marketing.rb
      insert  app/components/primer/beta/button_marketing.rb
        gsub  previews/primer/beta/button_marketing_preview.rb
        gsub  previews/primer/beta/button_marketing_preview.rb
      insert  previews/primer/beta/button_marketing_preview.rb
      insert  previews/primer/beta/button_marketing_preview.rb
        gsub  previews/primer/beta/button_marketing_preview.rb
        gsub  previews/primer/beta/button_marketing_preview.rb
        gsub  test/components/beta/button_marketing_test.rb
        gsub  docs/src/@primer/gatsby-theme-doctocat/nav.yml
        gsub  docs/src/@primer/gatsby-theme-doctocat/nav.yml
        gsub  app/components/primer/primer.ts
         run  grep -rl ButtonMarketing . --exclude=.overmind.sock --exclude=CHANGELOG.md --exclude=test/components/alpha/button_marketing_test.rb --exclude-dir={.git,.cache,.yardoc,builds,log,node_modules,tmp,vendor} | xargs sed -i '' 's/Primer::Alpha::ButtonMarketing/Primer::Beta::ButtonMarketing/g' from "."
      remove  app/components/primer/alpha/button_marketing.rb
      create  app/components/primer/alpha/button_marketing.rb
      insert  lib/primer/deprecations.yml
      insert  test/components/component_test.rb
         run  bundle exec rubocop -a; exit 0 from "."

[...]

Component Status Migration Completed
------------------------------------

Original Component: 'Primer::Alpha::ButtonMarketing'
     New Component: 'Primer::Beta::ButtonMarketing'

IMPORTANT NOTE:

The original component has been migrated, but may need additional configuration. Please update the entry in 'lib/primer/deprecations.yml'.
```

Migrating a component in the `app/components/primer` directory still works, too:

```sh
$ bundle exec thor component_status_migrator Box --status beta
Migrating Primer::Box -> Primer::Beta::Box
      create  app/components/primer/beta/box.rb
      remove  app/components/primer/box.rb
        gsub  app/components/primer/primer.pcss
      create  test/components/beta/box_test.rb
      remove  test/components/box_test.rb
      insert  app/components/primer/beta/box.rb
      insert  app/components/primer/beta/box.rb
        gsub  test/components/beta/box_test.rb
        gsub  docs/src/@primer/gatsby-theme-doctocat/nav.yml
        gsub  docs/src/@primer/gatsby-theme-doctocat/nav.yml
        gsub  app/components/primer/primer.ts
         run  grep -rl Box . --exclude=.overmind.sock --exclude=CHANGELOG.md --exclude=test/components/box_test.rb --exclude-dir={.git,.cache,.yardoc,builds,log,node_modules,tmp,vendor} | xargs sed -i '' 's/Primer::Box/Primer::Beta::Box/g' from "."
      remove  app/components/primer/box.rb
      create  app/components/primer/box.rb
      insert  lib/primer/deprecations.yml
      insert  test/components/component_test.rb
         run  bundle exec rubocop -a; exit 0 from "."

[...]

Component Status Migration Completed
------------------------------------

Original Component: 'Primer::Box'
     New Component: 'Primer::Beta::Box'

IMPORTANT NOTE:

The original component has been migrated, but may need additional configuration. Please update the entry in 'lib/primer/deprecations.yml'.
```

### Questions/notes for the reviewer:

- Right now we always assume we want to migrate from the "latest" version of the component: if there's both an `alpha` and `beta` release, migrate from `beta`. That's fine for this ticket, I think, but it'll be an issue if we ever want to downgrade a component (say `beta -> alpha`). We might want a `--from-status` flag or something some day.
- I haven't used `thor` too much, and defining this big `ComponentVersion` class in the same file as the migration script seems clunky. Would there be a canonical directory for that class? I'm reluctant to just dump it in `lib`.
- I've followed the current practice of not writing tests for this script. But if `ComponentVersion` were extracted somewhere it might be nice to backfill some tests for it; that version inference code's a little hairy. Sound good?
- There's some logic in here for parsing and rewriting module names with regexes. I think the changes are still simple enough that we can get away with this, but we're coming right up the point where I'd want to manipulate an AST instead of a text file (I *think* RuboCop provides some tools to make this easier?). If you'd rather go that route, let me know!

Closes #1263.

### Integration

> Does this change require any updates to code in production?

Nope! This is just an internal tool.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
