### PR TITLE
use correct psuedo selector for popover

### DIFF
--- a/.changeset/late-items-invite.md
+++ b/.changeset/late-items-invite.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix style bug in popovers using native popover

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -6,7 +6,7 @@
 }
 
 /* stylelint-disable-next-line selector-pseudo-class-no-unknown */
-.Overlay[popover]:not(:open) {
+.Overlay[popover]:not(:popover-open) {
   display: none;
 }
 


### PR DESCRIPTION
### Description

`popover` has changed to use `:popover-open`

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
