### PR TITLE
ensure direct clicks to the dialog can only close the dialog

### DIFF
--- a/.changeset/strange-windows-occur.md
+++ b/.changeset/strange-windows-occur.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Ensure only direct clicks to the dialog can close it

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -7,7 +7,6 @@ function dialogInvokerButtonHandler(event: Event) {
   // If the user is clicking a valid dialog trigger
   let dialogId = button?.getAttribute('data-show-dialog-id')
   if (dialogId) {
-    event.stopPropagation()
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof HTMLDialogElement) {
       dialog.showModal()

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -15,7 +15,6 @@ function dialogInvokerButtonHandler(event: Event) {
       // If the behaviour is allowed through the dialog will be shown but then
       // quickly hidden- as if it were never shown. This prevents that.
       event.preventDefault()
-      event.stopPropagation()
     }
   }
 
@@ -58,11 +57,8 @@ export class DialogHelperElement extends HTMLElement {
   handleEvent(event: MouseEvent) {
     const target = event.target as HTMLElement
     const dialog = this.dialog
-    if (!dialog?.open) return
-
-    // if the target is inside the dialog, but is not the dialog itself, leave
-    // the dialog open
-    if (target?.closest('dialog') === dialog && target !== dialog) return
+    // The click target _must_ be the dialog element itself, and not elements underneath or inside.
+    if (target !== dialog || !dialog?.open) return
 
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -93,5 +93,20 @@ module Alpha
       find(".ActionListItem", text: "Avocado").click
       assert_selector "dialog[open]"
     end
+
+    def test_click_events_can_be_added_to_invoker_buttons
+      # use this preview because it assigns a static ID to the invoker button
+      visit_preview(:with_header)
+
+      page.evaluate_script(<<~JS)
+        document.querySelector('#dialog-show-my-dialog').addEventListener('click', () => {
+          window.dialogInvokerClicked = true
+        })
+      JS
+
+      click_button("Show Dialog")
+
+      assert page.evaluate_script("window.dialogInvokerClicked"), "click event was not fired"
+    end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
In https://github.com/primer/view_components/pull/2549 we shipped a fix whereby clicking outside of a dialog would close the dialog, even if clicking an element that overflowed the bounds of the dialog - for example clicking an item in an action menu that overflowed.

While v0.17.1 fixes _that particular bug_ it introduced a regression with that fix; because we call `.stopPropagation()` on the click of the dialog show button, anything which reached into the dialog show button to add a click listener would no longer receive events. Consequently this caused a regression in some of dotcom.

This PR revisits that fix by taking an alternate route; see below.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
No visual changes.

### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->


Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
Rather than stopping propagation in the button, this checks that the inner-most click target is the dialog itself, and that that click is out of bounds of the dialogs bounding rect. This means:

 - clicking on the dialog will do nothing (as its inside the bounds)
 - clicking on an item that overflows the dialog will do nothing (as the target won't be the actual dialog element)
 - clicking on the backdrop will close (as the backdrop's target is always the dialog element, but it is outside of the bounds of the dialog rect). 
 - 
### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->

- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
