### PR TITLE
add note to nested dialog example

### DIFF
--- a/previews/primer/alpha/dialog_preview/nested_dialog.html.erb
+++ b/previews/primer/alpha/dialog_preview/nested_dialog.html.erb
@@ -12,3 +12,10 @@
     <% end %>
   <% end %>
 <% end %>
+
+<div style="margin-top:2rem">
+<%= render(Primer::Beta::Flash.new(scheme: :warning)) do %>
+  <p>Please be careful nesting dialogs! Note that in this example, opening the second dialog does not close the first.</p>
+  <p>Closing a dialog while opening a dialog inside, will cause both to be invisible which will lead to undesired effects!</p>
+<% end %>
+</div>


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
We have noticed some improper use of nested dialogs; where the outer dialog will close while the inner dialog remains open. This is incorrect behaviour and will lead to undesired effects - the whole page will be inert (because the dialog is open) but no dialog will be visible.

While it should be very obvious that something is broken, while testing, it may not be immediately obvious _why this_ or perhaps even _what_ is happening. 

This note serves to warn people that nested dialogs should be handled with care.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
![a screenshot showing the warning banner describing the issue, on the playground page](https://github.com/primer/view_components/assets/118266/71042c03-fab5-4a42-95f9-78f85f8d6f81)

### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

N/A

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
