### PR TITLE
Exclude rake tasks from published gem

### DIFF
--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/**/*", "previews/**/*"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/**/*", "previews/**/*"] - Dir["lib/**/*.rake"]
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency     "actionview", ">= 5.0.0"


### PR DESCRIPTION
### Description

Fixes https://github.com/primer/view_components/issues/1963

I can't think of a reason to include these dev-only rake tasks in published gems. They appear to interfere with Rails' `test` task as well.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
