### PR TITLE
Exclude hidden menu items from focus group

### DIFF
--- a/.changeset/silent-ravens-hide.md
+++ b/.changeset/silent-ravens-hide.md
@@ -1,0 +1,7 @@
+---
+"@primer/view-components": patch
+---
+
+Fix bug in ActionMenu keyboard navigation, where items aren't skipped when they're functionally `[hidden]`.
+
+<!-- Changed components: Primer::Alpha::ActionMenu -->

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -9,7 +9,8 @@ type SelectedItem = {
   element: Element
 }
 
-const menuItemSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
+const validSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
+const menuItemSelectors = validSelectors.map(selector => `:not([hidden]) > ${selector}`)
 
 @controller
 export class ActionMenuElement extends HTMLElement {

--- a/app/components/primer/focus_group.ts
+++ b/app/components/primer/focus_group.ts
@@ -1,6 +1,7 @@
 import '@oddbird/popover-polyfill'
 
-const menuItemSelector = '[role="menuitem"],[role="menuitemcheckbox"],[role="menuitemradio"]'
+const validSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
+const menuItemSelector = validSelectors.map(selector => `:not([hidden]) > ${selector}`).join(', ')
 
 const getMnemonicFor = (item: Element) => item.textContent?.trim()[0].toLowerCase()
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Currently, if `ActionMenu` contains items that are hidden via `hidden: true`, these items will still be present in the list of focusable items. This causes the focus trap to be blocked, as it tries to focus onto a item that is currently hidden from view.

This PR adds onto the selector to ensure that the parent is not `[hidden]`.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
<details>
<summary>Before PR; video shows focus trapped being blocked in overflow menu within ActionBar</summary>

https://github.com/primer/view_components/assets/26746305/952afe2d-14ab-4738-a208-586af181cb88

</details>

<details>
<summary>Current PR; video shows focus trap looping properly in overflow menu</summary>

https://github.com/primer/view_components/assets/26746305/680eb269-7e2e-4ddc-9451-91ef55c7400e

</details>


### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Relates to https://github.com/github/primer/issues/1131

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
     
Adds onto the menu item selector to exclude items that are hidden via `[hidden]`.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
