### PR TITLE
Add outlines for high contrast mode

### DIFF
--- a/.changeset/fair-kings-retire.md
+++ b/.changeset/fair-kings-retire.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Adds visible outlines to `Overlay` and `Tooltip` in high contrast mode.

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -25,3 +25,9 @@ anchored-position.not-anchored::backdrop, dialog::backdrop {
   background-color: var(--overlay-backdrop-bgColor, var(--color-neutral-muted));
 }
 
+@media (forced-colors: active) {
+  .Overlay {
+    outline: solid 1px transparent;
+  }
+}
+

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -187,6 +187,16 @@ class ToolTipElement extends HTMLElement {
         margin-top: -6px;
         border-right-color: var(--bgColor-emphasis, var(--color-neutral-emphasis-plus));
       }
+
+      @media (forced-colors: active) {
+        :host {
+          outline: solid 1px transparent;
+        }
+
+        :host:before {
+          display: none;
+        }
+      }
     `
   }
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I noticed that some of our components were not outlined in HCM (high contrast mode), meaning that they blended in with the background. This makes it harder for users using HCM to discern between the background content and the contents within the overlay.

This PR adds some support for HCM by providing an outline to components that utilize our `Overlay` styles, as well as the `Tooltip` component.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

<details>
<summary>HCM changes to ActionMenu</summary>

**Menu before HCM styles:**
<img width="211" alt="ActionMenu before high contrast mode specific styles were applied. Shows a menu against a black background. The menu contains multiple menu items, and the background of the menu blends with the background of the page, as they are both the same color with the menu also lacking an outline" src="https://github.com/primer/view_components/assets/26746305/6a45a1c2-18a5-4cf3-85ca-3fd0f4eb18dc">

**Menu after HCM styles:** 
<img width="211" alt="ActionMenu before high contrast mode specific styles were applied. Shows a menu against a black background. The menu contains multiple menu items, with a white outline encompassing the entirety of the menu" src="https://github.com/primer/view_components/assets/26746305/77b2b8de-442e-4dd3-bd18-f3c0d04db852">

</details>

<details>
<summary>HCM changes to Tooltip</summary>

**Tooltip before HCM styles:**
<img width="168" alt="A button with a tooltip attached. The tooltip does not have an outline and blends with the background which is the same color as the tooltip's background. The tooltip contains the text 'You can press a button'" src="https://github.com/primer/view_components/assets/26746305/9978dce2-acc1-432a-9c65-f875d9b581cf">

**Tooltip after HCM styles:**
<img width="168" alt="A button with a tooltip attached. Shown is a tooltip with a yellow outline and the text 'You can press a button'" src="https://github.com/primer/view_components/assets/26746305/5c8f7737-5e28-4f9e-a55c-7bfb45a635da">

</details>

<details>
<summary>HCM changes to Dialog</summary>

**Dialog before HCM styles:**
<img width="522" alt="Dialog with text inside. The dialog itself does not have an outline, so it blends with the black background due to the dialog having the same background color." src="https://github.com/primer/view_components/assets/26746305/445f2e44-a2ed-4b0c-bd2f-914b71aec8a6">

**Dialog after HCM styles:**
<img width="522" alt="Dialog with text inside. The dialog itself has a white outline encompassing the text." src="https://github.com/primer/view_components/assets/26746305/08fe4d10-aa14-43de-b61e-638d0c7157f8">
</details>

<details>
<summary>HCM changes to Overlay</summary>

**Overlay before HCM styles:**
<img width="224" alt="Overlay with text inside. The overlay itself does not have an outline, so it blends with the black background due to the overlay having the same background color." src="https://github.com/primer/view_components/assets/26746305/b92181e7-697a-4a72-b5bf-52fe7160d0fb">

**Overlay before HCM styles:**
<img width="224" alt="Overlay with text inside. The overlay itself has a white outline encompassing the text." src="https://github.com/primer/view_components/assets/26746305/2ff7f73c-5804-4e07-be37-29ed40b00eab">
</details>

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Adds hcm-only styles through the `forced-colors` media query. 

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->
     
 You can emulate high contrast mode in Chrome through the `forced-colors` option in the rendering tab. [More information on emulating HCM in Chrome](https://developer.chrome.com/docs/devtools/rendering/emulate-css#emulate_css_media_feature_forced-colors).

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
