### PR TITLE
Fix generation of static files

### DIFF
--- a/.github/workflows/static-files.yml
+++ b/.github/workflows/static-files.yml
@@ -9,19 +9,11 @@ jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-      # Use the primer GitHub App for authentication.
-      # See: https://github.com/organizations/primer/settings/apps/primer
-      - id: get-access-token
-        uses: camertron/github-app-installation-auth-action@v1
-        with:
-          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
-          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
+      # Unfortunately we can't use the primer GitHub App and camertron/github-app-installation-auth-action
+      # because branch protection rules cannot be bypassed by Apps.
       - uses: actions/checkout@v3
         with:
-          token: ${{ steps.get-access-token.outputs.access-token }}
+          token: ${{ secrets.GPR_AUTH_TOKEN_SHARED }}
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'


### PR DESCRIPTION
### What are you trying to accomplish?
A [recent PR](https://github.com/primer/view_components/pull/2194) switched us over to using the primer GitHub App (instead of a shared PAT) to commit static files back to the repo. Unfortunately it appears GitHub Apps cannot bypass branch protection rules, specifically required status checks and the changes-must-be-submitted-via-PR option. Let's revert back to the PAT for now while I research how to get this working with the App.

### Integration
<!-- Does this change require any updates to code in production? -->
No changes necessary in prod.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.