### PR TITLE
Fix action list item playground description control

### DIFF
--- a/previews/primer/alpha/action_list_preview.rb
+++ b/previews/primer/alpha/action_list_preview.rb
@@ -228,7 +228,7 @@ module Primer
 
           item.with_trailing_action(icon: "plus", "aria-label": "Button tooltip", size: :medium) if trailing_action && trailing_action != :none
 
-          item.description { description } if description
+          item.with_description { description } if description
 
           item.with_tooltip(text: "Tooltip text", for_id: "tooltip-test", type: :description) if tooltip
         end


### PR DESCRIPTION
### What are you trying to accomplish?

The `description` param on the `ActionList` item playground preview doesn't have any effect. This PR fixes it.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.