### PR TITLE
Add accessibility lint rule for `Primer::Experimental::Dialog`

### DIFF
--- a/.changeset/grumpy-lamps-clap.md
+++ b/.changeset/grumpy-lamps-clap.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Adds accessibility lint rule for `Primer::Experimental::Dialog`.
+
+<!-- Changed components: _none_ -->

--- a/lib/primer/view_components/linters/accessibility.yml
+++ b/lib/primer/view_components/linters/accessibility.yml
@@ -7,3 +7,5 @@ linters:
     enabled: true
   Primer::Accessibility::DetailsMenuMigration:
     enabled: true
+  Primer::Accessibility::ExperimentalDialogMigration:
+    enabled: true

--- a/lib/primer/view_components/linters/experimental_dialog_migration.rb
+++ b/lib/primer/view_components/linters/experimental_dialog_migration.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "helpers/rule_helpers"
+module ERBLint
+  module Linters
+    module Primer
+      module Accessibility
+        # Flag when `Primer::Experimental::Dialog` is being used and offer an alternative.
+        class ExperimentalDialogMigration < Linter
+          include LinterRegistry
+          include Helpers::RuleHelpers
+
+          MIGRATE_FROM_EXPERIMENTAL_DIALOG = "Primer::Experimental::Dialog has been deprecated. Please instead use Primer::Alpha::Dialog" \
+            " https://primer.style/design/components/dialog/rails/alpha"
+          EXPERIMENTAL_DIALOG_RUBY_PATTERN = /Primer::Experimental::Dialog/.freeze
+
+          def run(processed_source)
+            erb_nodes(processed_source).each do |node|
+              code = extract_ruby_from_erb_node(node)
+              generate_node_offense(self.class, processed_source, node, MIGRATE_FROM_EXPERIMENTAL_DIALOG) if code.match?(EXPERIMENTAL_DIALOG_RUBY_PATTERN)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lib/erblint/experimental_dialog_migration_test.rb
+++ b/test/lib/erblint/experimental_dialog_migration_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "lib/erblint_test_case"
+
+class ExperimentalDialogMigrationTest < ErblintTestCase
+  def linter_class
+    ERBLint::Linters::Primer::Accessibility::ExperimentalDialogMigration
+  end
+
+  def test_warns_if_primer_experimental_dialog_is_rendered
+    @file = <<~ERB
+      <%= render Primer::Experimental::Dialog.new(
+        dialog_id: "dialog-id",
+        title: "My Dialog",
+        width: :large,
+      ) %>
+    ERB
+    @linter.run(processed_source)
+
+    assert_equal 1, @linter.offenses.count
+    assert_match(/.Primer::Experimental::Dialog has been deprecated./, @linter.offenses.first.message)
+  end
+
+  def test_does_not_warn_if_inline_disable_comment
+    @file = <<~HTML
+      <%= render Primer::Experimental::Dialog.new() do %><%# erblint:disable Primer::Accessibility::ExperimentalDialogMigration %>
+    HTML
+    @linter.run_and_update_offense_status(processed_source)
+    offenses = @linter.offenses.reject(&:disabled?)
+    assert_equal 0, offenses.count
+  end
+end

--- a/test/lib/erblint/linter_config_works_test.rb
+++ b/test/lib/erblint/linter_config_works_test.rb
@@ -14,7 +14,7 @@ class LinterConfigWorksTest < ErblintTestCase
     end
     known_linter_names ||= ERBLint::LinterRegistry.linters.map(&:simple_name)
     known_linter_names_count = known_linter_names.count { |linter| linter.include?("Primer::Accessibility") }
-    assert_equal 2, rules_enabled_in_accessibility_config
-    assert_equal 2, known_linter_names_count
+    assert_equal 3, rules_enabled_in_accessibility_config
+    assert_equal 3, known_linter_names_count
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
