### PR TITLE
ensure scroll position does not change when opening actionmenu

### DIFF
--- a/.changeset/tall-emus-jump.md
+++ b/.changeset/tall-emus-jump.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure scroll position does not change when opening ActionMenus

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -107,6 +107,7 @@ export class ActionMenuElement extends HTMLElement {
     this.addEventListener('mouseover', this, {signal})
     this.addEventListener('focusout', this, {signal})
     this.addEventListener('mousedown', this, {signal})
+    this.popoverElement?.addEventListener('toggle', this, {signal})
     this.#setDynamicLabel()
     this.#updateInput()
     this.#softDisableItems()
@@ -181,6 +182,10 @@ export class ActionMenuElement extends HTMLElement {
   handleEvent(event: Event) {
     const targetIsInvoker = this.invokerElement?.contains(event.target as HTMLElement)
     const eventIsActivation = this.#isActivation(event)
+
+    if (event.type === 'toggle' && (event as ToggleEvent).newState === 'open') {
+      this.#firstItem?.focus()
+    }
 
     if (targetIsInvoker && event.type === 'mousedown') {
       this.#invokerBeingClicked = true
@@ -261,7 +266,6 @@ export class ActionMenuElement extends HTMLElement {
       this.#hide()
     } else {
       this.#show()
-      this.#firstItem?.focus()
     }
   }
 

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -323,6 +323,13 @@ module Primer
                              })
       end
 
+      # @label In Scoll container
+      #
+      def in_scroll_container
+        render_with_template()
+      end
+
+
       # @label Align end
       #
       def align_end(menu_id: "menu-1")

--- a/previews/primer/alpha/action_menu_preview/in_scroll_container.html.erb
+++ b/previews/primer/alpha/action_menu_preview/in_scroll_container.html.erb
@@ -1,0 +1,11 @@
+<div style="height: 400px"></div>
+
+<div style="position: relative">
+  <%= render Primer::Alpha::ActionMenu.new(anchor_align: :end) do |c| %>
+    <% c.with_show_button { "Edit" } %>
+    <% c.with_item(tag: :button, type: "button", label: "Rename") %>
+    <% c.with_item(tag: :button, type: "button", scheme: :danger, label: "Remove") %>
+  <% end %>
+</div>
+
+<div style="height: 1400px"></div>

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -729,5 +729,17 @@ module Alpha
       assert page.evaluate_script("window.activatedItemChecked")
       assert_equal "Fast forward", page.evaluate_script("window.activatedItemText")
     end
+
+    def test_doesnt_scroll_when_opened
+      visit_preview(:in_scroll_container)
+
+      page.evaluate_script("window.scrollTo(0,400)")
+
+      assert_equal 400, page.evaluate_script("window.scrollY")
+
+      click_on_invoker_button
+
+      assert_equal 400, page.evaluate_script("window.scrollY")
+    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -729,22 +729,5 @@ module Alpha
       assert page.evaluate_script("window.activatedItemChecked")
       assert_equal "Fast forward", page.evaluate_script("window.activatedItemText")
     end
-
-    def test_doesnt_scroll_when_opened
-      visit_preview(:in_scroll_container)
-      focus_on_invoker_button
-
-      # Scroll to the invoker button
-      page.evaluate_script("window.scrollTo(0,400)")
-
-      # Confirm that the page is scrolled
-      assert_equal 400, page.evaluate_script("window.scrollY")
-
-      # Click on the button to open the menu
-      page.driver.browser.keyboard.type(:enter)
-
-      # Assert we're still scrolled
-      assert_equal 400, page.evaluate_script("window.scrollY")
-    end
   end
 end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -732,13 +732,18 @@ module Alpha
 
     def test_doesnt_scroll_when_opened
       visit_preview(:in_scroll_container)
+      focus_on_invoker_button
 
+      # Scroll to the invoker button
       page.evaluate_script("window.scrollTo(0,400)")
 
+      # Confirm that the page is scrolled
       assert_equal 400, page.evaluate_script("window.scrollY")
 
-      click_on_invoker_button
+      # Click on the button to open the menu
+      page.driver.browser.keyboard.type(:enter)
 
+      # Assert we're still scrolled
       assert_equal 400, page.evaluate_script("window.scrollY")
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

Sometimes opening the actionmenu causes the page to jump to the top, due to subtle timing issues with the anchored element positioning itself; it starts at the top of the page and only positions itself when visible. The actionmenu focusses the first element and if the menu hasn't had time to position itself, the page will jump. This fixes that.

### Integration

No

#### List the issues that this change affects.

Closes https://github.com/github/primer/issues/2897, https://github.com/github/primer/issues/2900

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

I moved the focus to the `toggle` event, which is fired _after_ the popover is opened. `anchored-position` positions the element on a `beforetoggle` event which is always fired before the element becomes visible, so the position should be correct and the page won't jump.

### Anything you want to highlight for special attention from reviewers?

No

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
