### PR TITLE
Revert "Propose removing the validate classname check that forces system arguments instead of utility classes"

### DIFF
--- a/.changeset/wild-shirts-heal.md
+++ b/.changeset/wild-shirts-heal.md
@@ -1,5 +1,0 @@
----
-"@primer/view-components": minor
----
-
-Removing the validate classname check that forces system arguments instead of utility classes

--- a/lib/primer/classify.rb
+++ b/lib/primer/classify.rb
@@ -49,7 +49,9 @@ module Primer
             case key
             when :classes
               # insert :classes first to avoid huge doc diffs
-              result.unshift(val)
+              if (class_names = validated_class_names(val))
+                result.unshift(class_names)
+              end
               next
             when :style
               style = val
@@ -102,6 +104,29 @@ module Primer
       def validate(key, val, brk)
         brk_str = Primer::Classify::Utilities::BREAKPOINTS[brk]
         Primer::Classify::Utilities.validate(key, val, brk_str)
+      end
+
+      def validated_class_names(classes)
+        return if classes.blank?
+
+        if raise_on_invalid_options? && !ENV["PRIMER_WARNINGS_DISABLED"]
+          invalid_class_names =
+            classes.split.each_with_object([]) do |class_name, memo|
+              memo << class_name if Primer::Classify::Validation.invalid?(class_name)
+            end
+
+          if invalid_class_names.any?
+            raise ArgumentError, "Use System Arguments (https://primer.style/view-components/system-arguments) "\
+              "instead of Primer CSS class #{'name'.pluralize(invalid_class_names.length)} #{invalid_class_names.to_sentence}. "\
+              "This warning will not be raised in production. Set PRIMER_WARNINGS_DISABLED=1 to disable this warning."
+          end
+        end
+
+        classes
+      end
+
+      def raise_on_invalid_options?
+        Rails.application.config.primer_view_components.raise_on_invalid_options
       end
     end
   end

--- a/test/lib/classify_test.rb
+++ b/test/lib/classify_test.rb
@@ -411,10 +411,41 @@ class PrimerClassifyTest < Minitest::Test
     assert_generated_class("anim-hover-grow", { animation: :hover_grow })
   end
 
+  def test_does_not_raise_error_when_passing_in_a_primer_css_class_name_in_development_and_flag_is_set
+    ENV["PRIMER_WARNINGS_DISABLED"] = "1"
+    with_raise_on_invalid_options(true) do
+      assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
+    end
+  ensure
+    ENV["PRIMER_WARNINGS_DISABLED"] = nil
+  end
+
+  def test_does_not_raise_error_when_passing_in_a_primer_css_class_otherwise
+    with_raise_on_invalid_options(false) do
+      assert_generated_class("color-bg-primary text-center float-left ml-1", { classes: "color-bg-primary text-center float-left ml-1" })
+    end
+  end
+
   def test_does_include_leading_trailing_whitespace_in_class
     generated_class = Primer::Classify.call(classes: "foo-class")[:class]
     refute(generated_class.start_with?(" "))
     refute(generated_class.end_with?(" "))
+  end
+
+  def test_raises_if_not_using_system_arguments_when_raise_on_invalid_options_is_true
+    with_raise_on_invalid_options(true) do
+      exception = assert_raises ArgumentError do
+        Primer::Classify.call(classes: "d-block")
+      end
+
+      assert_includes exception.message, "Use System Arguments (https://primer.style/view-components/system-arguments) instead of Primer CSS class"
+    end
+  end
+
+  def test_does_not_raise_if_not_using_system_arguments_when_raise_on_invalid_options_is_false
+    with_raise_on_invalid_options(false) do
+      assert_generated_class("d-block", { classes: "d-block" })
+    end
   end
 
   private


### PR DESCRIPTION
Reverts primer/view_components#2477