### PR TITLE
Separating anchored position and Overlay class

### DIFF
--- a/.changeset/popular-impalas-sin.md
+++ b/.changeset/popular-impalas-sin.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Separating `<anchored-position>` web component and the .Overlay class into separate markup.

--- a/app/components/primer/alpha/overlay.html.erb
+++ b/app/components/primer/alpha/overlay.html.erb
@@ -1,11 +1,13 @@
 <%= show_button %>
 
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <%= header %>
-  <% if content.present? %>
-    <%= content %>
-  <% else %>
-    <%= body %>
-    <%= footer %>
+  <%= render Primer::BaseComponent.new(tag: :div, classes: @wrapper_classes) do %>
+    <%= header %>
+    <% if content.present? %>
+      <%= content %>
+    <% else %>
+      <%= body %>
+      <%= footer %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -7,6 +7,10 @@ anchored-position[popover] {
   overflow: visible;
 }
 
+.Overlay {
+  overflow: visible;
+}
+
 anchored-position[popover]:not(.\:popover-open) {
   display: none;
 }

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -8,7 +8,7 @@ anchored-position[popover] {
 }
 
 .Overlay {
-  overflow: visible;
+  display: flex;
 }
 
 anchored-position[popover]:not(.\:popover-open) {

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -1,25 +1,26 @@
-.Overlay[popover] {
+anchored-position[popover] {
   border-width: 0;
   padding: 0;
   position: absolute;
   min-width: 192px;
   inset: auto;
+  overflow: visible;
 }
 
-.Overlay[popover]:not(.\:popover-open) {
+anchored-position[popover]:not(.\:popover-open) {
   display: none;
 }
 
 /* This reverts the declaration above for native popover, where `:popover-open` is supported */
 @supports selector(:popover-open) {
-  .Overlay[popover]:not(.\:popover-open) {
+  anchored-position[popover]:not(.\:popover-open) {
     display: revert;
   }
 }
 
 /* This reverts the declaration above for native popover, where `:open` is supported (Chrome 113, Safari TP) */
 @supports selector(:open) {
-  .Overlay[popover]:not(.\:popover-open) {
+  anchored-position[popover]:not(.\:popover-open) {
       display: revert;
   }
 }

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -171,10 +171,9 @@ module Primer
         @system_arguments[:role] = fetch_or_fallback(ROLE_OPTIONS, role) if role.present?
 
         @system_arguments[:id] = id.to_s
-        @system_arguments[:classes] = class_names(
+        @wrapper_classes = class_names(
           "Overlay",
-          SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)],
-          system_arguments[:classes]
+          SIZE_MAPPINGS[fetch_or_fallback(SIZE_OPTIONS, size, DEFAULT_SIZE)]
         )
         @system_arguments[:tag] = "anchored-position"
         @system_arguments[:anchor] = anchor || "overlay-show-#{@system_arguments[:id]}"

--- a/app/components/primer/anchored_position.ts
+++ b/app/components/primer/anchored_position.ts
@@ -134,23 +134,9 @@ export default class AnchoredPositionElement extends HTMLElement implements Posi
     this.#animationFrame = requestAnimationFrame(() => {
       const anchor = this.anchorElement
       if (!anchor) return
-      const {left, top, anchorSide, anchorAlign} = getAnchoredPosition(this, anchor, this)
+      const {left, top} = getAnchoredPosition(this, anchor, this)
       this.style.top = `${top}px`
       this.style.left = `${left}px`
-      this.classList.remove(
-        'Overlay--anchorAlign-start',
-        'Overlay--anchorAlign-center',
-        'Overlay--anchorAlign-end',
-        'Overlay--anchorSide-insideTop',
-        'Overlay--anchorSide-insideBottom',
-        'Overlay--anchorSide-insideLeft',
-        'Overlay--anchorSide-insideRight',
-        'Overlay--anchorSide-insideCenter',
-        'Overlay--anchorSide-outsideTop',
-        'Overlay--anchorSide-outsideLeft',
-        'Overlay--anchorSide-outsideRight'
-      )
-      this.classList.add(`Overlay--anchorAlign-${anchorAlign}`, `Overlay--anchorSide-${anchorSide}`)
     })
   }
 }

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -163,6 +163,17 @@ module Primer
                                body_text: body_text
                              })
       end
+
+      # @label Dialog with header and footer
+      #
+      def dialog_with_header_footer
+        render(Primer::Alpha::Overlay.new(title: "Dialog", role: :dialog, size: :large, padding: :condensed)) do |d|
+          d.with_header(title: "Large Dialog Header", divider: true)
+          d.with_show_button { "Show Overlay" }
+          d.with_footer { "Large Dialog Footer" }
+          d.with_body { "This is a long body for the overlay dialog. <br>".html_safe * 20 }
+        end
+      end
     end
   end
 end

--- a/static/classes.json
+++ b/static/classes.json
@@ -342,8 +342,7 @@
     "Primer::Beta::Link"
   ],
   "Overlay": [
-    "Primer::Alpha::Dialog",
-    "Primer::Alpha::Overlay"
+    "Primer::Alpha::Dialog"
   ],
   "Overlay--hidden": [
     "Primer::Alpha::Dialog"

--- a/static/classes.json
+++ b/static/classes.json
@@ -342,7 +342,8 @@
     "Primer::Beta::Link"
   ],
   "Overlay": [
-    "Primer::Alpha::Dialog"
+    "Primer::Alpha::Dialog",
+    "Primer::Alpha::Overlay"
   ],
   "Overlay--hidden": [
     "Primer::Alpha::Dialog"


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Dialog overlay wasn't scrolling the body and fixing the header/footer properly. When the revert is applied, it's reverting to `display: block;` instead of the `display: flex` that it needs to be. I originally tried to fix this by seeing if there was a better option for `display: revert;` but that leads to other problems with the overlay not disappearing.

```css
@supports selector(:popover-open) {
  .Overlay[popover]:not(.\:popover-open) {
    display: revert;
  }
}
```

### Screenshots

**Before**
<img width="672" alt="image" src="https://github.com/primer/view_components/assets/54012/75919a53-16d3-420e-8b47-336ee7642b54">

**After**
<img width="701" alt="image" src="https://github.com/primer/view_components/assets/54012/fedf5548-59c9-4d71-954a-9c165bb70a99">

[Demo](http://primer-view-components-preview-2088.eastus.azurecontainer.io/view-components/lookbook/inspect/primer/alpha/overlay/dialog_with_header_footer)

### Integration

No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/2375

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
