### PR TITLE
Use ruby 3.2 in CI

### DIFF
--- a/.github/workflows/demo-production-deploy.yml
+++ b/.github/workflows/demo-production-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
         working-directory: 'demo/'
     - name: Docker login
@@ -70,12 +70,12 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - uses: actions/cache@v3.3.1
       with:
         path: demo/gemfiles/vendor/bundle
-        key: gems-build-kuby-main-ruby-3.0.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
+        key: gems-build-kuby-main-ruby-3.2.x-${{ hashFiles('demo/gemfiles/kuby.gemfile.lock') }}
     - name: Bundle
       run: |
         gem install bundler -v '~> 2.3'

--- a/.github/workflows/docs-production-deploy.yml
+++ b/.github/workflows/docs-production-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Set up Node

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       if: steps.changed-files.outputs.any_changed == 'true'
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Lint with Rubocop
       if: steps.changed-files.outputs.any_changed == 'true'
@@ -68,7 +68,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       if: steps.changed-files.outputs.any_changed == 'true'
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Lint with ERB Lint
       if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - name: Docker login
       env:
@@ -67,11 +67,11 @@ jobs:
       run: |
         docker image push --all-tags ${{ env.IMAGE_URL }}
     - name: Run ARM deploy
-      # This 'if' will be truth, if this workflow is...
+      # This condition will be truthy if this workflow is...
       #  - run as a workflow_dispatch
       #  - run because of a push to main (or when added to a merge queue)
       #  - run as a regular pull request
-      # But if it's a pull request, *and* for whatever reason, the pull
+      # But if it's a pull request, *and* for whatever reason the pull
       # request has "Auto-merge" enabled, don't bother.
       # The idea is that if auto-merge has been abled, by humans or by
       # bots, they have no intention of viewing the deployed preview anyway.
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
 
       - name: Setup Node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/static-files.yml
+++ b/.github/workflows/static-files.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.2'
           bundler-cache: true
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: true
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,8 @@ jobs:
             ruby_version: "3.0"
           - rails_version: "main"
             ruby_version: "3.1"
+          - rails_version: "main"
+            ruby_version: "3.2"
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -91,6 +93,8 @@ jobs:
             ruby_version: "3.0"
           - rails_version: "main"
             ruby_version: "3.1"
+          - rails_version: "main"
+            ruby_version: "3.2"
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -131,6 +135,8 @@ jobs:
             ruby_version: "3.0"
           - rails_version: "main"
             ruby_version: "3.1"
+          - rails_version: "main"
+            ruby_version: "3.2"
     steps:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
@@ -158,7 +164,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         bundler-cache: true
     - uses: actions/setup-node@v3
       with:
@@ -183,7 +189,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         bundler-cache: true
     - uses: actions/setup-node@v3
       with:
@@ -240,7 +246,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.2'
           bundler-cache: true
       - name: Setup Node
         uses: actions/setup-node@v3

--- a/test/performance/bench_classify.rb
+++ b/test/performance/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
   end
 
   def bench_allocations
-    assert_allocations "3.1" => 6, "3.0" => 6, "2.7" => 4 do
+    assert_allocations "3.2" => 6, "3.1" => 6, "3.0" => 6, "2.7" => 4 do
       Primer::Classify.call(**@values)
     end
   end

--- a/test/performance/bench_octicons.rb
+++ b/test/performance/bench_octicons.rb
@@ -17,7 +17,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::Beta::Octicon.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.1" => 29, "3.0" => 29, "2.7" => 30 do
+    assert_allocations "3.2" => 28, "3.1" => 29, "3.0" => 29, "2.7" => 30 do
       Primer::Beta::Octicon.new(**@options)
     end
   ensure
@@ -26,7 +26,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations "3.1" => 10, "3.0" => 10, "2.7" => 12 do
+    assert_allocations "3.2" => 10, "3.1" => 10, "3.0" => 10, "2.7" => 12 do
       Primer::Beta::Octicon.new(**@options)
     end
   end


### PR DESCRIPTION
### Description

This PR upgrades Ruby to v3.2 for all our CI jobs.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
