### PR TITLE
Use polymorphic slots in ActionList and NavList

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 18.0.0)
-      view_component (> 2.0, < 4.0)
+      view_component (>= 3.1, < 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -210,7 +210,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    view_component (3.0.0.rc2)
+    view_component (3.1.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)

--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -56,23 +56,38 @@ module Primer
         Heading.new(**system_arguments)
       }
 
-      # Items.
-      #
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      renders_many :items, lambda { |**system_arguments|
-        build_item(**system_arguments).tap do |item|
-          will_add_item(item)
-        end
-      }
+      # @!parse
+      #   # Adds an item to the list.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
+      #   def with_item(**system_arguments, &block)
+      #   end
 
-      # Adds a divider to the list of items.
+      # @!parse
+      #   # Adds a divider to the list. Dividers visually separate items.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
+      #   def with_divider(**system_arguments, &block)
+      #   end
+
+      # Items. Items can be individual items or dividers. See the documentation for `#with_item` and `#with_divider` respectively for more information.
       #
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
-      def with_divider(**system_arguments, &block)
-        # This is a giant hack that should be removed when :items can be converted into a polymorphic slot.
-        # This feature needs to land in view_component first: https://github.com/ViewComponent/view_component/pull/1652
-        set_slot(:items, { renderable: Divider, collection: true }, **system_arguments, &block)
-      end
+      renders_many :items, types: {
+        item: {
+          renders: lambda { |**system_arguments|
+            build_item(**system_arguments).tap do |item|
+              will_add_item(item)
+            end
+          },
+
+          as: :item
+        },
+
+        divider: {
+          renders: Divider,
+          as: :divider
+        }
+      }
 
       attr_reader :id, :select_variant, :role
 

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.2.2"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", '>= 3.0.0.rc5'
+gem "view_component", '>= 3.1.0'
 gem "lookbook", "~> 2.0.0" unless rails_version.to_f < 7
 
 group :development do

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -359,7 +359,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    view_component (3.0.0)
+    view_component (3.1.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -403,7 +403,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  view_component (>= 3.0.0.rc5)
+  view_component (>= 3.1.0)
 
 BUNDLED WITH
    2.2.33

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "actionview", ">= 5.0.0"
   spec.add_runtime_dependency     "activesupport", ">= 5.0.0"
   spec.add_runtime_dependency     "octicons", ">= 18.0.0"
-  spec.add_runtime_dependency     "view_component", ["> 2.0", "< 4.0"]
+  spec.add_runtime_dependency     "view_component", [">= 3.1", "< 4.0"]
 
   spec.add_development_dependency "allocation_stats", "~> 0.1"
   spec.add_development_dependency "allocation_tracer", "~> 0.6.3"


### PR DESCRIPTION
_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR removes a couple of hacks in `ActionList` and `NavList` that call a private view_component API method (i.e. `#set_slot`) in order to fill in a slot with heterogeneous objects. The view_component framework offers a [polymorphic slots](https://viewcomponent.org/guide/slots.html#polymorphic-slots) feature tailor-made for such a use-case, but we haven't been able to make use of it... until now! I recently landed a feature that allows customization of polymorphic slot setter methods, which allows us to maintain backwards-compatibility with the existing public APIs of the two components in question and stop calling that private VC method.

`NavList` and `ActionList` both manage a list of items. These items can be regular 'ol items, dividers, or groups of items. Before the advent of dividers and groups, the public APIs of these components only offered a `#with_item` method via the `items` slot. Converting the `items` slot into a polymorphic one would have caused the `#with_item` method to become something like eg. `#with_list_item`, while dividers could have been added via `#with_item_divider`, etc. This is because slot setter methods were automatically generated and did not allow customization. As of view_component v3.1.0 however, slot setters can be completely customized.

### Integration
<!-- Does this change require any updates to code in production? -->

Yes. Dotcom will need to be upgraded to use view_component v3.1.0. This should be very little trouble however, since 3.1.0 is only a single minor version away from the version dotcom is currently using.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/primer/view_components/issues/2041

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

~- [ ] Added/updated tests~
- [x] Added/updated documentation
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
