### PR TITLE
ensure overlay does not add aria-label if it has no role

### DIFF
--- a/.changeset/olive-readers-rule.md
+++ b/.changeset/olive-readers-rule.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Only supply aria-label on Overlays with a role assigned
+
+<!-- Changed components: Primer::Alpha::ActionMenu, Primer::Alpha::Overlay -->

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -178,10 +178,12 @@ module Primer
       end
 
       def before_render
-        if header?
-          @system_arguments[:aria][:labelledby] ||= title_id
-        else
-          @system_arguments[:aria][:label] = @title
+        if @system_arguments[:role].present?
+          if header?
+            @system_arguments[:aria][:labelledby] ||= title_id
+          else
+            @system_arguments[:aria][:label] = @title
+          end
         end
         with_body unless body?
       end

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -36,6 +36,17 @@ class PrimerAlphaOverlayTest < Minitest::Test
     assert_selector("anchored-position[role='menu']")
   end
 
+  def test_renders_with_no_role
+    render_inline(Primer::Alpha::Overlay.new(title: "Title")) do |component|
+      component.with_body { "Hello" }
+    end
+
+    assert_selector("anchored-position")
+    refute_selector("anchored-position[role]")
+    refute_selector("anchored-position[aria-label]")
+  end
+
+
   def test_renders_show_button
     render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
       component.with_body { "Hello" }

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -46,7 +46,6 @@ class PrimerAlphaOverlayTest < Minitest::Test
     refute_selector("anchored-position[aria-label]")
   end
 
-
   def test_renders_show_button
     render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
       component.with_body { "Hello" }


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Fix https://github.com/github/primer/issues/2668 which notes that there is an AXE violation due to the ActionMenu `<anchored-position>` having no `role` assigned, but having an `aria-label`.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/2668

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
I decided to guard the assignment of `aria-label` so that it isn't set if the `:role` isn't supplied.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
