### PR TITLE
Button tooltips should not have the label type.

### DIFF
--- a/.changeset/tasty-waves-rhyme.md
+++ b/.changeset/tasty-waves-rhyme.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Updates Primer::Beta::Button.with_tooltip to not accept `:label` type.
+
+<!-- Changed components: Primer::Beta::Button -->

--- a/app/components/primer/beta/button.rb
+++ b/app/components/primer/beta/button.rb
@@ -81,8 +81,9 @@ module Primer
       renders_one :tooltip, lambda { |**system_arguments|
         raise ArgumentError, "Buttons with a tooltip must have a unique `id` set on the `Button`." if @id.blank? && !Rails.env.production?
 
+        ActiveSupport::Deprecation.warn("Buttons with visible text should not use a `label` tooltip. Consider using Primer::Beta::IconButton instead.") if system_arguments[:type] == :label
         system_arguments[:for_id] = @id
-        system_arguments[:type] ||= :description
+        system_arguments[:type] = :description
 
         Primer::Alpha::Tooltip.new(**system_arguments)
       }

--- a/previews/primer/alpha/tooltip_preview.rb
+++ b/previews/primer/alpha/tooltip_preview.rb
@@ -36,6 +36,7 @@ module Primer
       def with_right_most_position(type: :description, direction: :s, tooltip_text: "A tooltip with very very very very long description that is not very concise...")
         render_with_template(
           locals: {
+            type: type,
             direction: direction,
             tooltip_text: tooltip_text
           }

--- a/previews/primer/alpha/tooltip_preview.rb
+++ b/previews/primer/alpha/tooltip_preview.rb
@@ -4,50 +4,38 @@ module Primer
   module Alpha
     # @label Tooltip
     class TooltipPreview < ViewComponent::Preview
-      # @param type [Symbol] select [["Description", description], ["Label", label]]
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def playground(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def playground(direction: :s, tooltip_text: "You can press a button")
         render(Primer::Beta::Button.new(id: "button-with-tooltip")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
+          component.with_tooltip(text: tooltip_text, direction: direction)
           "Button"
         end
       end
 
-      # @param type [Symbol] select [["Description", description], ["Label", label]]
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def default(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def default(direction: :s, tooltip_text: "You can press a button")
         render(Primer::Beta::Button.new(id: "button-with-tooltip")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
+          component.with_tooltip(text: tooltip_text, direction: direction)
           "Button"
         end
       end
 
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def label_tooltip_on_button_with_existing_labelledby(type: :label, direction: :s, tooltip_text: "You can press a button")
-        render(Primer::Beta::Button.new(id: "button-with-existing-label", "aria-labelledby": "existing-label-id")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
-          "Button"
-        end
-      end
-
-      # @param direction select [s, n, e, w, ne, nw, se, sw]
-      # @param tooltip_text text
-      def description_tooltip_on_button_with_existing_describedby(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def description_tooltip_on_button_with_existing_describedby(direction: :s, tooltip_text: "You can press a button")
         render(Primer::Beta::Button.new(id: "button-with-existing-description", "aria-describedby": "existing-description-id")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
+          component.with_tooltip(text: tooltip_text, direction: direction)
           "Button"
         end
       end
 
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def with_right_most_position(type: :description, direction: :s, tooltip_text: "A tooltip with very very very very long description that is not very concise...")
+      def with_right_most_position(direction: :s, tooltip_text: "A tooltip with very very very very long description that is not very concise...")
         render_with_template(
           locals: {
-            type: type,
             direction: direction,
             tooltip_text: tooltip_text
           }
@@ -56,10 +44,9 @@ module Primer
 
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def with_multiple_on_a_page(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def with_multiple_on_a_page(direction: :s, tooltip_text: "You can press a button")
         render_with_template(
           locals: {
-            type: type,
             direction: direction,
             tooltip_text: tooltip_text
           }
@@ -68,17 +55,17 @@ module Primer
 
       # @!group Tooltip enabled elements
       # @label Tooltip with Primer::Beta::Button
-      def tooltip_with_button(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def tooltip_with_button(direction: :s, tooltip_text: "You can press a button")
         render(Primer::Beta::Button.new(id: "button-with-tooltip")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
+          component.with_tooltip(text: tooltip_text, direction: direction)
           "Button"
         end
       end
 
       # @label Tooltip with Primer::Beta::Link
-      def tooltip_with_link(type: :description, direction: :s, tooltip_text: "You can press a button")
+      def tooltip_with_link(direction: :s, tooltip_text: "You can press a button")
         render(Primer::Beta::Link.new(href: "#link-with-tooltip", id: "link-with-tooltip")) do |component|
-          component.with_tooltip(text: tooltip_text, type: type, direction: direction)
+          component.with_tooltip(text: tooltip_text, direction: direction)
           "Button"
         end
       end

--- a/previews/primer/alpha/tooltip_preview.rb
+++ b/previews/primer/alpha/tooltip_preview.rb
@@ -33,7 +33,7 @@ module Primer
 
       # @param direction select [s, n, e, w, ne, nw, se, sw]
       # @param tooltip_text text
-      def with_right_most_position(direction: :s, tooltip_text: "A tooltip with very very very very long description that is not very concise...")
+      def with_right_most_position(type: :description, direction: :s, tooltip_text: "A tooltip with very very very very long description that is not very concise...")
         render_with_template(
           locals: {
             direction: direction,

--- a/previews/primer/alpha/tooltip_preview/with_multiple_on_a_page.html.erb
+++ b/previews/primer/alpha/tooltip_preview/with_multiple_on_a_page.html.erb
@@ -1,14 +1,14 @@
 <div>
   <%= render(Primer::Beta::Button.new(id: "button-1")) do |component| %>
-    <% component.with_tooltip(text: tooltip_text, type: type, direction: direction) %>
+    <% component.with_tooltip(text: tooltip_text, direction: direction) %>
     Button 1
   <% end %>
   <%= render(Primer::Beta::Button.new(id: "button-2")) do |component| %>
-    <% component.with_tooltip(text: tooltip_text, type: type, direction: direction) %>
+    <% component.with_tooltip(text: tooltip_text, direction: direction) %>
     Button 2
   <% end %>
   <%= render(Primer::Beta::Button.new(id: "button-3")) do |component| %>
-    <% component.with_tooltip(text: tooltip_text, type: type, direction: direction) %>
+    <% component.with_tooltip(text: tooltip_text, direction: direction) %>
     Button 3
   <% end %>
 </div>

--- a/test/system/alpha/tooltip_test.rb
+++ b/test/system/alpha/tooltip_test.rb
@@ -77,24 +77,6 @@ module Alpha
       assert_equal("existing-description-id #{tooltip_id}", find("button")["aria-describedby"])
     end
 
-    def test_does_not_render_duplicate_labelledby_id_when_attribute_callback_triggered
-      visit_preview(:label_tooltip_on_button_with_existing_labelledby)
-
-      tooltip_id = find("tool-tip", visible: :hidden)["id"]
-      assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
-      evaluate_script("(function(el) {
-        return (
-          el.setAttribute('data-type', 'description')
-        );
-      })(arguments[0]);", find("tool-tip", visible: :hidden))
-      evaluate_script("(function(el) {
-        return (
-          el.setAttribute('data-type', 'label')
-        );
-      })(arguments[0]);", find("tool-tip", visible: :hidden))
-      assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
-    end
-
     def test_never_aria_hidden_when_tooltip_is_description
       visit_preview(:default)
 

--- a/test/system/alpha/tooltip_test.rb
+++ b/test/system/alpha/tooltip_test.rb
@@ -52,13 +52,6 @@ module Alpha
       assert_selector("tool-tip", visible: :hidden)
     end
 
-    def test_appends_to_existing_aria_labelledby
-      visit_preview(:label_tooltip_on_button_with_existing_labelledby)
-
-      tooltip_id = find("tool-tip", visible: :hidden)["id"]
-      assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
-    end
-
     def test_appends_to_existing_aria_describedby
       visit_preview(:description_tooltip_on_button_with_existing_describedby)
 
@@ -100,14 +93,6 @@ module Alpha
         );
       })(arguments[0]);", find("tool-tip", visible: :hidden))
       assert_equal("existing-label-id #{tooltip_id}", find("button")["aria-labelledby"])
-    end
-
-    def test_always_aria_hidden_when_tooltip_is_label
-      visit_preview(:label_tooltip_on_button_with_existing_labelledby)
-
-      assert_selector("tool-tip[aria-hidden='true']", visible: :hidden)
-      find("button").send_keys("tab") # focus
-      assert_selector("tool-tip[aria-hidden='true']", visible: :visible)
     end
 
     def test_never_aria_hidden_when_tooltip_is_description


### PR DESCRIPTION
_Authors: @radglob_

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
`Primer::Beta::Button.with_tooltip` should no longer use the `label` type. This causes an issue documented in https://github.com/github/primer/issues/2194 where the generated `aria-labelledby` attribute would override the inner text of a button to users using screen readers. Tooltips on buttons with visible text should only use the `description` type, which generates an `aria-describedby` attribute.

Updated the previews for the Primer::Alpha::Tooltip (and removed one) to only show examples with the `:label` type and added a deprecation warning for cases where the `:label` type is used.

### Integration
Cases where `Primer::Beta::Button.with_tooltip` is called with the `:label` type will continue to render successfully, defaulting to the `:description` type instead. They should probably be updated to avoid the deprecation warning.

#### List the issues that this change affects.

Closes https://github.com/github/primer/issues/2194

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
Considering that it seemed somewhat difficult to detect all cases where a button has visible text, imploring users to use the `IconButton` component in cases where they want to use the tooltip as a label makes more sense.

### Accessibility
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [X] Added/updated previews (Lookbook)
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
