### PR TITLE
Respect autofocus attributes inside of a dialog when opening a dialog

### DIFF
--- a/.changeset/purple-fans-pump.md
+++ b/.changeset/purple-fans-pump.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Bug fix: Respect autofocus attributes inside of a Dialog when opening a modal-dialog. When the dialog was opening before it was always focusing the first focusable element which was always the close button.

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -107,7 +107,7 @@ export class ModalDialogElement extends HTMLElement {
       if (this.#focusAbortController.signal.aborted) {
         this.#focusAbortController = new AbortController()
       }
-      focusTrap(this, undefined, this.#focusAbortController.signal)
+      focusTrap(this, this.querySelector('[autofocus]') as HTMLElement, this.#focusAbortController.signal)
       overlayStack.push(this)
     } else {
       if (!this.open) return

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -166,6 +166,11 @@ module Primer
                                show_divider: show_divider
                              })
       end
+
+      # @label Autofocus element with autofocus attribute
+      def autofocus_element
+        render_with_template(locals: {})
+      end
     end
   end
 end

--- a/previews/primer/alpha/dialog_preview/autofocus_element.html.erb
+++ b/previews/primer/alpha/dialog_preview/autofocus_element.html.erb
@@ -1,0 +1,8 @@
+<%= render(Primer::Alpha::Dialog.new(id: "dialog-one", title: "Dialog")) do |d| %>
+  <% d.with_show_button { "Show Dialog" } %>
+  <% d.with_body do %>
+    <form>
+      <input type="text" placeholder="This element is focused on open" autofocus>
+    </form>
+  <% end %>
+<% end %>

--- a/previews/primer/alpha/tooltip_preview.rb
+++ b/previews/primer/alpha/tooltip_preview.rb
@@ -85,7 +85,7 @@ module Primer
       end
 
       # @label Tooltip with button moving focus to input
-      def tooltip_with_dialog_moving_focus_to_input()
+      def tooltip_with_dialog_moving_focus_to_input
         render_with_template(locals: {})
       end
     end

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -20,5 +20,11 @@ module Alpha
 
       assert_equal page.evaluate_script("document.activeElement")["aria-label"], "Close"
     end
+
+    def test_focuses_autofocus_elements_inside_dialog
+      visit_preview(:autofocus_element)
+
+      click_button("Show Dialog")
+    end
   end
 end

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -37,8 +37,10 @@ module Alpha
       visit_preview(:autofocus_element)
 
       click_button("Show Dialog")
+
+      assert_equal page.evaluate_script("document.activeElement")["placeholder"], "This element is focused on open"
     end
-    
+
     def test_closes_top_level_dialog
       visit_preview(:nested_dialog)
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Closes https://github.com/github/primer/issues/2749

The dialog component wasn't respecting autofocus attributes inside of the dialog when it's opened. Instead it was still focusing the close button. This updates to focus autofocus when it exists and still falls back to the close button when it doesn't exist.

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
