### PR TITLE
Prevent double rendering of ActionMenu content labels

### DIFF
--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -52,11 +52,18 @@ module Primer
             content_arguments[:disabled] = "" if content_arguments[:tag] == :button
           end
 
-          super(
-            **system_arguments,
-            content_arguments: content_arguments,
-            &block
-          )
+          super(**system_arguments, content_arguments: content_arguments) do
+            # Prevent double renders by using the capture method on the component
+            # that originally received the block.
+            #
+            # Handle blocks that originate from C code such as `&:method` by checking
+            # source_location. Such blocks don't allow access to their receiver.
+            if block && block.source_location
+              block.binding.receiver.capture(self, &block)
+            else
+              capture(self, &block)
+            end
+          end
         end
 
         # @param menu_id [String] ID of the parent menu.

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -58,7 +58,7 @@ module Primer
             #
             # Handle blocks that originate from C code such as `&:method` by checking
             # source_location. Such blocks don't allow access to their receiver.
-            if block && block.source_location
+            if block&.source_location
               block.binding.receiver.capture(self, &block)
             else
               capture(self, &block)

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -52,16 +52,20 @@ module Primer
             content_arguments[:disabled] = "" if content_arguments[:tag] == :button
           end
 
-          super(**system_arguments, content_arguments: content_arguments) do
+          super(**system_arguments, content_arguments: content_arguments) do |item|
             # Prevent double renders by using the capture method on the component
             # that originally received the block.
             #
             # Handle blocks that originate from C code such as `&:method` by checking
             # source_location. Such blocks don't allow access to their receiver.
             if block&.source_location
-              block.binding.receiver.capture(self, &block)
-            elsif block
-              capture(self, &block)
+              block_context = block.binding.receiver
+
+              if block_context.class < ActionView::Base
+                block_context.capture(item, &block)
+              else
+                capture(item, &block)
+              end
             end
           end
         end

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -60,7 +60,7 @@ module Primer
             # source_location. Such blocks don't allow access to their receiver.
             if block&.source_location
               block.binding.receiver.capture(self, &block)
-            else
+            elsif block
               capture(self, &block)
             end
           end

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -23,6 +23,11 @@ module Primer
         end
       end
 
+      # @label Content labels
+      #
+      def content_labels
+      end
+
       # @label Default
       #
       def default

--- a/previews/primer/alpha/action_menu_preview/content_labels.html.erb
+++ b/previews/primer/alpha/action_menu_preview/content_labels.html.erb
@@ -1,0 +1,9 @@
+<%= render(Primer::Alpha::ActionMenu.new) do |menu| %>
+  <% menu.with_show_button { "Menu" } %>
+  <% menu.with_item(value: "") do %>
+    <span class="copy-link">Copy link</span>
+  <% end %>
+  <% menu.with_item(value: "") do %>
+    <span class="quote-reply">Quote reply</span>
+  <% end %>
+<% end %>

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -129,6 +129,13 @@ module Primer
         assert_selector("li a[href='/']", text: "Your repositories")
         assert_selector("li span[aria-disabled=true]", text: "Disabled")
       end
+
+      def test_content_labels_render_correctly
+        render_preview(:content_labels)
+
+        assert_selector "li span.copy-link"
+        assert_selector "li span.quote-reply"
+      end
     end
   end
 end

--- a/test/css/component_selector_use_test.rb
+++ b/test/css/component_selector_use_test.rb
@@ -9,7 +9,7 @@ Dir["app/components/**/*.rb"].each { |file| require_relative "../../#{file}" }
 IGNORED_SELECTORS = {
   # these are all provided by primer/css
   :global => ["octicon", "btn-octicon", "btn", "btn-primary", "btn-danger", "btn-outline"],
-  Primer::Alpha::ActionMenu => ["ActionListItem-multiSelectIcon"], # this does actually exist
+  Primer::Alpha::ActionMenu => ["ActionListItem-multiSelectIcon", "copy-link", "quote-reply"],
   Primer::Alpha::AutoComplete => ["form-control", "ActionList"],
   Primer::Alpha::HiddenTextExpander => ["ellipsis-expander", "hidden-text-expander"],
   Primer::Beta::ButtonGroup => ["BtnGroup", "BtnGroup-item"],


### PR DESCRIPTION
### Description

Content labels in ActionMenu items are currently broken and result in weird double-rendering behavior:

<img width="526" alt="image" src="https://user-images.githubusercontent.com/575280/231901396-a405a5c4-5664-4029-b022-bb062a6f9308.png">

This PR uses @BlakeWilliams' awesome `block.binding.receiver` [trick](https://github.com/ViewComponent/view_component/blob/964a2c15f74588819ea64ff69d12dfb0de80fe3b/lib/view_component/capture_compatibility.rb#L34) to capture the content block using the view context where the block was originally defined.

### Integration

> Does this change require any updates to code in production?

No