### PR TITLE
Fix codespaces prebuilds (again)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,9 +41,8 @@ RUN curl --fail --location --output /usr/bin/overmind.gz https://github.com/Dart
 # Install Node.js
 RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
-# Install gems
-ARG BUNDLER_VERSION=2.2.11
-RUN gem install bundler:${BUNDLER_VERSION} solargraph:'~> 0.50.0'
+# Install gems (see script/setup for installing lib and app dependencies)
+RUN gem install solargraph:'~> 0.50.0'
 
 # Install chrome
 RUN curl --silent --show-error --location --fail --retry 3 --output /tmp/google-chrome-stable_current_amd64.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         include:
           - rails_version: "6.1.1"
-            ruby_version: "2.7"
+            ruby_version: "3.0"
           - rails_version: "7.0.3"
             ruby_version: "3.0"
           - rails_version: "7.1.1"
@@ -92,7 +92,7 @@ jobs:
       matrix:
         include:
           - rails_version: "6.1.1"
-            ruby_version: "2.7"
+            ruby_version: "3.0"
           - rails_version: "7.0.3"
             ruby_version: "3.0"
           - rails_version: "7.1.1"
@@ -136,7 +136,7 @@ jobs:
       matrix:
         include:
           - rails_version: "6.1.1"
-            ruby_version: "2.7"
+            ruby_version: "3.0"
           - rails_version: "7.0.3"
             ruby_version: "3.0"
           - rails_version: "7.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,10 +136,10 @@ GEM
     msgpack (1.7.2)
     mutex_m (0.1.2)
     nio4r (2.7.0)
-    nokogiri (1.15.4)
+    nokogiri (1.16.0)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.15.4-x86_64-linux)
+    nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     octicons (19.8.0)
     parallel (1.23.0)
@@ -319,4 +319,4 @@ DEPENDENCIES
   yard (~> 0.9.25)
 
 BUNDLED WITH
-   2.3.6
+   2.5.5

--- a/app/components/primer/alpha/segmented_control.pcss
+++ b/app/components/primer/alpha/segmented_control.pcss
@@ -11,8 +11,7 @@
 
 .SegmentedControl--iconOnly {
   & .Button--iconOnly.Button--small,
-  & .Button--iconOnly.Button--medium,
-  & .Button--iconOnly.Button--large {
+  & .Button--iconOnly.Button--medium {
     width: 100%;
     padding-inline: 0 !important;
   }

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -378,4 +378,4 @@ DEPENDENCIES
   view_component (>= 3.1.0)
 
 BUNDLED WITH
-   2.4.1
+   2.5.5


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes our codespaces prebuild by:

1. updating our bundler version
2. letting `bundle install` handle installing the right bundler version automatically instead of doing it in the Dockerfile

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.