### PR TITLE
Propose removing the validate classname check that forces system arguments instead of utility classes

### DIFF
--- a/.changeset/wild-shirts-heal.md
+++ b/.changeset/wild-shirts-heal.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Removing the validate classname check that forces system arguments instead of utility classes

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -49,9 +49,7 @@ module Primer
             case key
             when :classes
               # insert :classes first to avoid huge doc diffs
-              if (class_names = validated_class_names(val))
-                result.unshift(class_names)
-              end
+              result.unshift(class_names)
               next
             when :style
               style = val
@@ -104,29 +102,6 @@ module Primer
       def validate(key, val, brk)
         brk_str = Primer::Classify::Utilities::BREAKPOINTS[brk]
         Primer::Classify::Utilities.validate(key, val, brk_str)
-      end
-
-      def validated_class_names(classes)
-        return if classes.blank?
-
-        if raise_on_invalid_options? && !ENV["PRIMER_WARNINGS_DISABLED"]
-          invalid_class_names =
-            classes.split.each_with_object([]) do |class_name, memo|
-              memo << class_name if Primer::Classify::Validation.invalid?(class_name)
-            end
-
-          if invalid_class_names.any?
-            raise ArgumentError, "Use System Arguments (https://primer.style/view-components/system-arguments) "\
-              "instead of Primer CSS class #{'name'.pluralize(invalid_class_names.length)} #{invalid_class_names.to_sentence}. "\
-              "This warning will not be raised in production. Set PRIMER_WARNINGS_DISABLED=1 to disable this warning."
-          end
-        end
-
-        classes
-      end
-
-      def raise_on_invalid_options?
-        Rails.application.config.primer_view_components.raise_on_invalid_options
       end
     end
   end

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -49,7 +49,7 @@ module Primer
             case key
             when :classes
               # insert :classes first to avoid huge doc diffs
-              result.unshift(class_names)
+              result.unshift(val)
               next
             when :style
               style = val

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -411,41 +411,10 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("anim-hover-grow", { animation: :hover_grow })
   end
 
-  def test_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set
-    ENV["PRIMER_WARNINGS_DISABLED"] = "1"
-    with_raise_on_invalid_options(true) do
-      assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
-    end
-  ensure
-    ENV["PRIMER_WARNINGS_DISABLED"] = nil
-  end
-
-  def test_does_not_raise_error_when_passing_in_a_primer_css_class_otherwise
-    with_raise_on_invalid_options(false) do
-      assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
-    end
-  end
-
   def test_does_include_leading_trailing_whitespace_in_class
     generated_class = Primer::Classify.call(classes: "foo-class")[:class]
     refute(generated_class.start_with?(" "))
     refute(generated_class.end_with?(" "))
-  end
-
-  def test_raises_if_not_using_system_arguments_when_raise_on_invalid_options_is_true
-    with_raise_on_invalid_options(true) do
-      exception = assert_raises ArgumentError do
-        Primer::Classify.call(classes: "d-block")
-      end
-
-      assert_includes exception.message, "Use System Arguments (https://primer.style/view-components/system-arguments) instead of Primer CSS class"
-    end
-  end
-
-  def test_does_not_raise_if_not_using_system_arguments_when_raise_on_invalid_options_is_false
-    with_raise_on_invalid_options(false) do
-      assert_generated_class("d-block", { classes: "d-block" })
-    end
   end
 
   private


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This removes the dev/test environment warning that we put in place to force systems arguments instead of using utility classes. I think at the time we had a vision that we would control these more tightly, but we ended up making more friction for our selves. [example](https://github.com/github/github/pull/305716/commits/e92015e3cea902c4494e6ed148bd4b491e0fbba9)

### Integration

No

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Anything you want to highlight for special attention from reviewers?

This pr doesn't change support for system arguments only removes the barrier of using classnames instead.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
