### PR TITLE
Updating tooltip migration link to correct url

### DIFF
--- a/.changeset/lazy-cups-rush.md
+++ b/.changeset/lazy-cups-rush.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Updating tooltip migration linter link to correct url

--- a/lib/primer/view_components/linters/tooltipped_migration.rb
+++ b/lib/primer/view_components/linters/tooltipped_migration.rb
@@ -10,7 +10,7 @@ module ERBLint
           include LinterRegistry
           include Helpers::RuleHelpers
 
-          MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. There are major accessibility concerns with using this tooltip so please take action. See https://github.com/primer/view_components/blob/main/docs/content/guides/accessibility/tooltipped_migration.md."
+          MIGRATE_TO_NEWER_TOOLTIP = ".tooltipped has been deprecated. There are major accessibility concerns with using this tooltip so please take action. See https://primer.style/design/guides/development/rails/migration-guides/primer-css-tooltipped."
           TOOLTIPPED_RUBY_PATTERN = /classes:.*tooltipped|class:.*tooltipped/.freeze
 
           def run(processed_source)


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes a bad linter url to the correct link https://primer.style/design/guides/development/rails/migration-guides/primer-css-tooltipped

### Integration

No

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
