### PR TITLE
Only smooth radius if row is first/last and first/last child of Box

### DIFF
--- a/app/components/primer/beta/border_box.pcss
+++ b/app/components/primer/beta/border_box.pcss
@@ -105,16 +105,6 @@
   border-top-style: solid;
   border-top-width: var(--primer-borderWidth-thin, 1px);
 
-  &:first-of-type {
-    border-top-left-radius: var(--primer-borderRadius-medium, 6px);
-    border-top-right-radius: var(--primer-borderRadius-medium, 6px);
-  }
-
-  &:last-of-type {
-    border-bottom-right-radius: var(--primer-borderRadius-medium, 6px);
-    border-bottom-left-radius: var(--primer-borderRadius-medium, 6px);
-  }
-
   /* Adds a blue vertical line to the left of the row
   ** For indicating a row item is unread */
   &.Box-row--unread,
@@ -151,6 +141,18 @@
       }
     }
   }
+}
+
+/* Properly round corners if the first element of the Box is a row element */
+.Box > ul:first-child > li.Box-row:first-of-type {
+  border-top-left-radius: var(--primer-borderRadius-medium, 6px);
+  border-top-right-radius: var(--primer-borderRadius-medium, 6px);
+}
+
+/* Properly round corners if the last element of the Box is a row element */
+.Box > ul:last-child > li.Box-row:last-of-type {
+  border-bottom-right-radius: var(--primer-borderRadius-medium, 6px);
+  border-bottom-left-radius: var(--primer-borderRadius-medium, 6px);
 }
 
 .Box-row--focus-gray {


### PR DESCRIPTION
### Description

This changes the selector to make sure the parent `ul` element is either the first child or last child of the parent `.Box` element as well as if the row is the first or last child in the list. Previously we were only doing the latter, which lead to the rounded corners showing up when a row was below a header element, for example.

My CSS skills aren't the sharpest. If there is a better way to write this rule, please suggest a change. 🙏 

I've also not updated the changeset. Let me know if you would like me to. I've made this PR editable by maintainers as well. 👍 

Closes https://github.com/github/discussions/issues/3192

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews

## Before
<img width="510" alt="row1-before" src="https://user-images.githubusercontent.com/4742306/233196341-f448f934-19f1-46f9-b1eb-020c9a16f580.png">

## After
<img width="484" alt="row1-after" src="https://user-images.githubusercontent.com/4742306/233196326-319c31da-16e1-4c89-9918-e8d968404b86.png">
