### PR TITLE
Fixing bug in the ActionBar more menu items not including button type

### DIFF
--- a/.changeset/eleven-pillows-explain.md
+++ b/.changeset/eleven-pillows-explain.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fixing ActionBar more menu items including buttons with no type
+
+<!-- Changed components: _none_ -->

--- a/.changeset/eleven-pillows-explain.md
+++ b/.changeset/eleven-pillows-explain.md
@@ -4,4 +4,4 @@
 
 Fixing ActionBar more menu items including buttons with no type
 
-<!-- Changed components: _none_ -->
+<!-- Changed components: Primer::Alpha::ActionBar -->

--- a/app/components/primer/alpha/action_bar.rb
+++ b/app/components/primer/alpha/action_bar.rb
@@ -66,8 +66,6 @@ module Primer
         system_arguments = {
           **system_arguments,
           hidden: true,
-          tag: :button,
-          type: "button",
           "data-for": id,
           "data-action": "click:action-bar#menuItemClick"
         }

--- a/test/components/alpha/action_bar_test.rb
+++ b/test/components/alpha/action_bar_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "components/test_helper"
+
+module Primer
+  module Alpha
+    class ActionBarTest < Minitest::Test
+      include Primer::ComponentTestHelpers
+
+      def test_renders_action_menu_items_with_type_button
+        render_preview(:default)
+
+        assert_selector("action-menu[data-target=\"action-bar.moreMenu\"]", visible: :hidden) do
+          assert_selector("button[type=\"button\"]")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

I noticed the ActionBar more menu items weren't including `type="button"` which was defaulting them to submit type. This was trying to submit a form before it was ready.

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

There might be a bigger bug in ActionList that when including `type: "button", tag: :button` it somehow leaves off the type. But removing these from my instance because they're not necessary.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
