### PR TITLE
Add correct fallbacks to `State` label

### DIFF
--- a/.changeset/brave-shirts-hug.md
+++ b/.changeset/brave-shirts-hug.md
@@ -1,0 +1,7 @@
+---
+"@primer/view-components": patch
+---
+
+Add correct fallbacks to `State` label
+
+<!-- Changed components: _none_ -->

--- a/app/components/primer/beta/counter.pcss
+++ b/app/components/primer/beta/counter.pcss
@@ -9,7 +9,7 @@
   line-height: calc(var(--base-size-20) - var(--borderWidth-thin) * 2); /* 20px - 2px for the borders */
   color: var(--fgColor-default);
   text-align: center;
-  background-color: var(--bgColor-neutral-muted);
+  background-color: var(--bgColor-neutral-muted, var(--color-neutral-muted));
   border: var(--borderWidth-thin) solid var(--counter-borderColor);
   border-radius: 2em;
 

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -24,17 +24,17 @@
 
 .State--open {
   color: var(--fgColor-onEmphasis);
-  background-color: var(--bgColor-open-emphasis);
+  background-color: var(--bgColor-open-emphasis, var(--color-open-emphasis));
 }
 
 .State--merged {
   color: var(--fgColor-onEmphasis);
-  background-color: var(--bgColor-done-emphasis);
+  background-color: var(--bgColor-done-emphasis, var(--color-done-emphasis));
 }
 
 .State--closed {
   color: var(--fgColor-onEmphasis);
-  background-color: var(--bgColor-closed-emphasis);
+  background-color: var(--bgColor-closed-emphasis, var(--color-closed-emphasis));
 }
 
 /* Small 24px */


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The wrong fallback is in place for this CSS, resulting in a lighter shade

![Open label](https://github.com/primer/view_components/assets/18661030/7267c1a4-ae81-4214-ac0a-a39f6ff69f4e)

Just quickly comparing the old CSS to add it here, but will adjust the fallback JSON accordingly.

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
