### PR TITLE
Fix issue where dialog is unable to be closed

### DIFF
--- a/.changeset/eleven-steaks-press.md
+++ b/.changeset/eleven-steaks-press.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': patch
+---
+
+Fixes issue where sometimes a dialog cannot be closed if another is open
+
+<!-- Changed components: Primer::Alpha::Dialog -->

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -39,7 +39,7 @@ function clickHandler(event: Event) {
     if (dialog instanceof ModalDialogElement) {
       const dialogIndex = overlayStack.findIndex(ele => ele.id === dialogId)
       overlayStack.splice(dialogIndex, 1)
-      dialog.close()
+      dialog.close(button.hasAttribute('data-submit-dialog-id'))
     }
   }
 }

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -30,20 +30,17 @@ function clickHandler(event: Event) {
       return
     }
   }
-  // Find the top level dialog that is open.
-  const topLevelDialog = overlayStack[overlayStack.length - 1]
-  if (!topLevelDialog) return
 
-  dialogId = button.getAttribute('data-close-dialog-id')
-  if (dialogId === topLevelDialog.id) {
-    overlayStack.pop()
-    topLevelDialog.close()
-  }
+  if (!overlayStack.length) return
 
-  dialogId = button.getAttribute('data-submit-dialog-id')
-  if (dialogId === topLevelDialog.id) {
-    overlayStack.pop()
-    topLevelDialog.close(true)
+  dialogId = button.getAttribute('data-close-dialog-id') || button.getAttribute('data-submit-dialog-id')
+  if (dialogId) {
+    const dialog = document.getElementById(dialogId)
+    if (dialog instanceof ModalDialogElement) {
+      const dialogIndex = overlayStack.findIndex(ele => ele.id === dialogId)
+      overlayStack.splice(dialogIndex, 1)
+      dialog.close()
+    }
   }
 }
 

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -4,6 +4,18 @@ require "system/test_case"
 
 module Alpha
   class IntegrationDialogTest < System::TestCase
+    def click_on_initial_dialog_close_button
+      find("button[data-close-dialog-id='dialog-one']").trigger("click")
+    end
+
+    def click_on_nested_dialog_close_button
+      find("button[data-close-dialog-id='dialog-two']").click
+    end
+
+    def click_on_nested_dialog_button
+      find("#dialog-show-dialog-two").click
+    end
+
     def test_modal_has_accessible_name
       visit_preview(:default)
 
@@ -19,6 +31,33 @@ module Alpha
       click_button("Show Dialog")
 
       assert_equal page.evaluate_script("document.activeElement")["aria-label"], "Close"
+    end
+
+    def test_closes_top_level_dialog
+      visit_preview(:nested_dialog)
+
+      click_button("Show Dialog")
+      click_on_nested_dialog_button
+
+      assert_equal(find("modal-dialog#dialog-two")["open"], true)
+
+      click_on_nested_dialog_close_button
+
+      assert_selector "modal-dialog#dialog-two", visible: :hidden
+      assert_selector "modal-dialog#dialog-one"
+    end
+
+    def test_closes_dialog_that_is_not_top_level
+      visit_preview(:nested_dialog)
+
+      click_button("Show Dialog")
+      click_on_nested_dialog_button
+
+      assert_equal(find("modal-dialog#dialog-two")["open"], true)
+
+      click_on_initial_dialog_close_button
+
+      assert_selector "modal-dialog#dialog-one", visible: :hidden
     end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Fixes bug where dialog is unable to be closed if another dialog is opened at the time. 

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

https://github.com/github/primer/issues/2748

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
     
We currently store active dialogs in an array named `overlayStack`. When clicking the close button, we check if the button is within the dialog that was most recently opened. If it is not, then you are unable to close the dialog through clicking the button.

This PR aims to fix that issue by removing the `topLevelDialog` dependency.     

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
