### PR TITLE
Fix popover open selector for focus group

### DIFF
--- a/.changeset/ten-avocados-watch.md
+++ b/.changeset/ten-avocados-watch.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix focus groups when using native `popover`

--- a/app/components/primer/focus_group.ts
+++ b/app/components/primer/focus_group.ts
@@ -115,9 +115,8 @@ export default class FocusGroupElement extends HTMLElement {
           el = el.closest(`[popover]:not(${popoverSelector})`)
           if (el?.popover === 'auto') {
             el.showPopover()
-          } else {
-            el = el?.parentElement || null
           }
+          el = el?.parentElement || null
         } while (el)
       }
       focusEl?.focus()

--- a/app/components/primer/focus_group.ts
+++ b/app/components/primer/focus_group.ts
@@ -4,10 +4,10 @@ const menuItemSelector = '[role="menuitem"],[role="menuitemcheckbox"],[role="men
 
 const popoverSelector = (() => {
   try {
-    document.querySelector(':open')
-    return ':open'
+    document.querySelector(':popover-open')
+    return ':popover-open'
   } catch {
-    return '.\\:open'
+    return '.\\:popover-open'
   }
 })()
 


### PR DESCRIPTION
### Description

The focus group code doesn't work for popovers due to the use of the outdated selector. This changes the selector to the new `popover-open` selector.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
