### PR TITLE
ActionMenu: don't swallow events attached via addEventListener

### DIFF
--- a/.changeset/mighty-pandas-pump.md
+++ b/.changeset/mighty-pandas-pump.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+ActionMenu: don't swallow events attached via addEventListener

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -116,6 +116,20 @@ export class ActionMenuElement extends HTMLElement {
     if (event.type === 'include-fragment-replaced') {
       if (this.#firstItem) this.#firstItem.focus()
     } else if (this.#isActivationKeydown(event) || (event instanceof MouseEvent && event.type === 'click')) {
+      // Hide popover after current event loop to prevent changes in focus from
+      // altering the target of the event. Not doing this specifically affects
+      // <a> tags. It causes the event to be sent to the currently focused element
+      // instead of the anchor, which effectively prevents navigation, i.e. it
+      // appears as if hitting enter does nothing. Curiously, clicking instead
+      // works fine.
+      if (this.selectVariant !== 'multiple') {
+        setTimeout(() => this.popoverElement?.hidePopover())
+      }
+
+      // The rest of the code below deals with single/multiple selection behavior, and should not
+      // interfere with events fired by menu items whose behavior is specified outside the library.
+      if (this.selectVariant !== 'multiple' && this.selectVariant !== 'single') return
+
       const item = (event.target as Element).closest(menuItemSelectors.join(','))
       if (!item) return
       const ariaChecked = item.getAttribute('aria-checked')
@@ -135,15 +149,6 @@ export class ActionMenuElement extends HTMLElement {
       if (event instanceof KeyboardEvent && event.target instanceof HTMLButtonElement) {
         // prevent buttons from being clicked twice
         event.preventDefault()
-      }
-      // Hide popover after current event loop to prevent changes in focus from
-      // altering the target of the event. Not doing this specifically affects
-      // <a> tags. It causes the event to be sent to the currently focused element
-      // instead of the anchor, which effectively prevents navigation, i.e. it
-      // appears as if hitting enter does nothing. Curiously, clicking instead
-      // works fine.
-      if (this.selectVariant !== 'multiple') {
-        setTimeout(() => this.popoverElement?.hidePopover())
       }
     }
   }

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -180,19 +180,6 @@ module Primer
       # @label With actions
       #
       def with_actions
-        render(Primer::Alpha::ActionMenu.new) do |component|
-          component.with_show_button { "Trigger" }
-          component.with_item(label: "Alert", tag: :button, content_arguments: { onclick: "alert('Foo')", onkeydown: "if (event.key === 'Enter') { alert(event.key) }" })
-          component.with_item(label: "Navigate", tag: :a, content_arguments: { href: UrlHelpers.action_menu_landing_path })
-          component.with_item(label: "Copy text", tag: :"clipboard-copy", content_arguments: { value: "Text to copy" })
-          component.with_item(
-            label: "Submit form",
-            href: UrlHelpers.action_menu_form_action_path,
-            form_arguments: {
-              name: "foo", value: "bar", method: :post
-            }
-          )
-        end
       end
 
       # @label Single select form

--- a/previews/primer/alpha/action_menu_preview/with_actions.html.erb
+++ b/previews/primer/alpha/action_menu_preview/with_actions.html.erb
@@ -1,0 +1,21 @@
+<script type="text/javascript">
+  window.addEventListener('load', function() {
+    document.querySelector('button#alert-item').addEventListener('click', (_e) => {
+      alert('Foo')
+    });
+  }, false);
+</script>
+
+<%= render(Primer::Alpha::ActionMenu.new) do |component| %>
+  <% component.with_show_button { "Trigger" } %>
+  <% component.with_item(label: "Alert", tag: :button, id: "alert-item") %>
+  <% component.with_item(label: "Navigate", tag: :a, content_arguments: { href: action_menu_landing_path }) %>
+  <% component.with_item(label: "Copy text", tag: :"clipboard-copy", content_arguments: { value: "Text to copy" }) %>
+  <% component.with_item(
+    label: "Submit form",
+    href: action_menu_form_action_path,
+    form_arguments: {
+      name: "foo", value: "bar", method: :post
+    }
+  ) %>
+<% end %>


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR ensures events attached to `ActionMenu` items (buttons) outside the library work as expected.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary to production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes: https://github.com/github/primer/issues/2337

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

An issue came up today in Slack demonstrating that events attached to `ActionMenu` items (buttons) don't get fired when invoked via the keyboard. This happens because `ActionMenuElement` calls `preventDefault()` on the event, preventing it from bubbling up to any event handlers attached outside the library.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
