### PR TITLE
Updating yardoc build config for the custom @snapshot tag

### DIFF
--- a/lib/primer/yard.rb
+++ b/lib/primer/yard.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require "yard"
+
 module Primer
+  # :nodoc:
   module Yard
     autoload :Backend,              "primer/yard/backend"
     autoload :ComponentManifest,    "primer/yard/component_manifest"
@@ -11,5 +14,7 @@ module Primer
     autoload :Registry,             "primer/yard/registry"
     autoload :RendersManyHandler,   "primer/yard/renders_many_handler"
     autoload :RendersOneHandler,    "primer/yard/renders_one_handler"
+
+    ::YARD::Tags::Library.define_tag("Snapshot preview", :snapshot)
   end
 end

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -3,10 +3,10 @@
 require "active_support/inflector"
 
 task :init_pvc do
+  require "primer/yard"
+
   ENV["RAILS_ENV"] = "test"
   ENV["VC_COMPAT_PATCH_ENABLED"] = "true"
-
-  YARD::Tags::Library.define_tag("Snapshot preview", :snapshot)
 
   require File.expand_path("./../../demo/config/environment.rb", __dir__)
   Dir[File.expand_path("../../app/components/primer/**/*.rb", __dir__)].sort.each { |file| require file }


### PR DESCRIPTION
I added a custom `@snapshot` tag but there's a bunch of warning in test files. This fixes those

```
[warn]: Unknown tag @snapshot in file `/workspaces/view_components/previews/primer/alpha/segmented_control_preview.rb` near line 176
[warn]: Unknown tag @snapshot in file `/workspaces/view_components/previews/primer/alpha/segmented_control_preview.rb` near line 179
[warn]: Unknown tag @snapshot in file `/workspaces/view_components/previews/primer/beta/auto_complete_item_preview.rb` near line 27
[warn]: Unknown tag @snapshot in file `/workspaces/view_components/previews/primer/beta/auto_complete_item_preview.rb` near line 43
[warn]: Unknown tag @snapshot in file `/workspaces/view_components/previews/primer/alpha/radio_button_group_preview.rb` near line 35
```