### PR TITLE
Don't allow previously hidden items to be checkable; add ActionMenu js API

### DIFF
--- a/.changeset/strange-rings-confess.md
+++ b/.changeset/strange-rings-confess.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+[ActionMenu] Don't allow previously hidden items to be checkable; add JavaScript API

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -128,7 +128,7 @@ module Primer
         # @private
         renders_one :private_content
 
-        attr_reader :id, :list, :href, :active, :disabled, :parent
+        attr_reader :id, :item_id, :list, :href, :active, :disabled, :parent
 
         # Whether or not this item is active.
         #
@@ -143,6 +143,7 @@ module Primer
         # @param list [Primer::Alpha::ActionList] The list that contains this item. Used internally.
         # @param parent [Primer::Alpha::ActionList::Item] This item's parent item. `nil` if this item is at the root. Used internally.
         # @param label [String] Item label. If no label is provided, content is used.
+        # @param item_id [String] An ID that will be attached to the item's `<li>` element as `data-item-id` for distinguishing between items, perhaps in JavaScript.
         # @param label_classes [String] CSS classes that will be added to the label.
         # @param label_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the label.
         # @param content_arguments [Hash] <%= link_to_system_arguments_docs %> used to construct the item's anchor or button tag.
@@ -161,6 +162,7 @@ module Primer
         def initialize(
           list:,
           label: nil,
+          item_id: nil,
           label_classes: nil,
           label_arguments: {},
           content_arguments: {},
@@ -181,6 +183,7 @@ module Primer
           @list = list
           @parent = parent
           @label = label
+          @item_id = item_id
           @href = href || content_arguments[:href]
           @truncate_label = truncate_label
           @disabled = disabled
@@ -205,6 +208,15 @@ module Primer
 
           @system_arguments[:data] ||= {}
           @system_arguments[:data][:targets] = "#{list_class.custom_element_name}.items"
+
+          @system_arguments[:data] = merge_data(
+            @system_arguments, {
+              data: {
+                targets: "#{list_class.custom_element_name}.items",
+                **(@item_id ? { item_id: @item_id } : {})
+              }
+            }
+          )
 
           @label_arguments = {
             **label_arguments,

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -128,6 +128,28 @@ module Primer
     #
     #   Additional information around the keyboard functionality and implementation can be found on the
     #   [WAI-ARIA Authoring Practices](https://www.w3.org/TR/wai-aria-practices-1.2/#menu).
+    #
+    # ### JavaScript API
+    #
+    # `ActionList`s render an `<action-list>` custom element that exposes behavior to the client. For all these methods,
+    # `itemId` refers to the value of the `item_id:` argument (see below) that is used to populate the `data-item-id` HTML
+    # attribute.
+    #
+    # #### Query methods
+    #
+    # * `isItemChecked(itemId: string): boolean`: Returns `true` if the item is checked, `false` otherwise.
+    # * `isItemHidden(itemId: string): boolean`: Returns `true` if the item is hidden, `false` otherwise.
+    # * `isItemDisabled(itemId: string): boolean`: Returns `true` if the item is disabled, `false` otherwise.
+    # * `getItemById(itemId: string): HTMLElement`: Returns the item's HTML `<li>` element.
+    #
+    # #### State methods
+    #
+    # * `showItemById(itemId: string)`: Shows the item, i.e. makes it visible.
+    # * `hideItemById(itemId: string)`: Hides the item, i.e. makes it invisible.
+    # * `enableItemById(itemId: string)`: Enables the item, i.e. makes it clickable by the mouse and keyboard.
+    # * `disableItemById(itemId: string)`: Disables the item, i.e. makes it unclickable by the mouse and keyboard.
+    # * `checkItemById(itemId: string)`: Checks the item. Only has an effect in single- and multi-select modes.
+    # * `uncheckItemById(itemId: string)`: Unchecks the item. Only has an effect in multi-select mode, since items cannot be unchecked in single-select mode.
     class ActionMenu < Primer::Component
       status :alpha
 

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -137,19 +137,30 @@ module Primer
     #
     # #### Query methods
     #
-    # * `isItemChecked(itemId: string): boolean`: Returns `true` if the item is checked, `false` otherwise.
-    # * `isItemHidden(itemId: string): boolean`: Returns `true` if the item is hidden, `false` otherwise.
-    # * `isItemDisabled(itemId: string): boolean`: Returns `true` if the item is disabled, `false` otherwise.
-    # * `getItemById(itemId: string): HTMLElement`: Returns the item's HTML `<li>` element.
+    # * `getItemById(itemId: string): Element`: Returns the item's HTML `<li>` element. The return value can be passed as the `item` argument to the other methods listed below.
+    # * `isItemChecked(item: Element): boolean`: Returns `true` if the item is checked, `false` otherwise.
+    # * `isItemHidden(item: Element): boolean`: Returns `true` if the item is hidden, `false` otherwise.
+    # * `isItemDisabled(item: Element): boolean`: Returns `true` if the item is disabled, `false` otherwise.
     #
     # #### State methods
     #
-    # * `showItemById(itemId: string)`: Shows the item, i.e. makes it visible.
-    # * `hideItemById(itemId: string)`: Hides the item, i.e. makes it invisible.
-    # * `enableItemById(itemId: string)`: Enables the item, i.e. makes it clickable by the mouse and keyboard.
-    # * `disableItemById(itemId: string)`: Disables the item, i.e. makes it unclickable by the mouse and keyboard.
-    # * `checkItemById(itemId: string)`: Checks the item. Only has an effect in single- and multi-select modes.
-    # * `uncheckItemById(itemId: string)`: Unchecks the item. Only has an effect in multi-select mode, since items cannot be unchecked in single-select mode.
+    # * `showItem(item: Element)`: Shows the item, i.e. makes it visible.
+    # * `hideItem(item: Element)`: Hides the item, i.e. makes it invisible.
+    # * `enableItem(item: Element)`: Enables the item, i.e. makes it clickable by the mouse and keyboard.
+    # * `disableItem(item: Element)`: Disables the item, i.e. makes it unclickable by the mouse and keyboard.
+    # * `checkItem(item: Element)`: Checks the item. Only has an effect in single- and multi-select modes.
+    # * `uncheckItem(item: Element)`: Unchecks the item. Only has an effect in multi-select mode, since items cannot be unchecked in single-select mode.
+    #
+    # #### Events
+    #
+    # The `<action-menu>` element fires an `itemActivated` event whenever an item is activated (eg. clicked) via the mouse or keyboard.
+    #
+    # ```typescript
+    # document.querySelector("action-menu").addEventListener("itemActivated", (event: ItemActivatedEvent) => {
+    #   event.item  // Element: the <li> item that was activated
+    #   event.checked  // boolean: whether or not the result of the activation checked the item
+    # })
+    # ```
     class ActionMenu < Primer::Component
       status :alpha
 

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -12,6 +12,17 @@ type SelectedItem = {
 const validSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
 const menuItemSelectors = validSelectors.map(selector => `:not([hidden]) > ${selector}`)
 
+export type ItemActivatedEvent = {
+  item: Element
+  checked: boolean
+}
+
+declare global {
+  interface HTMLElementEventMap {
+    itemActivated: CustomEvent<ItemActivatedEvent>
+  }
+}
+
 @controller
 export class ActionMenuElement extends HTMLElement {
   @target
@@ -310,6 +321,11 @@ export class ActionMenuElement extends HTMLElement {
     }
 
     this.#updateInput()
+    this.dispatchEvent(
+      new CustomEvent('itemActivated', {
+        detail: {item: item.parentElement, checked: this.isItemChecked(item.parentElement)}
+      })
+    )
   }
 
   #activateItem(event: Event, item: Element) {
@@ -416,7 +432,7 @@ export class ActionMenuElement extends HTMLElement {
     return this.querySelector(menuItemSelectors.join(','))
   }
 
-  get #items(): HTMLElement[] {
+  get items(): HTMLElement[] {
     return Array.from(this.querySelectorAll(menuItemSelectors.join(',')))
   }
 
@@ -424,9 +440,7 @@ export class ActionMenuElement extends HTMLElement {
     return this.querySelector(`li[data-item-id="${itemId}"`)
   }
 
-  isItemDisabled(itemId: string): boolean {
-    const item = this.getItemById(itemId)
-
+  isItemDisabled(item: Element | null): boolean {
     if (item) {
       return item.classList.contains('ActionListItem--disabled')
     } else {
@@ -434,27 +448,21 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  disableItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  disableItem(item: Element | null) {
     if (item) {
       item.classList.add('ActionListItem--disabled')
       item.querySelector('.ActionListContent')!.setAttribute('aria-disabled', 'true')
     }
   }
 
-  enableItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  enableItem(item: Element | null) {
     if (item) {
       item.classList.remove('ActionListItem--disabled')
       item.querySelector('.ActionListContent')!.removeAttribute('aria-disabled')
     }
   }
 
-  isItemHidden(itemId: string): boolean {
-    const item = this.getItemById(itemId)
-
+  isItemHidden(item: Element | null): boolean {
     if (item) {
       return item.hasAttribute('hidden')
     } else {
@@ -462,25 +470,19 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  hideItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  hideItem(item: Element | null) {
     if (item) {
       item.setAttribute('hidden', 'hidden')
     }
   }
 
-  showItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  showItem(item: Element | null) {
     if (item) {
       item.removeAttribute('hidden')
     }
   }
 
-  isItemChecked(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  isItemChecked(item: Element | null) {
     if (item) {
       return item.querySelector('.ActionListContent')!.getAttribute('aria-checked') === 'true'
     } else {
@@ -488,9 +490,7 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  checkItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  checkItem(item: Element | null) {
     if (item && (this.selectVariant === 'single' || this.selectVariant === 'multiple')) {
       const itemContent = item.querySelector('.ActionListContent')!
       const ariaChecked = itemContent.getAttribute('aria-checked') === 'true'
@@ -501,9 +501,7 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  uncheckItemById(itemId: string) {
-    const item = this.getItemById(itemId)
-
+  uncheckItem(item: Element | null) {
     if (item && (this.selectVariant === 'single' || this.selectVariant === 'multiple')) {
       const itemContent = item.querySelector('.ActionListContent')!
       const ariaChecked = itemContent.getAttribute('aria-checked') === 'true'

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -93,7 +93,7 @@ export class ActionMenuElement extends HTMLElement {
       results.push({
         label: labelEl?.textContent,
         value: selectedItem?.getAttribute('data-value'),
-        element: selectedItem
+        element: selectedItem,
       })
     }
 
@@ -113,7 +113,7 @@ export class ActionMenuElement extends HTMLElement {
 
     if (this.includeFragment) {
       this.includeFragment.addEventListener('include-fragment-replaced', this, {
-        signal
+        signal,
       })
     }
   }
@@ -323,8 +323,8 @@ export class ActionMenuElement extends HTMLElement {
     this.#updateInput()
     this.dispatchEvent(
       new CustomEvent('itemActivated', {
-        detail: {item: item.parentElement, checked: this.isItemChecked(item.parentElement)}
-      })
+        detail: {item: item.parentElement, checked: this.isItemChecked(item.parentElement)},
+      }),
     )
   }
 

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -11,7 +11,7 @@ module Primer
 
         attr_reader :items
 
-        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::List) %>
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>
         def initialize(**system_arguments)
           @items = []
           @has_group = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "eslint": "^8.23.1",
         "eslint-plugin-custom-elements": "^0.0.6",
         "eslint-plugin-github": "^4.9.2",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-prettier": "^5.0.0",
         "markdownlint-cli2": "^0.10.0",
         "mocha": "^10.0.0",
         "playwright": "^1.35.1",
@@ -4913,35 +4913,6 @@
         "eslint": "^8.0.1"
       }
     },
-    "node_modules/eslint-plugin-github/node_modules/eslint-plugin-prettier": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
-      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
-      "dev": true,
-      "dependencies": {
-        "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.8.5"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/prettier"
-      },
-      "peerDependencies": {
-        "@types/eslint": ">=8.0.0",
-        "eslint": ">=8.0.0",
-        "prettier": ">=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/eslint": {
-          "optional": true
-        },
-        "eslint-config-prettier": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/eslint-plugin-i18n-text": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-i18n-text/-/eslint-plugin-i18n-text-1.0.1.tgz",
@@ -5059,21 +5030,29 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/prettier"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -15187,18 +15166,6 @@
         "jsx-ast-utils": "^3.3.2",
         "prettier": "^3.0.0",
         "svg-element-attributes": "^1.3.1"
-      },
-      "dependencies": {
-        "eslint-plugin-prettier": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
-          "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
-          "dev": true,
-          "requires": {
-            "prettier-linter-helpers": "^1.0.0",
-            "synckit": "^0.8.5"
-          }
-        }
       }
     },
     "eslint-plugin-i18n-text": {
@@ -15296,12 +15263,13 @@
       "dev": true
     },
     "eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
       "dev": true,
       "requires": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       }
     },
     "eslint-rule-documentation": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint": "^8.23.1",
     "eslint-plugin-custom-elements": "^0.0.6",
     "eslint-plugin-github": "^4.9.2",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "markdownlint-cli2": "^0.10.0",
     "mocha": "^10.0.0",
     "playwright": "^1.35.1",

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -148,10 +148,12 @@ module Primer
       def single_select
         render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu|
           menu.with_show_button { "Menu" }
-          menu.with_item(label: "Fast forward")
-          menu.with_item(label: "Recursive")
-          menu.with_item(label: "Ours")
-          menu.with_item(label: "Resolve")
+          menu.with_item(label: "Fast forward", item_id: :fast_forward)
+          menu.with_item(label: "Recursive", item_id: :recursive)
+          menu.with_item(label: "Ours", item_id: :ours)
+          menu.with_item(label: "Resolve", item_id: :resolve)
+          menu.with_item(label: "Disabled", disabled: true, item_id: :disabled)
+          menu.with_item(label: "Hidden", hidden: true, disabled: true, item_id: :hidden)
         end
       end
 
@@ -166,7 +168,8 @@ module Primer
             username: "langermank",
             full_name: "Katie Langerman",
             full_name_scheme: :inline,
-            avatar_arguments: { shape: :square }
+            avatar_arguments: { shape: :square },
+            item_id: :katie
           )
 
           menu.with_avatar_item(
@@ -174,7 +177,8 @@ module Primer
             username: "jonrohan",
             full_name: "Jon Rohan",
             full_name_scheme: :inline,
-            avatar_arguments: { shape: :square }
+            avatar_arguments: { shape: :square },
+            item_id: :jon
           )
 
           menu.with_avatar_item(
@@ -182,7 +186,8 @@ module Primer
             username: "broccolinisoup",
             full_name: "Armağan Ersöz",
             full_name_scheme: :inline,
-            avatar_arguments: { shape: :square }
+            avatar_arguments: { shape: :square },
+            item_id: :armagan
           )
         end
       end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -17,6 +17,10 @@ module Alpha
       items[idx - 1].click
     end
 
+    def click_on_item_by_id(id)
+      find("li[data-item-id='#{id}']").click
+    end
+
     def click_on_first_item
       click_on_item(1)
     end
@@ -598,6 +602,104 @@ module Alpha
       # clicking the invoker a second time should close the menu
       click_on_invoker_button
       refute_selector "action-menu ul li"
+    end
+
+    def test_unhidden_disabled_item_cannot_be_checked
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      refute_selector "li[data-item-id=hidden]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').showItemById('hidden');
+      JS
+
+      assert_selector "li[data-item-id=hidden]"
+
+      click_on_item_by_id("hidden")
+      refute_selector "li [aria-checked=true]"
+    end
+
+    def test_hide_item_via_js_api
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      assert_selector "li[data-item-id=recursive]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').hideItemById('recursive');
+      JS
+
+      refute_selector "li[data-item-id=recursive]"
+    end
+
+    def test_show_item_via_js_api
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      refute_selector "li[data-item-id=hidden]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').showItemById('hidden');
+      JS
+
+      assert_selector "li[data-item-id=hidden]"
+    end
+
+    def test_disable_item_via_js_api
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      refute_selector "li[data-item-id=resolve] [aria-disabled=true]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').disableItemById('resolve');
+      JS
+
+      assert_selector "li[data-item-id=resolve] [aria-disabled=true]"
+    end
+
+    def test_enable_item_via_js_api
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      assert_selector "li[data-item-id=disabled] [aria-disabled=true]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').enableItemById('disabled');
+      JS
+
+      refute_selector "li[data-item-id=disabled] [aria-disabled=true]"
+    end
+
+    def test_check_item_via_js_api
+      visit_preview(:single_select)
+
+      click_on_invoker_button
+      refute_selector "li[data-item-id=recursive] [aria-checked=true]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').checkItemById('recursive');
+      JS
+
+      click_on_invoker_button
+      assert_selector "li[data-item-id=recursive] [aria-checked=true]"
+    end
+
+    def test_uncheck_item_via_js_api
+      # use multiple_select preview here because single-select menus do not allow unchecking checked items
+      visit_preview(:multiple_select)
+
+      click_on_invoker_button
+      click_on_item_by_id("jon")
+
+      assert_selector "li[data-item-id=jon] [aria-checked=true]"
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('action-menu').uncheckItemById('jon');
+      JS
+
+      refute_selector "li[data-item-id=jon] [aria-checked=true]"
     end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR does three things for the `ActionMenu` component:

1. Fixes the issue described in https://github.com/github/primer/issues/2873
2. Adds a JavaScript API to `ActionMenu` to make it easier to hide, disable, and check items.
3. Fires a custom event called `itemActivated` whenever an item is activated by the mouse or keyboard.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/2873

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge