### PR TITLE
Allow form buttons to be disabled on click via data-disable-with

### DIFF
--- a/.changeset/curly-waves-travel.md
+++ b/.changeset/curly-waves-travel.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Allow form buttons to be disabled on click with data-disable-with
+
+<!-- Changed components: _none_ -->

--- a/app/forms/submit_button_form.rb
+++ b/app/forms/submit_button_form.rb
@@ -14,7 +14,7 @@ class SubmitButtonForm < ApplicationForm
     )
 
     my_form.group(layout: :horizontal) do |button_group|
-      button_group.submit(name: :submit, label: "Submit", scheme: :primary, mb: 3) do |component|
+      button_group.submit(name: :submit, label: "Submit", scheme: :primary, mb: 3, disabled: true) do |component|
         component.with_leading_visual_icon(icon: :"check-circle")
       end
 

--- a/lib/primer/forms/button.rb
+++ b/lib/primer/forms/button.rb
@@ -40,10 +40,9 @@ module Primer
         # rails uses a string for this, but PVC wants a symbol
         @input.merge_input_arguments!(type: type.to_sym)
 
-        # Never disable buttons. This overrides the global
-        # ActionView::Base.automatically_disable_submit_tag setting.
-        # Disabling buttons is not accessible.
-        @input.remove_input_data(:disable_with)
+        # Never allow buttons to be disabled. Disabling buttons is not accessible.
+        # See: https://primer.style/design/ui-patterns/saving#state
+        @input.input_arguments.delete(:disabled)
       end
 
       def input_arguments

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -147,9 +147,11 @@ module Primer
           input_data[key] = value
         end
 
+        # :nocov:
         def remove_input_data(key)
           input_data.delete(key)
         end
+        # :nocov:
 
         def merge_input_arguments!(arguments)
           arguments.each do |k, v|

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -132,11 +132,11 @@ class Primer::FormsTest < Minitest::Test
     end
   end
 
-  def test_renders_a_submit_button_without_data_disable_with
+  def test_disallows_disabled_buttons
     render_preview :submit_button_form
 
     button = page.find_all("button[type=submit]").first
-    assert_nil button["data-disable-with"]
+    assert_nil button["disabled"]
   end
 
   def test_renders_buttons_with_primer_utility_margins


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I was recently reading a discussion on Slack and realized the Primer forms framework does not support Rails' `data-disable-with` functionality. In fact, the framework explicitly _disallows_ it by deleting the `data-disable-with` attribute if it is applied to a button. My intent here was to disallow the `disabled` attribute, since form buttons should never be disabled according to [our guidelines](https://primer.style/design/ui-patterns/saving#state). The `data-disable-with` attribute is nice to have because it prevents forms from being submitted multiple times. This PR restores `data-disable-with` and removes `disabled` attributes instead.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes required in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated previews (Lookbook)