### PR TITLE
Allow Beta::Details to be disabled

### DIFF
--- a/.changeset/violet-keys-share.md
+++ b/.changeset/violet-keys-share.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Allow Beta::Details to be disabled

--- a/app/components/primer/beta/details.html.erb
+++ b/app/components/primer/beta/details.html.erb
@@ -1,4 +1,8 @@
-<%= render Primer::BaseComponent.new(**@system_arguments) do %>
+<% if disabled? %>
   <%= summary %>
-  <%= body %>
+<% else %>
+  <%= render(Primer::BaseComponent.new(**@system_arguments)) do %>
+    <%= summary %>
+    <%= body %>
+  <% end %>
 <% end %>

--- a/app/components/primer/beta/details.rb
+++ b/app/components/primer/beta/details.rb
@@ -23,13 +23,15 @@ module Primer
         system_arguments[:role] = "button"
 
         if disabled?
+          # rubocop:disable Primer/ComponentNameMigration
           Primer::ButtonComponent.new(**system_arguments, disabled: true)
+          # rubocop:enable Primer/ComponentNameMigration
+        elsif button
+          # rubocop:disable Primer/ComponentNameMigration
+          Primer::ButtonComponent.new(**system_arguments)
+          # rubocop:enable Primer/ComponentNameMigration
         else
-          if button
-            Primer::ButtonComponent.new(**system_arguments)
-          else
-            Primer::BaseComponent.new(**system_arguments)
-          end
+          Primer::BaseComponent.new(**system_arguments)
         end
       }
 

--- a/app/components/primer/beta/details.rb
+++ b/app/components/primer/beta/details.rb
@@ -58,6 +58,7 @@ module Primer
       #
       # @param overlay [Symbol] Dictates the type of overlay to render with. <%= one_of(Primer::Beta::Details::OVERLAY_MAPPINGS.keys) %>
       # @param reset [Boolean] Defaults to false. If set to true, it will remove the default caret and remove style from the summary element
+      # @param disabled [Boolean] Whether or not to disable the summary button.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
       def initialize(overlay: NO_OVERLAY, reset: false, disabled: false, **system_arguments)
         @system_arguments = deny_tag_argument(**system_arguments)

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 18.0.0)
-      view_component (> 2.0, < 4.0)
+      view_component (>= 3.1, < 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/previews/primer/beta/details_preview.rb
+++ b/previews/primer/beta/details_preview.rb
@@ -8,8 +8,9 @@ module Primer
       #
       # @param overlay [Symbol] select [none, default, dark]
       # @param reset [Boolean] toggle
-      def playground(reset: false, overlay: :default)
-        render Primer::Beta::Details.new(reset: reset, overlay: overlay) do |component|
+      # @param disabled [Boolean] toggle
+      def playground(reset: false, overlay: :default, disabled: false)
+        render Primer::Beta::Details.new(reset: reset, overlay: overlay, disabled: disabled) do |component|
           component.with_summary do
             "Summary"
           end
@@ -23,8 +24,9 @@ module Primer
       #
       # @param overlay [Symbol] select [none, default, dark]
       # @param reset [Boolean] toggle
-      def default(reset: false, overlay: :default)
-        render Primer::Beta::Details.new(reset: reset, overlay: overlay) do |component|
+      # @param disabled [Boolean] toggle
+      def default(reset: false, overlay: :default, disabled: false)
+        render Primer::Beta::Details.new(reset: reset, overlay: overlay, disabled: disabled) do |component|
           component.with_summary do
             "Summary"
           end
@@ -38,8 +40,9 @@ module Primer
       #
       # @param overlay [Symbol] select [none, default, dark]
       # @param reset [Boolean] toggle
-      def custom_button(reset: false, overlay: :default)
-        render Primer::Beta::Details.new(reset: reset, overlay: overlay) do |component|
+      # @param disabled [Boolean] toggle
+      def custom_button(reset: false, overlay: :default, disabled: false)
+        render Primer::Beta::Details.new(reset: reset, overlay: overlay, disabled: disabled) do |component|
           component.with_summary(size: :small, scheme: :primary) { "Click me" }
           component.with_body { "Body" }
         end
@@ -49,8 +52,8 @@ module Primer
       #
       # @param overlay [Symbol] select [none, default, dark]
       # @param reset [Boolean] toggle
-      def without_button(reset: false, overlay: :default)
-        render Primer::Beta::Details.new(reset: reset, overlay: overlay) do |component|
+      def without_button(reset: false, overlay: :default, disabled: false)
+        render Primer::Beta::Details.new(reset: reset, overlay: overlay, disabled: disabled) do |component|
           component.with_summary(button: false) { "Click me" }
           component.with_body { "Body" }
         end

--- a/test/components/beta/details_test.rb
+++ b/test/components/beta/details_test.rb
@@ -110,15 +110,33 @@ class PrimerBetaDetailsTest < Minitest::Test
 
   def test_prevents_rendering_without_slots
     render_inline(Primer::Beta::Details.new)
+
+    refute_selector("details")
+    refute_selector("summary")
+
     render_inline(Primer::Beta::Details.new) do |component|
       component.with_body { "Body" }
     end
+
+    refute_selector("details")
+    refute_selector("summary")
+
     render_inline(Primer::Beta::Details.new) do |component|
       component.with_summary { "Summary" }
     end
 
     refute_selector("details")
     refute_selector("summary")
+  end
+
+  def test_disabled
+    render_inline(Primer::Beta::Details.new(disabled: true)) do |component|
+      component.with_summary { "Summary" }
+      component.with_body { "Body" }
+    end
+
+    refute_selector("details")
+    assert_selector("button[disabled][aria-disabled=true]", text: "Summary")
   end
 
   def test_status


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A [recent PR](https://github.com/primer/view_components/pull/2070) ensured disabling buttons works as expected. Since buttons can use the `<summary>` tag, and because the `Details` component uses `<summary>` buttons, `Details` components can effectively not be disabled now 😱 

### Integration
<!-- Does this change require any updates to code in production? -->

This change will require investigating the following instances of `Beta::Details` in production:

1. [app/components/sponsors/explore/sort_menu_component.html.erb:2](https://github.com/github/github/blob/c3093c442cd2af13e1d7e78c11b5d4b9176fcec4/app/components/sponsors/explore/sort_menu_component.html.erb#L2)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Since `<summary>` elements can't be disabled, the component now renders only a disabled button if `disabled: true` is provided.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.