### PR TITLE
Action menu prevent scrolling on link click

### DIFF
--- a/.changeset/hot-dots-look.md
+++ b/.changeset/hot-dots-look.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prevent scrolling when activating ActionMenu form items via space

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -216,13 +216,16 @@ export class ActionMenuElement extends HTMLElement {
       this.#activateItem(event, item)
       this.#handleItemActivated(event, item)
 
-      // Pressing the space key on a button will cause the page to scroll unless preventDefault()
-      // is called. Unfortunately, calling preventDefault() will also skip form submission. The
-      // code below therefore only calls preventDefault() if the button submits a form and the
-      // button is being activated by the space key.
-      if (item.getAttribute('type') === 'submit' && this.#isKeyboardActivationViaSpace(event)) {
+      // Pressing the space key on a button or link will cause the page to scroll unless preventDefault()
+      // is called. While calling preventDefault() appears to have no effect on link navigation, it skips
+      // form submission. The code below therefore only calls preventDefault() if the button has been
+      // activated by the space key, and manually submits the form if the button is a submit button.
+      if (this.#isKeyboardActivationViaSpace(event)) {
         event.preventDefault()
-        item.closest('form')?.submit()
+
+        if (item.getAttribute('type') === 'submit') {
+          item.closest('form')?.submit()
+        }
       }
 
       return


### PR DESCRIPTION
### What are you trying to accomplish?

This PR prevents scrolling when an `ActionMenu` link item is activated via the `<Space>` key. This is a follow-on PR to https://github.com/primer/view_components/pull/2326, which addressed the same issue, but for `ActionMenu` items that are submit buttons, i.e. `<button type="submit">`.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

It turns out calling `event.preventDefault()` will stop forms from being submitted, but does not affect link navigation. The fix in this PR calls `event.preventDefault()` whenever an item is activated with `<Space>`, whereas previously `preventDefault()` was only called if the item was a submit button.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
