### PR TITLE
Fix action bar issue where keys don't loop around to end

### DIFF
--- a/.changeset/poor-rats-jam.md
+++ b/.changeset/poor-rats-jam.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix ActionBar issue where left and end key don't loop around to end of the action bar items.

--- a/app/components/primer/alpha/action_bar_element.ts
+++ b/app/components/primer/alpha/action_bar_element.ts
@@ -86,9 +86,16 @@ class ActionBarElement extends HTMLElement {
       bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.HomeAndEnd,
       focusOutBehavior: 'wrap',
       focusableElementFilter: element => {
-        return !element.closest('.ActionBar-item[hidden]') && !element.closest('li.ActionListItem')
+        return this.#isVisible(element)
       }
     })
+  }
+
+  #isVisible(element: HTMLElement): boolean {
+    // Safari doesn't support `checkVisibility` yet.
+    if (typeof element.checkVisibility === 'function') return element.checkVisibility()
+
+    return Boolean(element.offsetParent || element.offsetWidth || element.offsetHeight)
   }
 
   #itemGap(): number {

--- a/test/system/alpha/action_bar_test.rb
+++ b/test/system/alpha/action_bar_test.rb
@@ -81,4 +81,14 @@ class IntegrationAlphaActionBarTest < System::TestCase
     assert_equal page.evaluate_script("document.activeElement.classList.contains('Button--iconOnly')"), true
     assert_equal page.evaluate_script("!!document.activeElement.closest('action-menu')"), true
   end
+
+  def test_arrow_left_loops_to_last_item
+    visit_preview(:default)
+
+    # Tab to first item and press left arrow
+    page.driver.browser.keyboard.type(:tab, :left)
+
+    # The last item "Attach" should be focused
+    assert page.evaluate_script("document.activeElement.querySelector('svg.octicon-paperclip')")
+  end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

https://github.com/primer/view_components/assets/54012/a7dedc45-0e9d-4727-910f-a4fd73c5223d

https://view-components-storybook.eastus.cloudapp.azure.com/view-components/lookbook/inspect/primer/alpha/action_bar/default

Currently when you focus the first item you can't press `end` or `left` to get to the last item in the list. This is because it's trying to focus some of the menu items. 

### Integration

no

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

To simplify the filter check I'm using `checkVisibility` which is built into most browsers, (not safari).

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
