### PR TITLE
Aria disabled dialog

### DIFF
--- a/.changeset/late-melons-guess.md
+++ b/.changeset/late-melons-guess.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix Dialogs aria-disabled attribute

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -96,6 +96,7 @@ export class ModalDialogElement extends HTMLElement {
     if (value) {
       if (this.open) return
       this.setAttribute('open', '')
+      this.setAttribute('aria-disabled', 'false')
       this.#overlayBackdrop?.classList.remove('Overlay--hidden')
       document.body.style.paddingRight = `${window.innerWidth - document.body.clientWidth}px`
       document.body.style.overflow = 'hidden'
@@ -107,6 +108,7 @@ export class ModalDialogElement extends HTMLElement {
     } else {
       if (!this.open) return
       this.removeAttribute('open')
+      this.setAttribute('aria-disabled', 'true')
       this.#overlayBackdrop?.classList.add('Overlay--hidden')
       document.body.style.paddingRight = '0'
       document.body.style.overflow = 'initial'


### PR DESCRIPTION
### Description

In #1891 we added `aria-disabled=true` to `Dialog`, but this attribute is never changed, for example when the Dialog opens. This means AT will read all links within the dialog as disabled, even when open. This change introduces a toggle of `aria-disabled=` to `false` when the dialog is open, and `true` when closed.

Closes #1988 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
