### PR TITLE
enable focussing first element on space activation

### DIFF
--- a/.changeset/popular-apes-juggle.md
+++ b/.changeset/popular-apes-juggle.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+ActionMenu: enable focussing first element on space activation

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -94,7 +94,7 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   handleEvent(event: Event) {
-    if (event.target === this.invokerElement && this.#isEnterKeydown(event)) {
+    if (event.target === this.invokerElement && this.#isActivationKeydown(event)) {
       if (this.#firstItem) {
         event.preventDefault()
         this.popoverElement?.showPopover()
@@ -107,7 +107,7 @@ export class ActionMenuElement extends HTMLElement {
 
     if (event.type === 'focusout' && !this.contains((event as FocusEvent).relatedTarget as Node)) {
       this.popoverElement?.hidePopover()
-    } else if (this.#isEnterKeydown(event) || (event instanceof MouseEvent && event.type === 'click')) {
+    } else if (this.#isActivationKeydown(event) || (event instanceof MouseEvent && event.type === 'click')) {
       const item = (event.target as Element).closest(menuItemSelectors.join(','))?.closest('li')
       if (!item) return
       const ariaChecked = item.getAttribute('aria-checked')
@@ -201,12 +201,12 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  #isEnterKeydown(event: Event): boolean {
+  #isActivationKeydown(event: Event): boolean {
     return (
       event instanceof KeyboardEvent &&
       event.type === 'keydown' &&
       !(event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) &&
-      event.key === 'Enter'
+      (event.key === 'Enter' || event.key === ' ')
     )
   }
 


### PR DESCRIPTION
### Description

Focus on activation of the action menu can happen in multiple ways, primary keyboard behaviour is via Space or Enter. 

Currently we have logic to determine the key-press is happening, and focus the first element in the popover. This only happens on `Enter` though, which means when `Space` is pressed, the invoker is still focussed.

This fixes that by checking if any of the `Space`/`Enter` activation keys are pressed.

I'd like to eventually remove this code because it _should_ be handled by popover but need to investigate why it isn't.

### Integration

> Does this change require any updates to code in production?

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
