### PR TITLE
Adding a contributors markdown doc that lists examples of what we label for semver

### DIFF
--- a/docs/contributors/versioning.md
+++ b/docs/contributors/versioning.md
@@ -1,0 +1,23 @@
+# Versioning
+
+When deciding to version your pull request, consider the list. In addition to what is [typically considered](https://semver.org/#summary) for versioning by semver.org, below are a list of examples of what we consider a `Major, Minor, Patch` change. If you find that your change does not match the list, reach out to us for guidance.
+
+## Major
+
+- Removing/renaming component names, arguments, or slots.
+- Removing dependencies from the `primer_view_components.gemspec` or the `package.json`.
+
+## Minor
+
+- Changing the html output of a component.
+- Changing the CSS classnames of a component.
+
+## Patch
+
+- Updating dependency versions
+
+## Skip Versioning
+
+These are changes that we typically do not label.
+
+- Changing previews/docs/tests or any other scaffolding type files in this repository.


### PR DESCRIPTION
### Description

This adds a document that is meant to serve as a template for contributors to decide what type of change label they should add to their change.

I believe this will help us decide  on release versions, as it's been tricky to know what we should label changes with regards to UI. ie. Does markup count? What if it visually changes color?

I could use any suggestions to this, it's not meant to be all encompassing but serve as a FAQ type of deal we could add common changes to.

### Integration

> Does this change require any updates to code in production?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews
