### PR TITLE
Allow disabling submit buttons

### DIFF
--- a/.changeset/eighty-carrots-protect.md
+++ b/.changeset/eighty-carrots-protect.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Allow disabling submit buttons
+
+<!-- Changed components: Primer::Alpha::FormButton, Primer::Alpha::SubmitButton -->

--- a/lib/primer/forms/button.rb
+++ b/lib/primer/forms/button.rb
@@ -39,10 +39,6 @@ module Primer
 
         # rails uses a string for this, but PVC wants a symbol
         @input.merge_input_arguments!(type: type.to_sym)
-
-        # Never allow buttons to be disabled. Disabling buttons is not accessible.
-        # See: https://primer.style/design/ui-patterns/saving#state
-        @input.input_arguments.delete(:disabled)
       end
 
       def input_arguments

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -132,13 +132,6 @@ class Primer::FormsTest < Minitest::Test
     end
   end
 
-  def test_disallows_disabled_buttons
-    render_preview :submit_button_form
-
-    button = page.find_all("button[type=submit]").first
-    assert_nil button["disabled"]
-  end
-
   def test_renders_buttons_with_primer_utility_margins
     render_preview :submit_button_form
 


### PR DESCRIPTION
### What are you trying to accomplish?

In a [recent PR](https://github.com/primer/view_components/pull/2164), I removed the ability to disable submit buttons in the Primer forms framework. Unfortunately dotcom includes a [use-case](https://github.com/github/github/pull/200960) where I believe disabling the submit button is valid, so unfortunately the framework needs to allow it.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests