### PR TITLE
Bug: Autocomplete results padding

### DIFF
--- a/.changeset/strange-suns-study.md
+++ b/.changeset/strange-suns-study.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+add padding back to autocomplete

--- a/app/components/primer/beta/auto_complete.rb
+++ b/app/components/primer/beta/auto_complete.rb
@@ -41,7 +41,7 @@ module Primer
         system_arguments[:tag] = :ul
         system_arguments[:id] = @list_id
         system_arguments[:classes] = class_names(
-          "ActionListWrap",
+          "ActionListWrap ActionListWrap--inset",
           system_arguments[:classes]
         )
 

--- a/static/classes.json
+++ b/static/classes.json
@@ -375,10 +375,10 @@
   "ActionListWrap--inset": [
     "Primer::Alpha::ActionList"
   ],
-  "ActionListItem-action": [
+  "ActionListItem-visual": [
     "Primer::Alpha::ActionList"
   ],
-  "ActionListItem-visual": [
+  "ActionListItem-action": [
     "Primer::Alpha::ActionList"
   ],
   "SegmentedControl-item": [
@@ -513,10 +513,10 @@
   "FormControl-inlineValidation": [
     "Primer::Alpha::TextField"
   ],
-  "FormControl-check-group-wrap": [
+  "FormControl-radio-group-wrap": [
     "Primer::Alpha::TextField"
   ],
-  "FormControl-radio-group-wrap": [
+  "FormControl-check-group-wrap": [
     "Primer::Alpha::TextField"
   ],
   "Popover-message--bottom-left": [


### PR DESCRIPTION
### Description

While updating Autocomplete to use the new ActionList CSS, the inset padding was left off (which was previously the default setting). This adds the proper class.

Closes https://github.com/github/issues-graph/issues/2003

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
