### PR TITLE
Ensure popovers that open dialogs do not close when the dialog opens

### DIFF
--- a/.changeset/cool-meals-appear.md
+++ b/.changeset/cool-meals-appear.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Ensure Overlays that open dialogs do not close when the Dialog opens

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -46,6 +46,20 @@ export class DialogHelperElement extends HTMLElement {
       for (const record of records) {
         if (record.target === this.dialog) {
           this.ownerDocument.body.classList.toggle('has-modal', this.dialog.hasAttribute('open'))
+          // In some older browsers, such as Chrome 122, when a top layer element (such as a dialog)
+          // opens from within a popover, the "hide all popovers" internal algorithm runs, hiding
+          // any popover that is currently open, regardless of whether or not another top layer element,
+          // such as a <dialog> is nested inside.
+          // See https://github.com/whatwg/html/issues/9998.
+          // This is fixed by https://github.com/whatwg/html/pull/10116, but while we still support browsers that present this bug,
+          // we must undo the work they did to hide ancestral popovers of the dialog:
+          if (this.dialog.hasAttribute('open')) {
+            let node: HTMLElement | null = this.dialog
+            while (node) {
+              node = node.closest('[popover]:not(:popover-open)')
+              if (node) node.showPopover()
+            }
+          }
         }
       }
     }).observe(this, {subtree: true, attributeFilter: ['open']})

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -248,6 +248,30 @@ module Primer
                                visually_hide_title: visually_hide_title
                              })
       end
+
+      # @label Dialog inside Overlay
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param size [Symbol] select [small, medium, medium_portrait, large, xlarge]
+      # @param position [Symbol] select [center, right, left]
+      # @param position_narrow [Symbol] select [inherit, bottom, fullscreen, left, right]
+      # @param visually_hide_title [Boolean] toggle
+      # @param button_text [String] text
+      # @param body_text [String] text
+      # @snapshot interactive
+      def dialog_inside_overlay(title: "Test Dialog", subtitle: nil, position: :center, size: :medium, button_text: "Show Dialog", body_text: "Content", position_narrow: :fullscreen, visually_hide_title: false)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               position: position,
+                               size: size,
+                               button_text: button_text,
+                               body_text: body_text,
+                               position_narrow: position_narrow,
+                               visually_hide_title: visually_hide_title
+                             })
+      end
     end
   end
 end

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -259,7 +259,6 @@ module Primer
       # @param visually_hide_title [Boolean] toggle
       # @param button_text [String] text
       # @param body_text [String] text
-      # @snapshot interactive
       def dialog_inside_overlay(title: "Test Dialog", subtitle: nil, position: :center, size: :medium, button_text: "Show Dialog", body_text: "Content", position_narrow: :fullscreen, visually_hide_title: false)
         render_with_template(locals: {
                                title: title,

--- a/previews/primer/alpha/dialog_preview/dialog_inside_overlay.html.erb
+++ b/previews/primer/alpha/dialog_preview/dialog_inside_overlay.html.erb
@@ -1,0 +1,9 @@
+<%= render(Primer::Alpha::Overlay.new(title: "An overlay")) do |o| %>
+  <% o.with_show_button() { "Show overlay" } %>
+  <% o.with_body() do %>
+    <%= render(Primer::Alpha::Dialog.new(id: "dialog-one", title: title, position: position, subtitle: subtitle, visually_hide_title: false)) do |d| %>
+      <% d.with_show_button { button_text } %>
+      <% d.with_body { body_text} %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -93,5 +93,13 @@ module Alpha
       find(".ActionListItem", text: "Avocado").click
       assert_selector "dialog[open]"
     end
+
+    def test_dialog_inside_overlay_opens_when_clicked
+      visit_preview(:dialog_inside_overlay)
+
+      click_button("Show overlay")
+      click_button("Show Dialog")
+      assert_selector "dialog[open]"
+    end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Users of the `Primer::Alpha::Overlay` (which uses web native `popover`) component to create custom floating UI may run into an issue when they nest a `Primer::Alpha::Dialog` (which uses web native `<dialog>`) inside of the overlay. This is because at current the algorithm for `showModal()` runs the internal `hide all popovers` algorithm. This closes the Overlay, but as the Dialog inside is nested, it will be hidden (`display:none` effects all children). This issue is described in https://github.com/whatwg/html/issues/9998 and it is fixed in Chrome 124 (observable in the chromium nightlies). Until all browsers fix it though, we need to work around the issue.

One solution for now, is for engineers to _not nest dialogs_ in other floating UI. This is generally a very good idea, however it is also not always completely practical, and so we should cater to engineers with the design system where we can.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
I chose to watch for when our Dialog component opens, to reverse the steps taken by the `hide all popovers` algorithm. This means we will traverse up the tree, looking for `popover` elements that are `:popover-open`, and 

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
