### PR TITLE
Upgrade erblint-github to v0.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,7 @@ group :development do
   gem "capybara", "~> 3.39.2"
   gem "cuprite", "~> 0.14.3"
   gem "erb_lint", "~> 0.4.0"
-  gem "erblint-github", "~> 0.4.1"
+  gem "erblint-github", "~> 0.5.1"
   gem "listen", "~> 3.0"
   gem "matrix", "~> 0.4.2"
   gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       rainbow
       rubocop
       smart_properties
-    erblint-github (0.4.1)
+    erblint-github (0.5.1)
     erubi (1.12.0)
     ferrum (0.13)
       addressable (~> 2.5)
@@ -288,7 +288,7 @@ DEPENDENCIES
   capybara (~> 3.39.2)
   cuprite (~> 0.14.3)
   erb_lint (~> 0.4.0)
-  erblint-github (~> 0.4.1)
+  erblint-github (~> 0.5.1)
   kramdown (~> 2.4)
   listen (~> 3.0)
   lookbook (~> 2.1.1)

--- a/demo/app/views/action_menu/deferred.html.erb
+++ b/demo/app/views/action_menu/deferred.html.erb
@@ -11,7 +11,6 @@
   ) %>
 <% end %>
 
-
 <%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |d| %>
   <%= render(Primer::Alpha::Dialog::Body.new()) do %>
     Are you sure you want to delete this?

--- a/demo/app/views/action_menu/form_action.html.erb
+++ b/demo/app/views/action_menu/form_action.html.erb
@@ -1,2 +1,2 @@
-You selected <%= @value.inspect %><br/>
+You selected <%= @value.inspect %><br>
 Other params sent to server: <%= @other_params.inspect %>

--- a/demo/app/views/auto_complete_test/index.html.erb
+++ b/demo/app/views/auto_complete_test/index.html.erb
@@ -1,3 +1,4 @@
+<%# erblint:counter DeprecatedComponentsCounter 2 %>
 <% @fruit_list.each do |fruit| %>
   <% if params['version'] == "alpha" %>
     <%= render(Primer::Alpha::AutoComplete::Item.new(value: fruit)) { fruit } %>

--- a/demo/app/views/layouts/component_preview.html.erb
+++ b/demo/app/views/layouts/component_preview.html.erb
@@ -18,7 +18,7 @@
 
   <body>
     <div id="component-preview">
-      <% if params.dig(:lookbook, :display, :theme) == "all" || params.dig(:theme) == "all" %> 
+      <% if params.dig(:lookbook, :display, :theme) == "all" || params.dig(:theme) == "all" %>
         <div class="theme-wrap">
           <% color_themes.each do |theme| %>
             <div class="preview-wrap" <%= color_theme_attributes(theme) %>>

--- a/demo/app/views/layouts/mailer.html.erb
+++ b/demo/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/script/erblint
+++ b/script/erblint
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+bundle exec erblint \
+    app/**/*.html.erb \
+    lib/**/*.html.erb \
+    demo/app/**/*.html.erb \
+    test/**/*.html.erb \
+    ${@}


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR upgrades erblint-github to the latest version, v0.5.1.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production 👍 

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/2834

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Bumped the gem and ran it, correcting all violations.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.