### PR TITLE
Fix danger example in ActionMenu docs

### DIFF
--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -105,7 +105,7 @@ module Primer
       #    <% c.with_item(tag: :"clipboard-copy", value: "Text to copy") do %>
       #      Copy Text
       #    <% end %>
-      #    <% c.with_item(tag: :button, type: "button", is_dangerous: true) do %>
+      #    <% c.with_item(tag: :button, type: "button", scheme: :danger) do %>
       #      Delete
       #    <% end %>
       #  <% end %>


### PR DESCRIPTION
Fixes https://github.com/primer/view_components/issues/1993

### Description

The example uses the old `is_dangerous` argument from the experimental version of the component.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
