### PR TITLE
Use federated Azure login via OIDC for preview env destroy job

### DIFF
--- a/.github/workflows/demo-preview-destroy.yml
+++ b/.github/workflows/demo-preview-destroy.yml
@@ -12,18 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  destory:
+  destroy:
     if: ${{ github.event.pull_request.head.repo.full_name == 'primer/view_components' && github.actor != 'dependabot[bot]' }}
     name: Destroy
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment:
+      name: preview
     env:
       PR_NUMBER: ${{ github.event.number || github.event.inputs.PR_NUMBER }}
 
     steps:
       - uses: Azure/login@v1
         with:
-          creds: '{"clientId":"5ad1a188-b944-40eb-a2f8-cc683a6a65a0","clientSecret":"${{ secrets.AZURE_SPN_CLIENT_SECRET }}","subscriptionId":"550eb99d-d0c7-4651-a337-f53fa6520c4f","tenantId":"398a6654-997b-47e9-b12b-9515b896b4de"}'
+          # excluding a client secret here will cause a login via OpenID Connect (OIDC),
+          # which prevents us from having to rotate client credentials, etc
+          client-id: "5ad1a188-b944-40eb-a2f8-cc683a6a65a0"
+          tenant-id: "398a6654-997b-47e9-b12b-9515b896b4de"
+          subscription-id: "550eb99d-d0c7-4651-a337-f53fa6520c4f"
 
       - name: Check out repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### What are you trying to accomplish?

Our preview destroy job is failing because it's using hand-generated Azure credentials, which have expired. I switched our other jobs over to using federated OIDC creds a few months ago, but apparently forgot this one 🤦 

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.