### PR TITLE
Use new system args docs url

### DIFF
--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -185,7 +185,7 @@ namespace :docs do
     # add to this as more pages are migrated
     INTRO_URL_MAP = {
       "/" => "https://primer.style/design/guides/development/rails",
-      "/system-arguments" => "https://primer.style/design/foundations/system-arguments",
+      "/system-arguments" => "https://primer.style/view-components/lookbook/pages/system_arguments",
       "/status" => "https://primer.style/design/guides/status",
       "/migration" => "https://primer.style/design/guides/development/rails#migration-and-upgrade-guides"
     }.freeze


### PR DESCRIPTION
### What are you trying to accomplish?

We recently moved the docs for system arguments to Lookbook. While the old docsite is mostly gone, let's fix the URL for completeness sake.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes needed in prod.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.