### PR TITLE
fix popover close button

### DIFF
--- a/.changeset/real-cows-do.md
+++ b/.changeset/real-cows-do.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix Overlay close buttons

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -94,6 +94,7 @@ module Primer
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       renders_one :header, lambda { |divider: false, size: :medium, visually_hide_title: @visually_hide_title, **system_arguments|
         Primer::Alpha::Overlay::Header.new(
+          overlay_id: @id,
           id: title_id,
           title: @title,
           subtitle: @subtitle,

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -8,8 +8,10 @@
         <h2 class="Overlay-description"><%= @subtitle %></h2>
       <% end %>
     </div>
-    <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @overlay_id, "popovertargetaction": "hide") %>
-    </div>
+    <% if @overlay_id %>
+      <div class="Overlay-actionWrap">
+        <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @overlay_id, "popovertargetaction": "hide") %>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
     <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @id, "popovertargetaction": "hide") %>
+      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @overlay_id, "popovertargetaction": "hide") %>
     </div>
   </div>
 <% end %>

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -9,7 +9,7 @@
       <% end %>
     </div>
     <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popoverhidetarget": @id) %>
+      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @id, "popovertargetaction": "hide") %>
     </div>
   </div>
 <% end %>

--- a/app/components/primer/alpha/overlay/header.rb
+++ b/app/components/primer/alpha/overlay/header.rb
@@ -29,7 +29,7 @@ module Primer
           visually_hide_title: false,
           **system_arguments
         )
-          @overlay_id = id
+          @overlay_id = overlay_id
           @id = id
           @title = title
           @subtitle = subtitle

--- a/app/components/primer/alpha/overlay/header.rb
+++ b/app/components/primer/alpha/overlay/header.rb
@@ -14,15 +14,16 @@ module Primer
         SIZE_OPTIONS = SIZE_MAPPINGS.keys
 
         # @param title [String] Describes the content of the Overlay.
-        # @param subtitle [String] Provides dditional context for the Overlay, also setting the `aria-describedby` attribute.
+        # @param subtitle [String] Provides additional context for the Overlay, also setting the `aria-describedby` attribute.
+        # @param overlay_id [String] Provides the id of the overlay element so the close button can close it
         # @param size [Symbol] The size of the Header. <%= one_of(Primer::Alpha::Overlay::Header::SIZE_OPTIONS) %>
         # @param divider [Boolean] Show a divider between the header and body.
         # @param visually_hide_title [Boolean] Visually hide the `title` while maintaining a label for assistive technologies.
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(
-          overlay_id:,
           id:,
           title:,
+          overlay_id: nil,
           subtitle: nil,
           size: DEFAULT_SIZE,
           divider: false,

--- a/app/components/primer/alpha/overlay/header.rb
+++ b/app/components/primer/alpha/overlay/header.rb
@@ -20,6 +20,7 @@ module Primer
         # @param visually_hide_title [Boolean] Visually hide the `title` while maintaining a label for assistive technologies.
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(
+          overlay_id:,
           id:,
           title:,
           subtitle: nil,
@@ -28,6 +29,7 @@ module Primer
           visually_hide_title: false,
           **system_arguments
         )
+          @overlay_id = id
           @id = id
           @title = title
           @subtitle = subtitle


### PR DESCRIPTION
### Description

This refactors the close button for popovers, moving from the old `popoverhidetarget` to the standard `popovertarget`/`popovertargetaction=hide`.

Closes https://github.com/primer/view_components/issues/1989

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
