### PR TITLE
allow dialogs within deferred menus

### DIFF
--- a/.changeset/smart-scissors-type.md
+++ b/.changeset/smart-scissors-type.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fix dialog invocation within deferred ActionMenus
+
+<!-- Changed components: Primer::Alpha::ActionMenu -->

--- a/demo/app/views/action_menu/deferred.html.erb
+++ b/demo/app/views/action_menu/deferred.html.erb
@@ -2,4 +2,22 @@
   <% list.with_item(label: "Copy link", value: "", autofocus: true) %>
   <% list.with_item(label: "Quote reply", value: "") %>
   <% list.with_item(label: "Reference in new issue", value: "") %>
+  <% list.with_item(
+    label: "Show dialog",
+    tag: :button,
+    content_arguments: { "data-show-dialog-id": "my-dialog" },
+    value: "",
+    scheme: :danger
+  ) %>
+<% end %>
+
+
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |d| %>
+  <%= render(Primer::Alpha::Dialog::Body.new()) do %>
+    Are you sure you want to delete this?
+  <% end %>
+  <%= render(Primer::Alpha::Dialog::Footer.new()) do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
+    <%= render(Primer::Beta::Button.new(scheme: :danger)) { "Delete" } %>
+  <% end %>
 <% end %>

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -265,6 +265,16 @@ module Alpha
       assert_equal page.evaluate_script("document.activeElement").text, "Copy link"
     end
 
+    def test_deferred_dialog_opens
+      visit_preview(:with_deferred_content)
+
+      find("action-menu button[aria-controls]").click
+
+      find("action-menu ul li:nth-child(4)").click
+
+      assert_selector "modal-dialog[open]"
+    end
+
     def test_opening_second_menu_closes_first_menu
       visit_preview(:two_menus)
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

There are instances when one wants to render dialog contents deferred through the ActionMenu. Currently this doesn't work; it's buggy. The current behaviour is that the dialog flashes open, then hides because the ActionMenu itself closes. Re-opening the menu causes the Dialog to appear.

This is of course not ideal. We should enable this pattern to be expressed bug free.

/cc @jdennes 

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
#### Here's the broken behaviour:
[A video demonstrating broken behaviour](https://github.com/primer/view_components/assets/118266/69fbd135-74cc-4f75-a1af-9cd8e92f8a5b)
#### Here it is fixed:
[A video demonstrating fixed behaviour](https://github.com/primer/view_components/assets/118266/c33028ca-c86b-4abb-bf2f-4cbfc76c51db)


### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

An issue hasn't been filed. This was from Slack.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
