### PR TITLE
Remove redundant `aria-disabled` on list item

### DIFF
--- a/.changeset/hip-pens-attend.md
+++ b/.changeset/hip-pens-attend.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Removes redundant `aria-disabled` from list item within `ActionMenu`.

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -102,11 +102,6 @@ module Primer
               content_arguments,
               { aria: { disabled: true } }
             )
-
-            system_arguments[:aria] = merge_aria(
-              system_arguments,
-              { aria: { disabled: true } }
-            )
           end
 
           { data: data, **system_arguments, content_arguments: content_arguments }

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -114,7 +114,7 @@ module Primer
       def test_disabled
         render_preview(:with_disabled_items)
 
-        assert_selector("li[aria-disabled=true]") do
+        assert_selector("li[role=none]") do
           assert_selector("button.ActionListContent[aria-disabled=true]", text: "Does something")
           assert_selector("a.ActionListContent[aria-disabled=true]", text: "Site")
         end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Removes redundant `aria-disabled` that was placed on [both list item and menu item](https://primer.style/view-components/lookbook/inspect/primer/alpha/action_menu/with_disabled_items/).

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
