### PR TITLE
Fix codespaces by locking solargraph version and using Ruby 3

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
-ARG VARIANT="2.7"
+ARG VARIANT="3"
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
 
 ARG INSTALL_NODE="true"
@@ -43,7 +43,7 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 
 # Install gems
 ARG BUNDLER_VERSION=2.2.11
-RUN gem install bundler:${BUNDLER_VERSION} solargraph
+RUN gem install bundler:${BUNDLER_VERSION} solargraph:'~> 0.50.0'
 
 # Install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \


### PR DESCRIPTION
### What are you trying to accomplish?

Our docker image for codespaces is running into build errors. Looks like it's happening because we're using an older version of ruby and not specifying the version for solargraph. Solargraph pulls in a version of nokogiri that doesn't work on older rubies.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.