### PR TITLE
Sort classes.json to prevent annoying diffs

### DIFF
--- a/script/export-css-selectors
+++ b/script/export-css-selectors
@@ -91,7 +91,10 @@ exportSelectors('app/components/primer')
         Object.fromEntries(
           Object
             .entries(htmlClassToRubyClasses)
-            .map(([key, set]) => [key, [...set.values()]])
+            .sort()
+            .map(([key, set]) => {
+              return [key, [...Array.from(set.values()).sort()]]
+            })
         ),
         null,
         2

--- a/static/classes.json
+++ b/static/classes.json
@@ -1,201 +1,308 @@
 {
-  "Box": [
-    "Primer::Beta::BorderBox"
+  "ActionList-sectionDivider": [
+    "Primer::Alpha::ActionList"
   ],
-  "Link": [
-    "Primer::Beta::Link"
+  "ActionList-sectionDivider--filled": [
+    "Primer::Alpha::ActionList"
   ],
-  "Label": [
-    "Primer::Beta::Label"
+  "ActionListContent": [
+    "Primer::Alpha::ActionList"
   ],
-  "State": [
-    "Primer::Beta::State"
-  ],
-  "Banner": [
-    "Primer::Alpha::Banner"
-  ],
-  "Layout": [
-    "Primer::Alpha::Layout"
-  ],
-  "Button": [
-    "Primer::Beta::Button"
-  ],
-  "Overlay": [
-    "Primer::Alpha::Dialog",
-    "Primer::Alpha::Overlay"
-  ],
-  "Box-row": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Counter": [
-    "Primer::Beta::Counter"
-  ],
-  "Popover": [
-    "Primer::Beta::Popover"
-  ],
-  "Subhead": [
-    "Primer::Beta::Subhead"
-  ],
-  "Box-body": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Progress": [
-    "Primer::Beta::ProgressBar"
-  ],
-  "Truncate": [
-    "Primer::Beta::Truncate"
-  ],
-  "Box-title": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box--blue": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box-header": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box-footer": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Layout-main": [
-    "Primer::Alpha::Layout"
-  ],
-  "FormControl": [
-    "Primer::Alpha::TextField"
-  ],
-  "AvatarStack": [
-    "Primer::Beta::AvatarStack"
-  ],
-  "Box--danger": [
-    "Primer::Beta::BorderBox"
-  ],
-  "ButtonGroup": [
-    "Primer::Beta::ButtonGroup"
-  ],
-  "Label--info": [
-    "Primer::Beta::Label"
-  ],
-  "Label--open": [
-    "Primer::Beta::Label"
-  ],
-  "Label--done": [
-    "Primer::Beta::Label"
-  ],
-  "Link--muted": [
-    "Primer::Beta::Link"
-  ],
-  "State--open": [
-    "Primer::Beta::State"
-  ],
-  "Overlay-form": [
-    "Primer::Alpha::Dialog"
-  ],
-  "Overlay-body": [
-    "Primer::Alpha::Dialog"
-  ],
-  "ToggleSwitch": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "UnderlineNav": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "Box-row-link": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Button-label": [
-    "Primer::Beta::Button"
-  ],
-  "Button--link": [
-    "Primer::Beta::Button"
-  ],
-  "Label--large": [
-    "Primer::Beta::Label"
-  ],
-  "State--draft": [
-    "Primer::Beta::State"
-  ],
-  "State--small": [
-    "Primer::Beta::State"
-  ],
-  "TimelineItem": [
-    "Primer::Beta::TimelineItem"
-  ],
-  "Box--spacious": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box-row--blue": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box-row--gray": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Button-visual": [
-    "Primer::Beta::Button"
-  ],
-  "Button--small": [
-    "Primer::Beta::Button"
-  ],
-  "Button--large": [
-    "Primer::Beta::Button"
-  ],
-  "Label--inline": [
-    "Primer::Beta::Label"
-  ],
-  "Label--accent": [
-    "Primer::Beta::Label"
-  ],
-  "Label--severe": [
-    "Primer::Beta::Label"
-  ],
-  "Label--danger": [
-    "Primer::Beta::Label"
-  ],
-  "Label--closed": [
-    "Primer::Beta::Label"
-  ],
-  "Link--primary": [
-    "Primer::Beta::Link"
-  ],
-  "Link--onHover": [
-    "Primer::Beta::Link"
-  ],
-  "Progress-item": [
-    "Primer::Beta::ProgressBar"
-  ],
-  "State--merged": [
-    "Primer::Beta::State"
-  ],
-  "State--closed": [
-    "Primer::Beta::State"
-  ],
-  "ActionListWrap": [
+  "ActionListHeader": [
     "Primer::Alpha::ActionList"
   ],
   "ActionListItem": [
     "Primer::Alpha::ActionList"
   ],
-  "Overlay-header": [
-    "Primer::Alpha::Dialog"
+  "ActionListItem--subItem": [
+    "Primer::Alpha::ActionList"
   ],
-  "Overlay-footer": [
-    "Primer::Alpha::Dialog"
+  "ActionListItem--trailingActionHover": [
+    "Primer::Alpha::ActionList"
   ],
-  "Layout-divider": [
-    "Primer::Alpha::Layout"
+  "ActionListItem--withActions": [
+    "Primer::Alpha::ActionList"
   ],
-  "Layout-sidebar": [
-    "Primer::Alpha::Layout"
+  "ActionListItem-action": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-action--leading": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-action--trailing": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-description": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-descriptionWrap": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-descriptionWrap--inline": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-label": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-label--truncate": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-trailingAction": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual--leading": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListItem-visual--trailing": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListWrap": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListWrap--divided": [
+    "Primer::Alpha::ActionList"
+  ],
+  "ActionListWrap--inset": [
+    "Primer::Alpha::ActionList"
+  ],
+  "AvatarStack": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "AvatarStack--right": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "AvatarStack-body": [
+    "Primer::Beta::AvatarStack"
+  ],
+  "Banner": [
+    "Primer::Alpha::Banner"
+  ],
+  "Box": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box--blue": [
+    "Primer::Beta::BorderBox"
   ],
   "Box--condensed": [
     "Primer::Beta::BorderBox"
   ],
-  "Button-content": [
+  "Box--danger": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box--scrollable": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box--spacious": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-body": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-btn-octicon": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-footer": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-header": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-header--blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--drag-button": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--focus-blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--focus-gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--hover-blue": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--hover-gray": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row--yellow": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-row-link": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Box-title": [
+    "Primer::Beta::BorderBox"
+  ],
+  "Button": [
     "Primer::Beta::Button"
   ],
   "Button--danger": [
     "Primer::Beta::Button"
   ],
+  "Button--fullWidth": [
+    "Primer::Beta::Button"
+  ],
+  "Button--iconOnly": [
+    "Primer::Beta::Button"
+  ],
+  "Button--invisible": [
+    "Primer::Beta::Button"
+  ],
+  "Button--large": [
+    "Primer::Beta::Button"
+  ],
+  "Button--link": [
+    "Primer::Beta::Button"
+  ],
+  "Button--primary": [
+    "Primer::Beta::Button"
+  ],
+  "Button--secondary": [
+    "Primer::Beta::Button"
+  ],
+  "Button--small": [
+    "Primer::Beta::Button"
+  ],
+  "Button-content": [
+    "Primer::Beta::Button"
+  ],
+  "Button-content--alignStart": [
+    "Primer::Beta::Button"
+  ],
+  "Button-label": [
+    "Primer::Beta::Button"
+  ],
+  "Button-leadingVisual": [
+    "Primer::Beta::Button"
+  ],
+  "Button-trailingAction": [
+    "Primer::Beta::Button"
+  ],
+  "Button-trailingVisual": [
+    "Primer::Beta::Button"
+  ],
+  "Button-visual": [
+    "Primer::Beta::Button"
+  ],
+  "Button-withTooltip": [
+    "Primer::Beta::Button"
+  ],
+  "ButtonGroup": [
+    "Primer::Beta::ButtonGroup"
+  ],
+  "Counter": [
+    "Primer::Beta::Counter"
+  ],
+  "Counter--primary": [
+    "Primer::Beta::Counter"
+  ],
+  "Counter--secondary": [
+    "Primer::Beta::Counter"
+  ],
+  "FormControl": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl--fullWidth": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-caption": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-check-group-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-checkbox-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-horizontalGroup": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-inlineValidation": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-input": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-input-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-label": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-radio-group-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-radio-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-select": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-select-wrap": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-spacingWrapper": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-textarea": [
+    "Primer::Alpha::TextField"
+  ],
+  "FormControl-toggleSwitchInput": [
+    "Primer::Alpha::TextField"
+  ],
+  "Label": [
+    "Primer::Beta::Label"
+  ],
+  "Label--accent": [
+    "Primer::Beta::Label"
+  ],
+  "Label--attention": [
+    "Primer::Beta::Label"
+  ],
+  "Label--closed": [
+    "Primer::Beta::Label"
+  ],
+  "Label--danger": [
+    "Primer::Beta::Label"
+  ],
+  "Label--done": [
+    "Primer::Beta::Label"
+  ],
+  "Label--info": [
+    "Primer::Beta::Label"
+  ],
+  "Label--inline": [
+    "Primer::Beta::Label"
+  ],
+  "Label--large": [
+    "Primer::Beta::Label"
+  ],
+  "Label--open": [
+    "Primer::Beta::Label"
+  ],
   "Label--primary": [
+    "Primer::Beta::Label"
+  ],
+  "Label--secondary": [
+    "Primer::Beta::Label"
+  ],
+  "Label--severe": [
+    "Primer::Beta::Label"
+  ],
+  "Label--sponsors": [
     "Primer::Beta::Label"
   ],
   "Label--success": [
@@ -204,29 +311,129 @@
   "Label--warning": [
     "Primer::Beta::Label"
   ],
-  "Overlay--hidden": [
-    "Primer::Alpha::Dialog"
+  "Layout": [
+    "Primer::Alpha::Layout"
   ],
-  "Box--scrollable": [
-    "Primer::Beta::BorderBox"
+  "Layout-divider": [
+    "Primer::Alpha::Layout"
   ],
-  "Box-row--yellow": [
-    "Primer::Beta::BorderBox"
+  "Layout-main": [
+    "Primer::Alpha::Layout"
   ],
-  "Box-btn-octicon": [
-    "Primer::Beta::BorderBox"
+  "Layout-sidebar": [
+    "Primer::Alpha::Layout"
   ],
-  "Button--primary": [
-    "Primer::Beta::Button"
+  "Link": [
+    "Primer::Beta::Link"
   ],
-  "Label--sponsors": [
-    "Primer::Beta::Label"
+  "Link--muted": [
+    "Primer::Beta::Link"
+  ],
+  "Link--onHover": [
+    "Primer::Beta::Link"
+  ],
+  "Link--primary": [
+    "Primer::Beta::Link"
   ],
   "Link--secondary": [
     "Primer::Beta::Link"
   ],
+  "Overlay": [
+    "Primer::Alpha::Dialog",
+    "Primer::Alpha::Overlay"
+  ],
+  "Overlay--hidden": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay--visibilityHidden": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--anchor": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--anchor-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--center": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--center-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--full": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--full-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--side": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-backdrop--side-whenNarrow": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-body": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-closeButton": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-footer": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-form": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Overlay-header": [
+    "Primer::Alpha::Dialog"
+  ],
+  "Popover": [
+    "Primer::Beta::Popover"
+  ],
   "Popover-message": [
     "Primer::Beta::Popover"
+  ],
+  "Popover-message--bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--bottom-left": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--bottom-right": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--large": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--left": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--left-bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--left-top": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--no-caret": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--right": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--right-bottom": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--right-top": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--top-left": [
+    "Primer::Beta::Popover"
+  ],
+  "Popover-message--top-right": [
+    "Primer::Beta::Popover"
+  ],
+  "Progress": [
+    "Primer::Beta::ProgressBar"
   ],
   "Progress--large": [
     "Primer::Beta::ProgressBar"
@@ -234,349 +441,142 @@
   "Progress--small": [
     "Primer::Beta::ProgressBar"
   ],
-  "Subhead-heading": [
+  "Progress-item": [
+    "Primer::Beta::ProgressBar"
+  ],
+  "SegmentedControl": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "SegmentedControl--fullWidth": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "SegmentedControl-item": [
+    "Primer::Alpha::SegmentedControl"
+  ],
+  "State": [
+    "Primer::Beta::State"
+  ],
+  "State--closed": [
+    "Primer::Beta::State"
+  ],
+  "State--draft": [
+    "Primer::Beta::State"
+  ],
+  "State--merged": [
+    "Primer::Beta::State"
+  ],
+  "State--open": [
+    "Primer::Beta::State"
+  ],
+  "State--small": [
+    "Primer::Beta::State"
+  ],
+  "Subhead": [
+    "Primer::Beta::Subhead"
+  ],
+  "Subhead--spacious": [
     "Primer::Beta::Subhead"
   ],
   "Subhead-actions": [
     "Primer::Beta::Subhead"
   ],
-  "ActionListHeader": [
-    "Primer::Alpha::ActionList"
-  ],
-  "SegmentedControl": [
-    "Primer::Alpha::SegmentedControl"
-  ],
-  "AvatarStack-body": [
-    "Primer::Beta::AvatarStack"
-  ],
-  "Box-header--blue": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Button--iconOnly": [
-    "Primer::Beta::Button"
-  ],
-  "Counter--primary": [
-    "Primer::Beta::Counter"
-  ],
-  "Label--secondary": [
-    "Primer::Beta::Label"
-  ],
-  "Label--attention": [
-    "Primer::Beta::Label"
-  ],
-  "ActionListContent": [
-    "Primer::Alpha::ActionList"
-  ],
-  "FormControl-label": [
-    "Primer::Alpha::TextField"
-  ],
-  "FormControl-input": [
-    "Primer::Alpha::TextField"
-  ],
-  "ToggleSwitch-knob": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "UnderlineNav-body": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "UnderlineNav-item": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "Button--fullWidth": [
-    "Primer::Beta::Button"
-  ],
-  "Button--secondary": [
-    "Primer::Beta::Button"
-  ],
-  "Button--invisible": [
-    "Primer::Beta::Button"
-  ],
-  "Subhead--spacious": [
+  "Subhead-description": [
     "Primer::Beta::Subhead"
   ],
-  "TimelineItem-body": [
+  "Subhead-heading": [
+    "Primer::Beta::Subhead"
+  ],
+  "Subhead-heading--danger": [
+    "Primer::Beta::Subhead"
+  ],
+  "TimelineItem": [
     "Primer::Beta::TimelineItem"
   ],
-  "FormControl-select": [
-    "Primer::Alpha::TextField"
+  "TimelineItem--condensed": [
+    "Primer::Beta::TimelineItem"
   ],
-  "ToggleSwitch-track": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "ToggleSwitch-icons": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "UnderlineNav--full": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "AvatarStack--right": [
-    "Primer::Beta::AvatarStack"
-  ],
-  "Button-withTooltip": [
-    "Primer::Beta::Button"
-  ],
-  "Counter--secondary": [
-    "Primer::Beta::Counter"
+  "TimelineItem-avatar": [
+    "Primer::Beta::TimelineItem"
   ],
   "TimelineItem-badge": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "TimelineItem-badge--success": [
+    "Primer::Beta::TimelineItem"
+  ],
+  "TimelineItem-body": [
     "Primer::Beta::TimelineItem"
   ],
   "TimelineItem-break": [
     "Primer::Beta::TimelineItem"
   ],
-  "Overlay-closeButton": [
-    "Primer::Alpha::Dialog"
+  "ToggleSwitch": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "FormControl-caption": [
-    "Primer::Alpha::TextField"
+  "ToggleSwitch--checked": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "ToggleSwitch-status": [
+  "ToggleSwitch--disabled": [
     "Primer::Alpha::ToggleSwitch"
   ],
   "ToggleSwitch--small": [
     "Primer::Alpha::ToggleSwitch"
   ],
-  "UnderlineNav--right": [
-    "Primer::Alpha::UnderlineNav"
+  "ToggleSwitch--statusAtEnd": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "Box-row--focus-gray": [
-    "Primer::Beta::BorderBox"
+  "ToggleSwitch-circleIcon": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "Box-row--focus-blue": [
-    "Primer::Beta::BorderBox"
+  "ToggleSwitch-icons": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "Box-row--hover-gray": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Box-row--hover-blue": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Subhead-description": [
-    "Primer::Beta::Subhead"
-  ],
-  "TimelineItem-avatar": [
-    "Primer::Beta::TimelineItem"
-  ],
-  "ActionListItem-label": [
-    "Primer::Alpha::ActionList"
-  ],
-  "FormControl-textarea": [
-    "Primer::Alpha::TextField"
-  ],
-  "UnderlineNav-actions": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "UnderlineNav-octicon": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "Box-row--drag-button": [
-    "Primer::Beta::BorderBox"
-  ],
-  "Button-leadingVisual": [
-    "Primer::Beta::Button"
-  ],
-  "ActionListWrap--inset": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-action": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-visual": [
-    "Primer::Alpha::ActionList"
-  ],
-  "SegmentedControl-item": [
-    "Primer::Alpha::SegmentedControl"
-  ],
-  "ToggleSwitch--checked": [
+  "ToggleSwitch-knob": [
     "Primer::Alpha::ToggleSwitch"
   ],
   "ToggleSwitch-lineIcon": [
     "Primer::Alpha::ToggleSwitch"
   ],
-  "ToggleSwitch-statusOn": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "Button-trailingVisual": [
-    "Primer::Beta::Button"
-  ],
-  "Button-trailingAction": [
-    "Primer::Beta::Button"
-  ],
-  "Popover-message--left": [
-    "Primer::Beta::Popover"
-  ],
-  "Overlay-backdrop--side": [
-    "Primer::Alpha::Dialog"
-  ],
-  "Overlay-backdrop--full": [
-    "Primer::Alpha::Dialog"
-  ],
-  "FormControl--fullWidth": [
-    "Primer::Alpha::TextField"
-  ],
-  "FormControl-input-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "FormControl-radio-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "ToggleSwitch--disabled": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "ToggleSwitch-statusOff": [
-    "Primer::Alpha::ToggleSwitch"
-  ],
-  "UnderlineNav-container": [
-    "Primer::Alpha::UnderlineNav"
-  ],
-  "Popover-message--right": [
-    "Primer::Beta::Popover"
-  ],
-  "Popover-message--large": [
-    "Primer::Beta::Popover"
-  ],
-  "ActionListWrap--divided": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem--subItem": [
-    "Primer::Alpha::ActionList"
-  ],
-  "FormControl-select-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "ToggleSwitch-circleIcon": [
+  "ToggleSwitch-status": [
     "Primer::Alpha::ToggleSwitch"
   ],
   "ToggleSwitch-statusIcon": [
     "Primer::Alpha::ToggleSwitch"
   ],
-  "Popover-message--bottom": [
-    "Primer::Beta::Popover"
-  ],
-  "Subhead-heading--danger": [
-    "Primer::Beta::Subhead"
-  ],
-  "TimelineItem--condensed": [
-    "Primer::Beta::TimelineItem"
-  ],
-  "Overlay-backdrop--center": [
-    "Primer::Alpha::Dialog"
-  ],
-  "Overlay-backdrop--anchor": [
-    "Primer::Alpha::Dialog"
-  ],
-  "ActionList-sectionDivider": [
-    "Primer::Alpha::ActionList"
-  ],
-  "Overlay--visibilityHidden": [
-    "Primer::Alpha::Dialog"
-  ],
-  "FormControl-checkbox-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "ToggleSwitch--statusAtEnd": [
+  "ToggleSwitch-statusOff": [
     "Primer::Alpha::ToggleSwitch"
   ],
-  "Popover-message--no-caret": [
-    "Primer::Beta::Popover"
+  "ToggleSwitch-statusOn": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "Popover-message--top-left": [
-    "Primer::Beta::Popover"
+  "ToggleSwitch-track": [
+    "Primer::Alpha::ToggleSwitch"
   ],
-  "Popover-message--left-top": [
-    "Primer::Beta::Popover"
+  "Truncate": [
+    "Primer::Beta::Truncate"
   ],
-  "ActionListItem-description": [
-    "Primer::Alpha::ActionList"
+  "UnderlineNav": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "FormControl-spacingWrapper": [
-    "Primer::Alpha::TextField"
+  "UnderlineNav--full": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "Button-content--alignStart": [
-    "Primer::Beta::Button"
+  "UnderlineNav--right": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "Popover-message--top-right": [
-    "Primer::Beta::Popover"
+  "UnderlineNav-actions": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "Popover-message--right-top": [
-    "Primer::Beta::Popover"
+  "UnderlineNav-body": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "ActionListItem--withActions": [
-    "Primer::Alpha::ActionList"
+  "UnderlineNav-container": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "SegmentedControl--fullWidth": [
-    "Primer::Alpha::SegmentedControl"
+  "UnderlineNav-item": [
+    "Primer::Alpha::UnderlineNav"
   ],
-  "FormControl-horizontalGroup": [
-    "Primer::Alpha::TextField"
-  ],
-  "TimelineItem-badge--success": [
-    "Primer::Beta::TimelineItem"
-  ],
-  "FormControl-inlineValidation": [
-    "Primer::Alpha::TextField"
-  ],
-  "FormControl-check-group-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "FormControl-radio-group-wrap": [
-    "Primer::Alpha::TextField"
-  ],
-  "Popover-message--bottom-left": [
-    "Primer::Beta::Popover"
-  ],
-  "Popover-message--left-bottom": [
-    "Primer::Beta::Popover"
-  ],
-  "ActionListItem-trailingAction": [
-    "Primer::Alpha::ActionList"
-  ],
-  "FormControl-toggleSwitchInput": [
-    "Primer::Alpha::TextField"
-  ],
-  "Popover-message--bottom-right": [
-    "Primer::Beta::Popover"
-  ],
-  "Popover-message--right-bottom": [
-    "Primer::Beta::Popover"
-  ],
-  "ActionListItem-action--leading": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-visual--leading": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-descriptionWrap": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-label--truncate": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-visual--trailing": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionListItem-action--trailing": [
-    "Primer::Alpha::ActionList"
-  ],
-  "ActionList-sectionDivider--filled": [
-    "Primer::Alpha::ActionList"
-  ],
-  "Overlay-backdrop--side-whenNarrow": [
-    "Primer::Alpha::Dialog"
-  ],
-  "Overlay-backdrop--full-whenNarrow": [
-    "Primer::Alpha::Dialog"
-  ],
-  "ActionListItem--trailingActionHover": [
-    "Primer::Alpha::ActionList"
-  ],
-  "Overlay-backdrop--center-whenNarrow": [
-    "Primer::Alpha::Dialog"
-  ],
-  "Overlay-backdrop--anchor-whenNarrow": [
-    "Primer::Alpha::Dialog"
-  ],
-  "ActionListItem-descriptionWrap--inline": [
-    "Primer::Alpha::ActionList"
+  "UnderlineNav-octicon": [
+    "Primer::Alpha::UnderlineNav"
   ]
 }


### PR DESCRIPTION
### Description

Running `npm install` and a few other routine commands causes the contents of static/classes.json to change. Upon closer inspection, the file contains all the same entries, just reordered slightly. This PR sorts all the entries, which should prevent annoying diffs.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews~
