### PR TITLE
don't use to_sentence in linter

### DIFF
--- a/lib/primer/view_components/linters/disallow_component_css_counter.rb
+++ b/lib/primer/view_components/linters/disallow_component_css_counter.rb
@@ -62,7 +62,7 @@ module ERBLint
       end
 
       def ruby_classes_sentence_string(class_name)
-        CLASSES[class_name].to_sentence(last_word_connector: ", or ", two_words_connector: " or ")
+        CLASSES[class_name].join(" / ")
       end
     end
   end


### PR DESCRIPTION
### Description

We run our linters outside of Rails in some cases, which means we can't use `to_sentence`.