### PR TITLE
Add a variant to dialog headers

### DIFF
--- a/.changeset/stupid-otters-shake.md
+++ b/.changeset/stupid-otters-shake.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Add header variant to Dialog
+
+<!-- Changed components: Primer::Alpha::Dialog -->

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -74,7 +74,7 @@ module Primer
       #
       # @param show_divider [Boolean] Show a divider between the header and body.
       # @param visually_hide_title [Boolean] Visually hide the `title` while maintaining a label for assistive technologies.
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Dialog::Header) %>.
       renders_one :header, lambda { |show_divider: false, visually_hide_title: @visually_hide_title, **system_arguments|
         Primer::Alpha::Dialog::Header.new(
           id: @id,

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -9,10 +9,18 @@ module Primer
         status :alpha
         audited_at "2022-10-10"
 
+        DEFAULT_VARIANT = :medium
+        VARIANT_MAPPINGS = {
+          DEFAULT_VARIANT => "",
+          :large => "Overlay-header--large",
+        }.freeze
+        VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
+
         # @param title [String] Describes the content of the dialog.
         # @param subtitle [String] Provides dditional context for the dialog, also setting the `aria-describedby` attribute.
         # @param show_divider [Boolean] Show a divider between the header and body.
         # @param visually_hide_title [Boolean] Visually hide the `title` while maintaining a label for assistive technologies.
+        # @param variant [Symbol] <%= one_of(Primer::Alpha::Dialog::Header::VARIANT_OPTIONS) %>
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(
           id:,
@@ -20,6 +28,7 @@ module Primer
           subtitle: nil,
           show_divider: false,
           visually_hide_title: false,
+          variant: DEFAULT_VARIANT,
           **system_arguments
         )
           @id = id
@@ -28,8 +37,10 @@ module Primer
           @visually_hide_title = visually_hide_title
           @system_arguments = deny_tag_argument(**system_arguments)
           @system_arguments[:tag] = :div
+
           @system_arguments[:classes] = class_names(
             "Overlay-header",
+            VARIANT_MAPPINGS[fetch_or_fallback(VARIANT_OPTIONS, variant, DEFAULT_VARIANT)],
             { "Overlay-header--divided": show_divider },
             system_arguments[:classes]
           )

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -12,10 +12,11 @@ module Primer
         DEFAULT_VARIANT = :medium
         VARIANT_MAPPINGS = {
           DEFAULT_VARIANT => "",
-          :large => "Overlay-header--large",
+          :large => "Overlay-header--large"
         }.freeze
         VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
 
+        # @param id [String] The HTML element's ID value.
         # @param title [String] Describes the content of the dialog.
         # @param subtitle [String] Provides dditional context for the dialog, also setting the `aria-describedby` attribute.
         # @param show_divider [Boolean] Show a divider between the header and body.

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -60,6 +60,23 @@ module Primer
         end
       end
 
+      # @label With Header
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param header_variant [Symbol] select [medium, large]
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      def with_header(title: "Test Dialog", subtitle: nil, header_variant: :medium, button_text: "Show Dialog", show_divider: true)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               header_variant: header_variant,
+                               button_text: button_text,
+                               show_divider: show_divider
+                             })
+      end
+
       # @label With Footer
       #
       # @param title [String] text

--- a/previews/primer/alpha/dialog_preview/with_header.html.erb
+++ b/previews/primer/alpha/dialog_preview/with_header.html.erb
@@ -1,0 +1,5 @@
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: title, subtitle: subtitle)) do |d| %>
+  <% d.with_show_button { button_text } %>
+  <% d.with_body { "Content" } %>
+  <% d.with_header(show_divider: show_divider, variant: header_variant) %>
+<% end %>

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -69,6 +69,28 @@ module Primer
         end
       end
 
+      def test_renders_header
+        render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog")) do |component|
+          component.with_body { "content" }
+          component.with_header { "header" }
+        end
+
+        assert_selector("modal-dialog") do
+          assert_selector(".Overlay-header", text: "header")
+        end
+      end
+
+      def test_renders_large_header
+        render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog")) do |component|
+          component.with_body { "content" }
+          component.with_header(variant: :large) { "header" }
+        end
+
+        assert_selector("modal-dialog") do
+          assert_selector(".Overlay-header.Overlay-header--large", text: "header")
+        end
+      end
+
       def test_renders_footer_without_divider_by_default
         render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog", subtitle: "Subtitle")) do |component|
           component.with_body { "content" }


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The experimental `Dialog` component in dotcom had a header variant option that seems to have been lost during upstreaming to alpha. This PR restores the functionality.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

|Medium|Large|
|-|-|
|<img width="510" alt="A screenshot of a Dialog component with a medium-size header that reads 'Test Dialog.'" src="https://github.com/primer/view_components/assets/575280/4807a0af-9873-4a25-b134-dd24cd4143cf">|<img width="516" alt="A screenshot of a Dialog component with a large-size header that reads 'Test Dialog.'" src="https://github.com/primer/view_components/assets/575280/58764533-f2ca-4371-9eec-979362621574">|

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.