### PR TITLE
Add support for capitalize to text-transform

### DIFF
--- a/.changeset/six-students-repeat.md
+++ b/.changeset/six-students-repeat.md
@@ -3,3 +3,5 @@
 ---
 
 Add support for capitalize to text-transform
+
+<!-- Changed components: Primer::BaseComponent -->

--- a/.changeset/six-students-repeat.md
+++ b/.changeset/six-students-repeat.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Add support for capitalize to text-transform

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -139,7 +139,7 @@ module Primer
     # | `font_style` | Symbol | Font style. <%= one_of([:italic]) %> |
     # | `font_weight` | Symbol | Font weight. <%= one_of([:light, :normal, :bold, :emphasized]) %> |
     # | `text_align` | Symbol | Text alignment. <%= one_of([:left, :right, :center]) %> |
-    # | `text_transform` | Symbol | Text transformation. <%= one_of([:uppercase]) %> |
+    # | `text_transform` | Symbol | Text transformation. <%= one_of([:uppercase, :capitalize]) %> |
     # | `underline` | Boolean | Whether text should be underlined. |
     # | `word_break` | Symbol | Whether to break words on line breaks. <%= one_of(Primer::Classify::Utilities.mappings(:word_break)) %> |
     #

--- a/lib/primer/classify/utilities.yml
+++ b/lib/primer/classify/utilities.yml
@@ -1558,6 +1558,8 @@
 :text_transform:
   :uppercase:
   - text-uppercase
+  :capitalize:
+  - text-capitalize
 :text_align:
   :right:
   - text-right

--- a/lib/tasks/custom_utilities.yml
+++ b/lib/tasks/custom_utilities.yml
@@ -51,6 +51,8 @@
 :text_transform:
   :uppercase:
   - text-uppercase
+  :capitalize:
+  - text-capitalize
 :text_align:
   :right:
   - text-right

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -213,6 +213,7 @@ class PrimerClassifyTest < Minitest::Test
 
   def test_text_transform
     assert_generated_class("text-uppercase", { text_transform: :uppercase })
+    assert_generated_class("text-capitalize", { text_transform: :capitalize })
   end
 
   def test_font_weight


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Add support for capitalize on text-transform. It's already supported by the CSS class `text-capitalize` https://primer.style/design/foundations/css-utilities/typography#typographic-styles


#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Added the change to the list where these utilities are already defined

### Anything you want to highlight for special attention from reviewers?

Is there anything else that needs to be updated?

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
