### PR TITLE
Don't use aria-disabled for buttons

### DIFF
--- a/.changeset/forty-hairs-grin.md
+++ b/.changeset/forty-hairs-grin.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Don't use aria-disabled for buttons

--- a/app/components/primer/beta/base_button.rb
+++ b/app/components/primer/beta/base_button.rb
@@ -46,11 +46,6 @@ module Primer
 
         @system_arguments[:tag] = :button
         @system_arguments[:disabled] = ""
-        @system_arguments[:aria] = merge_aria(
-          @system_arguments, {
-            aria: { disabled: true }
-          }
-        )
       end
 
       def call

--- a/previews/primer/beta/base_button_preview.rb
+++ b/previews/primer/beta/base_button_preview.rb
@@ -22,6 +22,12 @@ module Primer
       def default(tag: :button, block: false, type: :button)
         render(Primer::Beta::BaseButton.new(tag: tag, block: block, type: type)) { "Button" }
       end
+
+      # @label Disabled
+      #
+      def disabled
+        render(Primer::Beta::BaseButton.new(disabled: true)) { "Button" }
+      end
     end
   end
 end

--- a/test/components/alpha/button_marketing_test.rb
+++ b/test/components/alpha/button_marketing_test.rb
@@ -45,6 +45,6 @@ class PrimerAlphaButtonMarketingTest < Minitest::Test
   def test_forces_button_tag_when_disabled
     render_inline(Primer::Alpha::ButtonMarketing.new(tag: :a, disabled: true)) { "content" }
 
-    assert_selector("button.btn-mktg[disabled][aria-disabled=true]")
+    assert_selector("button.btn-mktg[disabled]")
   end
 end

--- a/test/components/alpha/hellip_button_test.rb
+++ b/test/components/alpha/hellip_button_test.rb
@@ -52,6 +52,6 @@ class PrimerAlphaHellipButtonTest < Minitest::Test
   def test_disabled
     render_inline(Primer::Alpha::HellipButton.new(aria: { label: "Custom aria label" }, disabled: true))
 
-    assert_selector("button[disabled][aria-disabled=true]", text: "…")
+    assert_selector("button[disabled]", text: "…")
   end
 end

--- a/test/components/beta/close_button_test.rb
+++ b/test/components/beta/close_button_test.rb
@@ -66,6 +66,6 @@ class PrimerBetaCloseButtonTest < Minitest::Test
   def test_disabled
     render_inline(Primer::Beta::CloseButton.new(aria: { label: "Label" }, disabled: true))
 
-    assert_selector("button.close-button[disabled][aria-disabled=true]")
+    assert_selector("button.close-button[disabled]")
   end
 end

--- a/test/components/beta/details_test.rb
+++ b/test/components/beta/details_test.rb
@@ -136,7 +136,7 @@ class PrimerBetaDetailsTest < Minitest::Test
     end
 
     refute_selector("details")
-    assert_selector("button[disabled][aria-disabled=true]", text: "Summary")
+    assert_selector("button[disabled]", text: "Summary")
   end
 
   def test_status

--- a/test/components/primer/beta/icon_button_test.rb
+++ b/test/components/primer/beta/icon_button_test.rb
@@ -40,6 +40,6 @@ class PrimerBetaIconButtonTest < Minitest::Test
 
   def test_forces_button_tag_when_disabled
     render_inline(Primer::Beta::IconButton.new(icon: :star, "aria-label": "Star", disabled: true, tag: :a))
-    assert_selector(".Button-withTooltip button[disabled][aria-disabled=true]")
+    assert_selector(".Button-withTooltip button[disabled]")
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In a few recent PRs, I changed `Beta::BaseButton` so it adds both the `disabled` and `aria-disabled` attributes to disabled buttons. Unfortunately I did not add a preview that explicitly showcases disabled behavior, and so did not catch the fact that only `disabled` is necessary. Fortunately Axe checks in dotcom are keeping me honest.

### Integration
<!-- Does this change require any updates to code in production? -->

No additional changes required in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
- [x] Added/updated previews (Lookbook)
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.