### PR TITLE
Better gem caching for preview deploys

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -33,18 +33,27 @@ jobs:
       url: ${{ env.APP_URL }}
     steps:
     - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
+    - name: Install lib deps
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
         bundler-cache: true
       env:
         BUNDLE_GEMFILE: Gemfile
-    - uses: ruby/setup-ruby@v1
+    - name: Install demo app deps
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
         bundler-cache: true
       env:
         BUNDLE_GEMFILE: demo/Gemfile
+    - name: Install Kuby deps
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+      env:
+        BUNDLE_GEMFILE: demo/gemfiles/kuby.gemfile
     - name: Docker login
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -33,11 +33,18 @@ jobs:
       url: ${{ env.APP_URL }}
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.2'
         bundler-cache: true
+      env:
+        BUNDLE_GEMFILE: Gemfile
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.2'
+        bundler-cache: true
+      env:
+        BUNDLE_GEMFILE: demo/Gemfile
     - name: Docker login
       env:
         AZURE_ACR_PASSWORD: ${{ secrets.AZURE_ACR_PASSWORD }}


### PR DESCRIPTION
### What are you trying to accomplish?

We have three different gemfiles that install gems for 1) the lib, 2) the demo app, and 3) the Kuby deploy. Right now, we're only caching gems for the lib.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

This PR adds several additional ruby/setup-ruby steps for the other two gemfiles. Including this action multiple times seems to be ok and takes care of a lot of the difficult minutiae of caching bundles.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.