### PR TITLE
Add missing id-token permission in preview destroy CI config

### DIFF
--- a/.github/workflows/demo-preview-destroy.yml
+++ b/.github/workflows/demo-preview-destroy.yml
@@ -6,6 +6,10 @@ on:
       - closed
       - locked
 
+permissions:
+  id-token: write # This is required for requesting the OIDC JWT for authing with Azure
+  contents: read  # This is required for actions/checkout
+
 # This allows one deploy workflow to interrupt another
 concurrency:
   group: 'preview-env @ ${{ github.head_ref || github.run_id }} for ${{ github.event.number || github.event.inputs.PR_NUMBER }}'


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A [recent PR](https://github.com/primer/view_components/pull/2214) updated the preview destroy job to use Azure OIDC credentials, but unfortunately I forgot to set the `id-token` permission 🤦 

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.