### PR TITLE
Fix disabled button behavior

### DIFF
--- a/.changeset/tall-ducks-brake.md
+++ b/.changeset/tall-ducks-brake.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Fix disabled button behavior

--- a/app/components/primer/alpha/button_marketing.rb
+++ b/app/components/primer/alpha/button_marketing.rb
@@ -42,12 +42,14 @@ module Primer
       # @param variant [Symbol] <%= one_of(Primer::Alpha::ButtonMarketing::VARIANT_OPTIONS) %>
       # @param tag [Symbol] <%= one_of(Primer::Alpha::ButtonMarketing::TAG_OPTIONS) %>
       # @param type [Symbol] <%= one_of(Primer::Alpha::ButtonMarketing::TYPE_OPTIONS) %>
+      # @param disabled [Boolean] Whether or not the button is disabled. If true, this option forces `tag:` to `:button`.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         scheme: DEFAULT_SCHEME,
         variant: DEFAULT_VARIANT,
         tag: DEFAULT_TAG,
         type: DEFAULT_TYPE,
+        disabled: false,
         **system_arguments
       )
         @system_arguments = system_arguments
@@ -60,6 +62,7 @@ module Primer
           VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)],
           system_arguments[:classes]
         )
+        @system_arguments[:disabled] = disabled
       end
 
       def call

--- a/app/components/primer/alpha/hellip_button.rb
+++ b/app/components/primer/alpha/hellip_button.rb
@@ -19,8 +19,9 @@ module Primer
       #   <%= render(Primer::Alpha::HellipButton.new(p: 1, classes: "custom-class", "aria-label": "No effect")) %>
       #
       # @param inline [Boolean] Whether or not the button is inline.
+      # @param disabled [Boolean] Whether or not the button is disabled.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(inline: false, **system_arguments)
+      def initialize(inline: false, disabled: false, **system_arguments)
         @system_arguments = deny_tag_argument(**system_arguments)
 
         validate_aria_label
@@ -31,6 +32,7 @@ module Primer
           @system_arguments[:classes],
           "inline" => inline
         )
+        @system_arguments[:disabled] = disabled
       end
 
       def call

--- a/app/components/primer/beta/base_button.rb
+++ b/app/components/primer/beta/base_button.rb
@@ -42,16 +42,15 @@ module Primer
         )
 
         @disabled = disabled
+        return unless @disabled
 
-        if @disabled
-          @system_arguments[:tag] = :button
-          @system_arguments[:disabled] = ""
-          @system_arguments[:aria] = merge_aria(
-            @system_arguments, {
-              aria: { disabled: true }
-            }
-          )
-        end
+        @system_arguments[:tag] = :button
+        @system_arguments[:disabled] = ""
+        @system_arguments[:aria] = merge_aria(
+          @system_arguments, {
+            aria: { disabled: true }
+          }
+        )
       end
 
       def call

--- a/app/components/primer/beta/base_button.rb
+++ b/app/components/primer/beta/base_button.rb
@@ -12,6 +12,9 @@ module Primer
       DEFAULT_TYPE = :button
       TYPE_OPTIONS = [DEFAULT_TYPE, :reset, :submit].freeze
 
+      attr_reader :disabled
+      alias disabled? disabled
+
       # @example Block
       #   <%= render(Primer::Beta::BaseButton.new(block: :true)) { "Block" } %>
       #   <%= render(Primer::Beta::BaseButton.new(block: :true, scheme: :primary)) { "Primary block" } %>
@@ -19,11 +22,13 @@ module Primer
       # @param tag [Symbol] <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
       # @param type [Symbol] <%= one_of(Primer::Beta::BaseButton::TYPE_OPTIONS) %>
       # @param block [Boolean] Whether button is full-width with `display: block`.
+      # @param disabled [Boolean] Whether or not the button is disabled. If true, this option forces `tag:` to `:button`.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         tag: DEFAULT_TAG,
         type: DEFAULT_TYPE,
         block: false,
+        disabled: false,
         **system_arguments
       )
         @system_arguments = system_arguments
@@ -35,6 +40,18 @@ module Primer
           system_arguments[:classes],
           "btn-block" => block
         )
+
+        @disabled = disabled
+
+        if @disabled
+          @system_arguments[:tag] = :button
+          @system_arguments[:disabled] = ""
+          @system_arguments[:aria] = merge_aria(
+            @system_arguments, {
+              aria: { disabled: true }
+            }
+          )
+        end
       end
 
       def call

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -135,18 +135,21 @@ module Primer
       # @param align_content [Symbol] <%= one_of(Primer::Beta::Button::ALIGN_CONTENT_OPTIONS) %>
       # @param tag [Symbol] (Primer::Beta::BaseButton::DEFAULT_TAG) <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
       # @param type [Symbol] (Primer::Beta::BaseButton::DEFAULT_TYPE) <%= one_of(Primer::Beta::BaseButton::TYPE_OPTIONS) %>
+      # @param disabled [Boolean] Whether or not the button is disabled. If true, this option forces `tag:` to `:button`.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(
         scheme: DEFAULT_SCHEME,
         size: DEFAULT_SIZE,
         block: false,
         align_content: DEFAULT_ALIGN_CONTENT,
+        disabled: false,
         **system_arguments
       )
         @scheme = scheme
         @block = block
 
         @system_arguments = system_arguments
+        @system_arguments[:disabled] = disabled
 
         @id = @system_arguments[:id]
 

--- a/app/components/primer/beta/close_button.rb
+++ b/app/components/primer/beta/close_button.rb
@@ -18,8 +18,9 @@ module Primer
       #   <%= render(Primer::Beta::CloseButton.new) %>
       #
       # @param type [Symbol] <%= one_of(Primer::Beta::CloseButton::TYPE_OPTIONS) %>
+      # @param disabled [Boolean] Whether or not the button is disabled.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(type: DEFAULT_TYPE, **system_arguments)
+      def initialize(type: DEFAULT_TYPE, disabled: false, **system_arguments)
         @system_arguments = deny_tag_argument(**system_arguments)
         @system_arguments[:tag] = :button
         @system_arguments[:block] = false
@@ -29,6 +30,7 @@ module Primer
           system_arguments[:classes]
         )
         @system_arguments[:"aria-label"] = aria("label", system_arguments) || "Close"
+        @system_arguments[:disabled] = disabled
       end
 
       def call

--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -5,7 +5,7 @@ module Primer
     # Use `IconButton` to render Icon-only buttons without the default button styles.
     #
     # `IconButton` will always render with a tooltip unless the tag is `:summary`.
-    # `IconButton` will always render with a tooltip unless the tag is `:summary`.
+    #
     # @accessibility
     #   `IconButton` requires an `aria-label`, which will provide assistive technologies with an accessible label.
     #   The `aria-label` should describe the action to be invoked rather than the icon itself. For instance,
@@ -47,9 +47,11 @@ module Primer
       #   <%= render(Primer::Beta::IconButton.new(icon: :search, "aria-label": "Search", tooltip_direction: :e)) %>
       #
       # @param icon [String] Name of <%= link_to_octicons %> to use.
+      # @param tag [Symbol] <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
       # @param wrapper_arguments [Hash] Optional keyword arguments to be passed to the wrapper `<div>` tag.
       # @param scheme [Symbol] <%= one_of(Primer::Beta::IconButton::SCHEME_OPTIONS) %>
       # @param size [Symbol] <%= one_of(Primer::Beta::Button::SIZE_OPTIONS) %>
+      # @param disabled [Boolean] Whether or not the button is disabled. If true, this option forces `tag:` to `:button`.
       # @param tag [Symbol] <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
       # @param type [Symbol] <%= one_of(Primer::Beta::BaseButton::TYPE_OPTIONS) %>
       # @param aria-label [String] String that can be read by assistive technology. A label should be short and concise. See the accessibility section for more information.
@@ -57,13 +59,14 @@ module Primer
       # @param show_tooltip [Boolean] Whether or not to show a tooltip when this button is hovered. Tooltips should only be hidden if the aria label is redundant, i.e. if the icon has a widely understood definition.
       # @param tooltip_direction [Symbol] (Primer::Alpha::Tooltip::DIRECTION_DEFAULT) <%= one_of(Primer::Alpha::Tooltip::DIRECTION_OPTIONS) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(icon:, scheme: DEFAULT_SCHEME, wrapper_arguments: {}, show_tooltip: true, tooltip_direction: Primer::Alpha::Tooltip::DIRECTION_DEFAULT, size: Primer::Beta::Button::DEFAULT_SIZE, **system_arguments)
+      def initialize(icon:, tag: BaseButton::DEFAULT_TAG, scheme: DEFAULT_SCHEME, wrapper_arguments: {}, show_tooltip: true, tooltip_direction: Primer::Alpha::Tooltip::DIRECTION_DEFAULT, size: Primer::Beta::Button::DEFAULT_SIZE, disabled: false, **system_arguments)
         @icon = icon
 
         @wrapper_arguments = wrapper_arguments
         @show_tooltip = show_tooltip
         @system_arguments = system_arguments
         @system_arguments[:id] ||= self.class.generate_id
+        @system_arguments[:disabled] = disabled
 
         @system_arguments[:classes] = class_names(
           "Button",

--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -52,14 +52,13 @@ module Primer
       # @param scheme [Symbol] <%= one_of(Primer::Beta::IconButton::SCHEME_OPTIONS) %>
       # @param size [Symbol] <%= one_of(Primer::Beta::Button::SIZE_OPTIONS) %>
       # @param disabled [Boolean] Whether or not the button is disabled. If true, this option forces `tag:` to `:button`.
-      # @param tag [Symbol] <%= one_of(Primer::Beta::BaseButton::TAG_OPTIONS) %>
       # @param type [Symbol] <%= one_of(Primer::Beta::BaseButton::TYPE_OPTIONS) %>
       # @param aria-label [String] String that can be read by assistive technology. A label should be short and concise. See the accessibility section for more information.
       # @param aria-description [String] String that can be read by assistive technology. A description can be longer as it is intended to provide more context and information. See the accessibility section for more information.
       # @param show_tooltip [Boolean] Whether or not to show a tooltip when this button is hovered. Tooltips should only be hidden if the aria label is redundant, i.e. if the icon has a widely understood definition.
       # @param tooltip_direction [Symbol] (Primer::Alpha::Tooltip::DIRECTION_DEFAULT) <%= one_of(Primer::Alpha::Tooltip::DIRECTION_OPTIONS) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(icon:, tag: BaseButton::DEFAULT_TAG, scheme: DEFAULT_SCHEME, wrapper_arguments: {}, show_tooltip: true, tooltip_direction: Primer::Alpha::Tooltip::DIRECTION_DEFAULT, size: Primer::Beta::Button::DEFAULT_SIZE, disabled: false, **system_arguments)
+      def initialize(icon:, scheme: DEFAULT_SCHEME, wrapper_arguments: {}, show_tooltip: true, tooltip_direction: Primer::Alpha::Tooltip::DIRECTION_DEFAULT, size: Primer::Beta::Button::DEFAULT_SIZE, disabled: false, **system_arguments)
         @icon = icon
 
         @wrapper_arguments = wrapper_arguments

--- a/previews/primer/alpha/button_marketing_preview.rb
+++ b/previews/primer/alpha/button_marketing_preview.rb
@@ -9,8 +9,9 @@ module Primer
       # @param variant [Symbol] select [default, large]
       # @param tag [Symbol] select [button, a]
       # @param type [Symbol] select [button, submit]
-      def playground(tag: :button, type: :button, scheme: :default, variant: :default)
-        render(Primer::Alpha::ButtonMarketing.new(tag: tag, type: type, scheme: scheme, variant: variant)) { "Default" }
+      # @param disabled [Boolean]
+      def playground(tag: :button, type: :button, scheme: :default, variant: :default, disabled: false)
+        render(Primer::Alpha::ButtonMarketing.new(tag: tag, type: type, scheme: scheme, variant: variant, disabled: disabled)) { "Default" }
       end
 
       # @label Default options

--- a/previews/primer/alpha/hellip_button_preview.rb
+++ b/previews/primer/alpha/hellip_button_preview.rb
@@ -16,8 +16,9 @@ module Primer
       #
       # @param aria_label [String]
       # @param inline [Boolean]
-      def playground(inline: false, aria_label: "No effect")
-        render(Primer::Alpha::HellipButton.new(inline: inline, "aria-label": aria_label))
+      # @param disabled [Boolean]
+      def playground(inline: false, aria_label: "No effect", disabled: false)
+        render(Primer::Alpha::HellipButton.new(inline: inline, "aria-label": aria_label, disabled: disabled))
       end
     end
   end

--- a/previews/primer/beta/base_button_preview.rb
+++ b/previews/primer/beta/base_button_preview.rb
@@ -9,8 +9,9 @@ module Primer
       # @param type [Symbol] select [button, submit]
       # @param tag [Symbol] select [button, a, summary]
       # @param block [Boolean] toggle
-      def playground(tag: :button, block: false, type: :button)
-        render(Primer::Beta::BaseButton.new(tag: tag, block: block, type: type)) { "Button" }
+      # @param disabled [Boolean]
+      def playground(tag: :button, block: false, type: :button, disabled: false)
+        render(Primer::Beta::BaseButton.new(tag: tag, block: block, type: type, disabled: disabled)) { "Button" }
       end
 
       # @label Default options

--- a/previews/primer/beta/close_button_preview.rb
+++ b/previews/primer/beta/close_button_preview.rb
@@ -7,8 +7,9 @@ module Primer
       # @label Playground
       #
       # @param type [Symbol] select [button, submit]
-      def playground(type: :button)
-        render(Primer::Beta::CloseButton.new(type: type))
+      # @param disabled toggle
+      def playground(type: :button, disabled: false)
+        render(Primer::Beta::CloseButton.new(type: type, disabled: disabled))
       end
 
       # @label Default options

--- a/test/components/alpha/button_marketing_test.rb
+++ b/test/components/alpha/button_marketing_test.rb
@@ -41,4 +41,10 @@ class PrimerAlphaButtonMarketingTest < Minitest::Test
 
     assert_selector(".btn-mktg.btn-large-mktg")
   end
+
+  def test_forces_button_tag_when_disabled
+    render_inline(Primer::Alpha::ButtonMarketing.new(tag: :a, disabled: true)) { "content" }
+
+    assert_selector("button.btn-mktg[disabled][aria-disabled=true]")
+  end
 end

--- a/test/components/alpha/hellip_button_test.rb
+++ b/test/components/alpha/hellip_button_test.rb
@@ -48,4 +48,10 @@ class PrimerAlphaHellipButtonTest < Minitest::Test
 
     refute_text("content")
   end
+
+  def test_disabled
+    render_inline(Primer::Alpha::HellipButton.new(aria: { label: "Custom aria label" }, disabled: true))
+
+    assert_selector("button[disabled][aria-disabled=true]", text: "…")
+  end
 end

--- a/test/components/beta/close_button_test.rb
+++ b/test/components/beta/close_button_test.rb
@@ -62,4 +62,10 @@ class PrimerBetaCloseButtonTest < Minitest::Test
     assert_selector("button[type='button'][aria-label='Label'].close-button")
     refute_includes rendered_content, 'aria-label="Close"'
   end
+
+  def test_disabled
+    render_inline(Primer::Beta::CloseButton.new(aria: { label: "Label" }, disabled: true))
+
+    assert_selector("button.close-button[disabled][aria-disabled=true]")
+  end
 end

--- a/test/components/primer/beta/icon_button_test.rb
+++ b/test/components/primer/beta/icon_button_test.rb
@@ -37,4 +37,9 @@ class PrimerBetaIconButtonTest < Minitest::Test
     render_inline(Primer::Beta::IconButton.new(icon: :star, "aria-label": "Star", show_tooltip: false))
     assert_selector("[aria-label='Star']")
   end
+
+  def test_forces_button_tag_when_disabled
+    render_inline(Primer::Beta::IconButton.new(icon: :star, "aria-label": "Star", disabled: true, tag: :a))
+    assert_selector(".Button-withTooltip button[disabled][aria-disabled=true]")
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR updates all of our buttons (via the `BaseButton` component) to support being disabled. This is done by forcing the tag to `<button>` if `disabled: true` is specified.

### Screenshots

Screenshots are not necessary in this case because all buttons still appear visually disabled with this change.

### Integration

I wrote up a [fake ERB linter and Ruby code scanner](https://gist.github.com/camertron/e2cfea771cc7479acbc150dfdc0c5665) to identify cases where the `disabled:` option is passed to `Beta::Button`, `Alpha::ButtonMarketing`, `Alpha::HellipButton`, `Beta::IconButton`, `Beta::CloseButton`, and `Beta::BaseButton` that also specify a tag other than `<button>`.

The scripts linked above only identified a single usage that fits the criteria:

1. [app/components/repos/advisories/report_vulnerability_button_component.html.erb:L1](https://github.com/github/github/blob/e45446afa961a170b27390185da25aecfc353e19/app/components/repos/advisories/report_vulnerability_button_component.html.erb#L1)

Strictly speaking, we don't actually have to fix the usage above - the code will continue to work as written. No doubt the author discovered what this PR is trying to fix - namely that `<a>` tags cannot be disabled. That said, we should take the opportunity to clean this up by setting `tag: :a`.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/2222

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Currently a number of our buttons that allow tag customization can't be disabled if a tag other than `<button>` is used. This is because the other two types of allowed tag, `<a>` and `<summary>`, cannot be disabled by setting the `disabled` HTML attribute as can be done for `<button>`s. In the `ActionMenu` component, we solved this by forcing the tag to `<button>` if `disabled: true` is specified. This PR does the same for all users of `BaseButton`.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

This change could cause problems with code that assumes a particular tag will be used for any given button. I feel as though I did my due diligence tracking down usages though, so we should be good to go.

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

This change doesn't fix an Axe violation (that I know of), but it does make our buttons more accessible overall.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.