### PR TITLE
Prevent scrolling when activating ActionMenu items via space

### DIFF
--- a/.changeset/dry-cameras-attend.md
+++ b/.changeset/dry-cameras-attend.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prevent scrolling when activating ActionMenu items via space

--- a/app/components/primer/alpha/action_bar_element.ts
+++ b/app/components/primer/alpha/action_bar_element.ts
@@ -93,6 +93,8 @@ class ActionBarElement extends HTMLElement {
 
   #isVisible(element: HTMLElement): boolean {
     // Safari doesn't support `checkVisibility` yet.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     if (typeof element.checkVisibility === 'function') return element.checkVisibility()
 
     return Boolean(element.offsetParent || element.offsetWidth || element.offsetHeight)

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -134,11 +134,24 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #isKeyboardActivation(event: Event): boolean {
+    return this.#isKeyboardActivationViaEnter(event) || this.#isKeyboardActivationViaSpace(event)
+  }
+
+  #isKeyboardActivationViaEnter(event: Event): boolean {
     return (
       event instanceof KeyboardEvent &&
       event.type === 'keydown' &&
       !(event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) &&
-      (event.key === 'Enter' || event.key === ' ')
+      event.key === 'Enter'
+    )
+  }
+
+  #isKeyboardActivationViaSpace(event: Event): boolean {
+    return (
+      event instanceof KeyboardEvent &&
+      event.type === 'keydown' &&
+      !(event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) &&
+      event.key === ' '
     )
   }
 
@@ -202,6 +215,16 @@ export class ActionMenuElement extends HTMLElement {
 
       this.#activateItem(event, item)
       this.#handleItemActivated(event, item)
+
+      // Pressing the space key on a button will cause the page to scroll unless preventDefault()
+      // is called. Unfortunately, calling preventDefault() will also skip form submission. The
+      // code below therefore only calls preventDefault() if the button submits a form and the
+      // button is being activated by the space key.
+      if (item.getAttribute('type') === 'submit' && this.#isKeyboardActivationViaSpace(event)) {
+        event.preventDefault()
+        item.closest('form')?.submit()
+      }
+
       return
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR prevents scrolling when activating a single-select `ActionMenu` item that submits a form. I tried pretty hard to write a test for this but the behavior does not appear in Lookbook for some reason. I verified this will fix the issue in dotcom though, and I left a number of comments.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/2794

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

See inline comments.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge