### PR TITLE
Fix dialogs rendered inside menu items

### DIFF
--- a/.changeset/breezy-weeks-explode.md
+++ b/.changeset/breezy-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix dialogs rendered inside menu items

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -225,7 +225,7 @@ export class ActionMenuElement extends HTMLElement {
         const dialog = this.ownerDocument.getElementById(dialogInvoker.getAttribute('data-show-dialog-id') || '')
 
         if (dialog && this.contains(dialogInvoker) && this.contains(dialog)) {
-          this.#handleDialogItemActivated(event, dialog)
+          this.#handleDialogItemActivated(event, dialog as HTMLDialogElement)
           return
         }
       }
@@ -265,7 +265,7 @@ export class ActionMenuElement extends HTMLElement {
     }
   }
 
-  #handleDialogItemActivated(event: Event, dialog: HTMLElement) {
+  #handleDialogItemActivated(event: Event, dialog: HTMLDialogElement) {
     this.querySelector<HTMLElement>('.ActionListWrap')!.style.display = 'none'
     const dialog_controller = new AbortController()
     const {signal} = dialog_controller
@@ -282,8 +282,33 @@ export class ActionMenuElement extends HTMLElement {
         setTimeout(() => this.invokerElement?.focus(), 0)
       }
     }
-    // a modal <dialog> element will close all popovers
-    setTimeout(() => this.#show(), 0)
+
+    // At this point, the dialog is about to open. When it opens, all other popovers (incuding
+    // this ActionMenu) will be closed. We listen to the toggle event here, which will fire when
+    // the menu is closed and manually re-open it. When the menu is re-opened, it gets added to
+    // the top of the popover stack. Only the item at the top of the stack will close when the
+    // escape key is pressed, so we add another beforetoggle listener. When the escape key is
+    // pressed, the listener is invoked, which manually closes the dialog. Closing the dialog
+    // causes the dialog's close event to fire, which
+    this.popoverElement?.addEventListener(
+      'toggle',
+      (toggleEvent: Event) => {
+        if ((toggleEvent as ToggleEvent).newState === 'closed') {
+          this.#show()
+          this.popoverElement?.addEventListener(
+            'beforetoggle',
+            (beforeToggleEvent: Event) => {
+              if ((beforeToggleEvent as ToggleEvent).newState === 'closed') {
+                dialog.close()
+              }
+            },
+            {signal},
+          )
+        }
+      },
+      {signal, once: true},
+    )
+
     dialog.addEventListener('close', handleDialogClose, {signal})
     dialog.addEventListener('cancel', handleDialogClose, {signal})
   }


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A [recent PR](https://github.com/primer/view_components/pull/2364) refactored the `Dialog` component to use the `<dialog>` element. This caused a flake to appear in our test suite, which uncovered an issue displaying dialogs that are rendered inside `ActionMenu` items, a use-case we support for when `ActionMenu` items are fetched async via `<include-fragment>`s. This PR addresses the flake and ensures dialogs inside menu items can be dismissed via the escape key.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

See the comments in the code.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.