### PR TITLE
Bump popover-polyfill to v0.3.8

### DIFF
--- a/.changeset/rotten-shirts-march.md
+++ b/.changeset/rotten-shirts-march.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update @oddbird/popover-polyfill to v0.3.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.3.6",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       },
       "devDependencies": {
@@ -2456,9 +2456,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.7.tgz",
-      "integrity": "sha512-WNthEIPPXnFQkumLby6yVxhyOcA/GtMnlByHwEglMO9WZckoaqidnpLp2JFzAh2RDOZxn+Xt3ffSMKId9cPjOQ=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -13516,9 +13516,9 @@
       }
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.7.tgz",
-      "integrity": "sha512-WNthEIPPXnFQkumLby6yVxhyOcA/GtMnlByHwEglMO9WZckoaqidnpLp2JFzAh2RDOZxn+Xt3ffSMKId9cPjOQ=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@github/include-fragment-element": "^6.1.1",
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
-    "@oddbird/popover-polyfill": "^0.3.6",
+    "@oddbird/popover-polyfill": "^0.3.8",
     "@primer/behaviors": "^1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Bumps @oddbird/popover-polyfill to the latest version.

### Integration
<!-- Does this change require any updates to code in production? -->

No updates necessary in dotcom (to my knowledge).

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.