### PR TITLE
Label BorderBox lists with their header

### DIFF
--- a/.changeset/lemon-bulldogs-accept.md
+++ b/.changeset/lemon-bulldogs-accept.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Label BorderBox lists with their header
+
+<!-- Changed components: Primer::Beta::BorderBox -->

--- a/app/components/primer/beta/border_box.html.erb
+++ b/app/components/primer/beta/border_box.html.erb
@@ -2,11 +2,11 @@
   <%= header %>
   <%= body %>
   <% if rows.any? %>
-    <ul>
+    <%= render Primer::BaseComponent.new(**@list_arguments) do %>
       <% rows.each do |row| %>
         <%= row %>
       <% end %>
-    </ul>
+    <% end %>
   <% end %>
   <%= footer %>
 <% end %>

--- a/app/components/primer/beta/border_box.rb
+++ b/app/components/primer/beta/border_box.rb
@@ -82,10 +82,21 @@ module Primer
         )
 
         @system_arguments[:system_arguments_denylist] = { [:p, :pt, :pb, :pr, :pl] => PADDING_SUGGESTION }
+        @list_arguments = { tag: :ul }
       end
 
       def render?
         rows.any? || header.present? || body.present? || footer.present?
+      end
+
+      private
+
+      def before_render
+        return unless header
+
+        @list_arguments[:aria] = {
+          labelledby: header.id
+        }
       end
     end
   end

--- a/app/components/primer/beta/border_box/header.rb
+++ b/app/components/primer/beta/border_box/header.rb
@@ -7,6 +7,8 @@ module Primer
       #
       # @accessibility When using `header.with_title`, set `tag` to one of `h1`, `h2`, `h3`, etc. based on what is appropriate for the page context. <%= link_to_heading_practices %>
       class Header < Primer::Component
+        attr_reader :id
+
         status :beta
 
         TITLE_TAG_FALLBACK = :h2
@@ -29,11 +31,13 @@ module Primer
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(**system_arguments)
           @system_arguments = system_arguments
+          @system_arguments[:id] ||= self.class.generate_id
           @system_arguments[:tag] = :div
           @system_arguments[:classes] = class_names(
             "Box-header",
             system_arguments[:classes]
           )
+          @id = @system_arguments[:id]
         end
       end
     end

--- a/test/components/beta/border_box_test.rb
+++ b/test/components/beta/border_box_test.rb
@@ -29,7 +29,7 @@ class PrimerBetaBorderBoxTest < Minitest::Test
       component.with_row { "Row" }
     end
 
-    id = page.find_css('.Box-header').first[:id]
+    id = page.find_css(".Box-header").first[:id]
     assert_selector "ul[aria-labelledby='#{id}']"
   end
 

--- a/test/components/beta/border_box_test.rb
+++ b/test/components/beta/border_box_test.rb
@@ -23,6 +23,16 @@ class PrimerBetaBorderBoxTest < Minitest::Test
     assert_selector("div.Box-header", text: "Header")
   end
 
+  def test_labels_list_with_header
+    render_inline(Primer::Beta::BorderBox.new) do |component|
+      component.with_header { "Header" }
+      component.with_row { "Row" }
+    end
+
+    id = page.find_css('.Box-header').first[:id]
+    assert_selector "ul[aria-labelledby='#{id}']"
+  end
+
   def test_renders_body
     render_inline(Primer::Beta::BorderBox.new) do |component|
       component.with_body { "Body" }


### PR DESCRIPTION
### What are you trying to accomplish?

`BorderBox` lists, i.e. `<ul>`s, should have an `aria-labelledby` pointing at the header, if it exists.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes required in production,

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/2546

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.