### PR TITLE
Fix action list item color contrast issue (hover state, danger style)

### DIFF
--- a/.changeset/spicy-experts-exercise.md
+++ b/.changeset/spicy-experts-exercise.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fix color contrast issues for action list hover state (danger style)
+
+<!-- Changed components: Primer::Alpha::ActionList, Primer::Alpha::ActionMenu -->

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -255,7 +255,8 @@
         background: var(--control-danger-bgColor-hover);
 
         & .ActionListItem-label,
-        & .ActionListItem-visual {
+        & .ActionListItem-visual,
+        & .ActionListItem-description {
           color: var(--control-danger-fgColor-hover);
         }
       }
@@ -266,7 +267,8 @@
         background: var(--control-danger-bgColor-active);
 
         & .ActionListItem-label,
-        & .ActionListItem-visual {
+        & .ActionListItem-visual,
+        & .ActionListItem-description {
           color: var(--control-danger-fgColor-hover);
         }
       }


### PR DESCRIPTION
### What are you trying to accomplish?

This PR addresses a color contrast issue when hovering over `ActionList`/`ActionMenu` items, specifically when rendering in the "danger" style.

### Screenshots

|Before|After|
|-|-|
|<img width="217" alt="'Before' screenshot showing an ActionList. The last item is being hovered and has red label text, gray description text, and a lighter red background color." src="https://github.com/primer/view_components/assets/575280/55cb9f82-757f-4ff6-a1cf-8e67af960b4f">|<img width="215" alt="'After' screenshot showing an ActionList. The last item is being hovered and has red label text, red description text, and a lighter red background color." src="https://github.com/primer/view_components/assets/575280/2a54da3a-dfb9-4553-a316-6eb46a24cfc1">|

### Integration
<!-- Does this change require any updates to code in production? -->

No updates necessary in production.

#### List the issues that this change affects.

Partially addresses https://github.com/github/primer/issues/2249

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge