### PR TITLE
Allow several font sizes for Subhead headings

### DIFF
--- a/.changeset/shiny-buses-matter.md
+++ b/.changeset/shiny-buses-matter.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Allow several font sizes for Subhead headings

--- a/app/components/primer/beta/subhead.pcss
+++ b/app/components/primer/beta/subhead.pcss
@@ -26,7 +26,7 @@
 }
 
 .Subhead-heading--medium {
-  font-size: 20px;
+  font-size: var(--text-title-size-medium);
 }
 
 /* Make the text bold and red for dangerous content */

--- a/app/components/primer/beta/subhead.pcss
+++ b/app/components/primer/beta/subhead.pcss
@@ -22,7 +22,7 @@
 }
 
 .Subhead-heading--large {
-  font-size: 24px;
+  font-size: var(--base-size-24);
 }
 
 .Subhead-heading--medium {

--- a/app/components/primer/beta/subhead.pcss
+++ b/app/components/primer/beta/subhead.pcss
@@ -16,10 +16,17 @@
 
 /* <h2> sized heading with normal font weight */
 .Subhead-heading {
-  font-size: 24px;
   font-weight: var(--base-text-weight-normal);
   flex: 1 1 auto;
   order: 0;
+}
+
+.Subhead-heading--large {
+  font-size: 24px;
+}
+
+.Subhead-heading--medium {
+  font-size: 20px;
 }
 
 /* Make the text bold and red for dangerous content */

--- a/app/components/primer/beta/subhead.rb
+++ b/app/components/primer/beta/subhead.rb
@@ -17,16 +17,24 @@ module Primer
       DEFAULT_HEADING_TAG = :div
       HEADING_TAG_OPTIONS = [DEFAULT_HEADING_TAG, :h1, :h2, :h3, :h4, :h5, :h6].freeze
 
+      DEFAULT_HEADING_SIZE = :large
+      HEADING_SIZE_MAP = {
+        DEFAULT_HEADING_SIZE => "Subhead-heading--large",
+        :medium => "Subhead-heading--medium"
+      }.freeze
+      HEADING_SIZE_OPTIONS = HEADING_SIZE_MAP.keys.freeze
+
       # The heading
       #
       # @param tag [Symbol] <%= one_of(Primer::Beta::Subhead::HEADING_TAG_OPTIONS)%>
       # @param danger [Boolean] Whether to style the heading as dangerous.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_one :heading, lambda { |tag: DEFAULT_HEADING_TAG, danger: false, **system_arguments|
+      renders_one :heading, lambda { |tag: DEFAULT_HEADING_TAG, danger: false, size: DEFAULT_HEADING_SIZE, **system_arguments|
         system_arguments[:tag] = fetch_or_fallback(HEADING_TAG_OPTIONS, tag, DEFAULT_HEADING_TAG)
         system_arguments[:classes] = class_names(
           system_arguments[:classes],
           "Subhead-heading",
+          HEADING_SIZE_MAP[fetch_or_fallback(HEADING_SIZE_OPTIONS, size, DEFAULT_HEADING_SIZE)],
           "Subhead-heading--danger": danger
         )
 

--- a/previews/primer/beta/subhead_preview.rb
+++ b/previews/primer/beta/subhead_preview.rb
@@ -9,10 +9,11 @@ module Primer
       # @param spacious [Boolean]
       # @param hide_border [Boolean]
       # @param heading_danger [Boolean]
+      # @param heading_size [Symbol] select [medium, large]
       # @param heading_tag [Symbol] select [div, h1, h2, h3, h4, h5, h6]
-      def playground(spacious: false, hide_border: false, heading_tag: :div, heading_danger: false)
+      def playground(spacious: false, hide_border: false, heading_tag: :div, heading_size: Primer::Beta::Subhead::DEFAULT_HEADING_SIZE, heading_danger: false)
         render(Primer::Beta::Subhead.new(spacious: spacious, hide_border: hide_border)) do |component|
-          component.with_heading(tag: heading_tag, danger: heading_danger) do
+          component.with_heading(tag: heading_tag, size: heading_size, danger: heading_danger) do
             "My Heading"
           end
           component.with_description do
@@ -26,11 +27,12 @@ module Primer
       # @param spacious [Boolean]
       # @param hide_border [Boolean]
       # @param heading_danger [Boolean]
+      # @param heading_size [Symbol] select [medium, large]
       # @param heading_tag [Symbol] select [div, h1, h2, h3, h4, h5, h6]
       # @snapshot
-      def default(spacious: false, hide_border: false, heading_tag: :div, heading_danger: false)
+      def default(spacious: false, hide_border: false, heading_tag: :div, heading_size: Primer::Beta::Subhead::DEFAULT_HEADING_SIZE, heading_danger: false)
         render(Primer::Beta::Subhead.new(spacious: spacious, hide_border: hide_border)) do |component|
-          component.with_heading(tag: heading_tag, danger: heading_danger) do
+          component.with_heading(tag: heading_tag, size: heading_size, danger: heading_danger) do
             "My Heading"
           end
           component.with_description do

--- a/previews/primer/beta/subhead_preview.rb
+++ b/previews/primer/beta/subhead_preview.rb
@@ -100,6 +100,32 @@ module Primer
       end
       #
       # @!endgroup
+
+      # @!group Header size
+      #
+      # @label Large
+      def large_header
+        render(Primer::Beta::Subhead.new) do |component|
+          component.with_heading(size: :large) do
+            "Large Header"
+          end
+          component.with_description do
+            "Description"
+          end
+        end
+      end
+
+      # @label Medium
+      def medium_header
+        render(Primer::Beta::Subhead.new) do |component|
+          component.with_heading(size: :medium) do
+            "Medium Header"
+          end
+          component.with_description do
+            "Description"
+          end
+        end
+      end
     end
   end
 end

--- a/test/components/beta/subhead_test.rb
+++ b/test/components/beta/subhead_test.rb
@@ -79,6 +79,22 @@ class PrimerBetaSubheadTest < Minitest::Test
     assert_selector(".Subhead .Subhead-description", text: "My Description")
   end
 
+  def test_renders_medium_heading
+    render_inline(Primer::Beta::Subhead.new(heading: "Hello world")) do |component|
+      component.with_heading(size: :medium) { "Hello World" }
+    end
+
+    assert_selector(".Subhead .Subhead-heading--medium", text: "Hello World")
+  end
+
+  def test_renders_large_heading_by_default
+    render_inline(Primer::Beta::Subhead.new(heading: "Hello world")) do |component|
+      component.with_heading { "Hello World" }
+    end
+
+    assert_selector(".Subhead .Subhead-heading--large", text: "Hello World")
+  end
+
   def test_status
     assert_component_state(Primer::Beta::Subhead, :beta)
   end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR allows adjusting the (font) size of headings in the `Subhead` component. A Hubber asked in Slack why `Subhead` headings in PVC have a font size of 24px, but a font size of 20px in PRC and in Figma. Rather than change the font size and potentially mess with a bunch of existing usages in dotcom, I have chosen to introduce two heading sizes, large (the default), and medium.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

|Large|Medium|
|-|-|
|<img width="217" alt="A screenshot of the Subhead component. Some heading text of 'My Heading' appears above a muted description of 'My Description'. The font size of the heading is large (24px)." src="https://github.com/primer/view_components/assets/575280/ca7ce283-83da-4c37-8e32-ca5636b71d9b">|<img width="203" alt="A screenshot of the Subhead component. Some heading text of 'My Heading' appears above a muted description of 'My Description'. The font size of the heading is medium (20px)." src="https://github.com/primer/view_components/assets/575280/255564f8-ffd5-4a45-99a0-44f66b357d20">|

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
