### PR TITLE
Make dismiss action on Banner changeable

### DIFF
--- a/.changeset/warm-books-divide.md
+++ b/.changeset/warm-books-divide.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Make dismiss action on Banner translatable

--- a/app/components/primer/alpha/banner.html.erb
+++ b/app/components/primer/alpha/banner.html.erb
@@ -22,7 +22,7 @@
           Primer::Beta::IconButton.new(
             scheme: :invisible,
             icon: :x,
-            aria: { label: "Dismiss" },
+            aria: { label: @dismiss_label },
             data: { action: catalyst_action(event: "click", function: "dismiss") },
             autofocus: true
           )

--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -55,17 +55,21 @@ module Primer
         :hide
       ].freeze
 
+      DEFAULT_DISMISS_LABEL = "Dismiss"
+
       # @param full [Boolean] Whether the component should take up the full width of the screen.
       # @param full_when_narrow [Boolean] Whether the component should take up the full width of the screen when rendered inside smaller viewports.
       # @param dismiss_scheme [Symbol] Whether the component can be dismissed with an "x" button. <%= one_of(Primer::Alpha::Banner::DISMISS_SCHEMES) %>
+      # @param dismiss_label [String] The aria-label text of the dismiss "x" button
       # @param description [String] Description text rendered underneath the message.
       # @param icon [Symbol] The name of an <%= link_to_octicons %> icon to use. If no icon is provided, a default one will be chosen based on the scheme.
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::Banner::SCHEME_MAPPINGS.keys) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, description: nil, icon: nil, scheme: DEFAULT_SCHEME, **system_arguments)
+      def initialize(full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, **system_arguments)
         @scheme = fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)
         @icon = icon || DEFAULT_ICONS[@scheme]
         @dismiss_scheme = dismiss_scheme
+        @dismiss_label = dismiss_label
         @description = description
 
         @system_arguments = deny_tag_argument(**system_arguments)

--- a/previews/primer/alpha/banner_preview.rb
+++ b/previews/primer/alpha/banner_preview.rb
@@ -9,13 +9,14 @@ module Primer
       # @param full toggle
       # @param full_when_narrow toggle
       # @param dismiss_scheme [Symbol] select [none, remove, hide]
+      # @param dismiss_label text
       # @param icon [Symbol] octicon
       # @param scheme [Symbol] select [default, warning, danger, success]
       # @param content text
       # @param description text
-      def playground(full: false, full_when_narrow: false, dismiss_scheme: Primer::Alpha::Banner::DEFAULT_DISMISS_SCHEME, icon: :people, scheme: Primer::Alpha::Banner::DEFAULT_SCHEME, content: "This is a banner!", description: nil)
+      def playground(full: false, full_when_narrow: false, dismiss_scheme: Primer::Alpha::Banner::DEFAULT_DISMISS_SCHEME,  dismiss_label: Primer::Alpha::Banner::DEFAULT_DISMISS_LABEL, icon: :people, scheme: Primer::Alpha::Banner::DEFAULT_SCHEME, content: "This is a banner!", description: nil)
         icon = nil if icon == :none
-        render(Primer::Alpha::Banner.new(full: full, full_when_narrow: full_when_narrow, dismiss_scheme: dismiss_scheme, icon: icon == :none ? nil : icon, scheme: scheme, description: description)) { content }
+        render(Primer::Alpha::Banner.new(full: full, full_when_narrow: full_when_narrow, dismiss_scheme: dismiss_scheme, dismiss_label: dismiss_label, icon: icon == :none ? nil : icon, scheme: scheme, description: description)) { content }
       end
 
       # @label Default

--- a/test/components/alpha/banner_test.rb
+++ b/test/components/alpha/banner_test.rb
@@ -112,6 +112,13 @@ class PrimerBannerTest < Minitest::Test
     refute_selector(".Banner-close")
   end
 
+  def test_does_render_dismiss_label
+    render_inline(Primer::Alpha::Banner.new(dismiss_scheme: :remove, dismiss_label: "My new label")) { "foo" }
+
+    assert_selector(".Banner .Banner-close")
+    assert_selector("tool-tip", text: "My new label")
+  end
+
   def test_renders_action_button_slot
     render_inline(Primer::Alpha::Banner.new) do |component|
       component.with_action_button { "submit" }


### PR DESCRIPTION
### What are you trying to accomplish?
The `Alpha::Banner` component has the option to dismiss the banner via a button showing an "x". This button has an `aria-label` attribute with the hard coded text "Dismiss". This text is not changable. This PR aims to make the dismiss action customizable, e.g to open it for translations or different texts if the context requires it. 


#### List the issues that this change affects.

Closes #2453 

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
