### PR TITLE
Support old open format for popover

### DIFF
--- a/.changeset/odd-pumas-live.md
+++ b/.changeset/odd-pumas-live.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fix errors in older browsers with :popover-open
+
+<!-- Changed components: Primer::Alpha::Tooltip -->


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

According to https://github.slack.com/archives/CGJTTJ738/p1691782328384149 we're still getting some errors from Chrome clients that support popover but use the old `:open` psuedo state. This attempts to avoid those errors by conditionally checking `:open` if supported.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
N/A

### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->
https://github.slack.com/archives/CGJTTJ738/p1691782328384149

Resolves sentry issues.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
I chose to write a check to see if `:open` is supported; that gets cached so it only occurs once per session. If `:open` is supported then this will use that to check if the popover is open. If it's not supported then it falls back to `:popover-open`.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->
N/A

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
