### PR TITLE
ActionList - allow sizing `with_avatar_item`

### DIFF
--- a/app/components/primer/alpha/action_list.rb
+++ b/app/components/primer/alpha/action_list.rb
@@ -210,7 +210,8 @@ module Primer
         build_item(label: username, description_scheme: full_name_scheme, component_klass: component_klass, **system_arguments).tap do |item|
           item.with_leading_visual_raw_content do
             # no alt text necessary for presentational item
-            item.render(Primer::Beta::Avatar.new(src: src, **avatar_arguments, role: :presentation, size: 16))
+            avatar_arguments[:size] ||= 16
+            item.render(Primer::Beta::Avatar.new(src: src, **avatar_arguments, role: :presentation))
           end
 
           item.with_description_content(full_name) if full_name

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -230,6 +230,26 @@ module Primer
 
         assert_match(%r{lists/menus that act as form inputs must also allow item selection}, error.message)
       end
+
+      def test_supports_avatar_sizing
+        render_in_view_context do
+          foo = render(Primer::Alpha::ActionList.new) do |component|
+            component.with_avatar_item(
+              username: "default",
+              src: "https://avatars.githubusercontent.com/u/103004183?v=4"
+            )
+            component.with_avatar_item(
+              username: "non_default",
+              src: "https://avatars.githubusercontent.com/u/103004183?v=4",
+              avatar_arguments: { size: 24 }
+            )
+          end
+        end
+
+        # we should probably have an enum for this, looks like we have a non-standard default size?
+        assert_selector(".ActionListItem-visual--leading img[size='16']")
+        assert_selector(".ActionListItem-visual--leading img[size='24']")
+      end
     end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Currently the avatar size using `with_avatar_item` is hardcoded to 16px. The goal is to support a user-supplied value so that avatars in ActionLists can be sized.

### Screenshots

TODO

### Integration

TODO _maybe_ it could be that folks are relying on a `size` key currently being ignored.

#### List the issues that this change affects.

TODO

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
