### PR TITLE
Disable autoprefixer in docs:build instead of actions config

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -118,9 +118,7 @@ jobs:
         run: npm ci && cd docs && npm ci && cd ..
 
       - name: Generate static files
-        run: |
-          bundle exec rake utilities:build docs:build static:dump
-          echo -e "/* autoprefixer: off */\n$(cat docs/static/primer_view_components.css)" > docs/static/primer_view_components.css
+        run: bundle exec rake utilities:build docs:build static:dump
 
       - name: Build
         run: npm run build:docs:preview

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -63,6 +63,15 @@ namespace :docs do
 
     puts "Markdown compiled."
 
+    # Disable autoprefixer. The legacy Gatsby docsite uses an old version that doesn't support the
+    # @supports rule. Fortunately the build script that produces primer_view_components.css runs
+    # a modern version of autoprefixer, so prefixing is already handled and is safe to skip during
+    # the Gatsby build.
+    css = File.read("docs/static/primer_view_components.css")
+    css = "/* autoprefixer: off */\n#{css}"
+    File.write("docs/static/primer_view_components.css", css)
+    puts "Patched docs/static/primer_view_components.css"
+
     all_components = Primer::Component.descendants - [Primer::BaseComponent]
     components_needing_docs = all_components - Primer::Yard::ComponentManifest::COMPONENTS.keys
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I recently submitted a PR that disabled autoprefixer for Gatsby builds, since the build script already runs it and the legacy Gatsby docsite doesn't support a modern-enough version. Unfortunately I only fixed it for a single action. This PR moves the logic into the `docs:build` rake task, which should patch the CSS file for all actions.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.