### PR TITLE
Allow setting `test_selector` on select list options

### DIFF
--- a/.changeset/healthy-needles-tease.md
+++ b/.changeset/healthy-needles-tease.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Allow setting `test_selector` on select list options

--- a/lib/primer/forms/dsl/select_input.rb
+++ b/lib/primer/forms/dsl/select_input.rb
@@ -9,12 +9,14 @@ module Primer
 
         # :nodoc:
         class Option
+          include Primer::TestSelectorHelper
+
           attr_reader :label, :value, :system_arguments
 
           def initialize(label:, value:, **system_arguments)
             @label = label
             @value = value
-            @system_arguments = system_arguments
+            @system_arguments = add_test_selector(system_arguments)
           end
         end
 

--- a/test/lib/primer/forms/select_list_input_test.rb
+++ b/test/lib/primer/forms/select_list_input_test.rb
@@ -36,4 +36,21 @@ class Primer::Forms::SelectInputTest < Minitest::Test
 
     refute_selector ".field_with_errors", visible: :all
   end
+
+  def test_option_includes_test_selector
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |select_form|
+          select_form.select_list(name: :foo, label: "Foo", hidden: true) do |list|
+            list.option(
+              label: "Foo",
+              value: "foo",
+              test_selector: "test-selector-foo",
+            )
+          end
+        end
+      end
+    end
+    assert_selector "[data-test-selector='test-selector-foo']", visible: :hidden
+  end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

I was working on converting a form on dotcom to use the Primer form components (see https://github.com/github/github/pull/307881). We need to test in our component to make sure that certain options are included in the select menu, so we need to allow setting a test selector.

### Integration

I don't think we need to change anything in prod for this?

#### List the issues that this change affects.

Closes https://github.com/primer/view_components/issues/2494.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

Just allows setting `data-test-selector` when `test_selector` is included in the option arguments.

### What approach did you choose and why?

Used the `add_test_selector` helper to include the selector in non-production environments. I didn't include anything to do the Primer classify stuff since I don't think you can/should set other Primer arguments on select options.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
