### PR TITLE
Use `min-width` for ActionMenu

### DIFF
--- a/.changeset/clean-moons-unite.md
+++ b/.changeset/clean-moons-unite.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use min-width for ActionMenu to fix visual regression with inline descriptions

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -2,7 +2,7 @@
   border-width: 0;
   padding: 0;
   position: absolute;
-  width: min(192px, 100vw - 2rem);
+  min-width: 192px;
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-no-unknown */


### PR DESCRIPTION
### Description

Use `min-width` to respect auto sizing for default ActionMenu

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
