### PR TITLE
Integrate custom GitHub axe rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.6",
         "@changesets/cli": "^2.24.1",
+        "@github/axe-github": "^0.5.0",
         "@github/browserslist-config": "^1.0.0",
         "@github/markdownlint-github": "^0.2.2",
         "@github/prettier-config": "0.0.4",
@@ -35,7 +36,7 @@
         "@rollup/plugin-typescript": "^8.3.3",
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "@typescript-eslint/parser": "^5.31.0",
-        "axe-core": "^4.6.2",
+        "axe-core": "^4.7.1",
         "chokidar-cli": "^3.0.0",
         "cssnano": "^5.1.13",
         "eslint": "^8.23.1",
@@ -777,6 +778,12 @@
       "dependencies": {
         "@github/combobox-nav": "^2.1.7"
       }
+    },
+    "node_modules/@github/axe-github": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@github/axe-github/-/axe-github-0.5.0.tgz",
+      "integrity": "sha512-i1QpK8hs2asSFCLn0LL6VEYIGJ+qnvho8YyqM9eQcI7K5tcser8ugLZkLTgktteWNZqE9g9OSlC0VFPEWo+RsQ==",
+      "dev": true
     },
     "node_modules/@github/browserslist-config": {
       "version": "1.0.0",
@@ -1726,9 +1733,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz",
-      "integrity": "sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.1.tgz",
+      "integrity": "sha512-sCXXUhA+cljomZ3ZAwb8i1p3oOlkABzPy08ZDAoGcYuvtBPlQ1Ytde129ArXyHWDhfeewq7rlx9F+cUx2SSlkg==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -9935,6 +9942,12 @@
         "@github/combobox-nav": "^2.1.7"
       }
     },
+    "@github/axe-github": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@github/axe-github/-/axe-github-0.5.0.tgz",
+      "integrity": "sha512-i1QpK8hs2asSFCLn0LL6VEYIGJ+qnvho8YyqM9eQcI7K5tcser8ugLZkLTgktteWNZqE9g9OSlC0VFPEWo+RsQ==",
+      "dev": true
+    },
     "@github/browserslist-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@github/browserslist-config/-/browserslist-config-1.0.0.tgz",
@@ -10591,9 +10604,9 @@
       }
     },
     "axe-core": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.2.tgz",
-      "integrity": "sha512-b1WlTV8+XKLj9gZy2DZXgQiyDp9xkkoe2a6U6UbYccScq2wgH/YwCeI2/Jq2mgo0HzQxqJOjWZBLeA/mqsk5Mg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.1.tgz",
+      "integrity": "sha512-sCXXUhA+cljomZ3ZAwb8i1p3oOlkABzPy08ZDAoGcYuvtBPlQ1Ytde129ArXyHWDhfeewq7rlx9F+cUx2SSlkg==",
       "dev": true
     },
     "axobject-query": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",
     "@changesets/cli": "^2.24.1",
+    "@github/axe-github": "^0.5.0",
     "@github/browserslist-config": "^1.0.0",
     "@github/markdownlint-github": "^0.2.2",
     "@github/prettier-config": "0.0.4",
@@ -70,7 +71,7 @@
     "@rollup/plugin-typescript": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
-    "axe-core": "^4.6.2",
+    "axe-core": "^4.7.1",
     "chokidar-cli": "^3.0.0",
     "cssnano": "^5.1.13",
     "eslint": "^8.23.1",

--- a/test/system/test_case.rb
+++ b/test/system/test_case.rb
@@ -103,6 +103,7 @@ module System
       results = driver.evaluate_async_script <<~JS
         const callback = arguments[arguments.length - 1];
         #{File.read('node_modules/axe-core/axe.min.js') unless axe_exists}
+        #{File.read('node_modules/@github/axe-github/dist/configure-browser/configure-browser.js') unless axe_exists}
         // Remove cyclic references
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#examples
         const getCircularReplacer = () => {


### PR DESCRIPTION
### Description

The [a11y-tracker](https://github.com/github/a11y-tracker) that reports axe violations to Datadog uses the custom axe rules from [@github/axe-github](https://www.npmjs.com/package/@github/axe-github), so I thought we should incorporate them into our a11y tests too. This PR also bumps axe-core to 4.7.1.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
