### PR TITLE
Bump Doctocat 4.6.1

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@primer/behaviors": "^1.3.5",
         "@primer/css": "^21.0.7",
-        "@primer/gatsby-theme-doctocat": "^4.4.3",
+        "@primer/gatsby-theme-doctocat": "^4.6.1",
         "@primer/octicons-react": "^19.4.0",
         "@primer/primitives": "^7.11.14",
         "@primer/react": "^35.26.0",
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/@primer/gatsby-theme-doctocat": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.4.3.tgz",
-      "integrity": "sha512-OdvE6k9F6ZXbYFXpRVKWcCc7SwTQBER1ojcFzVQRUi9SXuEcF8Qzq/OG4ojliM+itvAx1kSyfo3G9yHxVl2xNw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.6.1.tgz",
+      "integrity": "sha512-E1hdvW0p6e8JPiH8aL1idz4WHgY/WqqOhquTIObqP/242dqjUFtwYL8VE73uwTfbP0m7wWq3faSddDUx8/VpvA==",
       "dependencies": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",
@@ -29648,9 +29648,9 @@
       }
     },
     "@primer/gatsby-theme-doctocat": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.4.3.tgz",
-      "integrity": "sha512-OdvE6k9F6ZXbYFXpRVKWcCc7SwTQBER1ojcFzVQRUi9SXuEcF8Qzq/OG4ojliM+itvAx1kSyfo3G9yHxVl2xNw==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-4.6.1.tgz",
+      "integrity": "sha512-E1hdvW0p6e8JPiH8aL1idz4WHgY/WqqOhquTIObqP/242dqjUFtwYL8VE73uwTfbP0m7wWq3faSddDUx8/VpvA==",
       "requires": {
         "@babel/preset-env": "^7.5.5",
         "@babel/preset-react": "^7.0.0",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@primer/behaviors": "^1.3.5",
     "@primer/css": "^21.0.7",
-    "@primer/gatsby-theme-doctocat": "^4.4.3",
+    "@primer/gatsby-theme-doctocat": "^4.6.1",
     "@primer/octicons-react": "^19.4.0",
     "@primer/primitives": "^7.11.14",
     "@primer/react": "^35.26.0",


### PR DESCRIPTION
- [x] Bumps @primer/gatsby-theme-doctocat from 4.4.3 to 4.6.1.
- [x] Removes custom primer navigation

Related issues and PR:
- Epic https://github.com/github/primer/issues/2015
- Doctocat bump in design: https://github.com/primer/design/pull/537
- Doctocat bump in brand: https://github.com/primer/brand/pull/357
- Doctocat bumo in react: https://github.com/primer/react/pull/3568