### PR TITLE
Prevent ActionMenu's show_button slot from rendering its content more than once

### DIFF
--- a/.changeset/late-windows-approve.md
+++ b/.changeset/late-windows-approve.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Prevent ActionMenu's show_button slot from rendering its content more than once

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -241,7 +241,9 @@ module Primer
       #
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
       def with_show_button(**system_arguments, &block)
-        @overlay.with_show_button(**system_arguments, id: "#{@menu_id}-button", controls: "#{@menu_id}-list", &block)
+        @overlay.with_show_button(**system_arguments, id: "#{@menu_id}-button", controls: "#{@menu_id}-list") do |button|
+          evaluate_block(button, &block)
+        end
       end
 
       # @!parse

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -176,6 +176,19 @@ module Primer
 
         assert_equal "ActionMenu groups cannot have dividers", err.message
       end
+
+      def test_does_not_double_render_show_button_content
+        render_inline_erb(<<~ERB)
+          <%= render(Primer::Alpha::ActionMenu.new) do |menu| %>
+            <% menu.with_show_button(scheme: :invisible) do |button| %>
+              test
+            <% end %>
+            <% menu.with_item { "an account" } %>
+          <% end %>
+        ERB
+
+        assert @rendered_content.scan(/test/).size == 1, "The show button rendered its content more than once"
+      end
     end
   end
 end

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -187,7 +187,7 @@ module Primer
           <% end %>
         ERB
 
-        assert @rendered_content.scan(/test/).size == 1, "The show button rendered its content more than once"
+        assert @rendered_content.scan("test").size == 1, "The show button rendered its content more than once"
       end
     end
   end

--- a/test/test_helpers/component_test_helpers.rb
+++ b/test/test_helpers/component_test_helpers.rb
@@ -67,5 +67,24 @@ module Primer
 
       raise ::Minitest::Assertion, "#{message}: #{e.message}"
     end
+
+    class DummyComponent
+      def self.type
+        "text/html"
+      end
+
+      def self.identifier
+        source_location
+      end
+    end
+
+    def render_inline_erb(erb)
+      @page = nil
+      handler = ActionView::Template.handler_for_extension("erb")
+      erb_code = handler.call(DummyComponent, erb)
+      view_context = vc_test_controller.view_context
+      @rendered_content = view_context.capture { view_context.instance_eval(erb_code) }
+      Nokogiri::HTML.fragment(@rendered_content)
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Providing content to `ActionMenu`'s `with_show_button` slot causes a double render.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

The issue is that the block provided to `with_show_button` is forwarded to `Overlay` and ultimately evaluated in `Overlay`'s view context. I made use of our shiny new `evaluate_block` method that evaluates blocks in their receiver's view context (i.e. the receiver of the block's binding).

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

I wasn't able to write a viable test using `render_inline` since I needed to actually run everything through the Rails render stack. I ended up adding a test helper called `render_inline_erb`. Would love some 👀 on it.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~