### PR TITLE
Update ActionBar::Item to accept an argument for the passed in IconButton

### DIFF
--- a/.changeset/sour-parrots-fetch.md
+++ b/.changeset/sour-parrots-fetch.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Moving the render for the ActionBar::Item from the slot initializer to the call method.
+
+<!-- Changed components: _none_ -->

--- a/app/components/primer/alpha/action_bar.rb
+++ b/app/components/primer/alpha/action_bar.rb
@@ -23,9 +23,7 @@ module Primer
             c.with_leading_visual_icon(icon: icon)
           end
 
-          render(Item.new) do
-            render(Primer::Beta::IconButton.new(id: item_id, icon: icon, "aria-label": label, size: @size, scheme: :invisible, **system_arguments))
-          end
+          Item.new(Primer::Beta::IconButton.new(id: item_id, icon: icon, "aria-label": label, size: @size, scheme: :invisible, **system_arguments))
         },
         divider: lambda {
           @action_menu.with_divider(hidden: true) if @overflow_menu

--- a/app/components/primer/alpha/action_bar/item.rb
+++ b/app/components/primer/alpha/action_bar/item.rb
@@ -7,7 +7,7 @@ module Primer
     class ActionBar
       # ActionBar::Item is an internal component that wraps the items in a div with the `ActionBar-item` class.
       class Item < Primer::Component
-        def initialize
+        def initialize(item_type)
           @system_arguments = {
             tag: :div,
             data: {
@@ -15,10 +15,11 @@ module Primer
             },
             classes: "ActionBar-item"
           }
+          @item_type = item_type
         end
 
         def call
-          render(Primer::BaseComponent.new(**@system_arguments)) { content }
+          render(Primer::BaseComponent.new(**@system_arguments)) { render(@item_type) }
         end
       end
     end

--- a/app/components/primer/alpha/action_bar/item.rb
+++ b/app/components/primer/alpha/action_bar/item.rb
@@ -7,7 +7,7 @@ module Primer
     class ActionBar
       # ActionBar::Item is an internal component that wraps the items in a div with the `ActionBar-item` class.
       class Item < Primer::Component
-        def initialize(item_type)
+        def initialize(item_content)
           @system_arguments = {
             tag: :div,
             data: {
@@ -15,11 +15,11 @@ module Primer
             },
             classes: "ActionBar-item"
           }
-          @item_type = item_type
+          @item_content = item_content
         end
 
         def call
-          render(Primer::BaseComponent.new(**@system_arguments)) { render(@item_type) }
+          render(Primer::BaseComponent.new(**@system_arguments)) { render(@item_content) }
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

This updates `ActionBar::Item` to accept an initialized component that would be rendered when the Item is rendered instead of rendering in the slot and returning a string.

### Screenshots

No visual change

### Integration

No, this unblocks integration in dotcom

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
