### PR TITLE
Add lint rule against .tooltipped and introduce accessibility.yml config

### DIFF
--- a/.changeset/cuddly-laws-peel.md
+++ b/.changeset/cuddly-laws-peel.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Add lint rule against .tooltipped and introduce accessibility.yml config

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,7 @@
 ---
 EnableDefaultLinters: true
+inherit_from:
+  - lib/primer/view_components/linters/accessibility.yml
 inherit_gem:
   erblint-github:
     - config/accessibility.yml

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -4,6 +4,8 @@ inherit_gem:
   erblint-github:
     - config/accessibility.yml
 linters:
+  NoUnusedDisable:
+    enabled: true
   DeprecatedComponentsCounter:
     enabled: true
   ButtonComponentMigrationCounter:

--- a/lib/primer/view_components/linters/accessibility.yml
+++ b/lib/primer/view_components/linters/accessibility.yml
@@ -1,4 +1,4 @@
-# Accessibility-focused lint rule configurations.
+# Accessibility-focused lint rule configurations, tracked by accessibility scorecard.
 ---
 linters:
   Primer::Accessibility::TooltippedMigration:

--- a/lib/primer/view_components/linters/accessibility.yml
+++ b/lib/primer/view_components/linters/accessibility.yml
@@ -1,0 +1,5 @@
+# Accessibility-focused lint rule configurations.
+---
+linters:
+  Primer::Accessibility::TooltippedMigration:
+    enabled: true

--- a/lib/primer/view_components/linters/accessibility.yml
+++ b/lib/primer/view_components/linters/accessibility.yml
@@ -1,5 +1,7 @@
 # Accessibility-focused lint rule configurations, tracked by accessibility scorecard.
 ---
 linters:
+  NoUnusedDisable:
+    enabled: true
   Primer::Accessibility::TooltippedMigration:
     enabled: true

--- a/lib/primer/view_components/linters/argument_mappers/base.rb
+++ b/lib/primer/view_components/linters/argument_mappers/base.rb
@@ -53,7 +53,7 @@ module ERBLint
           system_arguments = system_arguments_to_args(classes_node.value)
           args = classes_to_args(system_arguments[:classes]&.split || [])
 
-          invalid_classes = args[:classes].select { |class_name| Primer::Classify::Validation.invalid?(class_name) }
+          invalid_classes = args[:classes].select { |class_name| ::Primer::Classify::Validation.invalid?(class_name) }
 
           raise ConversionError, "Cannot convert #{'class'.pluralize(invalid_classes.size)} #{invalid_classes.join(',')}" if invalid_classes.present?
 
@@ -81,7 +81,7 @@ module ERBLint
         end
 
         def system_arguments_to_args(classes)
-          system_arguments = Primer::Classify::Utilities.classes_to_hash(classes)
+          system_arguments = ::Primer::Classify::Utilities.classes_to_hash(classes)
 
           # need to transform symbols to strings with leading `:`
           system_arguments.transform_values do |v|

--- a/lib/primer/view_components/linters/base_linter.rb
+++ b/lib/primer/view_components/linters/base_linter.rb
@@ -5,7 +5,7 @@ require "openssl"
 require "primer/view_components/constants"
 
 require_relative "tag_tree_helpers"
-
+require_relative "helpers/rule_helpers"
 # :nocov:
 
 module ERBLint
@@ -17,6 +17,7 @@ module ERBLint
     # * `REQUIRED_ARGUMENTS` - optional - A list of HTML attributes that are required by the component.
     class BaseLinter < Linter
       include TagTreeHelpers
+      include Helpers::RuleHelpers
 
       DUMP_FILE = ".erblint-counter-ignore.json"
       DISALLOWED_CLASSES = [].freeze
@@ -134,10 +135,6 @@ module ERBLint
         end
       end
 
-      def tags(processed_source)
-        processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
-      end
-
       def counter_correct?(processed_source)
         comment_node = nil
         expected_count = 0
@@ -176,13 +173,6 @@ module ERBLint
         elsif expected_count == @offenses_not_corrected && @offenses.size == @offenses_not_corrected
           clear_offenses
         end
-      end
-
-      def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
-        message ||= klass::MESSAGE
-        klass_name = klass.name.demodulize
-        offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
-        add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
       end
 
       def dump_data(processed_source)

--- a/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
+++ b/lib/primer/view_components/linters/helpers/deprecated_components_helpers.rb
@@ -8,11 +8,11 @@ module ERBLint
       # Helpers to share between DeprecatedComponents ERB lint and Rubocop cop
       module DeprecatedComponentsHelpers
         def message(component_name)
-          Primer::Deprecations.deprecation_message(component_name)
+          ::Primer::Deprecations.deprecation_message(component_name)
         end
 
         def deprecated_components
-          Primer::Deprecations.deprecated_components
+          ::Primer::Deprecations.deprecated_components
         end
       end
     end

--- a/lib/primer/view_components/linters/helpers/rule_helpers.rb
+++ b/lib/primer/view_components/linters/helpers/rule_helpers.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ERBLint
+  module Linters
+    module Helpers
+      # Helpers for writing rules
+      module RuleHelpers
+        def tags(processed_source)
+          processed_source.parser.nodes_with_type(:tag).map { |tag_node| BetterHtml::Tree::Tag.from_node(tag_node) }
+        end
+
+        def generate_offense(klass, processed_source, tag, message = nil, replacement = nil)
+          message ||= klass::MESSAGE
+          klass_name = klass.name.demodulize
+          offense = ["#{klass_name}:#{message}", tag.node.loc.source].join("\n")
+          add_offense(processed_source.to_source_range(tag.loc), offense, replacement)
+        end
+
+        # Generate offense for ERB node tag
+        def generate_node_offense(klass, processed_source, node, message = nil)
+          message ||= klass::MESSAGE
+          offense = ["#{klass.name}:#{message}", node.loc.source].join("\n")
+          add_offense(processed_source.to_source_range(node.loc), offense)
+        end
+
+        def erb_nodes(processed_source)
+          processed_source.parser.ast.descendants(:erb)
+        end
+
+        def extract_ruby_from_erb_node(erb_node)
+          return unless erb_node.type == :erb
+
+          _, _, code_node = *erb_node
+          code_node.loc.source.strip
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/tooltipped_migration.rb
+++ b/lib/primer/view_components/linters/tooltipped_migration.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require_relative "helpers/rule_helpers"
 
+require_relative "helpers/rule_helpers"
 module ERBLint
   module Linters
     module Primer

--- a/lib/primer/view_components/linters/tooltipped_migration.rb
+++ b/lib/primer/view_components/linters/tooltipped_migration.rb
@@ -10,8 +10,8 @@ module ERBLint
           include LinterRegistry
           include Helpers::RuleHelpers
 
-          MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. Tooltip should never be set on a non-interactive element (e.g. <span>, <div>, <li>) " \
-            "Find alternatives in https://primer.style/design/guides/accessibility/tooltip-alternatives/." \
+          MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. Tooltip should never be set on a non-interactive element (e.g. <span>, <div>, <li>). " \
+            "Find alternatives in https://primer.style/design/guides/accessibility/tooltip-alternatives/. " \
             "If you're setting a tooltip on an interactive element, use the latest tooltip in https://primer.style/view-components."
           TOOLTIPPED_RUBY_PATTERN = /classes:.*tooltipped|class:.*tooltipped/.freeze
 

--- a/lib/primer/view_components/linters/tooltipped_migration.rb
+++ b/lib/primer/view_components/linters/tooltipped_migration.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require_relative "helpers/rule_helpers"
+
+module ERBLint
+  module Linters
+    module Primer
+      module Accessibility
+        # Flag when `.tooltipped` is being used and offer alternatives.
+        class TooltippedMigration < Linter
+          include LinterRegistry
+          include Helpers::RuleHelpers
+
+          MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. Tooltip should never be set on a non-interactive element (e.g. <span>, <div>, <li>) " \
+            "Find alternatives in https://primer.style/design/guides/accessibility/tooltip-alternatives/." \
+            "If you're setting a tooltip on an interactive element, use the latest tooltip in https://primer.style/view-components."
+          TOOLTIPPED_RUBY_PATTERN = /classes:.*tooltipped/.freeze
+
+          def run(processed_source)
+            # HTML tags
+            tags(processed_source).each do |tag|
+              next if tag.closing?
+
+              classes = tag.attributes["class"]&.value
+              generate_offense(self.class, processed_source, tag, MIGRATE_TO_NEWER_TOOLTIP) if classes&.include?("tooltipped")
+            end
+
+            # ERB nodes
+            erb_nodes(processed_source).each do |node|
+              code = extract_ruby_from_erb_node(node)
+              generate_node_offense(self.class, processed_source, node, MIGRATE_TO_NEWER_TOOLTIP) if code.match?(TOOLTIPPED_RUBY_PATTERN)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/tooltipped_migration.rb
+++ b/lib/primer/view_components/linters/tooltipped_migration.rb
@@ -13,7 +13,7 @@ module ERBLint
           MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. Tooltip should never be set on a non-interactive element (e.g. <span>, <div>, <li>) " \
             "Find alternatives in https://primer.style/design/guides/accessibility/tooltip-alternatives/." \
             "If you're setting a tooltip on an interactive element, use the latest tooltip in https://primer.style/view-components."
-          TOOLTIPPED_RUBY_PATTERN = /classes:.*tooltipped/.freeze
+          TOOLTIPPED_RUBY_PATTERN = /classes:.*tooltipped|class:.*tooltipped/.freeze
 
           def run(processed_source)
             # HTML tags

--- a/test/lib/erblint/linter_config_works_test.rb
+++ b/test/lib/erblint/linter_config_works_test.rb
@@ -13,8 +13,8 @@ class RecommendedSetupWorksTest < ErblintTestCase
       rules_enabled_in_accessibility_config += 1 if linter[0].include?("Primer::Accessibility") && linter[1]["enabled"] == true
     end
     known_linter_names ||= ERBLint::LinterRegistry.linters.map(&:simple_name)
-
+    known_linter_names_count = known_linter_names.count { |linter| linter.include?("Primer::Accessibility") }
     assert_equal 1, rules_enabled_in_accessibility_config
-    assert_equal 1, known_linter_names.count { |linter| linter.include?("Primer::Accessibility") }
+    assert_equal 1, known_linter_names_count
   end
 end

--- a/test/lib/erblint/linter_config_works_test.rb
+++ b/test/lib/erblint/linter_config_works_test.rb
@@ -2,7 +2,7 @@
 
 require "lib/erblint_test_case"
 
-class RecommendedSetupWorksTest < ErblintTestCase
+class LinterConfigWorksTest < ErblintTestCase
   # The ability to share rules and configs from other gems in erb_lint is not well-documented.
   # This test validates that our recommended setup works.
   def test_asserts_recommended_setup_works

--- a/test/lib/erblint/linter_config_works_test.rb
+++ b/test/lib/erblint/linter_config_works_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "lib/erblint_test_case"
+
+class RecommendedSetupWorksTest < ErblintTestCase
+  # The ability to share rules and configs from other gems in erb_lint is not well-documented.
+  # This test validates that our recommended setup works.
+  def test_asserts_recommended_setup_works
+    erb_lint_config = ERBLint::RunnerConfig.new(file_loader.yaml(".erb-lint.yml"), file_loader)
+
+    rules_enabled_in_accessibility_config = 0
+    erb_lint_config.to_hash["linters"].each do |linter|
+      rules_enabled_in_accessibility_config += 1 if linter[0].include?("Primer::Accessibility") && linter[1]["enabled"] == true
+    end
+    known_linter_names ||= ERBLint::LinterRegistry.linters.map(&:simple_name)
+
+    assert_equal 1, rules_enabled_in_accessibility_config
+    assert_equal 1, known_linter_names.count { |linter| linter.include?("Primer::Accessibility") }
+  end
+end

--- a/test/lib/erblint/tooltipped_migration_test.rb
+++ b/test/lib/erblint/tooltipped_migration_test.rb
@@ -14,7 +14,17 @@ class TooltippedMigrationTest < ErblintTestCase
     assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
   end
 
-  def test_warns_if_tooltipped_class_is_used_on_ruby_component
+  def test_warns_if_tooltipped_class_is_used_on_view_component
+    @file = <<~HTML
+      <%= content_tag :span,
+      class: "tooltipped tooltipped-nw cursor-pointer" do %>
+    HTML
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_warns_if_tooltipped_class_is_used_on_ruby
     @file = '<%= render SomeComponent.new(classes: "tooltipped tooltipped-multiline tooltipped-s") do %>'
     @linter.run(processed_source)
     assert_equal 1, @linter.offenses.count
@@ -32,6 +42,7 @@ class TooltippedMigrationTest < ErblintTestCase
       <%= render SomeComponent.new(classes: "tooltipped") do %><%# erblint:disable Primer::Accessibility::TooltippedMigration %>
     HTML
     @linter.run_and_update_offense_status(processed_source)
-    assert_equal 0, @linter.offenses.count
+    offenses = @linter.offenses.reject(&:disabled?) # Reject offenses marked as disabled. (This happens at the runner level so we repliace it here)
+    assert_equal 0, offenses.count
   end
 end

--- a/test/lib/erblint/tooltipped_migration_test.rb
+++ b/test/lib/erblint/tooltipped_migration_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "lib/erblint_test_case"
+
+class TooltippedMigrationTest < ErblintTestCase
+  def linter_class
+    ERBLint::Linters::Primer::Accessibility::TooltippedMigration
+  end
+
+  def test_warns_if_tooltipped_class_is_used_on_html_tag
+    @file ="<li aria-label='Some text' class='tooltipped'>List item</li>"
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_warns_if_tooltipped_class_is_used_on_ruby_component
+    @file ='<%= render SomeComponent.new(classes: "tooltipped tooltipped-multiline tooltipped-s", "aria-label": "Text") do %>'
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_does_not_warn_if_tooltipped_is_not_used
+    @file ='<%= render SomeComponent.new("aria-label": "Text") do %>'
+    @linter.run(processed_source)
+    assert_equal 0, @linter.offenses.count
+  end
+end

--- a/test/lib/erblint/tooltipped_migration_test.rb
+++ b/test/lib/erblint/tooltipped_migration_test.rb
@@ -8,22 +8,30 @@ class TooltippedMigrationTest < ErblintTestCase
   end
 
   def test_warns_if_tooltipped_class_is_used_on_html_tag
-    @file ="<li aria-label='Some text' class='tooltipped'>List item</li>"
+    @file = "<li class='tooltipped'>List item</li>"
     @linter.run(processed_source)
     assert_equal 1, @linter.offenses.count
     assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
   end
 
   def test_warns_if_tooltipped_class_is_used_on_ruby_component
-    @file ='<%= render SomeComponent.new(classes: "tooltipped tooltipped-multiline tooltipped-s", "aria-label": "Text") do %>'
+    @file = '<%= render SomeComponent.new(classes: "tooltipped tooltipped-multiline tooltipped-s") do %>'
     @linter.run(processed_source)
     assert_equal 1, @linter.offenses.count
     assert_match(/.tooltipped has been deprecated./, @linter.offenses.first.message)
   end
 
   def test_does_not_warn_if_tooltipped_is_not_used
-    @file ='<%= render SomeComponent.new("aria-label": "Text") do %>'
+    @file = "<%= render SomeComponent.new do %>"
     @linter.run(processed_source)
+    assert_equal 0, @linter.offenses.count
+  end
+
+  def test_does_not_warn_if_inline_disable_comment
+    @file = <<~HTML
+      <%= render SomeComponent.new(classes: "tooltipped") do %><%# erblint:disable Primer::Accessibility::TooltippedMigration %>
+    HTML
+    @linter.run_and_update_offense_status(processed_source)
     assert_equal 0, @linter.offenses.count
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

I started this rule in dotcom, but then I realized that PVC might make more sense so this rule can be shared across many projects.

This PR:
* Introduce a lint rule against `.tooltipped` in favor of alternatives, or the more recent tooltip.
* Started a `accessibility.yml` which will allow consumers to easily pull in recommended accessibility linting configurations which we can count against the scorecard. This will specifically contain rules that count towards the accessibility scorecard.
* I moved helpers out of `base_linter.rb` to a helpers module. `BaseLinter` seems to come with a lot of additional things this rule doesn't need, but I need to use these helpers. 

I _think_ consumers can now add the following in their `.erb-lint.yml` to automatically pull in rules:

```yaml
inherit_gem:
  primer_view_components:
    - primer/view_components/linters/accessibility.yml
```

### Integration
No

#### List the issues that this change affects.

Closes https://github.com/github/accessibility/issues/3704

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

* I introduced a `accessibility.yml` config so consumers can easily configure recommended rules.
* I namespaced the rule as `Primer::Accessibility`.

### Anything you want to highlight for special attention from reviewers?

I namespaced the rule `Primer::Accessibility::` to align with what we do in [erblint-github](https://github.com/github/erblint-github). 

The pro of this is that it can help to identify where a rule originates from. The con, is that the disable comment is kind of long (e.g. `erblint:disable Primer::Accessibility::TooltipHasMigration).

This also isn't consistent with the other rules living in PVC. What do you think? @primer/rails-reviewers?? 📣

I would also like to add docs for this rule but I'm not sure where it belongs, also given the doc migration work. What do you think? 📣

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
