### PR TITLE
Remove animations on actionlist checkmark

### DIFF
--- a/.changeset/happy-ducks-lay.md
+++ b/.changeset/happy-ducks-lay.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove animations on actionlist checkmark

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -14,7 +14,8 @@
   list-style: none;
 }
 
-.ActionListWrap--inset, .ActionListWrap--inset[popover] {
+.ActionListWrap--inset,
+.ActionListWrap--inset[popover] {
   padding: var(--base-size-8);
 }
 
@@ -334,7 +335,9 @@
   &[aria-expanded] {
     & + .ActionList--subGroup {
       @media screen and (prefers-reduced-motion: no-preference) {
-        transition: opacity 160ms cubic-bezier(0.25, 1, 0.5, 1), transform 160ms cubic-bezier(0.25, 1, 0.5, 1);
+        transition:
+          opacity 160ms cubic-bezier(0.25, 1, 0.5, 1),
+          transform 160ms cubic-bezier(0.25, 1, 0.5, 1);
       }
 
       & .ActionListContent {
@@ -429,7 +432,9 @@
     & .ActionListItem-multiSelectCheckmark {
       visibility: visible;
       opacity: 1;
-      transition: visibility 0 linear 0, opacity 50ms;
+      transition:
+        visibility 0 linear 0,
+        opacity 50ms;
     }
 
     /* singleselect checkmark */
@@ -457,28 +462,15 @@
     & .ActionListItem-multiSelectCheckmark {
       visibility: hidden;
       opacity: 0;
-      transition: visibility 0 linear 50ms, opacity 50ms;
+      transition:
+        visibility 0 linear 50ms,
+        opacity 50ms;
     }
 
     /* singleselect checkmark */
     & .ActionListItem-singleSelectCheckmark {
       visibility: hidden;
       transition: visibility 0s linear 200ms;
-      clip-path: inset(16px 0 0 0);
-
-      @media screen and (prefers-reduced-motion: no-preference) {
-        animation: checkmarkOut 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
-
-        @keyframes checkmarkOut {
-          from {
-            clip-path: inset(0 0 0 0);
-          }
-
-          to {
-            clip-path: inset(16px 0 0 0);
-          }
-        }
-      }
     }
 
     /* checkbox */

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -435,20 +435,6 @@
     /* singleselect checkmark */
     & .ActionListItem-singleSelectCheckmark {
       visibility: visible;
-
-      @media screen and (prefers-reduced-motion: no-preference) {
-        animation: checkmarkIn 200ms cubic-bezier(0.11, 0, 0.5, 0) forwards;
-
-        @keyframes checkmarkIn {
-          from {
-            clip-path: inset(16px 0 0 0);
-          }
-
-          to {
-            clip-path: inset(0 0 0 0);
-          }
-        }
-      }
     }
 
     /* checkbox */


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Checkmarks are animated when they get selected/deselected, but also the way CSS animations work, the animation is also run whenever the element moves from `display:none` to a display where it is laid out.

This means whenever the menu is _opened_ all the checkboxes animate in, which looks... weird.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

https://github.com/primer/view_components/assets/118266/00d515a4-6cae-42be-8d48-0d7225490dea

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->
A user pointed this out on a public forum: https://ruby.social/@joeldrapper/111796664357341563

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
I delete the animation

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
