### PR TITLE
Use floats to hide ActionBar items to address Android Chrome overflow issue

### DIFF
--- a/.changeset/tough-pumas-guess.md
+++ b/.changeset/tough-pumas-guess.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Use floats to hide ActionBar items to address Android Chrome overflow issue

--- a/app/components/primer/alpha/action_bar.pcss
+++ b/app/components/primer/alpha/action_bar.pcss
@@ -12,20 +12,18 @@
 }
 
 .ActionBar-item-container {
-  display: flex;
   box-sizing: content-box;
-  align-items: center;
-  flex-shrink: 0;
-  flex-grow: 0;
+  overflow: hidden;
+  height: var(--control-medium-size);
 }
 
 .ActionBar-item {
   position: relative;
-  flex-shrink: 0;
+  float: left;
 }
 
 .ActionBar-more-menu {
-  flex-shrink: 0;
+  float: left;
 }
 
 .ActionBar--small {
@@ -42,6 +40,10 @@
   height: calc(var(--control-medium-size) / 2);
   margin: 0 var(--controlStack-medium-gap-condensed);
   border-left: var(--borderWidth-thin) solid var(--borderColor-muted);
+  float: left;
+  top: 50%;
+  bottom: 50%;
+  transform: translateY(-50%);
 }
 
 .ActionBar--small .ActionBar-divider {

--- a/app/components/primer/alpha/action_bar/divider.rb
+++ b/app/components/primer/alpha/action_bar/divider.rb
@@ -14,9 +14,6 @@ module Primer
             aria: {
               hidden: true
             },
-            data: {
-              targets: "action-bar.items"
-            },
             classes: "ActionBar-item ActionBar-divider"
           }
         end

--- a/app/components/primer/alpha/action_bar/divider.rb
+++ b/app/components/primer/alpha/action_bar/divider.rb
@@ -14,6 +14,9 @@ module Primer
             aria: {
               hidden: true
             },
+            data: {
+              targets: "action-bar.items"
+            },
             classes: "ActionBar-item ActionBar-divider"
           }
         end

--- a/app/components/primer/alpha/action_bar_element.ts
+++ b/app/components/primer/alpha/action_bar_element.ts
@@ -20,9 +20,14 @@ const resizeObserver = new ResizeObserver(entries => {
   }
 })
 
+// These are definitely used, but eslint is dumb apparently
+
+// eslint-disable-next-line no-unused-vars
 enum ItemType {
+  // eslint-disable-next-line no-unused-vars
   Item,
-  Divider
+  // eslint-disable-next-line no-unused-vars
+  Divider,
 }
 
 @controller

--- a/app/components/primer/alpha/action_bar_element.ts
+++ b/app/components/primer/alpha/action_bar_element.ts
@@ -1,5 +1,6 @@
 import {controller, targets, target} from '@github/catalyst'
 import {focusZone, FocusKeys} from '@primer/behaviors'
+import {ActionMenuElement} from './action_menu/action_menu_element'
 
 const instersectionObserver = new IntersectionObserver(entries => {
   for (const entry of entries) {
@@ -28,7 +29,7 @@ enum ItemType {
 class ActionBarElement extends HTMLElement {
   @targets items: HTMLElement[]
   @target itemContainer: HTMLElement
-  @target moreMenu: HTMLElement
+  @target moreMenu: ActionMenuElement
 
   #focusZoneAbortController: AbortController | null = null
 
@@ -109,7 +110,10 @@ class ActionBarElement extends HTMLElement {
       bindKeys: FocusKeys.ArrowHorizontal | FocusKeys.HomeAndEnd,
       focusOutBehavior: 'wrap',
       focusableElementFilter: element => {
-        return this.#isVisible(element)
+        const idx = this.items.indexOf(element.parentElement!)
+        const elementIsVisibleItem = idx > -1 && this.items[idx].style.visibility === 'visible'
+        const elementIsVisibleActionMenuInvoker = element === this.moreMenu.invokerElement && !this.moreMenu.hidden
+        return elementIsVisibleItem || elementIsVisibleActionMenuInvoker
       },
     })
   }
@@ -127,15 +131,6 @@ class ActionBarElement extends HTMLElement {
     })
 
     return foundItem
-  }
-
-  #isVisible(element: HTMLElement): boolean {
-    // Safari doesn't support `checkVisibility` yet.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    if (typeof element.checkVisibility === 'function') return element.checkVisibility()
-
-    return Boolean(element.offsetParent || element.offsetWidth || element.offsetHeight)
   }
 
   #showItem(index: number) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.2",
+        "@oddbird/popover-polyfill": "^0.3.6",
         "@primer/behaviors": "^1.3.4"
       },
       "devDependencies": {
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
-      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.6.tgz",
+      "integrity": "sha512-9y9vWw6svuva+pLahuK1CBScoXhk70yiS9l+Ll7IBsUC3gTmdHDGXBv+H0EwGsJ3iCytvTd98Ds3+fcQQABrPg=="
     },
     "node_modules/@pkgr/utils": {
       "version": "2.4.2",
@@ -13040,9 +13040,9 @@
       }
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.2.tgz",
-      "integrity": "sha512-H0Q8JcFkXrOt2FrP0cUz2qomU5O+Dfc51UYLk5GtDWmVhdmvtV2FhgaCUh3TA6U5dogMZOFAf3QbwiGXhe9LXQ=="
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.6.tgz",
+      "integrity": "sha512-9y9vWw6svuva+pLahuK1CBScoXhk70yiS9l+Ll7IBsUC3gTmdHDGXBv+H0EwGsJ3iCytvTd98Ds3+fcQQABrPg=="
     },
     "@pkgr/utils": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@github/include-fragment-element": "^6.1.1",
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
-    "@oddbird/popover-polyfill": "^0.3.2",
+    "@oddbird/popover-polyfill": "^0.3.6",
     "@primer/behaviors": "^1.3.4"
   },
   "devDependencies": {

--- a/test/system/alpha/action_bar_test.rb
+++ b/test/system/alpha/action_bar_test.rb
@@ -8,12 +8,12 @@ class IntegrationAlphaActionBarTest < System::TestCase
   def test_resizing_hides_items
     visit_preview(:default)
 
-    assert_items_visible(count: 7)
+    assert_items_visible(count: 9)
     refute_selector("[data-target=\"action-bar.moreMenu\"]")
 
     page.driver.browser.resize(width: 183, height: 350)
 
-    assert_items_visible(count: 4)
+    assert_items_visible(count: 3)
     assert_selector("[data-target=\"action-bar.moreMenu\"]")
   end
 
@@ -90,19 +90,40 @@ class IntegrationAlphaActionBarTest < System::TestCase
     assert page.evaluate_script("document.activeElement.querySelector('svg.octicon-paperclip')")
   end
 
+  def test_arrow_left_loops_to_last_item_after_resize
+    visit_preview(:default)
+
+    page.driver.browser.resize(width: 183, height: 350)
+    assert_items_visible(count: 3)
+
+    # Tab to first item and press left arrow to get to menu invoker, then last visible item
+    page.driver.browser.keyboard.type(:tab, :left, :left)
+
+    # The ActionMenu invoker button should be focused
+    assert page.evaluate_script("document.activeElement.querySelector('svg.octicon-archive')")
+  end
+
+  def test_dividers_are_never_right_most_item
+    # in other words, dividers are hidden when the item that immediately succeeds them is hidden
+
+    visit_preview(:default)
+    page.driver.browser.resize(width: 290, height: 350)
+    assert_items_visible(count: 9)
+
+    page.driver.browser.resize(width: 289, height: 350)
+    assert_items_visible(count: 7)
+  end
+
   def assert_items_visible(count:)
     actual_count = nil
 
     3.times do
       actual_count = evaluate_multiline_script(<<~JS)
-        const items = document.querySelectorAll('[data-targets=\"action-bar.items\"]');
-        const first_item_top = items[0].getBoundingClientRect().top;
+        const items = document.querySelectorAll('[data-targets="action-bar.items"]');
         let count = 0;
 
         items.forEach((item) => {
-          if (item.getBoundingClientRect().top === first_item_top) {
-            count ++;
-          }
+          if (item.style.visibility === "visible") count ++;
         });
 
         return count;
@@ -110,7 +131,12 @@ class IntegrationAlphaActionBarTest < System::TestCase
 
       return true if count == actual_count
 
-      sleep 0.1
+      # trigger component's #update method
+      page_width, page_height = page.driver.browser.viewport_size
+      page.driver.browser.resize(width: page_width + 1, height: page_height)
+      page.driver.browser.resize(width: page_width - 1, height: page_height)
+
+      sleep 0.2
     end
 
     assert count == actual_count, "Expected #{count} items to be visible, found #{actual_count}"


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR is attempting to address an issue mostly occurring on older Android phones where the container around `ActionBar` icon buttons does not resize properly on smaller screens and "squashes" the rest of the content to the left-hand side of the page:

### Screenshots

|Before|After|
|-|-|
|<img alt="A screenshot of Chrome running on a Galaxy A10 phone via Browserstack. A GitHub issue is displayed in the browser. Most of the page's content appears squished to the left-hand side. A series of icons above the comment text area appears to be the culprit, as they are the only bits of UI that stretch all the way to the right-hand side." src="https://github.com/github/primer/assets/575280/6186dadc-8d5f-48df-9bbf-f8fe9ee2b7a9" width="500">|<img alt="A screenshot of Chrome running on a Galaxy A10 phone via Browserstack. A GitHub issue is displayed in the browser. The page looks normal, with no content squishing or overflow issues visible." src="https://github.com/primer/view_components/assets/575280/e12a6eff-ed2f-4eec-a21f-ef90bddd38f5" width="500">|

### Integration
<!-- Does this change require any updates to code in production? -->

No updates required in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes: https://github.com/github/primer/issues/2859

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

The `ActionBar` component currently hides/shows items based on the amount of available horizontal space. Unfortunately such calculations are semi error-prone because padding, margin, and the presence of dividers must be taken into account, which is difficult to get right. This PR removes the width calculation logic and instead uses a container `<div>` with a fixed height and floated icon buttons. As the div shrinks, items are automatically wrapped to the next line. These items become invisible because of the container's fixed height. On each `resize` event, JavaScript loops over each item and compares its `top` to the first item's `top`. If greater, the element has wrapped to the next line and should be hidden. The corresponding menu item should be un-hidden. As the container grows, the process is done in reverse, showing items and hiding menu items.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

This is probably the first time I've ever _wanted_ `float`ed elements to wrap lol.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
