### PR TITLE
Adds `Box` preview

### DIFF
--- a/previews/primer/box_preview.rb
+++ b/previews/primer/box_preview.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Primer
+  # @label Box
+  class BoxPreview < ViewComponent::Preview
+    # @label Playground
+    #
+    # @param content [String] text
+    def playground(content: "Playground")
+      render(Primer::Box.new) { content }
+    end
+
+    # @label Default
+    def default(content: "Default")
+      render(Primer::Box.new) { content }
+    end
+
+    # @label Border
+    def border(content: "Box with border")
+      render(Primer::Box.new(border: true, p: 3)) { content }
+    end
+
+    # @label Border Bottom
+    def border_bottom(content: "Box with bottom border")
+      render(Primer::Box.new(border: :bottom, p: 3)) { content }
+    end
+  end
+end


### PR DESCRIPTION
### Description

Adds a preview for the [`Box` component](https://primer.style/view-components/components/box).

Relates to https://github.com/github/primer/issues/2118 (internal).

### Integration

> Does this change require any updates to code in production?

Nope

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews
