### PR TITLE
Adding an optional items_arguments to ActionBar::Item

### DIFF
--- a/.changeset/cuddly-stingrays-camp.md
+++ b/.changeset/cuddly-stingrays-camp.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Adding option item_arguments hash argument to ActionBar::Item that will control the item system arguments
+
+<!-- Changed components: Primer::Alpha::ActionBar -->

--- a/app/components/primer/alpha/action_bar.rb
+++ b/app/components/primer/alpha/action_bar.rb
@@ -16,14 +16,14 @@ module Primer
       SIZE_OPTIONS = SIZE_MAPPINGS.keys.freeze
 
       renders_many :items, types: {
-        icon_button: lambda { |icon:, label:, **system_arguments|
+        icon_button: lambda { |icon:, label:, item_arguments: {}, **system_arguments|
           item_id = self.class.generate_id
 
           with_menu_item(id: item_id, label: label) do |c|
             c.with_leading_visual_icon(icon: icon)
           end
 
-          Item.new(Primer::Beta::IconButton.new(id: item_id, icon: icon, "aria-label": label, size: @size, scheme: :invisible, **system_arguments))
+          Item.new(Primer::Beta::IconButton.new(id: item_id, icon: icon, "aria-label": label, size: @size, scheme: :invisible, **system_arguments), **item_arguments)
         },
         divider: lambda {
           @action_menu.with_divider(hidden: true) if @overflow_menu

--- a/app/components/primer/alpha/action_bar/item.rb
+++ b/app/components/primer/alpha/action_bar/item.rb
@@ -7,14 +7,18 @@ module Primer
     class ActionBar
       # ActionBar::Item is an internal component that wraps the items in a div with the `ActionBar-item` class.
       class Item < Primer::Component
-        def initialize(item_content)
+
+        # @param item_content [String] The content to render inside the item.
+        # @param item_arguments [Hash] <%= link_to_system_arguments_docs %>
+        def initialize(item_content, **item_arguments)
           @system_arguments = {
-            tag: :div,
+            tag: item_arguments[:tag] || :div,
             data: {
               targets: "action-bar.items"
-            },
-            classes: "ActionBar-item"
+            }.merge(item_arguments[:data] || {}),
+            classes: class_names("ActionBar-item", item_arguments[:classes])
           }
+
           @item_content = item_content
         end
 

--- a/app/components/primer/alpha/action_bar/item.rb
+++ b/app/components/primer/alpha/action_bar/item.rb
@@ -7,7 +7,6 @@ module Primer
     class ActionBar
       # ActionBar::Item is an internal component that wraps the items in a div with the `ActionBar-item` class.
       class Item < Primer::Component
-
         # @param item_content [String] The content to render inside the item.
         # @param item_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(item_content, **item_arguments)

--- a/test/components/primer/alpha/action_bar_test.rb
+++ b/test/components/primer/alpha/action_bar_test.rb
@@ -33,4 +33,12 @@ class PrimerAlphaActionBarTest < Minitest::Test
 
     assert_selector("[data-targets=\"action-bar.items\"] .Button--small", count: 4)
   end
+
+  def test_item_merges_item_arguments
+    render_inline(Primer::Alpha::ActionBar.new(size: :small)) do |component|
+      component.with_item_icon_button(icon: :pencil, label: "Button 1", item_arguments: { classes: "foo", tag: :span })
+    end
+
+    assert_selector("span.foo.ActionBar-item")
+  end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

I need to be able to pass arguments to the wrapping `ActionBar-item` element that will serve as system arguments.

### Integration

No this should ship without changes

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
