### PR TITLE
Link to 'Rails' tab when linking to new docsite

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -199,7 +199,7 @@ namespace :docs do
 
       content_path = File.join(primer_design_repo_path, "content")
       mdx_path = Pathname(mdx_file).relative_path_from(content_path).to_s.chomp(".mdx")
-      new_docsite_url = join_urls("https://primer.style", "design", mdx_path)
+      new_docsite_url = join_urls("https://primer.style", "design", mdx_path, "rails")
       docs = registry.find(Kernel.const_get(rails_id))
       status_path = docs.status_module.nil? ? "" : "#{docs.status_module}/"
       legacy_docsite_url = "/components/#{status_path}#{docs.short_name.downcase}"


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR links to the 'Rails' tab (instead of the 'Overview' tab) when linking component docs from the old docsite to the new one.

### Integration
<!-- Does this change require any updates to code in production? -->

This change does not require any changes to production as it is documentation-only.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes: https://github.com/github/primer/issues/2321

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~