### PR TITLE
Fix dialog click outside early return

### DIFF
--- a/.changeset/small-flowers-refuse.md
+++ b/.changeset/small-flowers-refuse.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Ensure dialogs do not close when a child menu item (or similar) is clicked

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -36,7 +36,7 @@ export class DialogHelperElement extends HTMLElement {
   #abortController: AbortController | null = null
   connectedCallback() {
     const {signal} = (this.#abortController = new AbortController())
-    document.addEventListener('click', dialogInvokerButtonHandler)
+    document.addEventListener('click', dialogInvokerButtonHandler, true)
     document.addEventListener('click', this, {signal})
     this.ownerDocument.body.style.setProperty(
       '--dialog-scrollgutter',

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -58,7 +58,7 @@ export class DialogHelperElement extends HTMLElement {
     const target = event.target as HTMLElement
     const dialog = this.dialog
     if (!dialog?.open) return
-    if (target?.closest('dialog') !== dialog) return
+    if (target?.closest('dialog') === dialog) return
 
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -15,6 +15,7 @@ function dialogInvokerButtonHandler(event: Event) {
       // If the behaviour is allowed through the dialog will be shown but then
       // quickly hidden- as if it were never shown. This prevents that.
       event.preventDefault()
+      event.stopPropagation()
     }
   }
 
@@ -62,7 +63,6 @@ export class DialogHelperElement extends HTMLElement {
     // if the target is inside the dialog, but is not the dialog itself, leave
     // the dialog open
     if (target?.closest('dialog') === dialog && target !== dialog) return
-    if (target?.closest('button')?.getAttribute('data-show-dialog-id')) return
 
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -58,7 +58,11 @@ export class DialogHelperElement extends HTMLElement {
     const target = event.target as HTMLElement
     const dialog = this.dialog
     if (!dialog?.open) return
-    if (target?.closest('dialog') === dialog) return
+
+    // if the target is inside the dialog, but is not the dialog itself, leave
+    // the dialog open
+    if (target?.closest('dialog') === dialog && target !== dialog) return
+    if (target?.closest('button')?.getAttribute('data-show-dialog-id')) return
 
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =

--- a/test/css/component_specific_selectors_test.rb
+++ b/test/css/component_specific_selectors_test.rb
@@ -37,7 +37,8 @@ class ComponentSpecificSelectorsTest < Minitest::Test
       ".Banner .Banner-close"
     ],
     Primer::Alpha::Dialog => [
-      ".Overlay"
+      ".Overlay",
+      ".has-modal"
     ],
     Primer::Alpha::Layout => [
       ".Layout-divider",

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -74,5 +74,24 @@ module Alpha
       visit_preview(:long_text)
       click_button("Show Dialog")
     end
+
+    def test_outside_click_closes_dialog
+      visit_preview(:default)
+
+      click_button("Show Dialog")
+      page.driver.browser.mouse.click(x: 0, y: 0)
+
+      refute_selector "dialog[open]"
+    end
+
+    def test_outside_menu_click_does_not_close_dialog
+      visit_preview(:with_auto_complete)
+
+      click_button("Show Dialog")
+      fill_in "input", with: "a"
+
+      find(".ActionListItem", text: "Avocado").click
+      assert_selector "dialog[open]"
+    end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
