### PR TITLE
Fix bug in ActionMenu button where return doesn't trigger menu

### DIFF
--- a/.changeset/gold-dingos-carry.md
+++ b/.changeset/gold-dingos-carry.md
@@ -3,3 +3,5 @@
 ---
 
 Fix bug in ActionMenu button where return doesn't trigger menu
+
+<!-- Changed components: Primer::Alpha::ActionMenu -->

--- a/.changeset/gold-dingos-carry.md
+++ b/.changeset/gold-dingos-carry.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix bug in ActionMenu button where return doesn't trigger menu

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -51,14 +51,14 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   get popoverElement(): HTMLElement | null {
-    return this.invokerElement?.popoverTargetElement
+    return this.invokerElement?.popoverTargetElement || null
   }
 
-  get invokerElement(): HTMLElement | null {
+  get invokerElement(): HTMLButtonElement | null {
     const id = this.querySelector('[role=menu]')?.id
     if (!id) return null
     for (const el of this.querySelectorAll(`[aria-controls]`)) {
-      if (el.getAttribute('aria-controls') === id) return el as HTMLElement
+      if (el.getAttribute('aria-controls') === id) return el as HTMLButtonElement
     }
     return null
   }

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -1,6 +1,5 @@
 import {controller, target} from '@github/catalyst'
 import '@oddbird/popover-polyfill'
-// eslint-disable-next-line import/no-named-as-default
 import type {IncludeFragmentElement} from '@github/include-fragment-element'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -1,5 +1,7 @@
 import {controller, target} from '@github/catalyst'
-import IncludeFragmentElement from '@github/include-fragment-element'
+import '@oddbird/popover-polyfill'
+// eslint-disable-next-line import/no-named-as-default
+import type IncludeFragmentElement from '@github/include-fragment-element'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null
 type SelectedItem = {
@@ -49,7 +51,7 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   get popoverElement(): HTMLElement | null {
-    return this.querySelector<HTMLElement>('[popover]')
+    return this.invokerElement?.popoverTargetElement
   }
 
   get invokerElement(): HTMLElement | null {

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -1,7 +1,7 @@
 import {controller, target} from '@github/catalyst'
 import '@oddbird/popover-polyfill'
 // eslint-disable-next-line import/no-named-as-default
-import type IncludeFragmentElement from '@github/include-fragment-element'
+import type {IncludeFragmentElement} from '@github/include-fragment-element'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null
 type SelectedItem = {

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -57,10 +57,9 @@ module Alpha
         document.querySelector('action-menu button[aria-controls]').focus()
       JS
 
-      accept_alert do
-        # open menu, "click" on first item
-        page.driver.browser.keyboard.type(:enter, :enter)
-      end
+      page.driver.browser.keyboard.type(:enter)
+
+      assert_selector "anchored-position"
     end
 
     def test_action_anchor

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -50,6 +50,19 @@ module Alpha
       end
     end
 
+    def test_action_keydown_on_icon_button
+      visit_preview(:with_icon_button)
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu button[aria-controls]').focus()
+      JS
+
+      accept_alert do
+        # open menu, "click" on first item
+        page.driver.browser.keyboard.type(:enter, :enter)
+      end
+    end
+
     def test_action_anchor
       visit_preview(:with_actions)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/github/primer/issues/2452

There was a bug with the ActionMenu where when the target was an IconButton the menu wouldn't appear. This was because the component was looking searching for a broad `[popover]` query on the page and it was picking up the Tooltip the button has.

### Integration

No

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
