### PR TITLE
add details_menu_migration linter

### DIFF
--- a/.changeset/dry-dryers-thank.md
+++ b/.changeset/dry-dryers-thank.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Add a linter discouraging use of <details-menu> in favor of Primer::Alpha::ActionMenu
+
+<!-- Changed components: _none_ -->

--- a/lib/primer/view_components/linters/accessibility.yml
+++ b/lib/primer/view_components/linters/accessibility.yml
@@ -5,3 +5,5 @@ linters:
     enabled: true
   Primer::Accessibility::TooltippedMigration:
     enabled: true
+  Primer::Accessibility::DetailsMenuMigration:
+    enabled: true

--- a/lib/primer/view_components/linters/argument_mappers/label.rb
+++ b/lib/primer/view_components/linters/argument_mappers/label.rb
@@ -7,24 +7,24 @@ module ERBLint
     module ArgumentMappers
       # Maps classes in a label element to arguments for the Label component.
       class Label < Base
-        SCHEME_MAPPINGS = Primer::ViewComponents::Constants.get(
+        SCHEME_MAPPINGS = ::Primer::ViewComponents::Constants.get(
           component: "Primer::Beta::Label",
           constant: "SCHEME_MAPPINGS",
           symbolize: true
         ).freeze
 
-        SIZE_MAPPINGS = Primer::ViewComponents::Constants.get(
+        SIZE_MAPPINGS = ::Primer::ViewComponents::Constants.get(
           component: "Primer::Beta::Label",
           constant: "SIZE_MAPPINGS",
           symbolize: true
         ).freeze
 
-        DEFAULT_TAG = Primer::ViewComponents::Constants.get(
+        DEFAULT_TAG = ::Primer::ViewComponents::Constants.get(
           component: "Primer::Beta::Label",
           constant: "DEFAULT_TAG"
         ).freeze
 
-        INLINE_CLASS = Primer::ViewComponents::Constants.get(
+        INLINE_CLASS = ::Primer::ViewComponents::Constants.get(
           component: "Primer::Beta::Label",
           constant: "INLINE_CLASS"
         ).freeze

--- a/lib/primer/view_components/linters/details_menu_migration.rb
+++ b/lib/primer/view_components/linters/details_menu_migration.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "helpers/rule_helpers"
+module ERBLint
+  module Linters
+    module Primer
+      module Accessibility
+        # Flag when `<details-menu>` is being used and offer alternatives.
+        class DetailsMenuMigration < Linter
+          include LinterRegistry
+          include Helpers::RuleHelpers
+
+          MIGRATE_FROM_DETAILS_MENU = "<details-menu> has been deprecated. Please instead use Primer::Alpha::ActionMenu" \
+            "https://primer.style/design/components/action-menu/rails/alpha"
+          DETAILS_MENU_RUBY_PATTERN = /tag:?\s+:"details-menu"/.freeze
+
+          def run(processed_source)
+            # HTML tags
+            tags(processed_source).each do |tag|
+              next if tag.closing?
+
+              generate_offense(self.class, processed_source, tag, MIGRATE_FROM_DETAILS_MENU) if tag.name == "details-menu"
+            end
+
+            # ERB nodes
+            erb_nodes(processed_source).each do |node|
+              code = extract_ruby_from_erb_node(node)
+              generate_node_offense(self.class, processed_source, node, MIGRATE_FROM_DETAILS_MENU) if code.match?(DETAILS_MENU_RUBY_PATTERN)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/primer/view_components/linters/label_component_migration_counter.rb
+++ b/lib/primer/view_components/linters/label_component_migration_counter.rb
@@ -10,7 +10,7 @@ module ERBLint
     class LabelComponentMigrationCounter < BaseLinter
       include Autocorrectable
 
-      TAGS = Primer::ViewComponents::Constants.get(
+      TAGS = ::Primer::ViewComponents::Constants.get(
         component: "Primer::Beta::Label",
         constant: "TAG_OPTIONS"
       ).freeze

--- a/test/lib/erblint/details_menu_migration_test.rb
+++ b/test/lib/erblint/details_menu_migration_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "lib/erblint_test_case"
+
+class DetailsMenuMigrationTest < ErblintTestCase
+  def linter_class
+    ERBLint::Linters::Primer::Accessibility::DetailsMenuMigration
+  end
+
+  def test_warns_if_details_menu_tag_is_used
+    @file = "<details-menu class='SelectMenu' role='menu'></details-menu>"
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.<details-menu> has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_warns_if_details_menu_content_tag_is_rendered
+    @file = <<~HTML
+      <%= content_tag :"details-menu",
+      class: "SelectMenu" do %>
+    HTML
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.<details-menu> has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_warns_if_details_menu_view_component_is_rendered
+    @file = '<%= render SomeComponent.new(tag: :"details-menu") do %>'
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.<details-menu> has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_warns_if_details_menu_view_component_slot_is_rendered
+    @file = '<% component.with_body(tag: :"details-menu") do %>'
+    @linter.run(processed_source)
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.<details-menu> has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_does_not_warn_if_inline_disable_comment
+    @file = <<~HTML
+      <%= render SomeComponent.new(tag: :"details-menu") do %><%# erblint:disable Primer::Accessibility::DetailsMenuMigration %>
+    HTML
+    @linter.run_and_update_offense_status(processed_source)
+    offenses = @linter.offenses.reject(&:disabled?)
+    assert_equal 0, offenses.count
+  end
+end

--- a/test/lib/erblint/linter_config_works_test.rb
+++ b/test/lib/erblint/linter_config_works_test.rb
@@ -14,7 +14,7 @@ class LinterConfigWorksTest < ErblintTestCase
     end
     known_linter_names ||= ERBLint::LinterRegistry.linters.map(&:simple_name)
     known_linter_names_count = known_linter_names.count { |linter| linter.include?("Primer::Accessibility") }
-    assert_equal 1, rules_enabled_in_accessibility_config
-    assert_equal 1, known_linter_names_count
+    assert_equal 2, rules_enabled_in_accessibility_config
+    assert_equal 2, known_linter_names_count
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
This adds a new linter to catch uses of `<details-menu>` which is likely from https://github.com/github/details-menu-element/. We'd like people to migrate because `Primer::Alpha::ActionMenu` offers better ergonomics and better support for assistive technologies, as well as more robust focus management. 

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
N/A

### Integration
<!-- Does this change require any updates to code in production? -->
Code in production will need to disable this rule, or disable each violation of this rule individually. 

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/accessibility/issues/3730. Refs https://github.com/github/primer/issues/2417

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
This one.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] ~~Added/updated documentation~~
- [x] ~~Added/updated previews (Lookbook)~~
- [x] ~~Tested in Chrome~~
- [x] ~~Tested in Firefox~~
- [x] ~~Tested in Safari~~
- [x] ~~Tested in Edge~~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
