### PR TITLE
guard all popover calls

### DIFF
--- a/.changeset/quiet-mirrors-cover.md
+++ b/.changeset/quiet-mirrors-cover.md
@@ -1,0 +1,7 @@
+---
+"@primer/view-components": patch
+---
+
+Guard tooltip popover calls from `Failed to execute 'showPopover' on 'HTMLElement': Not supported on elements that do not have a valid value for the 'popover' attribute.`
+
+<!-- Changed components: Primer::Alpha::Tooltip -->

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -124,7 +124,11 @@ export class ActionMenuElement extends HTMLElement {
       // appears as if hitting enter does nothing. Curiously, clicking instead
       // works fine.
       if (this.selectVariant !== 'multiple') {
-        setTimeout(() => this.popoverElement?.hidePopover())
+        setTimeout(() => {
+          if (this.popoverElement?.matches(':popover-open')) {
+            this.popoverElement?.hidePopover()
+          }
+        })
       }
 
       // The rest of the code below deals with single/multiple selection behavior, and should not

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -208,7 +208,7 @@ class ToolTipElement extends HTMLElement {
   set hiddenFromView(value: true | false) {
     if (value && this.matches(':popover-open')) {
       this.hidePopover()
-    } else if (!value && !this.matches(':popover-open')) {
+    } else if (!value && this.matches(':not(:popover-open)')) {
       this.showPopover()
     }
   }
@@ -277,9 +277,9 @@ class ToolTipElement extends HTMLElement {
     const shouldHide = isMouseLeaveFromButton || isEscapeKeydown || isMouseDownOnButton || isOpeningOtherPopover
 
     await Promise.resolve()
-    if (!showing && shouldShow) {
+    if (!showing && shouldShow && this.matches(':not(:popover-open)')) {
       this.showPopover()
-    } else if (showing && shouldHide) {
+    } else if (showing && shouldHide && this.matches(':popover-open')) {
       this.hidePopover()
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

We're seeing some errors related to showing/hiding of popovers; sometimes these are due to subtle timings and are a little difficult to catch. Mostly they just add noise to Sentry. An easy way to resolve these is to guard all calls to `showPopover`/`hidePopover` to do one last check before calling.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
N/A

### Integration
<!-- Does this change require any updates to code in production? -->
N/A

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->
N/A

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
