### PR TITLE
Fix keyboard functionality with deferred loading in ActionMenu

### DIFF
--- a/.changeset/moody-pens-cry.md
+++ b/.changeset/moody-pens-cry.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix keyboard functionality with deferred loading in ActionMenu

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -1,4 +1,5 @@
-import '@github/include-fragment-element'
+import {controller, target} from '@github/catalyst'
+import IncludeFragmentElement from '@github/include-fragment-element'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null
 type SelectedItem = {
@@ -9,7 +10,10 @@ type SelectedItem = {
 
 const menuItemSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
 
+@controller
 export class ActionMenuElement extends HTMLElement {
+  @target includeFragment: IncludeFragmentElement
+
   #abortController: AbortController
   #originalLabel = ''
   #inputName = ''
@@ -87,6 +91,10 @@ export class ActionMenuElement extends HTMLElement {
     this.addEventListener('focusout', this, {signal})
     this.#setDynamicLabel()
     this.#updateInput()
+
+    if (this.includeFragment) {
+      this.includeFragment.addEventListener('include-fragment-replaced', this, {signal})
+    }
   }
 
   disconnectedCallback() {
@@ -105,8 +113,8 @@ export class ActionMenuElement extends HTMLElement {
 
     if (!this.popoverElement?.matches(':popover-open')) return
 
-    if (event.type === 'focusout' && !this.contains((event as FocusEvent).relatedTarget as Node)) {
-      this.popoverElement?.hidePopover()
+    if (event.type === 'include-fragment-replaced') {
+      if (this.#firstItem) this.#firstItem.focus()
     } else if (this.#isActivationKeydown(event) || (event instanceof MouseEvent && event.type === 'click')) {
       const item = (event.target as Element).closest(menuItemSelectors.join(','))?.closest('li')
       if (!item) return

--- a/app/components/primer/primer.ts
+++ b/app/components/primer/primer.ts
@@ -1,3 +1,4 @@
+import '@github/include-fragment-element'
 import '@oddbird/popover-polyfill'
 import './alpha/dropdown'
 import './anchored_position'

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -284,6 +284,11 @@ module Primer
           end
         end
       end
+
+      # @label Two menus
+      #
+      def two_menus
+      end
     end
   end
 end

--- a/previews/primer/alpha/action_menu_preview/two_menus.html.erb
+++ b/previews/primer/alpha/action_menu_preview/two_menus.html.erb
@@ -1,0 +1,13 @@
+<%= render(Primer::Alpha::ActionMenu.new(menu_id: "menu-1")) do |menu| %>
+  <% menu.with_show_button { |button| button.with_trailing_action_icon(icon: :"triangle-down"); "Pac-Man" } %>
+  <% menu.with_item(label: "Eat a dot") %>
+  <% menu.with_item(label: "Avoid a ghost") %>
+  <% menu.with_item(label: "Eat a stunned ghost") %>
+<% end %>
+
+<%= render(Primer::Alpha::ActionMenu.new(menu_id: "menu-2")) do |menu| %>
+  <% menu.with_show_button { |button| button.with_trailing_action_icon(icon: :"triangle-down"); "Mario Bros" } %>
+  <% menu.with_item(label: "Stomp a turtle") %>
+  <% menu.with_item(label: "Collect a gold coin") %>
+  <% menu.with_item(label: "Save the princess") %>
+<% end %>

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -223,5 +223,31 @@ module Alpha
 
       assert_equal page.text, 'You selected "bar"'
     end
+
+    def test_deferred_loading
+      visit_preview(:with_deferred_content)
+
+      find("action-menu button[aria-controls]").click
+
+      assert_selector "action-menu ul li", text: "Copy link"
+      assert_selector "action-menu ul li", text: "Quote reply"
+      assert_selector "action-menu ul li", text: "Reference in new issue"
+
+      assert_equal page.evaluate_script("document.activeElement").text, "Copy link"
+    end
+
+    def test_deferred_loading_on_keydown
+      visit_preview(:with_deferred_content)
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu button[aria-controls]').focus()
+      JS
+
+      page.driver.browser.keyboard.type(:enter)
+
+      # wait for menu to load
+      assert_selector "action-menu ul li", text: "Copy link"
+      assert_equal page.evaluate_script("document.activeElement").text, "Copy link"
+    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -249,5 +249,19 @@ module Alpha
       assert_selector "action-menu ul li", text: "Copy link"
       assert_equal page.evaluate_script("document.activeElement").text, "Copy link"
     end
+
+    def test_opening_second_menu_closes_first_menu
+      visit_preview(:two_menus)
+
+      find("#menu-1-button").click
+
+      assert_selector "action-menu ul li", text: "Eat a dot"
+      refute_selector "action-menu ul li", text: "Stomp a turtle"
+
+      find("#menu-2-button").click
+
+      refute_selector "action-menu ul li", text: "Eat a dot"
+      assert_selector "action-menu ul li", text: "Stomp a turtle"
+    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -140,6 +140,9 @@ module Alpha
       find("action-menu ul li:nth-child(2)").click
 
       assert_selector "modal-dialog#my-dialog"
+
+      # opening the dialog should close the menu
+      refute_selector "action-menu ul li"
     end
 
     def test_opens_dialog_on_keydown


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR addresses the keyboard accessibility issues described in https://github.com/github/primer/issues/2245.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

See the issue linked above for a "before" video.

After:

https://github.com/primer/view_components/assets/575280/e02f97a6-4da8-4aee-af9a-d6fd87be58ed

### Integration
<!-- Does this change require any updates to code in production? -->

This change does not require any changes to production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes: https://github.com/github/primer/issues/2245

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I removed our handling of the `focusout` event and replaced it with code that handles events from the `<include-fragment-element>` to focus the first element after deferred content has loaded.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

I discovered the issue was that we were improperly handling the `focusout` event by using it to close the popover. This code was part of the original component built by the a11y team, so I fear I may have removed important functionality. Removing it however does not cause any tests to fail, so I assume we're good, but I need someone familiar with that old code to examine this PR carefully.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
