### PR TITLE
Change 'skip changelog' label to 'skip changeset'

### DIFF
--- a/.changeset/spicy-suns-behave.md
+++ b/.changeset/spicy-suns-behave.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Change the 'skip changelog' label to 'skip changeset'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "actions"
     schedule:
       interval: "monthly"
@@ -19,7 +19,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "npm"
     allow:
       - dependency-type: "production"
@@ -29,7 +29,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "npm"
     allow:
       - dependency-type: "production"
@@ -43,7 +43,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "npm"
     allow:
       - dependency-type: "production"
@@ -55,7 +55,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "bundler"
     allow:
       - dependency-type: "production"
@@ -65,7 +65,7 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
-      - "skip changelog"
+      - "skip changeset"
       - "bundler"
     allow:
       - dependency-type: "production"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -31,15 +31,15 @@ jobs:
     name: Check for changeset
     runs-on: ubuntu-latest
     env:
-      SKIP_LABEL: "skip changelog"
+      SKIP_LABEL: "skip changeset"
     steps:
-      - if: "contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+      - if: "contains(github.event.pull_request.labels.*.name, 'skip changeset')"
         run: echo "passed"; exit 0;
-      - if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+      - if: "!contains(github.event.pull_request.labels.*.name, 'skip changeset')"
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - if: "!contains(github.event.pull_request.labels.*.name, 'skip changelog')"
+      - if: "!contains(github.event.pull_request.labels.*.name, 'skip changeset')"
         name: "Check for changeset"
         run: script/check-for-changeset
 


### PR DESCRIPTION
### What are you trying to accomplish?

We'd like to change the `skip changelog` label to `skip changeset` to better reflect how we work and for consistency with primer/react. Several of our workflows are expecting the old `skip changelog` label. This PR corrects them.

### Integration

No code changes required in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.