### PR TITLE
Fix race condition causing dotcom axe check failures for icon button tooltips

### DIFF
--- a/.changeset/tame-trainers-remain.md
+++ b/.changeset/tame-trainers-remain.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fix race condition causing dotcom axe check failures for icon button tooltips
+
+<!-- Changed components: Primer::Alpha::Tooltip, Primer::Beta::IconButton -->

--- a/app/components/primer/alpha/tooltip.rb
+++ b/app/components/primer/alpha/tooltip.rb
@@ -29,6 +29,8 @@ module Primer
       TYPE_FALLBACK = :description
       TYPE_OPTIONS = [:label, :description].freeze
 
+      attr_reader :id
+
       # @param for_id [String] The ID of the element that the tooltip should be attached to.
       # @param type [Symbol] <%= one_of(Primer::Alpha::Tooltip::TYPE_OPTIONS) %>
       # @param direction [Symbol] <%= one_of(Primer::Alpha::Tooltip::DIRECTION_OPTIONS) %>
@@ -39,7 +41,7 @@ module Primer
 
         @text = text
         @system_arguments = system_arguments
-        @system_arguments[:id] ||= self.class.generate_id
+        @id = @system_arguments[:id] ||= self.class.generate_id
         @system_arguments[:tag] = :"tool-tip"
         @system_arguments[:for] = for_id
         @system_arguments[:popover] = "manual"

--- a/app/components/primer/beta/icon_button.html.erb
+++ b/app/components/primer/beta/icon_button.html.erb
@@ -2,5 +2,5 @@
   <%= render Primer::Beta::BaseButton.new(**@system_arguments) do -%>
     <%= render Primer::Beta::Octicon.new(icon: @icon, classes: "Button-visual") %>
   <% end -%>
-  <%= render Primer::Alpha::Tooltip.new(**@tooltip_arguments) if render_tooltip? %>
+  <%= render @tooltip if render_tooltip? %>
 <% end %>

--- a/app/components/primer/beta/icon_button.rb
+++ b/app/components/primer/beta/icon_button.rb
@@ -59,7 +59,7 @@ module Primer
         @aria_label = aria("label", @system_arguments)
         @aria_description = aria("description", @system_arguments)
 
-        return unless @show_tooltip
+        return unless render_tooltip?
 
         @tooltip_arguments = {
           for_id: @system_arguments[:id],
@@ -79,6 +79,13 @@ module Primer
           @tooltip_arguments[:text] = @aria_label
           @tooltip_arguments[:type] = :label
         end
+
+        @tooltip = Primer::Alpha::Tooltip.new(**@tooltip_arguments)
+        aria_key = @tooltip_arguments[:type] == :label ? :labelledby : :describedby
+
+        @system_arguments[:aria] = merge_aria(
+          @system_arguments, { aria: { aria_key => @tooltip.id } }
+        )
       end
 
       private

--- a/test/components/primer/beta/icon_button_test.rb
+++ b/test/components/primer/beta/icon_button_test.rb
@@ -11,13 +11,24 @@ class PrimerBetaIconButtonTest < Minitest::Test
     assert_selector(".Button.Button--iconOnly") do
       assert_selector(".Button-visual")
     end
+
     assert_selector("tool-tip", text: "Star", visible: :all)
+
+    # Labelling is also done in js, but we test it here where js doesn't execute to ensure
+    # it's also rendered server-side. This prevents race conditions when axe checking.
+    tooltip_id = page.find_css("tool-tip")[0].attributes["id"].value
+    assert_selector(".Button.Button--iconOnly[aria-labelledby='#{tooltip_id}']")
   end
 
   def test_renders_description_tooltip
     render_inline(Primer::Beta::IconButton.new(icon: :star, "aria-label": "Star", "aria-description": "Star this repository"))
 
     assert_selector("tool-tip", text: "Star this repository", visible: :all)
+
+    # Labelling is also done in js, but we test it here where js doesn't execute to ensure
+    # it's also rendered server-side. This prevents race conditions when axe checking.
+    tooltip_id = page.find_css("tool-tip")[0].attributes["id"].value
+    assert_selector(".Button.Button--iconOnly[aria-describedby='#{tooltip_id}']")
   end
 
   def test_adds_wrapper_arguments


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A recent slack conversation mentioned a number of `ActionBar` tests are failing axe checks (see: https://github.com/github/github/actions/runs/6124963111/job/16626078441?pr=287857, internal only). The issue appears to be happening because the `IconButton`s used in the `ActionBar` do not have an `aria-label` or `aria-labelledby` attribute set when axe runs. I discovered these attributes are [added in javascript](https://github.com/primer/view_components/blob/bc254f135eeb57b9872665d5e8ce1c30a8208f33/app/components/primer/alpha/tool_tip.ts#L335), which may or may not have finished executing by the time axe inspects the page.

The solution in this PR is to render the `aria-labelledby` or `aria-describedby` attribute on the server side.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~