### PR TITLE
Update tooltip docs to add note about `disabled`

### DIFF
--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -8,12 +8,12 @@ module Primer
     # When using a tooltip, follow the provided guidelines to avoid accessibility issues:
     # - Tooltips should contain only **non-essential text**. Tooltips can easily be missed and are not accessible on touch devices so never use tooltips to convey critical information.
     # - `Tooltip` should be rendered through the API of <%= link_to_component(Primer::ButtonComponent)%>, <%= link_to_component(Primer::Beta::Link)%>, or <%= link_to_component(Primer::IconButton)%>. Avoid using `Tooltip` a standalone component unless absolutely necessary (and **only** on interactive elements).
-    # - Tooltip text must be brief and concise whether it is a label or a description.
-    # - Tooltip can only hold string content.
-    # - Tooltip are not allowed on `disabled` elements due to how `disabled` elements are not keyboard accessible. If you must set a tooltip on a disabled element, use `aria-disabled="true"` and programatically disable the element to ensure the control can be focused.
-    # - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
-    # and screen reader users. Use of tooltip through <%= link_to_component(Primer::ButtonComponent) %>, <%= link_to_component(Primer::Beta::Link) %>, or <%= link_to_component(Primer::IconButton) %> will guarantee this.
-    # - If you must use `Tooltip` as a standalone component, place it adjacent after the trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip
+    # - Tooltip text must be brief and concise even when used to display a description.
+    # - Tooltips can only hold string content.
+    # - Tooltips are not allowed on `disabled` elements because such elements are not keyboard-accessible. If you must set a tooltip on a disabled element, use `aria-disabled="true"` instead and programmatically disable the element.
+    # - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only
+    # and screen reader users. Use of tooltips through <%= link_to_component(Primer::Beta::Button) %>, <%= link_to_component(Primer::Beta::Link) %>, or <%= link_to_component(Primer::Beta::IconButton) %> will guarantee this.
+    # - If you must use `Tooltip` as a standalone component, place it immediately after the trigger element in the DOM. This allows screen reader users to navigate to the tooltip and copy its contents if desired.
     #   content.
     #
     # Semantically, a tooltip will either act an accessible name or an accessible description for the element that it is associated with resulting in either a

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -10,7 +10,7 @@ module Primer
     # - `Tooltip` should be rendered through the API of <%= link_to_component(Primer::ButtonComponent)%>, <%= link_to_component(Primer::Beta::Link)%>, or <%= link_to_component(Primer::IconButton)%>. Avoid using `Tooltip` a standalone component unless absolutely necessary (and **only** on interactive elements).
     # - Tooltip text must be brief and concise whether it is a label or a description.
     # - Tooltip can only hold string content.
-    # - Tooltip are not allowed on `disabled` elements due to keyboard inaccessibility. If you must set a tooltip on a disabled element, use `aria-disabled="true"` and programatically disable the element to ensure the control can be focused.
+    # - Tooltip are not allowed on `disabled` elements due to how `disabled` elements are not keyboard accessible. If you must set a tooltip on a disabled element, use `aria-disabled="true"` and programatically disable the element to ensure the control can be focused.
     # - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
     # and screen reader users. Use of tooltip through <%= link_to_component(Primer::ButtonComponent) %>, <%= link_to_component(Primer::Beta::Link) %>, or <%= link_to_component(Primer::IconButton) %> will guarantee this.
     # - If you must use `Tooltip` as a standalone component, place it adjacent after the trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -8,20 +8,20 @@ module Primer
     # When using a tooltip, follow the provided guidelines to avoid accessibility issues:
     # - Tooltips should contain only **non-essential text**. Tooltips can easily be missed and are not accessible on touch devices so never use tooltips to convey critical information.
     # - `Tooltip` should be rendered through the API of <%= link_to_component(Primer::ButtonComponent)%>, <%= link_to_component(Primer::Beta::Link)%>, or <%= link_to_component(Primer::IconButton)%>. Avoid using `Tooltip` a standalone component unless absolutely necessary (and **only** on interactive elements).
-    # @accessibility
-    #   - Tooltip text must be brief and concise whether it is a label or a description.
-    #   - Tooltip can only hold string content.
-    #   - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
-    #   and screen reader users. Use of tooltip through <%= link_to_component(Primer::ButtonComponent) %>, <%= link_to_component(Primer::Beta::Link) %>, or <%= link_to_component(Primer::IconButton) %> will guarantee this.
-    #   - If you must use `Tooltip` as a standalone component, place it adjacent after the trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip
+    # - Tooltip text must be brief and concise whether it is a label or a description.
+    # - Tooltip can only hold string content.
+    # - Tooltip are not allowed on `disabled` elements due to keyboard inaccessibility. If you must set a tooltip on a disabled element, use `aria-disabled="true"` and programatically disable the element to ensure the control can be focused.
+    # - **Never set tooltips on static, non-interactive elements** like `span` or `div`. Tooltips should only be used on interactive elements like buttons or links to avoid excluding keyboard-only users
+    # and screen reader users. Use of tooltip through <%= link_to_component(Primer::ButtonComponent) %>, <%= link_to_component(Primer::Beta::Link) %>, or <%= link_to_component(Primer::IconButton) %> will guarantee this.
+    # - If you must use `Tooltip` as a standalone component, place it adjacent after the trigger element in the DOM. This allows screen reader users to navigate to and copy the tooltip
     #   content.
-    #   ### Which type should I set?
-    #   Semantically, a tooltip will either act an accessible name or an accessible description for the element that it is associated with resulting in either a
-    #   `aria-labelledby` or an `aria-describedby` association. The `type` drastically changes semantics and screen reader behavior so follow these guidelines carefully:
-    #   - When there is already a visible label text on the trigger element, the tooltip is likely intended be supplementary, so set `type: :description`.
-    #   The majority of tooltips will fall under this category.
-    #   - When there is no visible text on the trigger element and the tooltip content is appropriate as a label for the element, set `type: :label`.
-    #   `label` type is usually only appropriate for an icon-only control.
+    #
+    # Semantically, a tooltip will either act an accessible name or an accessible description for the element that it is associated with resulting in either a
+    # `aria-labelledby` or an `aria-describedby` association. The `type` drastically changes semantics and screen reader behavior so follow these guidelines carefully:
+    # - When there is already a visible label text on the trigger element, the tooltip is likely intended be supplementary, so set `type: :description`.
+    # The majority of tooltips will fall under this category.
+    # - When there is no visible text on the trigger element and the tooltip content is appropriate as a label for the element, set `type: :label`.
+    # `label` type is usually only appropriate for an icon-only control.
     class Tooltip < Primer::Component
       DIRECTION_DEFAULT = :s
       DIRECTION_OPTIONS = [DIRECTION_DEFAULT, :n, :e, :w, :ne, :nw, :se, :sw].freeze


### PR DESCRIPTION
### What are you trying to accomplish?

Documenting that tooltip should not be used with `disabled`.

#### List the issues that this change affects.

Follow up to [Slack thread](https://github.slack.com/archives/CGJTTJ738/p1687213191264059?thread_ts=1687209798.761689&cid=CGJTTJ738)

Closes https://github.com/primer/view_components/issues/2085
#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Anything you want to highlight for special attention from reviewers?

I noticed that the `Accessibility` section and the `What type do I set` information was not being rendered on the [doc page for tooltip](https://primer.style/design/components/tooltip/rails). I'm assuming this is due to the ongoing docs migration work, and we're only allowing top-level text.

I think this information is very important to surface so I opted to remove the headings to ensure it shows up in the doc.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
