### PR TITLE
Add event.stopPropogation to enter event

### DIFF
--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -167,12 +167,18 @@ export class ModalDialogElement extends HTMLElement {
   #keydown(event: Event) {
     if (!(event instanceof KeyboardEvent)) return
     if (event.isComposing) return
+    if (!this.open) return
 
     switch (event.key) {
       case 'Escape':
-        if (this.open) {
-          this.close()
-          event.preventDefault()
+        this.close()
+        event.preventDefault()
+        event.stopPropagation()
+        break
+      case 'Enter':
+        const target = event.target as HTMLElement
+
+        if (target.getAttribute('data-close-dialog-id') === this.id) {
           event.stopPropagation()
         }
         break


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This PR addresses behaviour in the dialog menu where pressing `Enter` while a cancel button was in focus would cause the dialog window to close and immediately re-open.

### Screenshots

Old Behaviour:

https://github.com/primer/view_components/assets/12400507/138b7a4c-adc1-4e59-be8a-4eebb18ca531

New Behaviour:

https://github.com/primer/view_components/assets/12400507/e9ff9476-d716-42a9-88ca-a726c74fc275


### Integration
Would like for this to be in production sooner to close out accessibility issues in our Team's app! 

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->


Closes https://github.com/primer/view_components/issues/2064#issue-1748433962
#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Enter should be a click event by default by browser standards, so it was weird that the Enter was re-opening the dialog. From what I can tell, the enter event was bubbling up to cause the dialog to re-open. The code change just adds the `Enter` event to the existing keydown eventListener and calls `event.stopPropogation`.


### Anything you want to highlight for special attention from reviewers?

I did a small refactor by taking the check for `this.open` outside of the switch statement. Also, I don't understand what was being triggered from the enter key. Could be useful to uncover, since I think there may be other components that are affected by this event cycle.


### Accessibility
Pressing Enter should activate a button (per [ARIA APG — Button Pattern — Keyboard Interaction](https://www.w3.org/WAI/ARIA/apg/patterns/button/#keyboardinteraction))

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
