### PR TITLE
Only attach validation IDs to form elements that support validation

### DIFF
--- a/.changeset/wet-fishes-fold.md
+++ b/.changeset/wet-fishes-fold.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Only attach validation IDs to form elements that support validation

--- a/lib/primer/forms/dsl/button_input.rb
+++ b/lib/primer/forms/dsl/button_input.rb
@@ -23,6 +23,10 @@ module Primer
         def type
           :button
         end
+
+        def supports_validation?
+          false
+        end
       end
     end
   end

--- a/lib/primer/forms/dsl/check_box_input.rb
+++ b/lib/primer/forms/dsl/check_box_input.rb
@@ -44,6 +44,10 @@ module Primer
           :check_box
         end
 
+        def supports_validation?
+          false
+        end
+
         private
 
         def caption_template_name

--- a/lib/primer/forms/dsl/check_box_input.rb
+++ b/lib/primer/forms/dsl/check_box_input.rb
@@ -27,9 +27,11 @@ module Primer
         end
 
         # check boxes cannot be invalid, as both checked and unchecked are valid states
+        # :nocov:
         def valid?
           true
         end
+        # :nocov:
 
         def to_component
           CheckBox.new(input: self)

--- a/lib/primer/forms/dsl/hidden_input.rb
+++ b/lib/primer/forms/dsl/hidden_input.rb
@@ -23,6 +23,10 @@ module Primer
         def type
           :hidden
         end
+
+        def supports_validation?
+          false
+        end
       end
     end
   end

--- a/lib/primer/forms/dsl/input.rb
+++ b/lib/primer/forms/dsl/input.rb
@@ -109,7 +109,7 @@ module Primer
           @base_id = SecureRandom.uuid
 
           @ids = {}.tap do |id_map|
-            id_map[:validation] = "validation-#{@base_id}"
+            id_map[:validation] = "validation-#{@base_id}" if supports_validation?
             id_map[:caption] = "caption-#{@base_id}" if caption? || caption_template?
           end
 
@@ -195,11 +195,11 @@ module Primer
         end
 
         def valid?
-          validation_messages.empty? && !@invalid
+          supports_validation? && validation_messages.empty? && !@invalid
         end
 
         def invalid?
-          !valid?
+          supports_validation? && !valid?
         end
 
         def hidden?
@@ -263,6 +263,10 @@ module Primer
         end
 
         def input?
+          true
+        end
+
+        def supports_validation?
           true
         end
 

--- a/lib/primer/forms/dsl/radio_button_input.rb
+++ b/lib/primer/forms/dsl/radio_button_input.rb
@@ -36,6 +36,10 @@ module Primer
           :radio_button
         end
         # :nocov:
+
+        def supports_validation?
+          false
+        end
       end
     end
   end

--- a/lib/primer/forms/dsl/radio_button_input.rb
+++ b/lib/primer/forms/dsl/radio_button_input.rb
@@ -18,9 +18,11 @@ module Primer
         end
 
         # radio buttons cannot be invalid, as both selected and unselected are valid states
+        # :nocov:
         def valid?
           true
         end
+        # :nocov:
 
         def to_component
           RadioButton.new(input: self)

--- a/lib/primer/forms/dsl/submit_button_input.rb
+++ b/lib/primer/forms/dsl/submit_button_input.rb
@@ -23,6 +23,10 @@ module Primer
         def type
           :submit_button
         end
+
+        def supports_validation?
+          false
+        end
       end
     end
   end

--- a/lib/primer/forms/form_control.html.erb
+++ b/lib/primer/forms/form_control.html.erb
@@ -9,7 +9,9 @@
       <% end %>
     <% end %>
     <%= content %>
-    <%= render(ValidationMessage.new(input: @input)) %>
+    <% if @input.supports_validation? %>
+      <%= render(ValidationMessage.new(input: @input)) %>
+    <% end %>
     <%= render(Caption.new(input: @input)) %>
   <% end %>
 <% else %>

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -120,6 +120,12 @@ class Primer::FormsTest < Minitest::Test
     assert_selector "button[type=button]"
   end
 
+  def test_buttons_are_not_described_by_validation_ids
+    render_preview :submit_button_form
+
+    refute_selector "button[aria-describedby]"
+  end
+
   def test_renders_buttons_with_slots
     render_preview :submit_button_form
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Certain Primer forms are failing dotcom axe checks because they attach `aria-describedby` attributes that point to non-existent elements. This happens because the framework does not distinguish between inputs that support validation (eg. text fields) vs those that do not (eg. buttons).

### Integration
<!-- Does this change require any updates to code in production? -->

No additional changes required in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I added a method called `supports_validation?` on the base `Input` class. By default it returns `true`. All the `Input` subclasses that don't support validation override this method and return `false`.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
- [x] Added/updated previews (Lookbook)
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
