### PR TITLE
Fix accessibility bug of missing accessible name on Dialog

### DIFF
--- a/.changeset/rich-donkeys-beam.md
+++ b/.changeset/rich-donkeys-beam.md
@@ -3,3 +3,5 @@
 ---
 
 Fix accessibility bug of missing accessible name on `Primer::Alpha::Dialog`
+
+<!-- Changed components: Primer::Alpha::Dialog -->

--- a/.changeset/rich-donkeys-beam.md
+++ b/.changeset/rich-donkeys-beam.md
@@ -2,4 +2,4 @@
 "@primer/view-components": minor
 ---
 
-Fix accessibility bug of missing accessible name on Dialog
+Fix accessibility bug of missing accessible name on `Primer::Alpha::Dialog`

--- a/.changeset/rich-donkeys-beam.md
+++ b/.changeset/rich-donkeys-beam.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Fix accessibility bug of missing accessible name on Dialog

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -133,7 +133,8 @@ module Primer
           @system_arguments, {
             aria: {
               disabled: true,
-              describedby: "#{@id}-title #{@id}-description"
+              labelledby: "#{@id}-title",
+              describedby: "#{@id}-description"
             }
           }
         )

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -63,7 +63,7 @@ module Primer
           component.with_body { "content" }
         end
 
-        assert_selector("modal-dialog[id='my-dialog'][aria-describedby='my-dialog-title my-dialog-description']") do
+        assert_selector("modal-dialog[id='my-dialog'][aria-labelledby='my-dialog-title'][aria-describedby='my-dialog-description']") do
           assert_selector("h1[id='my-dialog-title']", text: "Title")
           assert_selector("h2[id='my-dialog-description']", text: "Subtitle")
         end

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -18,7 +18,7 @@ module Alpha
 
       click_button("Show Dialog")
 
-      assert_equal page.evaluate_script("document.activeElement")['aria-label'], "Close"
+      assert_equal page.evaluate_script("document.activeElement")["aria-label"], "Close"
     end
   end
 end

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "system/test_case"
+
+module Alpha
+  class IntegrationDialogTest < System::TestCase
+    def test_modal_has_accessible_name
+      visit_preview(:default)
+
+      click_button("Show Dialog")
+
+      assert_selector("modal-dialog[aria-labelledby]")
+      assert_equal(find("modal-dialog")["aria-labelledby"], find("h1")["id"])
+    end
+
+    def test_autofocuses_close_button
+      visit_preview(:default)
+
+      click_button("Show Dialog")
+
+      assert_selector("button[aria-label='Close'][autofocus]")
+    end
+  end
+end

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -13,12 +13,12 @@ module Alpha
       assert_equal(find("modal-dialog")["aria-labelledby"], find("h1")["id"])
     end
 
-    def test_autofocuses_close_button
+    def test_focuses_close_button
       visit_preview(:default)
 
       click_button("Show Dialog")
 
-      assert_selector("button[aria-label='Close'][autofocus]")
+      assert_equal page.evaluate_script("document.activeElement")['aria-label'], "Close"
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

When I was doing unrelated work in dotcom, I noticed that `Primer::Alpha::Dialog` is not rendering with an accessible name resulting in an Axe failure of [aria-dialog-name](https://dequeuniversity.com/rules/axe/4.1/aria-dialog-name):

> Ensures every ARIA dialog and alertdialog node has an accessible name"

This is unexpected since having an accessible name is also [clearly documented in the docs](https://primer.style/design/components/dialog/rails/alpha#accessibility).

There's currently no corresponding behavioral test written for this component. It's likely we're not running an axe scan when the Dialog is an open state, causing us to miss this error.

This PR fixes the bug and adds a behavioral system test.

#### List the issues that this change affects.

Closes https://github.com/github/primer/issues/2556

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?

Fix bug and add missing behavioral test.

### Accessibility
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

### Merge checklist

- [x] Added/updated tests

### Questions to reviewers

📣 Are behavioral components (or components that render with JS) identified in any way? I couldn't find anything that would indicate a component has JS associated with it. I was thinking it might be worth having a check that ensures all behavioral components have a corresponding `system_test` written. 

This is beneficial because it would ensure that we have checks in place for how a component should behave, and would also make sure that axe is ran against various states of the component (e.g. when dialog is open). This is also extra important because we don't seem to have custom element tests. This would help surface more accessibility or behavioral issues at the testing stage.