### PR TITLE
ci: release notification

### DIFF
--- a/.github/workflows/release_notification.yml
+++ b/.github/workflows/release_notification.yml
@@ -1,0 +1,15 @@
+name: Release notification
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/release-notifier-action@v1
+        with:
+          app_id: ${{ secrets.RELEASE_NOTIFIER_APP_ID }}
+          private_key: ${{ secrets.RELEASE_NOTIFIER_APP_PRIVATE_KEY }}
+          dispatch_event_type: 'release:primer/view_components'


### PR DESCRIPTION
Follow up to https://github.com/primer/react/pull/3318

### Description

This pull request does not affect any code. It's sole purpose is to enable users of `primer/view_components` to be notified whenever there is a new release by installing [the primer-release-notifier app](https://github.com/apps/primer-release-notifier).

### Integration

> Does this change require any updates to code in production?

n/a

### Merge checklist

n/a