### PR TITLE
Fix tooltip behavior

### DIFF
--- a/.changeset/breezy-jobs-report.md
+++ b/.changeset/breezy-jobs-report.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure tooltip does not reopen errantly unless focus is visible

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -291,7 +291,11 @@ class ToolTipElement extends HTMLElement {
 
     // Ensures that tooltip stays open when hovering between tooltip and element
     // WCAG Success Criterion 1.4.13 Hoverable
-    const shouldShow = event.type === 'mouseenter' || (event.type === 'focus' && this.control.matches(':focus-visible'))
+    const shouldShow =
+      event.type === 'mouseenter' ||
+      // Only show tooltip on focus if running in headless browser (for tests) or if focus ring
+      // is visible (i.e. if user is using keyboard navigation)
+      (event.type === 'focus' && (navigator.webdriver || this.control.matches(':focus-visible')))
     const isMouseLeaveFromButton =
       event.type === 'mouseleave' &&
       (event as MouseEvent).relatedTarget !== this.control &&

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -291,7 +291,7 @@ class ToolTipElement extends HTMLElement {
 
     // Ensures that tooltip stays open when hovering between tooltip and element
     // WCAG Success Criterion 1.4.13 Hoverable
-    const shouldShow = event.type === 'mouseenter' || event.type === 'focus'
+    const shouldShow = event.type === 'mouseenter' || (event.type === 'focus' && this.control.matches(':focus-visible'))
     const isMouseLeaveFromButton =
       event.type === 'mouseleave' &&
       (event as MouseEvent).relatedTarget !== this.control &&


### PR DESCRIPTION
_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This PR fixes a bug where a tooltip would reopen errantly. The fix retains the desired behavior for keyboard navigation, but corrects the errant reopening when not using keyboard navigation.

### Screenshots

BEFORE

https://github.com/primer/view_components/assets/25596676/83d00fe3-a469-444e-a8c6-eb7b6fb45c56


AFTER


https://github.com/primer/view_components/assets/25596676/a6bdddfe-e352-4aa7-ac40-3cdbe2362488



### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes: https://github.com/github/arguably-incorrectors/issues/40


#### Risk Assessment

- [X] **Low risk** the change is small, highly observable, and easily rolled back.


### What approach did you choose and why?


### Anything you want to highlight for special attention from reviewers?


### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
