### PR TITLE
In tests, move forms inline to cut down on verbosity

### DIFF
--- a/.changeset/olive-students-begin.md
+++ b/.changeset/olive-students-begin.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Allow anonymous forms, mostly useful for tests
+
+<!-- Changed components: _none_ -->

--- a/app/helpers/primer/form_helper.rb
+++ b/app/helpers/primer/form_helper.rb
@@ -19,5 +19,13 @@ module Primer
         &block
       )
     end
+
+    def inline_form(*args, &block)
+      Primer::Forms.inline_form(*args, &block)
+    end
+
+    def render_inline_form(*args, &block)
+      render(inline_form(*args, &block))
+    end
   end
 end

--- a/app/helpers/primer/form_helper.rb
+++ b/app/helpers/primer/form_helper.rb
@@ -25,7 +25,9 @@ module Primer
     end
 
     def render_inline_form(*args, &block)
+      # rubocop:disable GitHub/RailsViewRenderLiteral
       render(inline_form(*args, &block))
+      # rubocop:enable GitHub/RailsViewRenderLiteral
     end
   end
 end

--- a/lib/primer/forms.rb
+++ b/lib/primer/forms.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Primer
+  # :nodoc:
+  module Forms
+    def self.inline_form(builder, base = nil, &block)
+      base ||= if defined?(ApplicationForm)
+        ApplicationForm
+      else
+        Primer::Forms::Base
+      end
+
+      klass = Class.new(base) do
+        form(&block)
+      end
+
+      klass.new(builder)
+    end
+  end
+end

--- a/lib/primer/forms.rb
+++ b/lib/primer/forms.rb
@@ -4,11 +4,7 @@ module Primer
   # :nodoc:
   module Forms
     def self.inline_form(builder, base = nil, &block)
-      base ||= if defined?(ApplicationForm)
-        ApplicationForm
-      else
-        Primer::Forms::Base
-      end
+      base ||= defined?(ApplicationForm) ? ApplicationForm : Primer::Forms::Base
 
       klass = Class.new(base) do
         form(&block)

--- a/lib/primer/forms/utils.rb
+++ b/lib/primer/forms/utils.rb
@@ -15,6 +15,8 @@ module Primer
       # conventions, so it should work ok. Zeitwerk also has this information but lacks a
       # public API to map constants to source files.
       def const_source_location(class_name)
+        return nil unless class_name
+
         # NOTE: underscore respects namespacing, i.e. will convert Foo::Bar to foo/bar.
         class_path = "#{class_name.underscore}.rb"
 

--- a/test/lib/primer/forms/checkbox_group_input_test.rb
+++ b/test/lib/primer/forms/checkbox_group_input_test.rb
@@ -5,18 +5,14 @@ require "lib/test_helper"
 class Primer::Forms::CheckboxGroupInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class HiddenCheckboxGroupForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box_group(label: "Foobar", hidden: true) do |check_group|
-        check_group.check_box(name: :foo, label: "Foo")
-      end
-    end
-  end
-
   def test_hidden_checkbox_group
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenCheckboxGroupForm.new(f))
+        render_inline_form(f) do |check_form|
+          check_form.check_box_group(label: "Foobar", hidden: true) do |check_group|
+            check_group.check_box(name: :foo, label: "Foo")
+          end
+        end
       end
     end
 
@@ -24,36 +20,28 @@ class Primer::Forms::CheckboxGroupInputTest < Minitest::Test
     assert_selector ".FormControl-checkbox-wrap", visible: :hidden
   end
 
-  class DisabledCheckboxGroupForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box_group(label: "Foobar", disabled: true) do |check_group|
-        check_group.check_box(name: :foo, label: "Foo")
-      end
-    end
-  end
-
   def test_disabled_checkbox_group_disables_constituent_checkboxes
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(DisabledCheckboxGroupForm.new(f))
+        render_inline_form(f) do |check_form|
+          check_form.check_box_group(label: "Foobar", disabled: true) do |check_group|
+            check_group.check_box(name: :foo, label: "Foo")
+          end
+        end
       end
     end
 
     assert_selector ".FormControl-checkbox-wrap input[disabled]"
   end
 
-  class DisabledCheckboxInGroupForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box_group(label: "Foobar") do |check_group|
-        check_group.check_box(name: :foo, label: "Foo", disabled: true)
-      end
-    end
-  end
-
   def test_checkbox_can_be_individually_disabled_in_group
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(DisabledCheckboxInGroupForm.new(f))
+        render_inline_form(f) do |check_form|
+          check_form.check_box_group(label: "Foobar") do |check_group|
+            check_group.check_box(name: :foo, label: "Foo", disabled: true)
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/checkbox_input_test.rb
+++ b/test/lib/primer/forms/checkbox_input_test.rb
@@ -5,17 +5,13 @@ require "lib/test_helper"
 class Primer::Forms::CheckboxInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class BadCheckboxesForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box(name: :alpha, label: "Alpha", scheme: :array)
-    end
-  end
-
   def test_array_checkboxes_require_values
     error = assert_raises(ArgumentError) do
       render_in_view_context do
         primer_form_with(url: "/foo") do |f|
-          render(BadCheckboxesForm.new(f))
+          render_inline_form(f) do |check_form|
+            check_form.check_box(name: :alpha, label: "Alpha", scheme: :array)
+          end
         end
       end
     end
@@ -32,20 +28,16 @@ class Primer::Forms::CheckboxInputTest < Minitest::Test
     end
   end
 
-  class HiddenCheckboxForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box(name: :foo, label: "Foo", hidden: true) do |foo_check|
-        foo_check.nested_form do |builder|
-          NestedForm.new(builder)
-        end
-      end
-    end
-  end
-
   def test_hidden_checkbox
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenCheckboxForm.new(f))
+        render_inline_form(f) do |check_form|
+          check_form.check_box(name: :foo, label: "Foo", hidden: true) do |foo_check|
+            foo_check.nested_form do |builder|
+              NestedForm.new(builder)
+            end
+          end
+        end
       end
     end
 
@@ -53,20 +45,16 @@ class Primer::Forms::CheckboxInputTest < Minitest::Test
     assert_selector "input[name=bar]", visible: :hidden
   end
 
-  class CheckboxWithHiddenNestedForm < ApplicationForm
-    form do |check_form|
-      check_form.check_box(name: :foo, label: "Foo") do |foo_check|
-        foo_check.nested_form(hidden: true) do |builder|
-          NestedForm.new(builder)
-        end
-      end
-    end
-  end
-
   def test_nested_form_can_be_hidden_independently
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(CheckboxWithHiddenNestedForm.new(f))
+        render_inline_form(f) do |check_form|
+          check_form.check_box(name: :foo, label: "Foo") do |foo_check|
+            foo_check.nested_form(hidden: true) do |builder|
+              NestedForm.new(builder)
+            end
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/form_control_test.rb
+++ b/test/lib/primer/forms/form_control_test.rb
@@ -6,25 +6,15 @@ require_relative "models/deep_thought"
 class Primer::Forms::FormControlTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class PlainTextFieldForm < ApplicationForm
-    form do |test_form|
-      test_form.text_field(name: :ultimate_answer, label: "Ultimate answer")
-    end
-  end
-
-  class AutoCheckTextFieldForm < ApplicationForm
-    form do |test_form|
-      test_form.text_field(name: :ultimate_answer, label: "Ultimate answer", auto_check_src: "/foo")
-    end
-  end
-
-  def test_plain_supports_server_errors
+  def test_supports_model_errors
     model = DeepThought.new(41)
     model.valid? # perform validations
 
     render_in_view_context do
       primer_form_with(url: "/foo", model: model) do |f|
-        render(PlainTextFieldForm.new(f))
+        render_inline_form(f) do |test_form|
+          test_form.text_field(name: :ultimate_answer, label: "Ultimate answer")
+        end
       end
     end
 
@@ -42,7 +32,9 @@ class Primer::Forms::FormControlTest < Minitest::Test
 
     render_in_view_context do
       primer_form_with(url: "/foo", model: model) do |f|
-        render(AutoCheckTextFieldForm.new(f))
+        render_inline_form(f) do |test_form|
+          test_form.text_field(name: :ultimate_answer, label: "Ultimate answer", auto_check_src: "/foo")
+        end
       end
     end
 

--- a/test/lib/primer/forms/multi_input_test.rb
+++ b/test/lib/primer/forms/multi_input_test.rb
@@ -6,29 +6,16 @@ require_relative "models/deep_thought"
 class Primer::Forms::MultiInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class MultipleFieldsVisibleForm < ApplicationForm
-    form do |test_form|
-      test_form.multi(name: :foo, label: "Thing") do |multi|
-        multi.text_field(name: :bar, label: "Text field")
-        multi.text_field(name: :baz, label: "Text field")
-      end
-    end
-  end
-
-  class FieldsWithDifferentNamesForm < ApplicationForm
-    form do |test_form|
-      test_form.multi(name: :foo, label: "Thing") do |multi|
-        multi.text_field(name: :bar, label: "Text field")
-        multi.text_field(name: :baz, label: "Text field", hidden: true)
-      end
-    end
-  end
-
   def test_disallows_two_visible_inputs
     error = assert_raises(ArgumentError) do
       render_in_view_context do
         primer_form_with(url: "/foo") do |f|
-          render(MultipleFieldsVisibleForm.new(f))
+          render_inline_form(f) do |test_form|
+            test_form.multi(name: :foo, label: "Thing") do |multi|
+              multi.text_field(name: :bar, label: "Text field")
+              multi.text_field(name: :baz, label: "Text field")
+            end
+          end
         end
       end
     end
@@ -39,21 +26,17 @@ class Primer::Forms::MultiInputTest < Minitest::Test
   def test_inputs_have_data_name
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(FieldsWithDifferentNamesForm.new(f))
+        render_inline_form(f) do |test_form|
+          test_form.multi(name: :foo, label: "Thing") do |multi|
+            multi.text_field(name: :bar, label: "Text field")
+            multi.text_field(name: :baz, label: "Text field", hidden: true)
+          end
+        end
       end
     end
 
     assert_selector "input[data-name=bar]"
     assert_selector "input[data-name=baz]", visible: :hidden
-  end
-
-  class MultiDeepThoughtForm < ApplicationForm
-    form do |text_area_form|
-      text_area_form.multi(name: :ultimate_answer, label: "Ultimate answer") do |ultimate_answer_multi|
-        ultimate_answer_multi.text_field(name: :foo)
-        ultimate_answer_multi.text_field(name: :bar, hidden: true)
-      end
-    end
   end
 
   def test_no_error_markup
@@ -62,7 +45,12 @@ class Primer::Forms::MultiInputTest < Minitest::Test
 
     render_in_view_context do
       primer_form_with(model: model, url: "/foo") do |f|
-        render(MultiDeepThoughtForm.new(f))
+        render_inline_form(f) do |test_form|
+          test_form.multi(name: :ultimate_answer, label: "Ultimate answer") do |ultimate_answer_multi|
+            ultimate_answer_multi.text_field(name: :foo)
+            ultimate_answer_multi.text_field(name: :bar, hidden: true)
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/radio_button_group_input_test.rb
+++ b/test/lib/primer/forms/radio_button_group_input_test.rb
@@ -5,18 +5,14 @@ require "lib/test_helper"
 class Primer::Forms::RadioButtonGroupInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class HiddenRadioGroupForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foobar, label: "Foobar", hidden: true) do |radio_group|
-        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
-      end
-    end
-  end
-
   def test_hidden_radio_button_group
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenRadioGroupForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foobar, label: "Foobar", hidden: true) do |radio_group|
+            radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
+          end
+        end
       end
     end
 
@@ -24,36 +20,28 @@ class Primer::Forms::RadioButtonGroupInputTest < Minitest::Test
     assert_selector ".FormControl-radio-wrap", visible: :hidden
   end
 
-  class DisabledRadioGroupForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foobar, label: "Foobar", disabled: true) do |radio_group|
-        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
-      end
-    end
-  end
-
   def test_disabled_radio_group_disables_constituent_radios
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(DisabledRadioGroupForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foobar, label: "Foobar", disabled: true) do |radio_group|
+            radio_group.radio_button(name: :foo, value: "Foo", label: "Foo")
+          end
+        end
       end
     end
 
     assert_selector ".FormControl-radio-wrap input[disabled]"
   end
 
-  class DisabledRadioInGroupForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foobar, label: "Foobar") do |radio_group|
-        radio_group.radio_button(name: :foo, value: "Foo", label: "Foo", disabled: true)
-      end
-    end
-  end
-
   def test_radio_can_be_individually_disabled_in_group
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(DisabledRadioInGroupForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foobar, label: "Foobar") do |radio_group|
+            radio_group.radio_button(name: :foo, value: "Foo", label: "Foo", disabled: true)
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/radio_button_input_test.rb
+++ b/test/lib/primer/forms/radio_button_input_test.rb
@@ -14,22 +14,18 @@ class Primer::Forms::RadioButtonInputTest < Minitest::Test
     end
   end
 
-  class HiddenRadioButtonForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foos, label: "Foos") do |radio_group|
-        radio_group.radio_button(name: :foo, label: "Foo", value: "foo", hidden: true) do |radio_button|
-          radio_button.nested_form do |builder|
-            NestedForm.new(builder)
-          end
-        end
-      end
-    end
-  end
-
   def test_hidden_radio_button
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenRadioButtonForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foos, label: "Foos") do |radio_group|
+            radio_group.radio_button(name: :foo, label: "Foo", value: "foo", hidden: true) do |radio_button|
+              radio_button.nested_form do |builder|
+                NestedForm.new(builder)
+              end
+            end
+          end
+        end
       end
     end
 
@@ -38,22 +34,18 @@ class Primer::Forms::RadioButtonInputTest < Minitest::Test
     assert_selector "input[name=bar]", visible: :hidden
   end
 
-  class RadioButtonWithHiddenNestedForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foos, label: "Foos") do |radio_group|
-        radio_group.radio_button(name: :foo, label: "Foo", value: "foo") do |radio_button|
-          radio_button.nested_form(hidden: true) do |builder|
-            NestedForm.new(builder)
-          end
-        end
-      end
-    end
-  end
-
   def test_nested_form_can_be_hidden_independently
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(RadioButtonWithHiddenNestedForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foos, label: "Foos") do |radio_group|
+            radio_group.radio_button(name: :foo, label: "Foo", value: "foo") do |radio_button|
+              radio_button.nested_form(hidden: true) do |builder|
+                NestedForm.new(builder)
+              end
+            end
+          end
+        end
       end
     end
 
@@ -61,18 +53,14 @@ class Primer::Forms::RadioButtonInputTest < Minitest::Test
     assert_selector "input[name=bar]", visible: :hidden
   end
 
-  class HiddenRadioButtonGroupForm < ApplicationForm
-    form do |radio_form|
-      radio_form.radio_button_group(name: :foos, label: "Foos", hidden: true) do |radio_group|
-        radio_group.radio_button(name: :foo, label: "Foo", value: "foo")
-      end
-    end
-  end
-
   def test_hidden_radio_button_group
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenRadioButtonGroupForm.new(f))
+        render_inline_form(f) do |radio_form|
+          radio_form.radio_button_group(name: :foos, label: "Foos", hidden: true) do |radio_group|
+            radio_group.radio_button(name: :foo, label: "Foo", value: "foo")
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/select_list_input_test.rb
+++ b/test/lib/primer/forms/select_list_input_test.rb
@@ -6,30 +6,18 @@ require_relative "models/deep_thought"
 class Primer::Forms::SelectInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class HiddenSelectForm < ApplicationForm
-    form do |select_form|
-      select_form.select_list(name: :foo, label: "Foo", hidden: true) do |list|
-        list.option(label: "Foo", value: "foo")
-      end
-    end
-  end
-
   def test_hidden_select_list
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenSelectForm.new(f))
+        render_inline_form(f) do |select_form|
+          select_form.select_list(name: :foo, label: "Foo", hidden: true) do |list|
+            list.option(label: "Foo", value: "foo")
+          end
+        end
       end
     end
 
     assert_selector "select#foo", visible: :hidden
-  end
-
-  class SelectDeepThoughtForm < ApplicationForm
-    form do |select_form|
-      select_form.select_list(name: :ultimate_answer, label: "Ultimate answer") do |list|
-        list.option(label: "Foo", value: "foo")
-      end
-    end
   end
 
   def test_no_error_markup
@@ -38,7 +26,11 @@ class Primer::Forms::SelectInputTest < Minitest::Test
 
     render_in_view_context do
       primer_form_with(model: model, url: "/foo") do |f|
-        render(SelectDeepThoughtForm.new(f))
+        render_inline_form(f) do |select_form|
+          select_form.select_list(name: :ultimate_answer, label: "Ultimate answer") do |list|
+            list.option(label: "Foo", value: "foo")
+          end
+        end
       end
     end
 

--- a/test/lib/primer/forms/text_area_input_test.rb
+++ b/test/lib/primer/forms/text_area_input_test.rb
@@ -6,26 +6,16 @@ require_relative "models/deep_thought"
 class Primer::Forms::TextAreaInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class HiddenTextAreaForm < ApplicationForm
-    form do |text_area_form|
-      text_area_form.text_area(name: :foo, label: "Foo", hidden: true)
-    end
-  end
-
   def test_hidden_text_area
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenTextAreaForm.new(f))
+        render_inline_form(f) do |text_area_form|
+          text_area_form.text_area(name: :foo, label: "Foo", hidden: true)
+        end
       end
     end
 
     assert_selector "textarea#foo", visible: :hidden
-  end
-
-  class TextAreaDeepThoughtForm < ApplicationForm
-    form do |text_area_form|
-      text_area_form.text_area(name: :ultimate_answer, label: "Ultimate answer")
-    end
   end
 
   def test_no_error_markup
@@ -34,7 +24,9 @@ class Primer::Forms::TextAreaInputTest < Minitest::Test
 
     render_in_view_context do
       primer_form_with(model: model, url: "/foo") do |f|
-        render(TextAreaDeepThoughtForm.new(f))
+        render_inline_form(f) do |text_area_form|
+          text_area_form.text_area(name: :ultimate_answer, label: "Ultimate answer")
+        end
       end
     end
 

--- a/test/lib/primer/forms/text_field_input_test.rb
+++ b/test/lib/primer/forms/text_field_input_test.rb
@@ -6,16 +6,12 @@ require_relative "models/deep_thought"
 class Primer::Forms::TextFieldInputTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
-  class HiddenTextFieldForm < ApplicationForm
-    form do |text_field_form|
-      text_field_form.text_field(name: :foo, label: "Foo", hidden: true)
-    end
-  end
-
   def test_hidden_text_field
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(HiddenTextFieldForm.new(f))
+        render_inline_form(f) do |text_field_form|
+          text_field_form.text_field(name: :foo, label: "Foo", hidden: true)
+        end
       end
     end
 
@@ -35,16 +31,12 @@ class Primer::Forms::TextFieldInputTest < Minitest::Test
     refute_selector ".field_with_errors", visible: :all
   end
 
-  class LeadingVisualTextFieldForm < ApplicationForm
-    form do |text_field_form|
-      text_field_form.text_field(name: :foo, label: "Foo", leading_visual: { icon: :search })
-    end
-  end
-
   def test_leading_visual
     render_in_view_context do
       primer_form_with(url: "/foo") do |f|
-        render(LeadingVisualTextFieldForm.new(f))
+        render_inline_form(f) do |text_field_form|
+          text_field_form.text_field(name: :foo, label: "Foo", leading_visual: { icon: :search })
+        end
       end
     end
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In the tests for the forms framework, it's common to see this pattern:

```ruby
class Primer::Forms::SomeTest < Minitest::Test
  class SomeForm < ApplicationForm
    form do |some_form|
      some_form.field(...)
    end
  end

  def test_hidden_checkbox_group
    render_in_view_context do
      primer_form_with(url: "/foo") do |f|
        render(SomeForm.new(f))
      end
    end

    assert_selector ".some-selector"
  end
end
```

The framework makes us define a separate class for our form. There are a couple of drawbacks to this, at least in tests:

1. The form and the test are defined in separate places, making it difficult to "see" all the logic at play.
2. Forms are designed to be re-usable, hence why they are defined as classes. In tests however, forms are usually specific to a single test and are not re-used in other tests.

This PR adds the ability to define forms inline:

```ruby
class Primer::Forms::SomeTest < Minitest::Test
  def test_hidden_checkbox_group
    render_in_view_context do
      primer_form_with(url: "/foo") do |f|
        render_inline_form(f) do |some_form|
          some_form.field(...)
        end
      end
    end

    assert_selector ".some-selector"
  end
end
```

Now, the form is defined _inside_ the test, making it easier to reason about the test as a whole. There are probably too many nesting levels at play here, but that's a problem for another day.

There are a couple of obvious drawbacks with this approach:

1. You cannot pass arguments to the form's constructor on initialization, meaning there's no way to encapsulate data in an inline form instance.
2. Inline forms cannot define any methods, including instance or class methods.
3. There is no way to retain a reference to the class that is dynamically defined for the inline form, meaning it has to be defined anew every time the template is rendered. That's not an issue in tests, but certainly an issue for a production app. So yeah, don't use this in prod.

If you need to circumvent any of these drawbacks, define a form class.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production. This change is largely test-only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.