### PR TITLE
Improve clarity of system_arguments docs, specifically for the `width:` attribute

### DIFF
--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -30,25 +30,27 @@ module Primer
     SELF_CLOSING_TAGS = [:area, :base, :br, :col, :embed, :hr, :img, :input, :link, :meta, :param, :source, :track, :wbr].freeze
     # ## HTML attributes
     #
-    # System arguments include most HTML attributes. For example:
+    # Use system arguments to add HTML attributes to elements. For the most part, system arguments map 1:1 to
+    # HTML attributes. For example, `render(Component.new(title: "Foo"))` will result in eg. `<div title="foo">`.
+    # However, ViewComponents applies special handling to certain system arguments. See the table below for details.
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | `aria` | `Hash` | Aria attributes: `aria: { label: "foo" }` renders `aria-label='foo'`. |
     # | `data` | `Hash` | Data attributes: `data: { foo: :bar }` renders `data-foo='bar'`. |
-    # | `height` | `Integer` | Height. |
-    # | `hidden` | `Boolean` | Whether to assign the `hidden` attribute. |
-    # | `style` | `String` | Inline styles. |
-    # | `title` | `String` | The `title` attribute. |
-    # | `width` | `Integer` | Width. |
     #
-    # ## Animation
+    # ## Utility classes
+    #
+    # ViewComponents provides a convenient way to add Primer CSS utility classes to HTML elements. Use the shorthand
+    # documented in the tables below instead of adding CSS classes directly.
+    #
+    # ### Animation
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | `animation` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:animation)) %> |
     #
-    # ## Border
+    # ### Border
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -60,7 +62,7 @@ module Primer
     # | `border` | Symbol | <%= one_of([:left, :top, :bottom, :right, :y, :x, true]) %> |
     # | `box_shadow` | Boolean, Symbol | Box shadow. <%= one_of([true, :medium, :large, :extra_large, :none]) %> |
     #
-    # ## Color
+    # ### Color
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -68,7 +70,7 @@ module Primer
     # | `border_color` | Symbol | Border color. <%= one_of(Primer::Classify::Utilities.mappings(:border_color)) %> |
     # | `color` | Symbol | Text color. <%= one_of(Primer::Classify::Utilities.mappings(:color)) %> |
     #
-    # ## Flex
+    # ### Flex
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -81,7 +83,7 @@ module Primer
     # | `flex_wrap` | Symbol | <%= one_of(Primer::Classify::FLEX_WRAP_MAPPINGS.keys) %> |
     # | `justify_content` | Symbol | <%= one_of(Primer::Classify::FLEX_JUSTIFY_CONTENT_VALUES) %> |
     #
-    # ## Grid
+    # ### Grid
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -89,18 +91,18 @@ module Primer
     # | `col` | Integer | Number of columns. <%= one_of(Primer::Classify::Utilities.mappings(:col)) %> |
     # | `container` | Symbol | Size of the container. <%= one_of(Primer::Classify::Utilities.mappings(:container)) %> |
     #
-    # ## Layout
+    # ### Layout
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
     # | `display` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:display)) %> |
-    # | `w` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:w)) %> |
-    # | `h` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:h)) %> |
+    # | `w` | Symbol | Sets the element's width. <%= one_of(Primer::Classify::Utilities.mappings(:w)) %> |
+    # | `h` | Symbol | Sets the element's height. <%= one_of(Primer::Classify::Utilities.mappings(:h)) %> |
     # | `hide` | Symbol | Hide the element at a specific breakpoint. <%= one_of(Primer::Classify::Utilities.mappings(:hide)) %> |
     # | `visibility` | Symbol | Visibility. <%= one_of(Primer::Classify::Utilities.mappings(:visibility)) %> |
     # | `vertical_align` | Symbol | <%= one_of(Primer::Classify::Utilities.mappings(:vertical_align)) %> |
     #
-    # ## Position
+    # ### Position
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -111,7 +113,7 @@ module Primer
     # | `right` | Boolean | If `false`, sets `right: 0`. |
     # | `top` | Boolean | If `false`, sets `top: 0`. |
     #
-    # ## Spacing
+    # ### Spacing
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -130,7 +132,7 @@ module Primer
     # | `px` | Integer | Horizontal padding. <%= one_of(Primer::Classify::Utilities.mappings(:px)) %> |
     # | `py` | Integer | Vertical padding. <%= one_of(Primer::Classify::Utilities.mappings(:py)) %> |
     #
-    # ## Typography
+    # ### Typography
     #
     # | Name | Type | Description |
     # | :- | :- | :- |
@@ -143,7 +145,7 @@ module Primer
     # | `underline` | Boolean | Whether text should be underlined. |
     # | `word_break` | Symbol | Whether to break words on line breaks. <%= one_of(Primer::Classify::Utilities.mappings(:word_break)) %> |
     #
-    # ## Other
+    # ### Other
     #
     # | Name | Type | Description |
     # | :- | :- | :- |


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A Hubber reached out in Slack a few days ago to clarify which system argument to use to set the width of an element. The docs include a reference to `width`, and if you're Ctrl+Fing through the site, that's what you land on first. Unfortunately that reference is not the right one - it's simply an example of how system arguments turn into HTML attributes, and is not itself a special Primer argument that turns into a utility class. The one the Hubber wanted was `w`, which is documented further down the page.

Fixes https://github.com/primer/view_components/issues/2435

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I clarified the documentation by removing all the examples from that first table that aren't handled in a special way by the library.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.