### PR TITLE
prevent default when showing dialog

### DIFF
--- a/.changeset/wet-seahorses-attack.md
+++ b/.changeset/wet-seahorses-attack.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix bug where dialogs aren't shown due to keydown and pointer events firing

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -23,6 +23,10 @@ function clickHandler(event: Event) {
     if (dialog instanceof ModalDialogElement) {
       dialog.openButton = button
       dialog.show()
+      // A buttons default behaviour in some browsers it to send a pointer event
+      // If the behaviour is allowed through the dialog will be shown but then
+      // quickly hidden- as if it were never shown. This prevents that.
+      event.preventDefault()
       return
     }
   }


### PR DESCRIPTION
### Description

In Chrome Dev with Experimental Web Platform features enabled, I noticed that pressing Enter on a button to open a dialog will also trigger a pointer event (simulating the `click` of the button). This happens in a task _after_ the keypress, and so the code does the following:

 - Chrome fires a keypress event for the `Enter` key.
 - The `Enter` key is on a `data-show-dialog-id` button, so `dialog.show()` is called.
 - Chrome fires a `click` pointer event.
 - The dialog is in the open state, but the click event is on an element outside the dialog, so `dialog.hide()` is called.

The effect of this is that the dialog is never shown. We can combat this by calling `event.preventDefault()` on the click when the dialog is being shown. This prevents the pointer event from being fired.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
