### PR TITLE
Fixing the utilities build not matching properly for `font_size`

### DIFF
--- a/.changeset/tall-bugs-laugh.md
+++ b/.changeset/tall-bugs-laugh.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fixing the utilities build not matching properly for `font_size`

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -18,6 +18,7 @@ module Primer
 
       # Replacements for some classnames that end up being a different argument key
       REPLACEMENT_KEYS = {
+        "^f" => "font_size",
         "^anim" => "animation",
         "^v-align" => "vertical_align",
         "^d" => "display",
@@ -28,7 +29,6 @@ module Primer
         "^color-bg" => "bg",
         "^color-border" => "border_color",
         "^color-fg" => "color",
-        "^f" => "font_size",
         "^rounded" => "border_radius"
       }.freeze
 

--- a/lib/primer/classify/utilities.yml
+++ b/lib/primer/classify/utilities.yml
@@ -1,24 +1,13 @@
 ---
-:font_size:
-  '00':
-  - f00
-  1:
-  - f1
-  2:
-  - f2
-  3:
-  - f3
-  4:
-  - f4
-  5:
-  - f5
-  6:
-  - f6
-  :small:
-  - text-small
-  :normal:
-  - text-normal
 :animation:
+  :fade_in:
+  - anim-fade-in
+  :fade_out:
+  - anim-fade-out
+  :fade_up:
+  - anim-fade-up
+  :fade_down:
+  - anim-fade-down
   :grow_x:
   - anim-grow-x
   :shrink_x:
@@ -221,12 +210,21 @@
   - float-lg-none
   - float-xl-none
 :w:
+  :fit:
+  - width-fit
+  :full:
+  - width-full
   :auto:
   - width-auto
   - width-sm-auto
   - width-md-auto
   - width-lg-auto
   - width-xl-auto
+:h:
+  :fit:
+  - height-fit
+  :full:
+  - height-full
 :m:
   0:
   - m-0
@@ -1363,6 +1361,12 @@
   - d-md-block
   - d-lg-block
   - d-xl-block
+  :flex:
+  - d-flex
+  - d-sm-flex
+  - d-md-flex
+  - d-lg-flex
+  - d-xl-flex
   :inline:
   - d-inline
   - d-sm-inline
@@ -1399,12 +1403,6 @@
   - d-md-table-cell
   - d-lg-table-cell
   - d-xl-table-cell
-  :flex:
-  - 
-  - d-sm-flex
-  - d-md-flex
-  - d-lg-flex
-  - d-xl-flex
 :visibility:
   :hidden:
   - v-hidden
@@ -1507,6 +1505,25 @@
   - col-md-12
   - col-lg-12
   - col-xl-12
+:font_size:
+  '00':
+  - f00
+  1:
+  - f1
+  2:
+  - f2
+  3:
+  - f3
+  4:
+  - f4
+  5:
+  - f5
+  6:
+  - f6
+  :small:
+  - text-small
+  :normal:
+  - text-normal
 :top:
   0:
   - top-0


### PR DESCRIPTION
### What are you trying to accomplish?

This fixes the utilities build for not matching all classes properly

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

The builder loops through the keys of the classname transforms and returns early when it gets a match. Moving the `^f` fixes the issue because it matches the `.f5` classes first.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
