### PR TITLE
Toggle switch debounce

### DIFF
--- a/.changeset/sixty-ears-play.md
+++ b/.changeset/sixty-ears-play.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+ToggleSwitch: Remove @debounce annotation in favor of a boolean flag to prevent confusing screen reader output

--- a/app/components/primer/alpha/toggle_switch.ts
+++ b/app/components/primer/alpha/toggle_switch.ts
@@ -1,11 +1,12 @@
 import {controller, target} from '@github/catalyst'
-import {debounce} from '@github/mini-throttle/decorators'
 
 @controller
 class ToggleSwitchElement extends HTMLElement {
   @target switch: HTMLElement
   @target loadingSpinner: HTMLElement
   @target errorIcon: HTMLElement
+
+  private toggling = false
 
   get src(): string | null {
     const src = this.getAttribute('src')
@@ -31,14 +32,18 @@ class ToggleSwitchElement extends HTMLElement {
     return this.src != null
   }
 
-  @debounce(300)
   async toggle() {
+    if (this.toggling) return
+
+    this.toggling = true
+
     if (this.isDisabled()) {
       return
     }
 
     if (!this.isRemote()) {
       this.performToggle()
+      this.toggling = false
       return
     }
 
@@ -57,6 +62,8 @@ class ToggleSwitchElement extends HTMLElement {
       }
 
       return
+    } finally {
+      this.toggling = false
     }
 
     this.setSuccessState()

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@github/details-menu-element": "^1.0.12",
         "@github/image-crop-element": "^5.0.0",
         "@github/include-fragment-element": "^6.1.1",
-        "@github/mini-throttle": "^2.1.0",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@github/details-menu-element": "^1.0.12",
     "@github/image-crop-element": "^5.0.0",
     "@github/include-fragment-element": "^6.1.1",
-    "@github/mini-throttle": "^2.1.0",
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
     "@oddbird/popover-polyfill": "^0.2.1",


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR attempts to address the third bullet on [this list](https://github.com/github/primer/issues/1866#issuecomment-1585070320) of accessibility feedback (under "rechecks").

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Partially addresses https://github.com/github/primer/issues/1866

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

The component currently uses github/mini-throttle's `@debounce` annotation to prevent a switch from being clicked twice in rapid succession, which could cause multiple requests to be sent to the server. In the currently published version of the component, the switch cannot be toggled twice if the two toggles occur within 300ms of each other. I used this annotation when first building the component because I had seen it used somewhere else and thought it was appropriate. Unfortunately, this 300ms delay causes issues with screen readers, which, because of the delay, do not recognize the change in toggle state. Furthermore, what we actually want is for the switch to not be clickable until the previous toggle operation has completed. In accordance with this goal, I have removed the debounce functionality and instead effectively disable the switch until the previous toggle has finished.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
