### PR TITLE
Bug fix in ActionBar: When collapsed the menu and tooltips aren't visible in Firefox

### DIFF
--- a/.changeset/smart-insects-cheat.md
+++ b/.changeset/smart-insects-cheat.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Bug fix in ActionBar: When collapsed the menu and tooltips aren't visible in Firefox

--- a/app/components/primer/alpha/action_bar_element.ts
+++ b/app/components/primer/alpha/action_bar_element.ts
@@ -50,7 +50,13 @@ class ActionBarElement extends HTMLElement {
     resizeObserver.observe(this)
     instersectionObserver.observe(this)
 
-    requestAnimationFrame(() => this.update())
+    requestAnimationFrame(() => {
+      // This overflow visible is needed for browsers that don't support PopoverElement
+      // to ensure the menu and tooltips are visible when the action bar is in a collapsed state
+      // once popover is fully supported we can remove this.style.overflow = 'visible'
+      this.style.overflow = 'visible'
+      this.update()
+    })
   }
 
   disconnectedCallback() {


### PR DESCRIPTION
### What are you trying to accomplish?

Found a bug in `0.16.0` that hides the menu for the action bar. This is because we removed the initial style change that changed the overflow to visible.

The approach I took was to add this back. I could have taken the style out of `.ActionBar` but I like that having it there will avoid layout shifts when the page is loading, or broken layout if javascript didn't load.

### Screenshots

<img width="717" alt="Screenshot 2024-01-04 at 10 22 18 AM" src="https://github.com/primer/view_components/assets/54012/7eae83e4-bea5-4325-94e7-8e97505f3da0">

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
