### PR TITLE
Action menu form input

### DIFF
--- a/.changeset/fuzzy-beans-smoke.md
+++ b/.changeset/fuzzy-beans-smoke.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Action menu form input

--- a/app/components/primer/alpha/action_list.html.erb
+++ b/app/components/primer/alpha/action_list.html.erb
@@ -1,5 +1,5 @@
 <%= render(Primer::BaseComponent.new(tag: :div)) do %>
-  <% if @form_builder && @input_name && allows_selection? %>
+  <% if acts_as_form_input? %>
     <span data-list-inputs="true">
       <%= @form_builder.hidden_field(@input_name, multiple: multi_select?, skip_default_ids: true) %>
     </span>

--- a/app/components/primer/alpha/action_list.html.erb
+++ b/app/components/primer/alpha/action_list.html.erb
@@ -1,4 +1,9 @@
 <%= render(Primer::BaseComponent.new(tag: :div)) do %>
+  <% if @form_builder && @input_name && allows_selection? %>
+    <span data-list-inputs="true">
+      <%= @form_builder.hidden_field(@input_name, multiple: multi_select?, skip_default_ids: true) %>
+    </span>
+  <% end %>
   <% if heading %>
     <%= heading %>
   <% end %>

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -82,6 +82,7 @@ module Primer
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::ActionList::SCHEME_OPTIONS) %> `inset` children are offset (vertically and horizontally) from list edges. `full` (default) children are flush (vertically and horizontally) with list edges.
       # @param show_dividers [Boolean] Display a divider above each item in the list when it does not follow a header or divider.
       # @param select_variant [Symbol] How items may be selected in the list. <%= one_of(Primer::Alpha::ActionList::SELECT_VARIANT_OPTIONS) %>
+      # @param form_arguments [Hash]
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         id: self.class.generate_id,
@@ -90,6 +91,7 @@ module Primer
         scheme: DEFAULT_SCHEME,
         show_dividers: false,
         select_variant: DEFAULT_SELECT_VARIANT,
+        form_arguments: {},
         **system_arguments
       )
         @system_arguments = system_arguments
@@ -111,6 +113,9 @@ module Primer
         @system_arguments[:role] = @role
 
         @list_wrapper_arguments = {}
+
+        @form_builder = form_arguments[:builder]
+        @input_name = form_arguments[:name]
       end
 
       # @private

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -117,7 +117,7 @@ module Primer
         @form_builder = form_arguments[:builder]
         @input_name = form_arguments[:name]
 
-        return unless required_form_arguments? && !allows_selection_given?
+        return unless required_form_arguments_given? && !allows_selection_given?
 
         raise ArgumentError, "lists/menus that act as form inputs must also allow item selection (please pass the `select_variant:` option)"
       end
@@ -172,7 +172,7 @@ module Primer
       end
 
       def acts_as_form_input?
-        required_form_arguments? && allows_selection_given?
+        required_form_arguments_given? && allows_selection_given?
       end
 
       # @private

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -117,9 +117,9 @@ module Primer
         @form_builder = form_arguments[:builder]
         @input_name = form_arguments[:name]
 
-        if has_required_form_arguments? && !allows_selection?
-          raise ArgumentError, "lists/menus that act as form inputs must also allow item selection (please pass the `select_variant:` option)"
-        end
+        return unless required_form_arguments? && !allows_selection_given?
+
+        raise ArgumentError, "lists/menus that act as form inputs must also allow item selection (please pass the `select_variant:` option)"
       end
 
       # @private
@@ -167,12 +167,12 @@ module Primer
         @system_arguments[:role] == :menu
       end
 
-      def has_required_form_arguments?
+      def required_form_arguments_given?
         @form_builder && @input_name
       end
 
       def acts_as_form_input?
-        has_required_form_arguments? && allows_selection?
+        required_form_arguments? && allows_selection_given?
       end
 
       # @private

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -82,7 +82,7 @@ module Primer
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::ActionList::SCHEME_OPTIONS) %> `inset` children are offset (vertically and horizontally) from list edges. `full` (default) children are flush (vertically and horizontally) with list edges.
       # @param show_dividers [Boolean] Display a divider above each item in the list when it does not follow a header or divider.
       # @param select_variant [Symbol] How items may be selected in the list. <%= one_of(Primer::Alpha::ActionList::SELECT_VARIANT_OPTIONS) %>
-      # @param form_arguments [Hash]
+      # @param form_arguments [Hash] Allows an `ActionList` to act as a select list in multi- and single-select modes. Pass the `builder:` and `name:` options to this hash. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which are created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission. *NOTE*: Consider using an <%= link_to_component(Primer::Alpha::ActionMenu) %> instead of using this feature directly.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         id: self.class.generate_id,

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -117,7 +117,7 @@ module Primer
         @form_builder = form_arguments[:builder]
         @input_name = form_arguments[:name]
 
-        return unless required_form_arguments_given? && !allows_selection_given?
+        return unless required_form_arguments_given? && !allows_selection?
 
         raise ArgumentError, "lists/menus that act as form inputs must also allow item selection (please pass the `select_variant:` option)"
       end
@@ -172,7 +172,7 @@ module Primer
       end
 
       def acts_as_form_input?
-        required_form_arguments_given? && allows_selection_given?
+        required_form_arguments_given? && allows_selection?
       end
 
       # @private

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -116,6 +116,10 @@ module Primer
 
         @form_builder = form_arguments[:builder]
         @input_name = form_arguments[:name]
+
+        if has_required_form_arguments? && !allows_selection?
+          raise ArgumentError, "lists/menus that act as form inputs must also allow item selection (please pass the `select_variant:` option)"
+        end
       end
 
       # @private
@@ -161,6 +165,14 @@ module Primer
 
       def acts_as_menu?
         @system_arguments[:role] == :menu
+      end
+
+      def has_required_form_arguments?
+        @form_builder && @input_name
+      end
+
+      def acts_as_form_input?
+        has_required_form_arguments? && allows_selection?
       end
 
       # @private

--- a/app/components/primer/alpha/action_list/form_wrapper.html.erb
+++ b/app/components/primer/alpha/action_list/form_wrapper.html.erb
@@ -1,0 +1,10 @@
+<% if form_required? %>
+  <%= form_with(url: @action, method: @http_method, **@form_arguments) do %>
+    <% if render_input? %>
+      <%= render(Primer::BaseComponent.new(tag: :input, **@input_arguments)) %>
+    <% end %>
+    <%= content %>
+  <% end %>
+<% else %>
+  <%= content %>
+<% end %>

--- a/app/components/primer/alpha/action_list/form_wrapper.rb
+++ b/app/components/primer/alpha/action_list/form_wrapper.rb
@@ -30,7 +30,7 @@ module Primer
             name: name,
             value: value,
             data: { list_item_input: true },
-            **(@form_arguments.delete(:input_arguments) || {}),
+            **(@form_arguments.delete(:input_arguments) || {})
           }
         end
 
@@ -49,7 +49,7 @@ module Primer
         private
 
         def extract_http_method(args)
-          if http_method = args.delete(:method)
+          if (http_method = args.delete(:method))
             HTTP_METHOD_OPTIONS.include?(http_method) ? http_method : DEFAULT_HTTP_METHOD
           else
             DEFAULT_HTTP_METHOD

--- a/app/components/primer/alpha/action_list/form_wrapper.rb
+++ b/app/components/primer/alpha/action_list/form_wrapper.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Primer
+  module Alpha
+    class ActionList
+      # Utility component for wrapping ActionLists or individual ActionList::Items in forms.
+      class FormWrapper < Primer::Component
+        DEFAULT_HTTP_METHOD = :get
+        HTTP_METHOD_OPTIONS = [
+          DEFAULT_HTTP_METHOD,
+          :post,
+          :patch,
+          :put,
+          :delete,
+          :head
+        ].freeze
+
+        def initialize(list:, action: nil, **form_arguments)
+          @list = list
+          @form_arguments = form_arguments
+
+          @action = action
+          @http_method = extract_http_method(@form_arguments)
+
+          name = @form_arguments.delete(:name)
+          value = @form_arguments.delete(:value) || name
+
+          @input_arguments = {
+            type: :hidden,
+            name: name,
+            value: value,
+            data: { list_item_input: true },
+            **(@form_arguments.delete(:input_arguments) || {}),
+          }
+        end
+
+        def get?
+          @http_method == :get
+        end
+
+        def form_required?
+          @action && !get?
+        end
+
+        def render_input?
+          @input_arguments[:name].present?
+        end
+
+        private
+
+        def extract_http_method(args)
+          if http_method = args.delete(:method)
+            HTTP_METHOD_OPTIONS.include?(http_method) ? http_method : DEFAULT_HTTP_METHOD
+          else
+            DEFAULT_HTTP_METHOD
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/alpha/action_list/item.html.erb
+++ b/app/components/primer/alpha/action_list/item.html.erb
@@ -8,11 +8,14 @@
       <% end %>
       <% if list.select_variant == :single || list.select_variant == :multiple %>
         <span class="ActionListItem-visual ActionListItem-action--leading">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="ActionListItem-singleSelectCheckmark"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>
+          <%= render(Primer::Alpha::Octicon.new(icon: :check, classes: "ActionListItem-singleSelectCheckmark")) %>
         </span>
       <% elsif list.select_variant == :multiple_checkbox %>
         <span class="ActionListItem-visual ActionListItem-action--leading">
-          <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" class="ActionListItem-multiSelectIcon"><rect x="2" y="2" width="12" height="12" rx="4" class="ActionListItem-multiSelectIconRect"></rect><path fill-rule="evenodd" d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z" class="ActionListItem-multiSelectCheckmark"></path></svg>
+          <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" class="ActionListItem-multiSelectIcon">
+            <rect x="2" y="2" width="12" height="12" rx="4" class="ActionListItem-multiSelectIconRect"></rect>
+            <path fill-rule="evenodd" d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z" class="ActionListItem-multiSelectCheckmark"></path>
+          </svg>
         </span>
       <% end %>
       <% if leading_visual %>

--- a/app/components/primer/alpha/action_list/item.html.erb
+++ b/app/components/primer/alpha/action_list/item.html.erb
@@ -1,43 +1,45 @@
 <%= render(Primer::BaseComponent.new(tag: :li, **@system_arguments)) do %>
-  <%= render(Primer::BaseComponent.new(**@content_arguments)) do %>
-    <% if private_leading_action_icon %>
-      <span class="ActionListItem-visual ActionListItem-action--leading">
-        <%= private_leading_action_icon %>
-      </span>
-    <% end %>
-    <% if list.select_variant == :single || list.select_variant == :multiple %>
-      <span class="ActionListItem-visual ActionListItem-action--leading">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="ActionListItem-singleSelectCheckmark"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>
-      </span>
-    <% elsif list.select_variant == :multiple_checkbox %>
-      <span class="ActionListItem-visual ActionListItem-action--leading">
-        <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" class="ActionListItem-multiSelectIcon"><rect x="2" y="2" width="12" height="12" rx="4" class="ActionListItem-multiSelectIconRect"></rect><path fill-rule="evenodd" d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z" class="ActionListItem-multiSelectCheckmark"></path></svg>
-      </span>
-    <% end %>
-    <% if leading_visual %>
-      <span class="ActionListItem-visual ActionListItem-visual--leading">
-        <%= leading_visual %>
-      </span>
-    <% end %>
-    <%= render(Primer::ConditionalWrapper.new(condition: description?, tag: :span, **@description_wrapper_arguments)) do %>
-      <%= render(Primer::BaseComponent.new(tag: :span, **@label_arguments)) do %>
-        <%= @label || content %>
-      <% end %>
-      <% if description? %>
-        <span class="ActionListItem-description">
-          <%= description %>
+  <%= render(@form_wrapper) do %>
+    <%= render(Primer::BaseComponent.new(**@content_arguments)) do %>
+      <% if private_leading_action_icon %>
+        <span class="ActionListItem-visual ActionListItem-action--leading">
+          <%= private_leading_action_icon %>
         </span>
       <% end %>
-    <% end %>
-    <% if trailing_visual %>
-      <span class="ActionListItem-visual ActionListItem-visual--trailing">
-        <%= trailing_visual %>
-      </span>
-    <% end %>
-    <% if private_trailing_action_icon %>
-      <span class="ActionListItem-visual ActionListItem-action--trailing">
-        <%= private_trailing_action_icon %>
-      </span>
+      <% if list.select_variant == :single || list.select_variant == :multiple %>
+        <span class="ActionListItem-visual ActionListItem-action--leading">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" class="ActionListItem-singleSelectCheckmark"><path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>
+        </span>
+      <% elsif list.select_variant == :multiple_checkbox %>
+        <span class="ActionListItem-visual ActionListItem-action--leading">
+          <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" class="ActionListItem-multiSelectIcon"><rect x="2" y="2" width="12" height="12" rx="4" class="ActionListItem-multiSelectIconRect"></rect><path fill-rule="evenodd" d="M4.03231 8.69862C3.84775 8.20646 4.49385 7.77554 4.95539 7.77554C5.41693 7.77554 6.80154 9.85246 6.80154 9.85246C6.80154 9.85246 10.2631 4.314 10.4938 4.08323C10.7246 3.85246 11.8785 4.08323 11.4169 5.00631C11.0081 5.82388 7.26308 11.4678 7.26308 11.4678C7.26308 11.4678 6.80154 12.1602 6.34 11.4678C5.87846 10.7755 4.21687 9.19077 4.03231 8.69862Z" class="ActionListItem-multiSelectCheckmark"></path></svg>
+        </span>
+      <% end %>
+      <% if leading_visual %>
+        <span class="ActionListItem-visual ActionListItem-visual--leading">
+          <%= leading_visual %>
+        </span>
+      <% end %>
+      <%= render(Primer::ConditionalWrapper.new(condition: description?, tag: :span, **@description_wrapper_arguments)) do %>
+        <%= render(Primer::BaseComponent.new(tag: :span, **@label_arguments)) do %>
+          <%= @label || content %>
+        <% end %>
+        <% if description? %>
+          <span class="ActionListItem-description">
+            <%= description %>
+          </span>
+        <% end %>
+      <% end %>
+      <% if trailing_visual %>
+        <span class="ActionListItem-visual ActionListItem-visual--trailing">
+          <%= trailing_visual %>
+        </span>
+      <% end %>
+      <% if private_trailing_action_icon %>
+        <span class="ActionListItem-visual ActionListItem-action--trailing">
+          <%= private_trailing_action_icon %>
+        </span>
+      <% end %>
     <% end %>
   <% end %>
   <%= tooltip %>

--- a/app/components/primer/alpha/action_list/item.html.erb
+++ b/app/components/primer/alpha/action_list/item.html.erb
@@ -8,7 +8,7 @@
       <% end %>
       <% if list.select_variant == :single || list.select_variant == :multiple %>
         <span class="ActionListItem-visual ActionListItem-action--leading">
-          <%= render(Primer::Alpha::Octicon.new(icon: :check, classes: "ActionListItem-singleSelectCheckmark")) %>
+          <%= render(Primer::Beta::Octicon.new(icon: :check, classes: "ActionListItem-singleSelectCheckmark")) %>
         </span>
       <% elsif list.select_variant == :multiple_checkbox %>
         <span class="ActionListItem-visual ActionListItem-action--leading">

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -225,6 +225,14 @@ module Primer
             end
           end
 
+          if @content_arguments[:tag] != :button && @form_wrapper.form_required?
+            raise ArgumentError, "items that submit forms must use a \"button\" tag instead of \"#{@content_arguments[:tag]}\""
+          end
+
+          if @content_arguments[:tag] != :button && @list.acts_as_form_input?
+            raise ArgumentError, "items within lists/menus that act as form inputs must use \"button\" tags instead of \"#{@content_arguments[:tag]}\""
+          end
+
           if @disabled
             @content_arguments[:aria] ||= merge_aria(
               @content_arguments,

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -225,6 +225,7 @@ module Primer
             end
           end
 
+          # rubocop:disable Style/IfUnlessModifier
           if @content_arguments[:tag] != :button && @form_wrapper.form_required?
             raise ArgumentError, "items that submit forms must use a \"button\" tag instead of \"#{@content_arguments[:tag]}\""
           end
@@ -232,6 +233,7 @@ module Primer
           if @content_arguments[:tag] != :button && @list.acts_as_form_input?
             raise ArgumentError, "items within lists/menus that act as form inputs must use \"button\" tags instead of \"#{@content_arguments[:tag]}\""
           end
+          # rubocop:enable Style/IfUnlessModifier
 
           if @disabled
             @content_arguments[:aria] ||= merge_aria(

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -137,6 +137,7 @@ module Primer
         # @param label_classes [String] CSS classes that will be added to the label.
         # @param label_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the label.
         # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or button tag.
+        # @param form_arguments [Hash] Allows the item to submit a form on click. The URL passed in the `href:` option will be used as the form action. Pass the `method:` option to this hash to control what kind of request is made, <%= one_of(Primer::Alpha::ActionList::FormWrapper::HTTP_METHOD_OPTIONS) %> The `name:` option is required and specifies the desired name of the field that will be included in the params sent to the server on form submission. Specify the `value:` option to send a custom value to the server; otherwise the value of `name:` is sent.
         # @param truncate_label [Boolean] Truncate label with ellipsis.
         # @param href [String] Link URL.
         # @param role [String] ARIA role describing the function of the item.

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -154,6 +154,7 @@ module Primer
           label_classes: nil,
           label_arguments: {},
           content_arguments: {},
+          form_arguments: {},
           parent: nil,
           truncate_label: false,
           href: nil,
@@ -170,13 +171,14 @@ module Primer
           @list = list
           @parent = parent
           @label = label
-          @href = href
+          @href = href || content_arguments[:href]
           @truncate_label = truncate_label
           @disabled = disabled
           @active = active
           @id = id
           @system_arguments = system_arguments
           @content_arguments = content_arguments
+          @form_wrapper = FormWrapper.new(list: @list, action: @href, **form_arguments)
 
           @size = fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)
           @scheme = fetch_or_fallback(SCHEME_OPTIONS, scheme, DEFAULT_SCHEME)
@@ -212,11 +214,12 @@ module Primer
           )
 
           unless @content_arguments[:tag]
-            if @href && !@disabled
+            if @href && @form_wrapper.get? && !@disabled
               @content_arguments[:tag] = :a
               @content_arguments[:href] = @href
             else
               @content_arguments[:tag] = :button
+              @content_arguments[:type] = @form_wrapper.form_required? ? :submit : :button
               @content_arguments[:onclick] = on_click if on_click
             end
           end

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -3,9 +3,9 @@
 
 module Primer
   module Alpha
-    # The ActionMenu should be used when a user can select a single option triggering an action from a list of items. Primer will automatically nest an `Item` within a presentational `<li>` tag.
+    # ActionMenu is used for actions, navigation, to display secondary options, or single/multi select lists. They appear when users interact with buttons, actions, or other controls.
     #
-    # The only allowed elements for the `Item` components are: `:a`, `:button`, and `:clipboard-copy`. If one isn't selected, a fallback `:span` will be used. To add functionality, use a `.js` class to create the functionality, or an `onclick` handler.
+    # The only allowed elements for the `Item` components are: `:a`, `:button`, and `:clipboard-copy`. The default is `:button`.
     #
     # @accessibility
     #   The action for the menu item needs to be on the element with `role="menuitem"`. Semantics are removed for everything nested inside of it. When a menu item is selected, the menu will close immediately.
@@ -38,6 +38,9 @@ module Primer
       #    <% end %>
       #    <% c.with_item(tag: :"clipboard-copy", value: "Text to copy") do %>
       #      Copy Text
+      #    <% end %>
+      #    <% c.with_item(href: "https://google.com", form_arguments: { name: "foo", value: "bar", method: :post }) do %>
+      #      Submit form
       #    <% end %>
       #  <% end %>
       #
@@ -271,6 +274,28 @@ module Primer
       #    <% c.with_show_button(icon: :"kebab-horizontal", "aria-label": "Menu") %>
       #  <% end %>
       #
+      # @example Using a single-select ActionMenu as a form input
+      #   <%= form_with(url: action_menu_form_action_path) do |f| %>
+      #     <%= render(Primer::Alpha::ActionMenu.new(select_variant: :single, dynamic_label: true, dynamic_label_prefix: "Strategy", form_arguments: { builder: f, name: "foo" })) do |menu| %>
+      #       <% menu.with_show_button { "Strategy" } %>
+      #       <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
+      #       <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
+      #       <% menu.with_item(label: "Ours", data: { value: "ours" }) %>
+      #       <% menu.with_item(label: "Resolve", data: { value: "resolve" }) %>
+      #     <% end %>
+      #   <% end %>
+      #
+      # @example Using a multi-select ActionMenu as a form input
+      #   <%= form_with(url: action_menu_form_action_path) do |f| %>
+      #     <%= render(Primer::Alpha::ActionMenu.new(select_variant: :multiple, form_arguments: { builder: f, name: "foo" })) do |menu| %>
+      #       <% menu.with_show_button { "Strategy" } %>
+      #       <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
+      #       <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
+      #       <% menu.with_item(label: "Ours", data: { value: "ours" }) %>
+      #       <% menu.with_item(label: "Resolve", data: { value: "resolve" }) %>
+      #     <% end %>
+      #   <% end %>
+      #
       # @param menu_id [String] Id of the menu.
       # @param anchor_align [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_ALIGN_OPTIONS) %>.
       # @param anchor_side [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_SIDE_OPTIONS) %>.
@@ -278,7 +303,8 @@ module Primer
       # @param preload [Boolean] When true, and src is present, loads the `include-fragment` on trigger hover.
       # @param dynamic_label [Boolean] Whether or not to display the text of the currently selected item in the show button.
       # @param dynamic_label_prefix [String] If provided, the prefix is prepended to the dynamic label and displayed in the show button.
-      # @param select_variant [Symbol]. <%= one_of(Primer::Alpha::ActionMenu::SELECT_VARIANT_OPTIONS) %>.
+      # @param select_variant [Symbol] <%= one_of(Primer::Alpha::ActionMenu::SELECT_VARIANT_OPTIONS) %>
+      # @param form_arguments [Hash] Allows an `ActionMenu` to act as a select list in multi- and single-select modes. Pass the `builder:` and `name:` options to this hash. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which are created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
       def initialize(
         menu_id: self.class.generate_id,
@@ -321,6 +347,12 @@ module Primer
         )
       end
 
+      # @!parse
+      #   # Button to activate the menu.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
+      #   renders_one(:show_button)
+
       # Button to activate the menu.
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
@@ -328,16 +360,17 @@ module Primer
         @overlay.with_show_button(**system_arguments, id: "#{@menu_id}-button", controls: "#{@menu_id}-list", &block)
       end
 
+      # @!parse
+      #   # Adds a new item to the list.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
+      #   renders_many(:items)
+
       # Adds a new item to the list.
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
       def with_item(**system_arguments, &block)
         @list.with_item(**system_arguments, &block)
-      end
-
-      # Retrieves the list of items.
-      def items
-        @list.items
       end
 
       # Adds a divider to the list.
@@ -352,11 +385,11 @@ module Primer
       def before_render
         content
 
-        raise ArgumentError, "`items` cannot be set when `src` is specified" if @src.present? && items.any?
+        raise ArgumentError, "`items` cannot be set when `src` is specified" if @src.present? && @list.items.any?
       end
 
       def render?
-        items.any? || @src.present?
+        @list.items.any? || @src.present?
       end
     end
   end

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -289,6 +289,7 @@ module Primer
         dynamic_label: false,
         dynamic_label_prefix: nil,
         select_variant: DEFAULT_SELECT_VARIANT,
+        form_arguments: {},
         **system_arguments
       )
         @menu_id = menu_id
@@ -315,7 +316,8 @@ module Primer
 
         @list = Primer::Alpha::ActionMenu::List.new(
           menu_id: @menu_id,
-          select_variant: select_variant
+          select_variant: select_variant,
+          form_arguments: form_arguments
         )
       end
 

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -16,14 +16,9 @@ module Primer
         def with_item(**system_arguments, &block)
           content_arguments = system_arguments.delete(:content_arguments) || {}
 
-          content_arguments[:tag] =
-            if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
-              system_arguments[:tag]
-            elsif system_arguments[:href] && !system_arguments[:disabled]
-              :a
-            else
-              DEFAULT_ITEM_TAG
-            end
+          if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
+            content_arguments[:tag] = system_arguments[:tag]
+          end
 
           # disallow setting item's tag
           system_arguments.delete(:tag)

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -12,8 +12,9 @@ module Primer
 
         # Adds a new item to the list.
         #
+        # @param data [Hash] When the menu is used as a form input (see the <%= link_to_component(Primer::Alpha::ActionMenu) %> docs), the label is submitted to the server by default. However, if the `data: { value: }` or `"data-value":` attribute is provided, it will be sent to the server instead.
         # @param system_arguments [Hash] The same arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-        def with_item(**system_arguments, &block)
+        def with_item(data: {}, **system_arguments, &block)
           content_arguments = system_arguments.delete(:content_arguments) || {}
 
           if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
@@ -46,7 +47,7 @@ module Primer
             content_arguments[:disabled] = "" if content_arguments[:tag] == :button
           end
 
-          super(**system_arguments, content_arguments: content_arguments) do |item|
+          super(data: data, **system_arguments, content_arguments: content_arguments) do |item|
             # Prevent double renders by using the capture method on the component
             # that originally received the block.
             #
@@ -65,7 +66,7 @@ module Primer
         end
 
         # @param menu_id [String] ID of the parent menu.
-        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>
         def initialize(menu_id:, **system_arguments, &block)
           @menu_id = menu_id
 

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -17,9 +17,11 @@ module Primer
         def with_item(data: {}, **system_arguments, &block)
           content_arguments = system_arguments.delete(:content_arguments) || {}
 
+          # rubocop:disable Style/IfUnlessModifier
           if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
             content_arguments[:tag] = system_arguments[:tag]
           end
+          # rubocop:enable Style/IfUnlessModifier
 
           # disallow setting item's tag
           system_arguments.delete(:tag)

--- a/demo/app/controllers/action_menu_controller.rb
+++ b/demo/app/controllers/action_menu_controller.rb
@@ -13,4 +13,22 @@ class ActionMenuController < ApplicationController
   def deferred_preload
     render "action_menu/deferred_preload"
   end
+
+  def form_action
+    respond_to do |format|
+      format.html do
+        @value = form_action_selected_value
+      end
+
+      format.json do
+        render json: { value: form_action_selected_value }
+      end
+    end
+  end
+
+  private
+
+  def form_action_selected_value
+    params.permit(:foo)[:foo] || params.permit(foo: [])[:foo]
+  end
 end

--- a/demo/app/views/action_menu/form_action.html.erb
+++ b/demo/app/views/action_menu/form_action.html.erb
@@ -1,0 +1,1 @@
+You selected <%= @value.inspect %>

--- a/demo/config/routes.rb
+++ b/demo/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     post "/example_check/random", to: "auto_check#random", as: :example_check_random
 
     get "/action_menu/landing_page", to: "action_menu#landing", as: :action_menu_landing
+    post "/action_menu/form_action", to: "action_menu#form_action", as: :action_menu_form_action
     get "/action_menu/deferred", to: "action_menu#deferred", as: :action_menu_deferred
     get "/action_menu/deferred_preload", to: "action_menu#deferred_preload", as: :action_menu_deferred_preload
   end

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -166,7 +166,26 @@ module Primer
           component.with_item(label: "Alert", tag: :button, content_arguments: { onclick: "alert('Foo')", onkeydown: "if (event.key === 'Enter') { alert(event.key) }" })
           component.with_item(label: "Navigate", tag: :a, content_arguments: { href: UrlHelpers.action_menu_landing_path })
           component.with_item(label: "Copy text", tag: :"clipboard-copy", content_arguments: { value: "Text to copy" })
+          component.with_item(
+            label: "Submit form",
+            href: UrlHelpers.action_menu_form_action_path,
+            form_arguments: {
+              name: "foo", value: "bar", method: :post
+            }
+          )
         end
+      end
+
+      # @label Single select form
+      #
+      def single_select_form(route_format: :html)
+        render_with_template(locals: { route_format: route_format })
+      end
+
+      # @label Multiple select form
+      #
+      def multiple_select_form(route_format: :html)
+        render_with_template(locals: { route_format: route_format })
       end
 
       # @label With disabled items

--- a/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
+++ b/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(url: action_menu_form_action_path(format: route_format)) do |f| %>
+  <%= render(Primer::Alpha::ActionMenu.new(select_variant: :multiple, dynamic_label: true, dynamic_label_prefix: "Strategy", form_arguments: { builder: f, name: "foo" })) do |menu| %>
+    <% menu.with_show_button { "Strategy" } %>
+    <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
+    <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
+    <% menu.with_item(label: "Ours", data: { value: "ours" }) %>
+    <% menu.with_item(label: "Resolve") %>
+  <% end %>
+  <hr>
+  <div>
+    <%= f.submit(class: "Button--secondary Button--medium Button") %>
+  </div>
+<% end %>

--- a/previews/primer/alpha/action_menu_preview/single_select_form.html.erb
+++ b/previews/primer/alpha/action_menu_preview/single_select_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(url: action_menu_form_action_path(format: route_format)) do |f| %>
+  <%= render(Primer::Alpha::ActionMenu.new(select_variant: :single, dynamic_label: true, dynamic_label_prefix: "Strategy", form_arguments: { builder: f, name: "foo" })) do |menu| %>
+    <% menu.with_show_button { "Strategy" } %>
+    <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
+    <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
+    <% menu.with_item(label: "Ours", data: { value: "ours" }) %>
+    <% menu.with_item(label: "Resolve") %>
+  <% end %>
+  <hr>
+  <div>
+    <%= f.submit(class: "Button--secondary Button--medium Button") %>
+  </div>
+<% end %>

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -162,6 +162,52 @@ module Primer
 
         assert_match(/only a single item may be active/, error.message)
       end
+
+      def test_raises_when_non_button_tag_passed_to_form_item
+        error = assert_raises ArgumentError do
+          render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |component|
+            component.with_item(label: "Item 1")
+            component.with_item(
+              label: "Item 2",
+              href: "/foo",
+              content_arguments: { tag: :span },
+              form_arguments: { method: :post, name: "foo" }
+            )
+          end
+        end
+
+        assert_equal 'items that submit forms must use a "button" tag instead of "span"', error.message
+      end
+
+      def test_raises_when_non_button_item_added_to_list_acting_as_form_input
+        error = assert_raises ArgumentError do
+          render_in_view_context do
+            form_with(url: "/foo") do |f|
+              render(Primer::Alpha::ActionList.new(aria: { label: "List" }, select_variant: :single, form_arguments: { builder: f, name: "foo" })) do |component|
+                component.with_item(label: "Item 1")
+                component.with_item(label: "Item 2", content_arguments: { tag: :span })
+              end
+            end
+          end
+        end
+
+        assert_equal 'items within lists/menus that act as form inputs must use "button" tags instead of "span"', error.message
+      end
+
+      def test_raises_when_list_acting_as_form_input_doesnt_allow_selection
+        error = assert_raises ArgumentError do
+          render_in_view_context do
+            form_with(url: "/foo") do |f|
+              render(Primer::Alpha::ActionList.new(aria: { label: "List" }, form_arguments: { builder: f, name: "foo" })) do |component|
+                component.with_item(label: "Item 1")
+                component.with_item(label: "Item 2", content_arguments: { tag: :span })
+              end
+            end
+          end
+        end
+
+        assert_match /lists\/menus that act as form inputs must also allow item selection/, error.message
+      end
     end
   end
 end

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -206,7 +206,7 @@ module Primer
           end
         end
 
-        assert_match /lists\/menus that act as form inputs must also allow item selection/, error.message
+        assert_match(%r{lists/menus that act as form inputs must also allow item selection}, error.message)
       end
     end
   end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -129,6 +129,7 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Alpha::ActionList::Heading",
       "Primer::Alpha::ActionList::Item",
       "Primer::Alpha::ActionList::Divider",
+      "Primer::Alpha::ActionList::FormWrapper",
       "Primer::Alpha::ActionMenu::List",
       "Primer::Alpha::NavList::Item",
       "Primer::Alpha::NavList::Group",

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -154,5 +154,65 @@ module Alpha
 
       assert_selector "modal-dialog#my-dialog"
     end
+
+    def test_single_select_form_submission
+      visit_preview(:single_select_form, route_format: :json)
+
+      find("action-menu button[aria-controls]").click
+      find("action-menu ul li:first-child").click
+
+      find("input[type=submit]").click
+
+      # for some reason the JSON response is wrapped in HTML, I have no idea why
+      response = JSON.parse(find("pre").text)
+      assert_equal response["value"], "fast_forward"
+    end
+
+    def test_single_select_form_uses_label_if_no_value_provided
+      visit_preview(:single_select_form, route_format: :json)
+
+      find("action-menu button[aria-controls]").click
+      find("action-menu ul li:last-child").click
+
+      find("input[type=submit]").click
+
+      # for some reason the JSON response is wrapped in HTML, I have no idea why
+      response = JSON.parse(find("pre").text)
+      assert_equal response["value"], "Resolve"
+    end
+
+    def test_multiple_select_form_submission
+      visit_preview(:multiple_select_form, route_format: :json)
+
+      find("action-menu button[aria-controls]").click
+      find("action-menu ul li:first-child").click
+      find("action-menu ul li:nth-child(2)").click
+
+      # close the menu to reveal the submit button
+      page.driver.browser.keyboard.type(:escape)
+
+      find("input[type=submit]").click
+
+      # for some reason the JSON response is wrapped in HTML, I have no idea why
+      response = JSON.parse(find("pre").text)
+      assert_equal response["value"], ["fast_forward", "recursive"]
+    end
+
+    def test_multiple_select_form_uses_label_if_no_value_provided
+      visit_preview(:multiple_select_form, route_format: :json)
+
+      find("action-menu button[aria-controls]").click
+      find("action-menu ul li:first-child").click
+      find("action-menu ul li:last-child").click
+
+      # close the menu to reveal the submit button
+      page.driver.browser.keyboard.type(:escape)
+
+      find("input[type=submit]").click
+
+      # for some reason the JSON response is wrapped in HTML, I have no idea why
+      response = JSON.parse(find("pre").text)
+      assert_equal response["value"], ["fast_forward", "Resolve"]
+    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -214,5 +214,14 @@ module Alpha
       response = JSON.parse(find("pre").text)
       assert_equal response["value"], ["fast_forward", "Resolve"]
     end
+
+    def test_individual_items_can_submit_post_requests_via_forms
+      visit_preview(:with_actions)
+
+      find("action-menu button[aria-controls]").click
+      find("action-menu ul li:last-child").click
+
+      assert_equal page.text, 'You selected "bar"'
+    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -195,7 +195,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], ["fast_forward", "recursive"]
+      assert_equal response["value"], %w[fast_forward recursive]
     end
 
     def test_multiple_select_form_uses_label_if_no_value_provided
@@ -212,7 +212,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], ["fast_forward", "Resolve"]
+      assert_equal response["value"], %w[fast_forward Resolve]
     end
 
     def test_individual_items_can_submit_post_requests_via_forms


### PR DESCRIPTION
### Description

`ActionMenu`s support two main use-cases:

1. **Navigation/Actions**. Supports links, clipboard copy, triggering js behavior, etc.
2. **Select lists**. Essentially a replacement for the `<select>` tag when in single- or multi-select mode.

Despite supporting select behavior however, `ActionMenu`s currently don't work very well with forms. This PR adds form integration for entire (select-enabled) lists and also for individual list items.

### Individual list items

It has come to our attention that at least one team at GitHub needs a menu item that submits a POST request instead of the GET request links (i.e. `<a>` tags) do. Here's how to do that with this PR:

```ruby
render(Primer::Alpha::ActionMenu.new) do |component|
  component.with_show_button { "Trigger" }
  component.with_item(
    label: "Submit form",
    href: "/some/url",
    form_arguments: {
      name: "foo", value: "bar", method: :post
    }
  )
end
```

### Select-enabled lists

`ActionMenu`s can now be rendered as form inputs. On submit, the items the user has selected are sent to the server as params like any other form input.  Example:

```ruby
form_with(url: "/some/url") do |f|
  render(Primer::Alpha::ActionMenu.new(
      select_variant: :single,
      dynamic_label: true,
      dynamic_label_prefix: "Strategy",
      form_arguments: { builder: f, name: "foo" })) do |menu|
    menu.with_show_button { "Strategy" }
    menu.with_item(label: "Fast forward", data: { value: "fast_forward" })
    menu.with_item(label: "Recursive", data: { value: "recursive" })
    menu.with_item(label: "Ours", data: { value: "ours" })
    menu.with_item(label: "Resolve", data: { value: "ours" })
  end
end
```

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews