### PR TITLE
Make ActionList leading visual icons the same color as the item text

### DIFF
--- a/.changeset/funny-tomatoes-sparkle.md
+++ b/.changeset/funny-tomatoes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Make ActionList leading visual icons the same color as the item text.

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -42,9 +42,7 @@ module Primer
         #
         # To render custom content, call the `with_leading_visual_content` method and pass a block that returns a string.
         renders_one :leading_visual, types: {
-          icon: lambda { |**system_arguments|
-            Primer::Beta::Octicon.new(classes: "ActionListItem-visual ActionListItem-visual--leading", **system_arguments)
-          },
+          icon: Primer::Beta::Octicon,
           avatar: ->(**kwargs) { Primer::Beta::Avatar.new(**{ **kwargs, size: 16 }) },
           svg: lambda { |**system_arguments|
             Primer::BaseComponent.new(tag: :svg, width: "16", height: "16", **system_arguments)


### PR DESCRIPTION
### Description

Fixes https://github.com/github/primer/issues/2240. Turns out the `ActionListItem-visual` class should only be applied to the wrapping element and not the icon itself.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
