### PR TITLE
Update id in docs example to prevent page jump in rendered docs

### DIFF
--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -228,7 +228,7 @@ module Primer
       #     <% end %>
       #
       # @example With deferred menu content loaded with an `include-fragment`
-      #  <%= render Primer::Alpha::ActionMenu.new(menu_id: "my-action-menu-3", src: "/") do |c| %>
+      #  <%= render Primer::Alpha::ActionMenu.new(menu_id: "my-action-menu-17", src: "/") do |c| %>
       #    <% c.with_show_button(icon: :"kebab-horizontal", "aria-label": "Menu") %>
       #  <% end %>
       #


### PR DESCRIPTION
Replace duplicate id with unique id, fixes bug in docs rendering.

### Description

There is a bug in the docs rendering at https://primer.style/view-components/components/alpha/actionmenu. There is a duplicate id, causing a click on the button to jump to the first instance of the id, higher up in the page.

https://user-images.githubusercontent.com/4742306/231262361-d6eef51c-9b98-4f78-b7ac-662d7f6b7e3b.mp4

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
