### PR TITLE
bump @primer/behaviors to 1.3.4

### DIFF
--- a/.changeset/purple-drinks-suffer.md
+++ b/.changeset/purple-drinks-suffer.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix positioning for native popovers

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.1.1",
-        "@primer/behaviors": "^1.2.0"
+        "@primer/behaviors": "^1.3.4"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.6",
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/@primer/behaviors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
-      "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.4.tgz",
+      "integrity": "sha512-j6PhkDD1IdL9xrlKbUQ3YEM74B7Fgr1mIZJ6JaYJjM1Mvdutd/nBouM8SnwFZdBBbS+ZRfGhnx3plr833Pvf1Q=="
     },
     "node_modules/@primer/css": {
       "version": "21.0.1",
@@ -10090,9 +10090,9 @@
       }
     },
     "@primer/behaviors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.3.tgz",
-      "integrity": "sha512-iHMRuu8YWDJIdqCi1krx0cyFNeqszNKTOb0dXFu2wQ5BeIqxqPJLD7rjZ2Vjf/+YaPSbWuIQE1H6TaGMMsDfdA=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@primer/behaviors/-/behaviors-1.3.4.tgz",
+      "integrity": "sha512-j6PhkDD1IdL9xrlKbUQ3YEM74B7Fgr1mIZJ6JaYJjM1Mvdutd/nBouM8SnwFZdBBbS+ZRfGhnx3plr833Pvf1Q=="
     },
     "@primer/css": {
       "version": "21.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
     "@oddbird/popover-polyfill": "^0.1.1",
-    "@primer/behaviors": "^1.2.0"
+    "@primer/behaviors": "^1.3.4"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",


### PR DESCRIPTION
### Description

Bumps `@primer/behaviors` to `1.3.4` which includes the https://github.com/primer/behaviors/pull/195 fix for anchored positions on dialogs/popovers.

Closes #2000 

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
