### PR TITLE
Fix guide URLs (in lib/primer/deprecations.yml)

### DIFF
--- a/.changeset/chilly-poems-sparkle.md
+++ b/.changeset/chilly-poems-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@primer/view-components": patch
+---
+
+Fix guide URLs (in lib/primer/deprecations.yml)
+
+<!-- Changed components: _none_ -->

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -20,7 +20,7 @@ deprecations:
   - component: "Primer::ButtonComponent"
     autocorrect: false
     replacement: "Primer::Beta::Button"
-    guide: "https://primer.style/view-components/guides/primer_button_component"
+    guide: "https://primer.style/design/guides/development/rails/migration-guides/primer-button-component"
 
   - component: "Primer::IconButton"
     autocorrect: true
@@ -29,7 +29,7 @@ deprecations:
   - component: "Primer::LayoutComponent"
     autocorrect: false
     replacement: "Primer::Alpha::Layout"
-    guide: "https://primer.style/view-components/guides/primer_layout_component"
+    guide: "https://primer.style/design/guides/development/rails/migration-guides/primer-layout-component"
 
   - component: "Primer::Navigation::TabComponent"
     autocorrect: true
@@ -42,4 +42,4 @@ deprecations:
   - component: "Primer::Truncate"
     autocorrect: false
     replacement: "Primer::Beta::Truncate"
-    guide: "https://primer.style/view-components/guides/primer_truncate"
+    guide: "https://primer.style/design/guides/development/rails/migration-guides/primer-truncate"


### PR DESCRIPTION
The previous URLs are returning 404 at the moment.

_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Fix guide URLs which I think are used for instance with ERB lint, which is where I originally saw the issue.

### Screenshots

<img width="1040" alt="Screenshot of logs from Action saying: 'Primer:: ButtonComponent' has been deprecated. Please update your code to use 'Primer:: Beta:: Button'. See https://primer.style/view-components/guides/primer_button_component for more information." src="https://github.com/primer/view_components/assets/809707/149d64c5-66e8-484d-99ff-7a18cc07ff1b">

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Searched the docs and found replacement URLs.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
