### PR TITLE
Fixing modal document padding on mobile

### DIFF
--- a/.changeset/small-pants-search.md
+++ b/.changeset/small-pants-search.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Checking document scrollbar width before making dialog backdrop visible to fix issue with document padding on mobile screens.
+
+<!-- Changed components: Primer::Alpha::Dialog -->

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -101,9 +101,9 @@ export class ModalDialogElement extends HTMLElement {
       if (this.open) return
       this.setAttribute('open', '')
       this.setAttribute('aria-disabled', 'false')
-      this.#overlayBackdrop?.classList.remove('Overlay--hidden')
       document.body.style.paddingRight = `${window.innerWidth - document.body.clientWidth}px`
       document.body.style.overflow = 'hidden'
+      this.#overlayBackdrop?.classList.remove('Overlay--hidden')
       if (this.#focusAbortController.signal.aborted) {
         this.#focusAbortController = new AbortController()
       }


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Fixing an issue where modals could render offscreen due to adding too much document padding on mobile screens. Not 100% sure why showing the backdrop on dotcom causes window.innerWidth to increase far beyond document.body.clientWidth on mobile screens. It makes more sense to get the page's scrollbar width before showing the backdrop though and it fixes the issue in this case.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Before
<img width="508" alt="Screenshot 2023-07-20 at 5 45 10 PM" src="https://github.com/primer/view_components/assets/955442/ed7a94f1-3537-423b-988d-b5241fa829a8">

After
![Screenshot 2023-07-20 at 5 51 01 PM](https://github.com/primer/view_components/assets/955442/ffddf2c2-4e71-4e57-86aa-cf43e79e8db9)

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/primer/view_components/issues/2150

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Show the backdrop after the scrollbar width calculation since it seems to throw it off.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests - Not sure how to test this in capybara. I don't see the body style getting modified in the dialog tests.
- [ ] Added/updated documentation - N/A
- [ ] Added/updated previews (Lookbook) - There's an existing preview for this.
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
