### PR TITLE
Fixing deprecated blankslate docs

### DIFF
--- a/lib/primer/yard/component_manifest.rb
+++ b/lib/primer/yard/component_manifest.rb
@@ -23,6 +23,7 @@ module Primer
         Primer::Beta::BaseButton => {},
         Primer::Alpha::Banner => { js: true },
         Primer::Beta::Blankslate => {},
+        Primer::BlankslateComponent => {},
         Primer::Beta::BorderBox => {},
         Primer::Beta::BorderBox::Header => {},
         Primer::Box => {},


### PR DESCRIPTION
### Description

This fixes the blankslatecomponent missing docs

Closes https://github.com/primer/view_components/issues/1930

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
