### PR TITLE
Support font_size and border_radius in classify/utilities

### DIFF
--- a/.changeset/four-shoes-think.md
+++ b/.changeset/four-shoes-think.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Support font_size and border_radius in classify/utilities

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -27,7 +27,9 @@ module Primer
         "^height" => "h",
         "^color-bg" => "bg",
         "^color-border" => "border_color",
-        "^color-fg" => "color"
+        "^color-fg" => "color",
+        "^f" => "font_size",
+        "^rounded" => "border_radius"
       }.freeze
 
       SUPPORTED_KEY_CACHE = Hash.new { |h, k| h[k] = !UTILITIES[k].nil? }

--- a/test/lib/classify/utilities_test.rb
+++ b/test/lib/classify/utilities_test.rb
@@ -104,6 +104,7 @@ class PrimerClassifyUtilitiesTest < Minitest::Test
     assert_equal('mr: 1, mb: 2, classes: "foo"', Primer::Classify::Utilities.classes_to_args("mr-1 mb-2 foo"))
     assert_equal('classes: "foo"', Primer::Classify::Utilities.classes_to_args("foo"))
     assert_equal("mx: :auto", Primer::Classify::Utilities.classes_to_args("mx-auto"))
+    assert_equal("font_size: 3, border_radius: 0", Primer::Classify::Utilities.classes_to_args("f3 rounded-0"))
     assert_equal('mr: [1, 2], classes: "baz bin"', Primer::Classify::Utilities.classes_to_args("mr-1 mr-sm-2 baz bin"))
     assert_equal('mr: [1, nil, 2], classes: "foo bar"', Primer::Classify::Utilities.classes_to_args("mr-1 mr-md-2 foo bar"))
   end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This adds support to the `Primer::Classify::Utilities` class for converting class names like `f3` and `rounded-0` to the system args/values of `font_size: 3` and `border_radius: 0`, respectively.

### Integration

I don't believe so. Was there a reason that this wasn't added that causes conflicts?

#### List the issues that this change affects.

Closes # https://github.com/primer/view_components/issues/2448

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

1. added a failing test to the utilities test file
2. added a new entry for the `REPLACEMENT_KEYS` hash constant that targeted `f` and `radius` class names
3. committed the results

### Anything you want to highlight for special attention from reviewers?

Am I missing anything?


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
