### PR TITLE
add aria-invalid when fields are invalid

### DIFF
--- a/.changeset/thick-snakes-sin.md
+++ b/.changeset/thick-snakes-sin.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+add aria-invalid when fields are invalid
+
+<!-- Changed components: Primer::Alpha::CheckBox, Primer::Alpha::CheckBoxGroup, Primer::Alpha::FormButton, Primer::Alpha::MultiInput, Primer::Alpha::RadioButton, Primer::Alpha::RadioButtonGroup, Primer::Alpha::Select, Primer::Alpha::SubmitButton, Primer::Alpha::TextArea, Primer::Alpha::TextField, Primer::Alpha::ToggleSwitch -->

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -115,6 +115,7 @@ module Primer
           end
 
           add_input_aria(:required, true) if required?
+          add_input_aria(:invalid, true) if invalid?
           add_input_aria(:describedby, ids.values) if ids.any?
 
           # avoid browser-native validation, which doesn't match Primer's style

--- a/test/components/alpha/text_field_test.rb
+++ b/test/components/alpha/text_field_test.rb
@@ -64,6 +64,7 @@ class PrimerAlphaTextFieldTest < MiniTest::Test
     render_inline(Primer::Alpha::TextField.new(**@default_params, invalid: true))
 
     assert_selector "input[invalid]"
+    assert_selector "input[aria-invalid]"
   end
 
   def test_renders_the_component_with_an_inset_style

--- a/test/lib/primer/forms/form_control_test.rb
+++ b/test/lib/primer/forms/form_control_test.rb
@@ -28,6 +28,8 @@ class Primer::Forms::FormControlTest < Minitest::Test
       end
     end
 
+    # the input field is marked as invalid
+    assert_selector("input[name=deep_thought\\[ultimate_answer\\]][invalid][aria-invalid]")
     # there are validation-related elements
     assert_selector(".FormControl-inlineValidation", visible: :visible)
     # the validation elements don't have the data attributes that primer-text-field needs
@@ -35,7 +37,7 @@ class Primer::Forms::FormControlTest < Minitest::Test
     refute_selector("[data-target='primer-text-field.validationMessageElement']", visible: :all)
   end
 
-  def test_auto_check_generates_validtion_elements
+  def test_auto_check_generates_validation_elements
     model = DeepThought.new(42)
 
     render_in_view_context do

--- a/test/lib/primer/forms/form_helper_test.rb
+++ b/test/lib/primer/forms/form_helper_test.rb
@@ -36,6 +36,19 @@ class Primer::Forms::FormHelperTest < Minitest::Test
     assert_equal text_field["name"], "deep_thought[ultimate_answer]"
   end
 
+  def test_the_input_is_marked_as_invalid
+    model = DeepThought.new(41)
+    model.valid? # populate validation error messages
+
+    render_in_view_context do
+      primer_form_with(model: model, url: "/foo") do |f|
+        render(SingleTextFieldForm.new(f))
+      end
+    end
+
+    assert_selector("input[name=deep_thought\\[ultimate_answer\\]][invalid][aria-invalid]")
+  end
+
   def test_the_input_is_described_by_the_validation_message
     model = DeepThought.new(41)
     model.valid? # populate validation error messages

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -145,6 +145,12 @@ class Primer::FormsTest < Minitest::Test
     assert_selector "input.color-fg-success[type=text]"
   end
 
+  def test_the_input_is_marked_as_invalid
+    render_preview :invalid_form
+
+    assert_selector "input[type=text][name=last_name][invalid][aria-invalid]"
+  end
+
   def test_autofocuses_the_first_invalid_input
     render_preview :invalid_form
 


### PR DESCRIPTION
### What are you trying to accomplish?

During an [accessibly review](https://github.com/github/github/pull/283228#issuecomment-1671835190) of https://github.com/github/github/pull/283228 it was noted that when we add the `invalid` attribute to an input element we should also be adding the `aria-invalid` attribute. 

### Integration
N/A


#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

I modified `Primer::Forms::Dsl::Input` to include `aria-invalid` as needed. 

### Anything you want to highlight for special attention from reviewers?

Are there other places I should be adding tests for this? 

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
