### PR TITLE
ActionMenu: Move `aria-checked` to button

### DIFF
--- a/.changeset/gorgeous-paws-lay.md
+++ b/.changeset/gorgeous-paws-lay.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+ActionMenu: Move aria-checked to button

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -158,95 +158,6 @@
     }
   }
 
-  /*
-  * checkbox item [aria-checked]
-  * listbox [aria-selected]
-  */
-  &[aria-checked='true'],
-  &[aria-selected='true'] {
-    /* multiselect checkmark */
-    & .ActionListItem-multiSelectCheckmark {
-      visibility: visible;
-      opacity: 1;
-      transition: visibility 0 linear 0, opacity 50ms;
-    }
-
-    /* singleselect checkmark */
-    & .ActionListItem-singleSelectCheckmark {
-      visibility: visible;
-
-      @media screen and (prefers-reduced-motion: no-preference) {
-        animation: checkmarkIn 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
-        @keyframes checkmarkIn {
-          from {
-            clip-path: inset(16px 0 0 0);
-          }
-
-          to {
-            clip-path: inset(0 0 0 0);
-          }
-        }
-      }
-    }
-
-    /* checkbox */
-    & .ActionListItem-multiSelectIcon {
-      & .ActionListItem-multiSelectIconRect {
-        fill: var(--color-accent-fg);
-        stroke: var(--color-accent-fg);
-        stroke-width: var(--borderWidth-thin, 1px);
-      }
-
-      & .ActionListItem-multiSelectCheckmark {
-        fill: var(--color-fg-on-emphasis);
-      }
-    }
-  }
-
-  &[aria-checked='false'],
-  &[aria-selected='false'] {
-    /* multiselect checkmark */
-    & .ActionListItem-multiSelectCheckmark {
-      visibility: hidden;
-      opacity: 0;
-      transition: visibility 0 linear 50ms, opacity 50ms;
-    }
-
-    /* singleselect checkmark */
-    & .ActionListItem-singleSelectCheckmark {
-      visibility: hidden;
-      transition: visibility 0s linear 200ms;
-      clip-path: inset(16px 0 0 0);
-
-      @media screen and (prefers-reduced-motion: no-preference) {
-        animation: checkmarkOut 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
-        @keyframes checkmarkOut {
-          from {
-            clip-path: inset(0 0 0 0);
-          }
-
-          to {
-            clip-path: inset(16px 0 0 0);
-          }
-        }
-      }
-    }
-
-    /* checkbox */
-    & .ActionListItem-multiSelectIcon {
-      & .ActionListItem-multiSelectIconRect {
-        fill: var(--color-canvas-default);
-        stroke: var(--color-border-default);
-        stroke-width: var(--borderWidth-thin, 1px);
-      }
-    }
-
-    & .ActionListItem-multiSelectIconRect {
-      fill: var(--color-canvas-default);
-      border: var(--borderWidth-thin, 1px) solid var(--color-border-default);
-    }
-  }
-
   /* Autocomplete [aria-selected] items */
 
   &[aria-selected='true'] {
@@ -500,6 +411,95 @@
       &::after {
         @mixin activeIndicatorLine;
       }
+    }
+  }
+
+  /*
+  * checkbox item [aria-checked]
+  * listbox [aria-selected]
+  */
+  &[aria-checked='true'],
+  &[aria-selected='true'] {
+    /* multiselect checkmark */
+    & .ActionListItem-multiSelectCheckmark {
+      visibility: visible;
+      opacity: 1;
+      transition: visibility 0 linear 0, opacity 50ms;
+    }
+
+    /* singleselect checkmark */
+    & .ActionListItem-singleSelectCheckmark {
+      visibility: visible;
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        animation: checkmarkIn 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
+        @keyframes checkmarkIn {
+          from {
+            clip-path: inset(16px 0 0 0);
+          }
+
+          to {
+            clip-path: inset(0 0 0 0);
+          }
+        }
+      }
+    }
+
+    /* checkbox */
+    & .ActionListItem-multiSelectIcon {
+      & .ActionListItem-multiSelectIconRect {
+        fill: var(--color-accent-fg);
+        stroke: var(--color-accent-fg);
+        stroke-width: var(--borderWidth-thin, 1px);
+      }
+
+      & .ActionListItem-multiSelectCheckmark {
+        fill: var(--color-fg-on-emphasis);
+      }
+    }
+  }
+
+  &[aria-checked='false'],
+  &[aria-selected='false'] {
+    /* multiselect checkmark */
+    & .ActionListItem-multiSelectCheckmark {
+      visibility: hidden;
+      opacity: 0;
+      transition: visibility 0 linear 50ms, opacity 50ms;
+    }
+
+    /* singleselect checkmark */
+    & .ActionListItem-singleSelectCheckmark {
+      visibility: hidden;
+      transition: visibility 0s linear 200ms;
+      clip-path: inset(16px 0 0 0);
+
+      @media screen and (prefers-reduced-motion: no-preference) {
+        animation: checkmarkOut 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
+        @keyframes checkmarkOut {
+          from {
+            clip-path: inset(0 0 0 0);
+          }
+
+          to {
+            clip-path: inset(16px 0 0 0);
+          }
+        }
+      }
+    }
+
+    /* checkbox */
+    & .ActionListItem-multiSelectIcon {
+      & .ActionListItem-multiSelectIconRect {
+        fill: var(--color-canvas-default);
+        stroke: var(--color-border-default);
+        stroke-width: var(--borderWidth-thin, 1px);
+      }
+    }
+
+    & .ActionListItem-multiSelectIconRect {
+      fill: var(--color-canvas-default);
+      border: var(--borderWidth-thin, 1px) solid var(--color-border-default);
     }
   }
 

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -261,8 +261,8 @@ module Primer
 
         def before_render
           if @list.allows_selection?
-            @system_arguments[:aria] = merge_aria(
-              @system_arguments,
+            @content_arguments[:aria] = merge_aria(
+              @content_arguments,
               { aria: { checked: active? } }
             )
           end

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -108,15 +108,13 @@ export class ActionMenuElement extends HTMLElement {
     if (event.type === 'focusout' && !this.contains((event as FocusEvent).relatedTarget as Node)) {
       this.popoverElement?.hidePopover()
     } else if (this.#isActivationKeydown(event) || (event instanceof MouseEvent && event.type === 'click')) {
-      const item = (event.target as Element).closest(menuItemSelectors.join(','))?.closest('li')
+      const item = (event.target as Element).closest(menuItemSelectors.join(','))
       if (!item) return
       const ariaChecked = item.getAttribute('aria-checked')
       const checked = ariaChecked !== 'true'
       item.setAttribute('aria-checked', `${checked}`)
       if (this.selectVariant === 'single') {
-        const selector = menuItemSelectors.map(s => `li[aria-checked] ${s}`).join(',')
-        for (const checkedItemContent of this.querySelectorAll(selector)) {
-          const checkedItem = checkedItemContent.closest('li')!
+        for (const checkedItem of this.querySelectorAll('[aria-checked]')) {
           if (checkedItem !== item) {
             checkedItem.setAttribute('aria-checked', 'false')
           }

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -8,7 +8,7 @@ module Primer
       # used as a standalone component.
       class List < Primer::Alpha::ActionList
         DEFAULT_ITEM_TAG = :button
-        ITEM_TAG_OPTIONS = [:a, :button, :"clipboard-copy", DEFAULT_ITEM_TAG].freeze
+        ITEM_TAG_OPTIONS = [:a, :"clipboard-copy", DEFAULT_ITEM_TAG].freeze
 
         # Adds a new item to the list.
         #
@@ -34,6 +34,11 @@ module Primer
 
           content_arguments[:tabindex] = -1
           system_arguments[:autofocus] = "" if system_arguments[:autofocus]
+
+          content_arguments[:data] = merge_data(
+            content_arguments,
+            { data: { value: data.delete(:value) || system_arguments.delete(:"data-value") } }
+          )
 
           if system_arguments[:disabled]
             content_arguments[:aria] = merge_aria(

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -165,7 +165,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], "fast_forward"
+      assert_equal "fast_forward", response["value"]
     end
 
     def test_single_select_form_uses_label_if_no_value_provided
@@ -178,7 +178,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], "Resolve"
+      assert_equal "Resolve", response["value"]
     end
 
     def test_multiple_select_form_submission
@@ -195,7 +195,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], %w[fast_forward recursive]
+      assert_equal %w[fast_forward recursive], response["value"]
     end
 
     def test_multiple_select_form_uses_label_if_no_value_provided
@@ -212,7 +212,7 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal response["value"], %w[fast_forward Resolve]
+      assert_equal %w[fast_forward Resolve], response["value"]
     end
 
     def test_individual_items_can_submit_post_requests_via_forms


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes an issue causing screen readers to not announce the checked/unchecked status of `ActionMenu` items.

### Integration
<!-- Does this change require any updates to code in production? -->

No code changes required in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/2244

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

As suggested in https://github.com/github/primer/issues/2244, I moved the `aria-checked` attribute from the `<li>` element to the `<button>`.

### Accessibility
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
