### PR TITLE
Avoid building assets twice in CI for the CSS selector test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,5 @@ jobs:
           cache: 'npm'
       - name: NPM Build
         run: npm ci
-      - name: Build Output Selectors
-        run: script/build-assets
       - name: Test CSS
         run: bundle exec rake test:component_css


### PR DESCRIPTION
### What are you trying to accomplish?

`npm ci` builds assets after install, so there's no need to run `script/build-assets` again.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.