### PR TITLE
Update index.md documentation with correct install path

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -40,7 +40,7 @@ Optionally, to add the JavaScript behaviours, in your `application.html.erb` in 
 Or alternatively, you can install the `@primer/view-components` npm package and in your JavaScript code add:
 
 ```js
-import '@primer/view-components'
+import '@primer/view-components/app/assets/javascripts/primer_view_components.js'
 ```
 
 You can also import only the components you need:


### PR DESCRIPTION
Use the full import path in documentation as recommended in the PR here https://github.com/primer/view_components/pull/1731#issuecomment-1367848262 to avoid `Uncaught DOMException` errors around double registration of web components.
