### PR TITLE
Fix and expose ActionMenu docs

### DIFF
--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -126,7 +126,7 @@ module Primer
       #         Item 2 that does another thing
       #       <% end %>
       #     <% end %>
-      #     <%= render Primer::Alpha::Alpha.new(menu_id: "my-action-menu-7", anchor_align: :center, anchor_side: :outside_right) do |c| %>
+      #     <%= render Primer::Alpha::ActionMenu.new(menu_id: "my-action-menu-7", anchor_align: :center, anchor_side: :outside_right) do |c| %>
       #       <% c.with_show_button(with_caret: true) { "Outside right" } %>
       #       <% c.with_item do %>
       #         Item 1 that does something

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -35,7 +35,7 @@ gem "puma", "~> 6.2.1"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", '>= 2.81.0'
+gem "view_component", '= 3.0.0.rc5'
 gem "lookbook", "~> 1.5.3" unless rails_version.to_f < 7
 
 group :development do

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -35,7 +35,7 @@ gem "puma", "~> 6.2.1"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", '= 3.0.0.rc5'
+gem "view_component", '>= 3.0.0.rc5'
 gem "lookbook", "~> 1.5.3" unless rails_version.to_f < 7
 
 group :development do

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    view_component (2.82.0)
+    view_component (3.0.0.rc5)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -404,7 +404,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  view_component (>= 2.81.0)
+  view_component (>= 3.0.0.rc5)
 
 BUNDLED WITH
    2.2.33

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -47,4 +47,8 @@ Rails.application.configure do
 
   config.autoload_paths << Rails.root.join("..", "test", "forms")
   config.view_component.preview_paths << Rails.root.join("..", "test", "previews")
+
+  if ENV.fetch("VC_COMPAT_PATCH_ENABLED", "false") == "true"
+    config.view_component.capture_compatibility_patch_enabled = true
+  end
 end

--- a/demo/config/environments/test.rb
+++ b/demo/config/environments/test.rb
@@ -48,7 +48,9 @@ Rails.application.configure do
   config.autoload_paths << Rails.root.join("..", "test", "forms")
   config.view_component.preview_paths << Rails.root.join("..", "test", "previews")
 
+  # rubocop:disable Style/IfUnlessModifier
   if ENV.fetch("VC_COMPAT_PATCH_ENABLED", "false") == "true"
     config.view_component.capture_compatibility_patch_enabled = true
   end
+  # rubocop:enable Style/IfUnlessModifier
 end

--- a/docs/src/@primer/gatsby-theme-doctocat/nav.yml
+++ b/docs/src/@primer/gatsby-theme-doctocat/nav.yml
@@ -15,6 +15,8 @@
     url: "/status"
 - title: Components
   children:
+  - title: ActionMenu
+    url: "/components/alpha/actionmenu"
   - title: AutoComplete
     url: "/components/beta/autocomplete"
   - title: AutoCompleteItem

--- a/lib/primer/yard/component_manifest.rb
+++ b/lib/primer/yard/component_manifest.rb
@@ -65,6 +65,7 @@ module Primer
         Primer::Alpha::Tooltip => { js: true },
         Primer::Alpha::ToggleSwitch => { js: true },
         Primer::Alpha::Overlay => { js: true },
+        Primer::Alpha::ActionMenu => { js: true },
 
         # Examples can be seen in the NavList docs
         Primer::Alpha::NavList => { js: true },

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -4,6 +4,8 @@ require "active_support/inflector"
 
 task :init_pvc do
   ENV["RAILS_ENV"] = "test"
+  ENV["VC_COMPAT_PATCH_ENABLED"] = "true"
+
   require File.expand_path("./../../demo/config/environment.rb", __dir__)
   Dir[File.expand_path("../../app/components/primer/**/*.rb", __dir__)].sort.each { |file| require file }
 end


### PR DESCRIPTION
### Description

I totally forgot to generate the docs for the newly upstreamed `ActionMenu`. I had to bump view_component to v3 in order to bring in the new capture compatibility module, without which I observed some double-rendering in the `ActionMenu` examples. The problem does not appear to happen in Lookbook or in dotcom, so I believe it has something to do with the non-standard way we render examples for the legacy Gatsby site.

### Integration

> Does this change require any updates to code in production?

No