### PR TITLE
Fix multi-select behavior when ActionMenus are embedded in dialogs

### DIFF
--- a/.changeset/large-actors-reply.md
+++ b/.changeset/large-actors-reply.md
@@ -1,0 +1,7 @@
+---
+'@primer/view-components': minor
+---
+
+Fix multi-select behavior when ActionMenus are embedded in dialogs
+
+<!-- Changed components: Primer::Alpha::ActionMenu -->

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -172,11 +172,6 @@ export class ActionMenuElement extends HTMLElement {
       return
     }
 
-    // Ignore events within dialogs within menus
-    if ((event.target as Element)?.closest('dialog') || (event.target as Element)?.closest('modal-dialog')) {
-      return
-    }
-
     if (event.type === 'focusout') {
       if (this.#invokerBeingClicked) return
 

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -346,7 +346,7 @@ module Alpha
       click_on_invoker_button
       click_on_second_item
 
-      assert_selector "modal-dialog#my-dialog"
+      assert_selector "modal-dialog[open]"
 
       # opening the dialog should close the menu
       refute_selector "action-menu ul li"
@@ -474,6 +474,9 @@ module Alpha
       click_on_fourth_item
 
       assert_selector "modal-dialog[open]"
+
+      # menu should close
+      refute_selector "action-menu ul li"
     end
 
     def test_opening_second_menu_closes_first_menu


### PR DESCRIPTION
### What are you trying to accomplish?

This PR fixes an issue preventing single- and multi-select behavior from working when the menu is rendered inside a dialog.

### Integration

No changes necessary in production.

#### List the issues that this change affects.

Fixes https://github.com/github/primer/issues/2633

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

I removed code added in [this PR](https://github.com/primer/view_components/pull/2212) that specifically ignores events generated by menus rendered inside dialogs. I was able to determine that removing the code does not cause a regression.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
