### PR TITLE
Suggest ViewComponents on reserved class use

### DIFF
--- a/.changeset/tall-phones-battle.md
+++ b/.changeset/tall-phones-battle.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix up reserved CSS class linter

--- a/lib/primer/view_components/linters/disallow_component_css_counter.rb
+++ b/lib/primer/view_components/linters/disallow_component_css_counter.rb
@@ -13,18 +13,57 @@ module ERBLint
   module Linters
     # Counts the number of times a class reserved for ViewComponents is used
     class DisallowComponentCssCounter < BaseLinter
+      CLASSES_COVERED_BY_OTHER_LINTERS =
+        BaseLinter.subclasses.reduce([]) do |html_classes, klass|
+          html_classes.concat(klass.const_get(:CLASSES))
+        end
+
       CLASSES = (
         JSON.parse(
           File.read(
             File.join(__dir__, "..", "..", "..", "..", "static", "classes.json")
           )
-        ) - BaseLinter.subclasses.reduce([]) do |html_classes, klass|
-          html_classes.concat(klass.const_get(:CLASSES))
+        ).reject do |html_class, _ruby_classes|
+          CLASSES_COVERED_BY_OTHER_LINTERS.include?(html_class)
         end
       ).freeze
 
-      TAGS = nil
-      MESSAGE = "Primer ViewComponents defines some HTML classes with associated styles that should not be used outside those components. (These classes might have their styles changed or even disappear in the future.) Instead of using this class directly, please use its component if appropriate or define the styles you need some other way."
+      def run(processed_source)
+        @total_offenses = 0
+        @offenses_not_corrected = 0
+
+        processed_source
+          .parser
+          .nodes_with_type(:tag)
+          .each do |node|
+            tag = BetterHtml::Tree::Tag.from_node(node)
+
+            tag.attributes["class"]&.value&.split(/\s+/)&.each do |class_name|
+              if CLASSES.key? class_name
+                @total_offenses += 1
+                @offenses_not_corrected += 1
+                add_offense(
+                  processed_source.to_source_range(tag.loc),
+                  format_message(class_name)
+                )
+              end
+            end
+          end
+
+        counter_correct?(processed_source)
+
+        dump_data(processed_source) if ENV["DUMP_LINT_DATA"] == "1"
+      end
+
+      private
+
+      def format_message(class_name)
+        "DisallowComponentCssCounter:HTML class \"#{class_name}\" is reserved for Primer ViewComponents. It might disappear or have different styles in the future. You might want to use #{ruby_classes_sentence_string(class_name)} from Primer ViewComponents instead."
+      end
+
+      def ruby_classes_sentence_string(class_name)
+        CLASSES[class_name].to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+      end
     end
   end
 end

--- a/script/export-css-selectors
+++ b/script/export-css-selectors
@@ -8,11 +8,16 @@ const CSSwhat = require('css-what')
 
 console.log('Exporting CSS selectors...')
 
+const capitalize = (s) => s.slice(0, 1).toUpperCase() + s.slice(1)
+const snakeToCamelCase = (s) => s.split('_').map(capitalize).join('')
+const componentNameToRubyClass = (componentName) =>
+  'Primer::' + componentName.split('/').map(snakeToCamelCase).join('::')
+
 const exportSelectors = (folder) => {
-  const folder_glob = folder + '/**/*.css'
+  const folderGlob = `${folder}/**/*.css`
   const componentNameRegex = new RegExp(`${folder.replace('/','\\/')}\\/(.*).css`)
 
-  return glob(folder_glob).then(files =>
+  return glob(folderGlob).then(files =>
     Promise.all(
       files.map(async (file) => {
         console.log(`Processing ${file}`)
@@ -21,7 +26,7 @@ const exportSelectors = (folder) => {
         const componentName = componentNameRegex.exec(file)[1]
 
         const selectors = []
-        const classes = []
+        const classFiles = []
 
         root.walkRules(rule => {
           // @keyframes at-rules have children that look like they have normal
@@ -34,11 +39,11 @@ const exportSelectors = (folder) => {
 
           rule.selectors.forEach(ruleSelector => {
             selectors.push(ruleSelector)
-            CSSwhat.parse(ruleSelector)[0].forEach(ruleObj => {
-              if (ruleObj.type === 'attribute' && ruleObj.name === 'class') {
-                classes.push(ruleObj.value)
-              }
-            })
+            const ruleObj = CSSwhat.parse(ruleSelector)[0][0]
+            if (ruleObj.type === 'attribute' && ruleObj.name === 'class') {
+              const baseHtmlClass = ruleObj.value
+              classFiles.push([baseHtmlClass, componentNameToRubyClass(componentName)])
+            }
           })
         })
 
@@ -47,37 +52,54 @@ const exportSelectors = (folder) => {
           `${file}.json`,
           JSON.stringify({
             name: componentName,
-            selectors: [...new Set(selectors)],
-            classes: [...new Set(classes)]
+            selectors: [...new Set(selectors)]
           }, null, 2)
         ).catch(error => console.error(`Failed to write ${file}.json`, { error }))
 
-        return classes
+        return classFiles
       })
     )
   )
 }
 
-// stylesheets under app/lib/primer/css need their individual
-// json files generated
-exportSelectors('app/lib/primer/css')
-
 // class names referenced under app/components/primer might need
 // to be reserved in addition to getting individual json files
 const classShouldBeReserved = className =>
   (className[0].toUpperCase() === className[0])
+
 exportSelectors('app/components/primer')
   .then(classLists => {
-    console.log(`Writing static/classes.json`)
+    const htmlClassToRubyClasses = {}
+
+    classLists
+      .reduce(((a, b) => a.concat(b)), [])
+      .filter(cf => classShouldBeReserved(cf[0]))
+      // sort by length so we process e.g. "Label" before "Label--accent"
+      .sort(([htmlClassA], [htmlClassB]) => htmlClassA.length - htmlClassB.length)
+      .forEach(([htmlClass, rubyClass]) => {
+        if (!htmlClassToRubyClasses[htmlClass]) {
+          htmlClassToRubyClasses[htmlClass] = new Set()
+        }
+
+        htmlClassToRubyClasses[htmlClass].add(rubyClass)
+      })
+
+    console.log('Writing static/classes.json')
     return writeFile(
       'static/classes.json',
       JSON.stringify(
-        [...new Set(classLists.reduce((a, b) => a.concat(b)))]
-          .filter(classShouldBeReserved)
-          .sort(),
+        Object.fromEntries(
+          Object
+            .entries(htmlClassToRubyClasses)
+            .map(([key, set]) => [key, [...set.values()]])
+        ),
         null,
         2
       )
     )
   })
   .catch(error => console.error("failed to write static/classes.json", { error }))
+
+// stylesheets under app/lib/primer/css need their individual
+// json files generated
+exportSelectors('app/lib/primer/css')

--- a/static/classes.json
+++ b/static/classes.json
@@ -1,311 +1,576 @@
-[
-  "ActionList--subGroup",
-  "ActionList-sectionDivider",
-  "ActionList-sectionDivider--filled",
-  "ActionList-sectionDivider-title",
-  "ActionListContent",
-  "ActionListContent--blockDescription",
-  "ActionListContent--hasActiveSubItem",
-  "ActionListContent--sizeLarge",
-  "ActionListContent--sizeXLarge",
-  "ActionListContent--visual16",
-  "ActionListContent--visual20",
-  "ActionListContent--visual24",
-  "ActionListItem",
-  "ActionListItem--danger",
-  "ActionListItem--hasSubItem",
-  "ActionListItem--navActive",
-  "ActionListItem--subItem",
-  "ActionListItem--trailingActionHover",
-  "ActionListItem--withActions",
-  "ActionListItem-action",
-  "ActionListItem-action--leading",
-  "ActionListItem-action--trailing",
-  "ActionListItem-collapseIcon",
-  "ActionListItem-description",
-  "ActionListItem-descriptionWrap",
-  "ActionListItem-descriptionWrap--inline",
-  "ActionListItem-label",
-  "ActionListItem-label--truncate",
-  "ActionListItem-multiSelectCheckmark",
-  "ActionListItem-multiSelectIcon",
-  "ActionListItem-multiSelectIconRect",
-  "ActionListItem-singleSelectCheckmark",
-  "ActionListItem-trailingAction",
-  "ActionListItem-visual",
-  "ActionListItem-visual--leading",
-  "ActionListItem-visual--trailing",
-  "ActionListWrap",
-  "ActionListWrap--divided",
-  "ActionListWrap--inset",
-  "AvatarStack",
-  "AvatarStack--right",
-  "AvatarStack--three-plus",
-  "AvatarStack--two",
-  "AvatarStack-body",
-  "Banner",
-  "Banner--error",
-  "Banner--full",
-  "Banner--full-whenNarrow",
-  "Banner--success",
-  "Banner--warning",
-  "Banner-actions",
-  "Banner-close",
-  "Banner-message",
-  "Banner-title",
-  "Banner-visual",
-  "Box",
-  "Box--blue",
-  "Box--condensed",
-  "Box--danger",
-  "Box--scrollable",
-  "Box--spacious",
-  "Box-body",
-  "Box-btn-octicon",
-  "Box-footer",
-  "Box-header",
-  "Box-header--blue",
-  "Box-row",
-  "Box-row--blue",
-  "Box-row--drag-button",
-  "Box-row--drag-hide",
-  "Box-row--focus-blue",
-  "Box-row--focus-gray",
-  "Box-row--gray",
-  "Box-row--hover-blue",
-  "Box-row--hover-gray",
-  "Box-row--unread",
-  "Box-row--yellow",
-  "Box-row-link",
-  "Box-title",
-  "Button",
-  "Button--danger",
-  "Button--fullWidth",
-  "Button--iconOnly",
-  "Button--invisible",
-  "Button--invisible-noVisuals",
-  "Button--large",
-  "Button--link",
-  "Button--medium",
-  "Button--primary",
-  "Button--secondary",
-  "Button--small",
-  "Button-content",
-  "Button-content--alignStart",
-  "Button-label",
-  "Button-leadingVisual",
-  "Button-trailingAction",
-  "Button-trailingVisual",
-  "Button-visual",
-  "Button-withTooltip",
-  "Counter",
-  "Counter--primary",
-  "Counter--secondary",
-  "FormControl",
-  "FormControl--fullWidth",
-  "FormControl-caption",
-  "FormControl-check-group-wrap",
-  "FormControl-checkbox",
-  "FormControl-checkbox-labelWrap",
-  "FormControl-checkbox-wrap",
-  "FormControl-error",
-  "FormControl-horizontalGroup",
-  "FormControl-inlineValidation",
-  "FormControl-input",
-  "FormControl-input-leadingVisual",
-  "FormControl-input-leadingVisualWrap",
-  "FormControl-input-trailingAction",
-  "FormControl-input-trailingAction--divider",
-  "FormControl-input-wrap",
-  "FormControl-input-wrap--leadingVisual",
-  "FormControl-input-wrap--trailingAction",
-  "FormControl-input-wrap-trailingAction--divider",
-  "FormControl-inset",
-  "FormControl-label",
-  "FormControl-large",
-  "FormControl-medium",
-  "FormControl-monospace",
-  "FormControl-radio",
-  "FormControl-radio-group-wrap",
-  "FormControl-radio-labelWrap",
-  "FormControl-radio-wrap",
-  "FormControl-select",
-  "FormControl-select-wrap",
-  "FormControl-small",
-  "FormControl-spacingWrapper",
-  "FormControl-success",
-  "FormControl-textarea",
-  "FormControl-toggleSwitchInput",
-  "FormControl-warning",
-  "Label",
-  "Label--accent",
-  "Label--attention",
-  "Label--closed",
-  "Label--danger",
-  "Label--done",
-  "Label--info",
-  "Label--inline",
-  "Label--large",
-  "Label--open",
-  "Label--primary",
-  "Label--secondary",
-  "Label--severe",
-  "Label--sponsors",
-  "Label--success",
-  "Label--warning",
-  "Layout",
-  "Layout--divided",
-  "Layout--flowRow-until-lg",
-  "Layout--flowRow-until-md",
-  "Layout--gutter-condensed",
-  "Layout--gutter-none",
-  "Layout--gutter-spacious",
-  "Layout--sidebar-narrow",
-  "Layout--sidebar-wide",
-  "Layout--sidebarPosition-end",
-  "Layout--sidebarPosition-flowRow-end",
-  "Layout--sidebarPosition-flowRow-none",
-  "Layout--sidebarPosition-flowRow-start",
-  "Layout--sidebarPosition-start",
-  "Layout-divider",
-  "Layout-divider--flowRow-hidden",
-  "Layout-divider--flowRow-shallow",
-  "Layout-main",
-  "Layout-main-centered-lg",
-  "Layout-main-centered-md",
-  "Layout-main-centered-xl",
-  "Layout-sidebar",
-  "Link",
-  "Link--muted",
-  "Link--onHover",
-  "Link--primary",
-  "Link--secondary",
-  "Overlay",
-  "Overlay--height-auto",
-  "Overlay--height-large",
-  "Overlay--height-medium",
-  "Overlay--height-small",
-  "Overlay--height-xlarge",
-  "Overlay--height-xsmall",
-  "Overlay--hidden",
-  "Overlay--motion-scaleFade",
-  "Overlay--size-auto",
-  "Overlay--size-full",
-  "Overlay--size-large",
-  "Overlay--size-medium",
-  "Overlay--size-medium-portrait",
-  "Overlay--size-small",
-  "Overlay--size-small-portrait",
-  "Overlay--size-xlarge",
-  "Overlay--size-xsmall",
-  "Overlay--visibilityHidden",
-  "Overlay--width-auto",
-  "Overlay--width-large",
-  "Overlay--width-medium",
-  "Overlay--width-small",
-  "Overlay--width-xlarge",
-  "Overlay--width-xxlarge",
-  "Overlay-actionWrap",
-  "Overlay-backdrop--anchor",
-  "Overlay-backdrop--anchor-whenNarrow",
-  "Overlay-backdrop--center",
-  "Overlay-backdrop--center-whenNarrow",
-  "Overlay-backdrop--full",
-  "Overlay-backdrop--full-whenNarrow",
-  "Overlay-backdrop--placement-bottom",
-  "Overlay-backdrop--placement-bottom-whenNarrow",
-  "Overlay-backdrop--placement-left",
-  "Overlay-backdrop--placement-left-whenNarrow",
-  "Overlay-backdrop--placement-right",
-  "Overlay-backdrop--placement-right-whenNarrow",
-  "Overlay-backdrop--placement-top",
-  "Overlay-backdrop--placement-top-whenNarrow",
-  "Overlay-backdrop--side",
-  "Overlay-backdrop--side-whenNarrow",
-  "Overlay-body",
-  "Overlay-body--paddingCondensed",
-  "Overlay-body--paddingNone",
-  "Overlay-closeButton",
-  "Overlay-description",
-  "Overlay-footer",
-  "Overlay-footer--alignCenter",
-  "Overlay-footer--alignEnd",
-  "Overlay-footer--alignStart",
-  "Overlay-footer--divided",
-  "Overlay-form",
-  "Overlay-header",
-  "Overlay-header--divided",
-  "Overlay-header--large",
-  "Overlay-headerContentWrap",
-  "Overlay-title",
-  "Overlay-titleWrap",
-  "Overlay-whenNarrow",
-  "Popover",
-  "Popover-message",
-  "Popover-message--bottom",
-  "Popover-message--bottom-left",
-  "Popover-message--bottom-right",
-  "Popover-message--large",
-  "Popover-message--left",
-  "Popover-message--left-bottom",
-  "Popover-message--left-top",
-  "Popover-message--no-caret",
-  "Popover-message--right",
-  "Popover-message--right-bottom",
-  "Popover-message--right-top",
-  "Popover-message--top-left",
-  "Popover-message--top-right",
-  "Progress",
-  "Progress--large",
-  "Progress--small",
-  "Progress-item",
-  "SegmentedControl",
-  "SegmentedControl--fullWidth",
-  "SegmentedControl-item",
-  "SegmentedControl-item--selected",
-  "State",
-  "State--closed",
-  "State--draft",
-  "State--merged",
-  "State--open",
-  "State--small",
-  "Subhead",
-  "Subhead--spacious",
-  "Subhead-actions",
-  "Subhead-description",
-  "Subhead-heading",
-  "Subhead-heading--danger",
-  "TimelineItem",
-  "TimelineItem--condensed",
-  "TimelineItem-avatar",
-  "TimelineItem-badge",
-  "TimelineItem-badge--success",
-  "TimelineItem-body",
-  "TimelineItem-break",
-  "ToggleSwitch",
-  "ToggleSwitch--checked",
-  "ToggleSwitch--disabled",
-  "ToggleSwitch--small",
-  "ToggleSwitch--statusAtEnd",
-  "ToggleSwitch-circleIcon",
-  "ToggleSwitch-icons",
-  "ToggleSwitch-knob",
-  "ToggleSwitch-lineIcon",
-  "ToggleSwitch-status",
-  "ToggleSwitch-statusIcon",
-  "ToggleSwitch-statusOff",
-  "ToggleSwitch-statusOn",
-  "ToggleSwitch-track",
-  "Truncate",
-  "Truncate-text",
-  "Truncate-text--expandable",
-  "Truncate-text--primary",
-  "UnderlineNav",
-  "UnderlineNav--full",
-  "UnderlineNav--right",
-  "UnderlineNav-actions",
-  "UnderlineNav-body",
-  "UnderlineNav-container",
-  "UnderlineNav-item",
-  "UnderlineNav-octicon"
-]
+{
+  "Box": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Link": [
+    "Primer::Beta::Link"
+  ],
+  "Label": [
+    "Primer::Beta::Label"
+  ],
+  "State": [
+    "Primer::Beta::State"
+  ],
+  "Banner": [
+    "Primer::Alpha::Banner"
+  ],
+  "Layout": [
+    "Primer::Alpha::Layout"
+  ],
+  "Button": [
+    "Primer::Beta::Button"
+  ],
+  "Overlay": [
+    "Primer::Alpha::Dialog",
+    "Primer::Alpha::Overlay"
+  ],
+  "Box-row": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Counter": [
+    "Primer::Beta::Counter"
+  ],
+  "Popover": [
+    "Primer::Beta::Popover"
+  ],
+  "Subhead": [
+    "Primer::Beta::Subhead"
+  ],
+  "Box-body": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Progress": [
+    "Primer::Beta::ProgressBar"
+  ],
+  "Truncate": [
+    "Primer::Beta::Truncate"
+  ],
+  "Box-title": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box--blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-header": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-footer": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Layout-main": [
+    "Primer::Alpha::Layout"
+  ],
+  "FormControl": [
+    "Primer::Alpha::TextField"
+  ],
+  "AvatarStack": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "Box--danger": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Label--info": [
+    "Primer::Beta::Label"
+  ],
+  "Label--open": [
+    "Primer::Beta::Label"
+  ],
+  "Label--done": [
+    "Primer::Beta::Label"
+  ],
+  "Link--muted": [
+    "Primer::Beta::Link"
+  ],
+  "State--open": [
+    "Primer::Beta::State"
+  ],
+  "Overlay-form": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-body": [
+    "Primer::Alpha::Dialog"
+  ],
+  "ToggleSwitch": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "UnderlineNav": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "Box-row-link": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button-label": [
+    "Primer::Beta::Button"
+  ],
+  "Button--link": [
+    "Primer::Beta::Button"
+  ],
+  "Label--large": [
+    "Primer::Beta::Label"
+  ],
+  "State--draft": [
+    "Primer::Beta::State"
+  ],
+  "State--small": [
+    "Primer::Beta::State"
+  ],
+  "TimelineItem": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "Box--spacious": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button-visual": [
+    "Primer::Beta::Button"
+  ],
+  "Button--small": [
+    "Primer::Beta::Button"
+  ],
+  "Button--large": [
+    "Primer::Beta::Button"
+  ],
+  "Label--inline": [
+    "Primer::Beta::Label"
+  ],
+  "Label--accent": [
+    "Primer::Beta::Label"
+  ],
+  "Label--severe": [
+    "Primer::Beta::Label"
+  ],
+  "Label--danger": [
+    "Primer::Beta::Label"
+  ],
+  "Label--closed": [
+    "Primer::Beta::Label"
+  ],
+  "Link--primary": [
+    "Primer::Beta::Link"
+  ],
+  "Link--onHover": [
+    "Primer::Beta::Link"
+  ],
+  "Progress-item": [
+    "Primer::Beta::ProgressBar"
+  ],
+  "State--merged": [
+    "Primer::Beta::State"
+  ],
+  "State--closed": [
+    "Primer::Beta::State"
+  ],
+  "ActionListWrap": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem": [
+    "Primer::Alpha::ActionList"
+  ],
+  "Overlay-header": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-footer": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Layout-divider": [
+    "Primer::Alpha::Layout"
+  ],
+  "Layout-sidebar": [
+    "Primer::Alpha::Layout"
+  ],
+  "Box--condensed": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button-content": [
+    "Primer::Beta::Button"
+  ],
+  "Button--danger": [
+    "Primer::Beta::Button"
+  ],
+  "Label--primary": [
+    "Primer::Beta::Label"
+  ],
+  "Label--success": [
+    "Primer::Beta::Label"
+  ],
+  "Label--warning": [
+    "Primer::Beta::Label"
+  ],
+  "Overlay--hidden": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Box--scrollable": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--yellow": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-btn-octicon": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button--primary": [
+    "Primer::Beta::Button"
+  ],
+  "Label--sponsors": [
+    "Primer::Beta::Label"
+  ],
+  "Link--secondary": [
+    "Primer::Beta::Link"
+  ],
+  "Popover-message": [
+    "Primer::Beta::Popover"
+  ],
+  "Progress--large": [
+    "Primer::Beta::ProgressBar"
+  ],
+  "Progress--small": [
+    "Primer::Beta::ProgressBar"
+  ],
+  "Subhead-heading": [
+    "Primer::Beta::Subhead"
+  ],
+  "Subhead-actions": [
+    "Primer::Beta::Subhead"
+  ],
+  "SegmentedControl": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "AvatarStack-body": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "Box-header--blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button--iconOnly": [
+    "Primer::Beta::Button"
+  ],
+  "Counter--primary": [
+    "Primer::Beta::Counter"
+  ],
+  "Label--secondary": [
+    "Primer::Beta::Label"
+  ],
+  "Label--attention": [
+    "Primer::Beta::Label"
+  ],
+  "ActionListContent": [
+    "Primer::Alpha::ActionList"
+  ],
+  "FormControl-label": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-input": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch-knob": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "UnderlineNav-body": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "UnderlineNav-item": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "Button--fullWidth": [
+    "Primer::Beta::Button"
+  ],
+  "Button--secondary": [
+    "Primer::Beta::Button"
+  ],
+  "Button--invisible": [
+    "Primer::Beta::Button"
+  ],
+  "Subhead--spacious": [
+    "Primer::Beta::Subhead"
+  ],
+  "TimelineItem-body": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "FormControl-select": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch-track": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch-icons": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "UnderlineNav--full": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "AvatarStack--right": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "Button-withTooltip": [
+    "Primer::Beta::Button"
+  ],
+  "Counter--secondary": [
+    "Primer::Beta::Counter"
+  ],
+  "TimelineItem-badge": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "TimelineItem-break": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "Overlay-closeButton": [
+    "Primer::Alpha::Dialog"
+  ],
+  "FormControl-caption": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch-status": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch--small": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "UnderlineNav--right": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "Box-row--focus-gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--focus-blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--hover-gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--hover-blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Subhead-description": [
+    "Primer::Beta::Subhead"
+  ],
+  "TimelineItem-avatar": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "ActionListItem-label": [
+    "Primer::Alpha::ActionList"
+  ],
+  "FormControl-textarea": [
+    "Primer::Alpha::TextField"
+  ],
+  "UnderlineNav-actions": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "UnderlineNav-octicon": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "Box-row--drag-button": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button-leadingVisual": [
+    "Primer::Beta::Button"
+  ],
+  "ActionListWrap--inset": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-action": [
+    "Primer::Alpha::ActionList"
+  ],
+  "SegmentedControl-item": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "ToggleSwitch--checked": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch-lineIcon": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch-statusOn": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "Button-trailingVisual": [
+    "Primer::Beta::Button"
+  ],
+  "Button-trailingAction": [
+    "Primer::Beta::Button"
+  ],
+  "Popover-message--left": [
+    "Primer::Beta::Popover"
+  ],
+  "Overlay-backdrop--side": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--full": [
+    "Primer::Alpha::Dialog"
+  ],
+  "FormControl--fullWidth": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-input-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-radio-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch--disabled": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch-statusOff": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "UnderlineNav-container": [
+    "Primer::Alpha::UnderlineNav"
+  ],
+  "Popover-message--right": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--large": [
+    "Primer::Beta::Popover"
+  ],
+  "ActionListWrap--divided": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem--subItem": [
+    "Primer::Alpha::ActionList"
+  ],
+  "FormControl-select-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch-circleIcon": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "ToggleSwitch-statusIcon": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "Popover-message--bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "Subhead-heading--danger": [
+    "Primer::Beta::Subhead"
+  ],
+  "TimelineItem--condensed": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "Overlay-backdrop--center": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--anchor": [
+    "Primer::Alpha::Dialog"
+  ],
+  "ActionList-sectionDivider": [
+    "Primer::Alpha::ActionList"
+  ],
+  "Overlay--visibilityHidden": [
+    "Primer::Alpha::Dialog"
+  ],
+  "FormControl-checkbox-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "ToggleSwitch--statusAtEnd": [
+    "Primer::Alpha::ToggleSwitch"
+  ],
+  "Popover-message--no-caret": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--top-left": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--left-top": [
+    "Primer::Beta::Popover"
+  ],
+  "ActionListItem-description": [
+    "Primer::Alpha::ActionList"
+  ],
+  "FormControl-spacingWrapper": [
+    "Primer::Alpha::TextField"
+  ],
+  "Button-content--alignStart": [
+    "Primer::Beta::Button"
+  ],
+  "Popover-message--top-right": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--right-top": [
+    "Primer::Beta::Popover"
+  ],
+  "ActionListItem--withActions": [
+    "Primer::Alpha::ActionList"
+  ],
+  "SegmentedControl--fullWidth": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "FormControl-horizontalGroup": [
+    "Primer::Alpha::TextField"
+  ],
+  "TimelineItem-badge--success": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "FormControl-inlineValidation": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-radio-group-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-check-group-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "Popover-message--bottom-left": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--left-bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "ActionListItem-trailingAction": [
+    "Primer::Alpha::ActionList"
+  ],
+  "FormControl-toggleSwitchInput": [
+    "Primer::Alpha::TextField"
+  ],
+  "Popover-message--bottom-right": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--right-bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "ActionListItem-action--leading": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual--leading": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-descriptionWrap": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-label--truncate": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual--trailing": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-action--trailing": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionList-sectionDivider--filled": [
+    "Primer::Alpha::ActionList"
+  ],
+  "Overlay-backdrop--side-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--full-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "ActionListItem--trailingActionHover": [
+    "Primer::Alpha::ActionList"
+  ],
+  "Overlay-backdrop--center-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--anchor-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "ActionListItem-descriptionWrap--inline": [
+    "Primer::Alpha::ActionList"
+  ]
+}

--- a/test/lib/erblint/disallow_component_css_counter_test.rb
+++ b/test/lib/erblint/disallow_component_css_counter_test.rb
@@ -3,42 +3,52 @@
 require "lib/erblint_test_case"
 
 class DisallowComponentCssCounterTest < ErblintTestCase
-  include Primer::BasicLinterSharedTests
-
   def test_no_warning_on_unrestricted_class
-    @file = "<div class=\"favorite\">Hello</div>"
+    @file = <<~HTML
+      <div class="favorite">This is legal</div>
+    HTML
     @linter.run(processed_source)
     assert_empty offenses
   end
 
   def test_warns_on_restricted_class
-    @file = "<div class=\"ActionListContent--sizeLarge\">Reserved for ActionList</div>"
+    @file = <<~HTML
+      <div class="Box--danger">
+        Reserved for BorderBox
+      </div>
+    HTML
     @linter.run(processed_source)
     refute_empty offenses
   end
 
+  def test_suggests_two_components
+    @file = <<~HTML
+      <div class="Overlay">
+        Used by two different components
+      </div>
+    HTML
+    @linter.run(processed_source)
+    assert_includes offenses.first.message, "Primer::Alpha::Dialog or Primer::Alpha::Overlay"
+  end
+
   def test_no_warning_on_class_covered_by_others
-    @file = "<div class=\"Label\">Covered by other linter</div>"
+    @file = <<~HTML
+      <div class="Label">
+        Covered by the LabelComponentMigrationCounter linter
+      </div>
+    HTML
     @linter.run(processed_source)
     assert_empty offenses
   end
 
-  def test_does_not_warn_if_wrong_tag
-    # this test defined in BasicLinterSharedTests does not apply
-    # to this linter (this linter is designed to check all tags)
+  def test_adds_counter
+    @file = '<div class="Box--danger">Reserved for BorderBox</div>'
+    assert_equal "<%# erblint:counter DisallowComponentCssCounter 1 %>\n#{@file}", corrected_content
   end
 
   private
 
   def linter_class
     ERBLint::Linters::DisallowComponentCssCounter
-  end
-
-  def default_tag
-    "div"
-  end
-
-  def default_class
-    "ActionListContent--sizeLarge"
   end
 end


### PR DESCRIPTION
### Description

When developers use HTML classes that we reserve for Primer ViewCompoents, we want to suggest relevant components they might want to use instead.

Closes [Primer#1901](https://github.com/github/primer/issues/1901)

### Implementation

This changes the generated `static/classes.json` file from a pure array of HTML classes to restrict into an object where the keys are those HTML classes and the values are arrays of the Ruby class (or classes) associated with that HTML class.

### Merge checklist

- [x] Added/updated tests
- ~[ ] Added/updated documentation~
- ~[ ] Added/updated previews~
