### PR TITLE
Asset compilation failures should break the build

### DIFF
--- a/.changeset/kind-years-wink.md
+++ b/.changeset/kind-years-wink.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix typo in argument passed to event listener in ToolTip

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -276,7 +276,7 @@ class ToolTipElement extends HTMLElement {
     })
     this.ownerDocument.addEventListener('focusout', focusOutListener)
     this.ownerDocument.addEventListener('focusin', focusInListener)
-    this.ownerDocument.addEventListener('keydown', this, {signal, captures: true})
+    this.ownerDocument.addEventListener('keydown', this, {signal, capture: true})
   }
 
   disconnectedCallback() {

--- a/script/build-assets
+++ b/script/build-assets
@@ -5,19 +5,17 @@ export INPUT_TYPE=$1
 build_css() {
   # Get a list of all the CSS files in the src directory
   CSS_FILES=$(find app/components/primer -name '*.pcss' ! -path '*/primer.pcss')
-  npx postcss $CSS_FILES --dir app/components --base app/components --ext css
-  # Build main CSS bundle
-  npx postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss
-
-  # Export CSS selectors as json
-  script/export-css-selectors
+  npx postcss $CSS_FILES --dir app/components --base app/components --ext css && \
+    # Build main CSS bundle \
+    npx postcss -o app/assets/styles/primer_view_components.css app/components/primer/primer.pcss && \
+    # Export CSS selectors as json \
+    script/export-css-selectors
 }
 
 # Function to build the assets
 build_js() {
   # Build the assets
-  npx tsc
-  npx rollup -c
+  npx tsc && npx rollup -c
 }
 
 if [ "$INPUT_TYPE" = "css" ]; then
@@ -29,6 +27,5 @@ elif [ "$INPUT_TYPE" = "js" ]; then
   build_js
 else
   echo "Building all assets..."
-  build_js
-  build_css
+  build_js && build_css
 fi


### PR DESCRIPTION
### What are you trying to accomplish?

Problems reported during asset compilation do not currently break the build, which lets TypeScript compiler errors into main.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes required in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

This PR contains a fix for a compiler error introduced in https://github.com/primer/view_components/pull/2414. The build did not fail because of the way our script/build-assets script is written, so that's been fixed too.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.