### PR TITLE
Lookbook embeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "webpacker", "~> 5.0"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
 
-gem "lookbook", "~> 2.0.0" unless rails_version.to_f < 7
+gem "lookbook", "~> 2.1.1" unless rails_version.to_f < 7
 gem "view_component", path: ENV["VIEW_COMPONENT_PATH"] if ENV["VIEW_COMPONENT_PATH"]
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    css_parser (1.14.0)
+    css_parser (1.16.0)
       addressable
     cuprite (0.14.3)
       capybara (~> 3.0)
@@ -93,7 +93,7 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    lookbook (2.0.2)
+    lookbook (2.1.1)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
@@ -158,7 +158,7 @@ GEM
     redcarpet (3.6.0)
     regexp_parser (2.6.2)
     rexml (3.2.5)
-    rouge (4.1.1)
+    rouge (4.1.3)
     rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -249,7 +249,7 @@ DEPENDENCIES
   erb_lint (~> 0.4.0)
   erblint-github (= 0.4.0)
   listen (~> 3.0)
-  lookbook (~> 2.0.0)
+  lookbook (~> 2.1.1)
   matrix (~> 0.4.2)
   minitest (< 5.19)
   mocha

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -38,7 +38,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
 gem "view_component", '>= 3.1.0'
-gem "lookbook", "~> 2.0.5" unless rails_version.to_f < 7
+gem "lookbook", "~> 2.1.1" unless rails_version.to_f < 7
 
 group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
-    css_parser (1.14.0)
+    css_parser (1.16.0)
       addressable
     docker-remote (0.8.0)
     domain_name (0.5.20190701)
@@ -221,7 +221,7 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lookbook (2.0.5)
+    lookbook (2.1.1)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
@@ -393,7 +393,7 @@ DEPENDENCIES
   kuby-core (~> 0.20)
   kuby-kind (~> 0.1)
   listen
-  lookbook (~> 2.0.5)
+  lookbook (~> 2.1.1)
   primer_view_components!
   pry-byebug
   puma (~> 6.3.1)

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -97,6 +97,7 @@ module Demo
         # rubocop:enable Style/WordArray
       }
 
+      config.lookbook.preview_embeds.policy = "ALLOWALL"
       config.lookbook.page_paths = [Rails.root.join("..", "previews", "pages")]
       config.lookbook.component_paths = [Primer::ViewComponents::Engine.root.join("app", "components")]
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR bumps Lookbook to the latest version and configures it to allow cross-origin embedding, i.e. inside primer.style.

### Screenshots

Here's how `ActionList`'s playground preview renders on a locally-running primer.style:

![A screenshot of the "Examples" section of the ActionList component Rails docs. The majority of the screenshot is taken up by an embedded Lookbook preview showing ActionList's playground example rendered in dark mode. Below the preview content are three tabs marked "Source," "Params," and "Assets," just as you would see in Lookbook itself.](https://github.com/primer/view_components/assets/575280/309df06e-6ddd-4a6f-b404-bacc1f71c412)

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Anything you want to highlight for special attention from reviewers?

This PR is a companion to [this PR in primer/design](https://github.com/primer/design/pull/608) that makes use of the now-enabled embedding functionality.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.