### PR TITLE
Don't show separator lines on first child

### DIFF
--- a/.changeset/fast-cobras-design.md
+++ b/.changeset/fast-cobras-design.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Don't show segmented control item separator on first item

--- a/app/components/primer/alpha/segmented_control.pcss
+++ b/app/components/primer/alpha/segmented_control.pcss
@@ -46,13 +46,15 @@
   }
 
   /* Separator lines */
-  &::before {
-    position: absolute;
-    inset: 0 0 0 -1px;
-    margin-top: var(--control-medium-paddingBlock, 6px);
-    margin-bottom: var(--control-medium-paddingBlock, 6px);
-    content: '';
-    border-left: var(--borderWidth-thin, max(1px, 0.0625rem)) solid var(--color-border-default);
+  &:not(:first-child) {
+    &::before {
+      position: absolute;
+      inset: 0 0 0 -1px;
+      margin-top: var(--control-medium-paddingBlock, 6px);
+      margin-bottom: var(--control-medium-paddingBlock, 6px);
+      content: '';
+      border-left: var(--borderWidth-thin, max(1px, 0.0625rem)) solid var(--color-border-default);
+    }
   }
 
   /* Button ----------------------------------------- */

--- a/app/components/primer/alpha/segmented_control.pcss
+++ b/app/components/primer/alpha/segmented_control.pcss
@@ -28,7 +28,7 @@
     }
 
     &::before {
-      border-color: transparent;
+      border-color: transparent !important;
     }
 
     & + .SegmentedControl-item::before {


### PR DESCRIPTION
### Description

This PR resolves a subtle bug with the `Primer::Alpha::SegmentedControl` component, where the separator line shows on the left side of the first segmented control item. 

The bug is visible in production in the Discussions product:
<img width="226" alt="Screenshot 2023-04-28 at 10 46 15 AM" src="https://user-images.githubusercontent.com/34409939/235237010-ca2097fd-a4b4-4ad7-aff5-69bae36507c3.png">

...as well as [in the Primer docs for the component](https://primer.style/view-components/components/alpha/segmentedcontrol):
<img width="244" alt="Screenshot 2023-04-28 at 10 42 26 AM" src="https://user-images.githubusercontent.com/34409939/235237034-398aec09-5548-48bc-bbba-d591c0b52547.png">

The separator is built entirely in CSS it looks like, so as a fix I've wrapped the entire separator block so that it applies to all items _except_ the first child _(potentially easier to see by viewing the diff [with whitespace disabled](https://github.com/primer/view_components/pull/1969/files?diff=unified&w=1).)_ 

I'm certainly open to feedback if there is another way you would prefer for this to be resolved!