### PR TITLE
add actionmenu example for submitting forms

### DIFF
--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -206,6 +206,12 @@ module Primer
         end
       end
 
+      # @label [Item] Submitting Forms
+      #
+      def submitting_forms
+        render_with_template(locals: {})
+      end
+
       # @label [Item] Inline description
       #
       def inline_description

--- a/previews/primer/alpha/action_menu_preview/submitting_forms.html.erb
+++ b/previews/primer/alpha/action_menu_preview/submitting_forms.html.erb
@@ -1,0 +1,15 @@
+<form method="get" action="?" id="my-form">
+  <input type="hidden" name="time" value="<%= Time.now.iso8601 %>">
+</form>
+<%= render(Primer::Alpha::ActionMenu.new(menu_id: "menu-1")) do |menu| %>
+  <% menu.with_show_button { params["label"] || "Menu" } %>
+  <% menu.with_item(label: "Submit form", tag: "button", content_arguments: {
+    form: "my-form", type: "submit", name: "label", value: "Submitted!"
+  }) do |item| %>
+    <% if params["time"] %>
+      <% item.with_description.with_content("Last submitted at #{params["time"]}") %>
+    <% elsif %>
+      <% item.with_description.with_content("Not yet submitted") %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
### Description

This demonstrates how forms can be submitted using ActionMenu today.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
