### PR TITLE
Prevent default on escape key press when dismissing tooltip

### DIFF
--- a/.changeset/bright-glasses-taste.md
+++ b/.changeset/bright-glasses-taste.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prevent other Overlays closing when Escape is pressed while Tooltips are open

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -35,7 +35,7 @@ const DIRECTION_CLASSES = [
   'tooltip-ne',
   'tooltip-se',
   'tooltip-nw',
-  'tooltip-sw'
+  'tooltip-sw',
 ]
 
 function closeOpenTooltips(except?: Element) {
@@ -272,11 +272,11 @@ class ToolTipElement extends HTMLElement {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore popoverTargetElement is not in the type definition
     this.control.popoverTargetElement?.addEventListener('beforetoggle', this, {
-      signal
+      signal,
     })
     this.ownerDocument.addEventListener('focusout', focusOutListener)
     this.ownerDocument.addEventListener('focusin', focusInListener)
-    this.ownerDocument.addEventListener('keydown', this, {signal})
+    this.ownerDocument.addEventListener('keydown', this, {signal, captures: true})
   }
 
   disconnectedCallback() {
@@ -300,6 +300,11 @@ class ToolTipElement extends HTMLElement {
     const isMouseDownOnButton = event.type === 'mousedown' && event.currentTarget === this.control
     const isOpeningOtherPopover = event.type === 'beforetoggle' && event.currentTarget !== this
     const shouldHide = isMouseLeaveFromButton || isEscapeKeydown || isMouseDownOnButton || isOpeningOtherPopover
+
+    if (showing && isEscapeKeydown) {
+      event.stopImmediatePropagation()
+      event.preventDefault()
+    }
 
     await Promise.resolve()
     if (!showing && shouldShow && !isPopoverOpen(this)) {
@@ -408,7 +413,7 @@ class ToolTipElement extends HTMLElement {
     const position = getAnchoredPosition(this, this.control, {
       side: this.#side,
       align: this.#align,
-      anchorOffset: TOOLTIP_OFFSET
+      anchorOffset: TOOLTIP_OFFSET,
     })
     const anchorSide = position.anchorSide
     const align = position.anchorAlign

--- a/test/system/alpha/tooltip_test.rb
+++ b/test/system/alpha/tooltip_test.rb
@@ -136,5 +136,25 @@ module Alpha
 
       assert_selector("tool-tip[for='dialog-show-my-dialog']", visible: :hidden)
     end
+
+    def test_tooltip_escape_hides_only_tooltip
+      visit_preview(:tooltip_inside_primer_overlay)
+
+      find("button[popovertarget]").click
+
+      assert_selector("anchored-position[popover]", visible: :visible)
+
+      assert_selector("tool-tip[for='overlay-button']", visible: :hidden)
+
+      find("button#overlay-button").hover
+
+      assert_selector("tool-tip[for='overlay-button']", visible: :visible)
+
+      find("button#overlay-button").send_keys(:escape)
+
+      assert_selector("tool-tip[for='overlay-button']", visible: :hidden)
+
+      assert_selector("anchored-position[popover]", visible: :visible)
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Pressing `Escape` when a tooltip is open will propagate through to overlays, meaning the tooltip and overlay are both closed.

#2410 points out that  a conclusion of https://github.com/github/accessibility-audits/issues/5653 was that this should not happen and only the tooltip should close.

This fixes that.

### Integration

No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/primer/view_components/issues/2410

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

I called `preventDefault()` and `stopImmediatePropagation()` to ensure any other listeners don't trigger. There is also a need to upgrade https://github.com/oddbird/popover-polyfill to `0.3.6` but it has yet to be released, so that'll be a followup.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
