### PR TITLE
Bug fix: Text field validation wrap styles

### DIFF
--- a/.changeset/friendly-buses-thank.md
+++ b/.changeset/friendly-buses-thank.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Bug fix: Text field validation wrap styles

--- a/app/components/primer/alpha/form_control.html.erb
+++ b/app/components/primer/alpha/form_control.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <% if @validation_message %>
     <%= render(Primer::BaseComponent.new(tag: :div, **@validation_arguments)) do %>
-      <%= render(Primer::Beta::Octicon.new(icon: :"alert-fill", size: :xsmall, aria: { hidden: true })) %>
+      <span class="FormControl-inlineValidation--visual"><%= render(Primer::Beta::Octicon.new(icon: :"alert-fill", size: :xsmall, aria: { hidden: true })) %></span>
       <span><%= @validation_message %></span>
     <% end %>
   <% end %>

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -34,16 +34,23 @@
 .FormControl-inlineValidation {
   display: flex;
   font-size: var(--text-caption-size, 12px);
+  line-height: var(--text-caption-lineHeight, calc(16 / 12));
   font-weight: var(--base-text-weight-semibold, 600);
   color: var(--color-danger-fg);
   fill: var(--color-danger-fg);
   flex-direction: row;
-  align-items: center;
+  align-items: start;
   gap: var(--base-size-4, 4px);
 
   & p {
     margin-bottom: 0;
   }
+}
+
+.FormControl-inlineValidation--visual {
+  align-items: center;
+  display: flex;
+  height: var(--base-size-16, 16px);
 }
 
 .FormControl-spacingWrapper {

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -50,7 +50,7 @@
 .FormControl-inlineValidation--visual {
   align-items: center;
   display: flex;
-  height: var(--base-size-16, 16px);
+  min-height: var(--base-size-16, 16px);
 }
 
 .FormControl-spacingWrapper {

--- a/lib/primer/forms/form_control.html.erb
+++ b/lib/primer/forms/form_control.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     <%= content %>
     <%= content_tag(:div, **@input.validation_arguments) do %>
-      <%= render(Primer::Beta::Octicon.new(icon: :"alert-fill", size: :xsmall, aria: { hidden: true })) %>
+      <span class="FormControl-inlineValidation--visual"><%= render(Primer::Beta::Octicon.new(icon: :"alert-fill", size: :xsmall, aria: { hidden: true })) %></span>
       <%= content_tag(:span, @input.invalid? ? @input.validation_messages.first : "", **@input.validation_message_arguments) %>
     <% end %>
     <%= render(Caption.new(input: @input)) %>

--- a/static/classes.json
+++ b/static/classes.json
@@ -378,10 +378,10 @@
   "ActionListWrap--inset": [
     "Primer::Alpha::ActionList"
   ],
-  "ActionListItem-action": [
+  "ActionListItem-visual": [
     "Primer::Alpha::ActionList"
   ],
-  "ActionListItem-visual": [
+  "ActionListItem-action": [
     "Primer::Alpha::ActionList"
   ],
   "SegmentedControl-item": [
@@ -516,10 +516,10 @@
   "FormControl-inlineValidation": [
     "Primer::Alpha::TextField"
   ],
-  "FormControl-check-group-wrap": [
+  "FormControl-radio-group-wrap": [
     "Primer::Alpha::TextField"
   ],
-  "FormControl-radio-group-wrap": [
+  "FormControl-check-group-wrap": [
     "Primer::Alpha::TextField"
   ],
   "Popover-message--bottom-left": [
@@ -575,6 +575,9 @@
   ],
   "Overlay-backdrop--anchor-whenNarrow": [
     "Primer::Alpha::Dialog"
+  ],
+  "FormControl-inlineValidation--visual": [
+    "Primer::Alpha::TextField"
   ],
   "ActionListItem-descriptionWrap--inline": [
     "Primer::Alpha::ActionList"


### PR DESCRIPTION
### Description

Adjusts the height of the leading visual, flex alignment and line-height of the validation message to improve wrapping styles

| before | after |
| -- | -- |
| <img width="465" alt="text field before change" src="https://github.com/primer/view_components/assets/18661030/d64a9125-f559-4bd7-8dc4-7dc8da0c2eb9"> |  <img width="458" alt="text field after change" src="https://github.com/primer/view_components/assets/18661030/ea3b43d2-610d-464a-a7a6-f113959808b0"> |


### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
