### PR TITLE
Fix select doc example

### DIFF
--- a/.changeset/forty-tomatoes-rule.md
+++ b/.changeset/forty-tomatoes-rule.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix embedded example in SelectInput docs

--- a/lib/primer/yard/lookbook_pages_backend.rb
+++ b/lib/primer/yard/lookbook_pages_backend.rb
@@ -10,7 +10,7 @@ module Primer
       PREVIEW_MAP = {
         Primer::Alpha::TextField => [:single_text_field_form, :multi_text_field_form],
         Primer::Alpha::TextArea => [],
-        Primer::Alpha::Select => [:select_field_form],
+        Primer::Alpha::Select => [:select_form],
         Primer::Alpha::MultiInput => [:multi_input_form],
         Primer::Alpha::RadioButton => [:radio_button_with_nested_form],
         Primer::Alpha::RadioButtonGroup => [:radio_button_group_form],

--- a/lib/primer/yard/lookbook_pages_backend.rb
+++ b/lib/primer/yard/lookbook_pages_backend.rb
@@ -49,9 +49,11 @@ module Primer
 
         preview_methods = PREVIEW_MAP[component]
         preview_erbs = preview_methods.map do |preview_method|
-          if !Primer::Forms::FormsPreview.instance_methods.include?(preview_method)
+          # rubocop:disable Style/IfUnlessModifier
+          if Primer::Forms::FormsPreview.instance_methods.exclude?(preview_method)
             raise "Preview '#{preview_method}' does not exist in Primer::Forms::FormsPreview"
           end
+          # rubocop:enable Style/IfUnlessModifier
 
           "<%= embed Primer::Forms::FormsPreview, #{preview_method.inspect} %>"
         end

--- a/lib/primer/yard/lookbook_pages_backend.rb
+++ b/lib/primer/yard/lookbook_pages_backend.rb
@@ -10,7 +10,7 @@ module Primer
       PREVIEW_MAP = {
         Primer::Alpha::TextField => [:single_text_field_form, :multi_text_field_form],
         Primer::Alpha::TextArea => [],
-        Primer::Alpha::Select => [:select_form],
+        Primer::Alpha::Select => [:select_field_form],
         Primer::Alpha::MultiInput => [:multi_input_form],
         Primer::Alpha::RadioButton => [:radio_button_with_nested_form],
         Primer::Alpha::RadioButtonGroup => [:radio_button_group_form],
@@ -49,6 +49,10 @@ module Primer
 
         preview_methods = PREVIEW_MAP[component]
         preview_erbs = preview_methods.map do |preview_method|
+          if !Primer::Forms::FormsPreview.instance_methods.include?(preview_method)
+            raise "Preview '#{preview_method}' does not exist in Primer::Forms::FormsPreview"
+          end
+
           "<%= embed Primer::Forms::FormsPreview, #{preview_method.inspect} %>"
         end
         # rubocop:enable Lint/UselessAssignment

--- a/lib/primer/yard/lookbook_pages_backend.rb
+++ b/lib/primer/yard/lookbook_pages_backend.rb
@@ -10,7 +10,7 @@ module Primer
       PREVIEW_MAP = {
         Primer::Alpha::TextField => [:single_text_field_form, :multi_text_field_form],
         Primer::Alpha::TextArea => [],
-        Primer::Alpha::Select => [:select_list_form],
+        Primer::Alpha::Select => [:select_form],
         Primer::Alpha::MultiInput => [:multi_input_form],
         Primer::Alpha::RadioButton => [:radio_button_with_nested_form],
         Primer::Alpha::RadioButtonGroup => [:radio_button_group_form],


### PR DESCRIPTION
### Description

The `Select` component was renamed a little while ago which also affected the corresponding previews. Unfortunately the name of the preview was not updated in the doc generator code. I fixed the preview name and made sure the generator code raises an error now if the preview doesn't exist.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
