### PR TITLE
Fix HTML escaping in system arguments docs

### DIFF
--- a/lib/primer/yard/lookbook_pages_backend.rb
+++ b/lib/primer/yard/lookbook_pages_backend.rb
@@ -218,8 +218,8 @@ module Primer
           path, <<~ERB
             #{YAML.dump(frontmatter)}
             ---
-            <%= @page.data[:description_md] %>
-            <%= @page.data[:args_md] %>
+            <%= @page.data[:description_md].html_safe %>
+            <%= @page.data[:args_md].html_safe %>
           ERB
         )
       end


### PR DESCRIPTION
### What are you trying to accomplish?

A few HTML entities are being escaped in our [system arguments docs](https://primer.style/view-components/lookbook/pages/system_arguments/).

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes: https://github.com/github/primer/issues/2882

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.