### PR TITLE
Fixup animations in dialog

### DIFF
--- a/app/components/primer/alpha/dialog.pcss
+++ b/app/components/primer/alpha/dialog.pcss
@@ -87,18 +87,27 @@ dialog.Overlay:not([open]) {
   &.Overlay--placement-left, &.Overlay--placement-right {
     height: 100%;
     max-height: unset;
+    position: fixed;
+  }
+
+  &.Overlay--motion-scaleFade, &.Overlay--placement-left, &.Overlay--placement-right {
+    @media screen and (prefers-reduced-motion: no-preference) {
+      animation: 200ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-scaleFade;
+    }
   }
 
   &.Overlay--placement-left {
     inset: 0 auto 0 0;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+    animation-name: Overlay--motion-slideInRight;
   }
 
   &.Overlay--placement-right {
     inset: 0 0 0 auto;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    animation-name: Overlay--motion-slideInLeft;
   }
 
   /* start deprecate in favor of Alpha::Dialog */
@@ -147,12 +156,6 @@ dialog.Overlay:not([open]) {
   }
 
   /* end deprecate */
-
-  &.Overlay--motion-scaleFade {
-    @media screen and (prefers-reduced-motion: no-preference) {
-      animation: 200ms cubic-bezier(0.33, 1, 0.68, 1) 0s 1 normal none running Overlay--motion-scaleFade;
-    }
-  }
 }
 
 @keyframes Overlay--motion-scaleFade {
@@ -340,29 +343,33 @@ dialog.Overlay:not([open]) {
 
 /* --viewportRange-narrowLandscape */
 @media (max-width: 767px) {
-  .Overlay--placement-left-whenNarrow, .Overlay--placement-right-whenNarrow {
+  .Overlay.Overlay--placement-left-whenNarrow, .Overlay--placement-right-whenNarrow {
     height: 100%;
     max-height: 100vh;
+    position: fixed;
   }
 
-  .Overlay--placement-left-whenNarrow {
+  .Overlay.Overlay--placement-left-whenNarrow {
     inset: 0 auto 0 0;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
+    animation-name: Overlay--motion-slideInLeft;
   }
 
-  .Overlay--placement-right-whenNarrow {
+  .Overlay.Overlay--placement-right-whenNarrow {
     inset: 0 0 0 auto;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    animation-name: Overlay--motion-slideInLeft;
   }
 
-  .Overlay--placement-bottom-whenNarrow {
+  .Overlay.Overlay--placement-bottom-whenNarrow {
     width: 100%;
     max-width: 100vw;
     inset: auto 0 0;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+    animation-name: Overlay--motion-slideUp;
   }
 
   .Overlay--full-whenNarrow {


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
When integrating #2492 which is the big change to `<dialog>` I noticed that #2496 regressed some of the animations (I had not initially spotted this as I use `prefers-reduced-motion` and I forgot to toggle it off during #2496 during development but I remembered when integrating into dotcom).

This PR reintroduces the animations. I've marked `skip changeset` as this should be rolled up into the #2496 changeset.

### Integration
<!-- Does this change require any updates to code in production? -->

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
