### PR TITLE
Lint for `stopPropagation` calls in JavaScript

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,7 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": "2022",
+    "ecmaVersion": 2022,
     "sourceType": "module"
   },
   "plugins": [
@@ -38,7 +38,7 @@
       ],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {
-        "ecmaVersion": "2022",
+        "ecmaVersion": 2022,
         "sourceType": "module"
       },
       "plugins": [
@@ -63,7 +63,20 @@
         "custom-elements/tag-name-matches-class": [
           "error", {"suffix": "Element"}
         ],
-        "i18n-text/no-en": "off"
+        "i18n-text/no-en": "off",
+        "no-restricted-syntax": [
+          "error",
+          {
+            "message": "stopPropagation() and friends are considered dangerous because they swallow events that consumers may listen for. Consider alternatives.",
+            "selector":
+              "CallExpression[callee.property.name='stopPropagation']"
+          },
+          {
+            "message": "stopImmediatePropagation() and friends are considered dangerous because they swallow events that consumers may listen for. Consider alternatives.",
+            "selector":
+              "CallExpression[callee.property.name='stopImmediatePropagation']"
+          }
+        ]
       }
     }
   ]

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -141,7 +141,9 @@ export class ActionMenuElement extends HTMLElement {
 
     if (item.getAttribute('aria-disabled')) {
       event.preventDefault()
+      /* eslint-disable-next-line no-restricted-syntax */
       event.stopPropagation()
+      /* eslint-disable-next-line no-restricted-syntax */
       event.stopImmediatePropagation()
       return true
     }
@@ -260,6 +262,7 @@ export class ActionMenuElement extends HTMLElement {
 
   #handleInvokerActivated(event: Event) {
     event.preventDefault()
+    /* eslint-disable-next-line no-restricted-syntax */
     event.stopPropagation()
 
     if (this.#isOpen()) {
@@ -353,6 +356,7 @@ export class ActionMenuElement extends HTMLElement {
 
     // otherwise, event will not result in activation by default, so we stop it and
     // simulate a click
+    /* eslint-disable-next-line no-restricted-syntax */
     event.stopPropagation()
     const elem = item as HTMLElement
     elem.click()

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -18,6 +18,7 @@ function clickHandler(event: Event) {
   // If the user is clicking a valid dialog trigger
   let dialogId = button?.getAttribute('data-show-dialog-id')
   if (dialogId) {
+    /* eslint-disable-next-line no-restricted-syntax */
     event.stopPropagation()
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof ModalDialogElement) {
@@ -170,12 +171,14 @@ export class ModalDialogElement extends HTMLElement {
       case 'Escape':
         this.close()
         event.preventDefault()
+        /* eslint-disable-next-line no-restricted-syntax */
         event.stopPropagation()
         break
       case 'Enter': {
         const target = event.target as HTMLElement
 
         if (target.getAttribute('data-close-dialog-id') === this.id) {
+          /* eslint-disable-next-line no-restricted-syntax */
           event.stopPropagation()
         }
         break

--- a/app/components/primer/alpha/toggle_switch.ts
+++ b/app/components/primer/alpha/toggle_switch.ts
@@ -163,9 +163,9 @@ class ToggleSwitchElement extends HTMLElement {
         credentials: 'same-origin',
         method: 'POST',
         headers: {
-          'Requested-With': 'XMLHttpRequest'
+          'Requested-With': 'XMLHttpRequest',
         },
-        body
+        body,
       })
     } catch (error) {
       throw new Error('A network error occurred, please try again.')

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -316,6 +316,7 @@ class ToolTipElement extends HTMLElement {
     const shouldHide = isMouseLeaveFromButton || isEscapeKeydown || isMouseDownOnButton || isOpeningOtherPopover
 
     if (showing && isEscapeKeydown) {
+      /* eslint-disable-next-line no-restricted-syntax */
       event.stopImmediatePropagation()
       event.preventDefault()
     }

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -50,6 +50,6 @@ document.addEventListener('clipboard-copy', ({target}) => {
     setTimeout(() => {
       showCopy(target)
       clipboardCopyElementTimers.delete(target)
-    }, CLIPBOARD_COPY_TIMER_DURATION)
+    }, CLIPBOARD_COPY_TIMER_DURATION),
   )
 })

--- a/app/components/primer/beta/nav_list.ts
+++ b/app/components/primer/beta/nav_list.ts
@@ -74,6 +74,7 @@ export class NavListElement extends HTMLElement {
       this.expandItem(button)
     }
 
+    /* eslint-disable-next-line no-restricted-syntax */
     e.stopPropagation()
   }
 
@@ -96,6 +97,7 @@ export class NavListElement extends HTMLElement {
       this.collapseItem(button)
     }
 
+    /* eslint-disable-next-line no-restricted-syntax */
     e.stopPropagation()
   }
 

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -36,6 +36,7 @@ function dialogInvokerButtonHandler(event: Event) {
       if (fixed) {
         // We need to re-open the dialog as modal, and also ensure no close event listeners
         // are trying to act on the close
+        /* eslint-disable-next-line no-restricted-syntax */
         dialog.addEventListener('close', e => e.stopImmediatePropagation(), {once: true})
         dialog.close()
         dialog.showModal()

--- a/app/components/primer/focus_group.ts
+++ b/app/components/primer/focus_group.ts
@@ -85,7 +85,7 @@ export default class FocusGroupElement extends HTMLElement {
                   }
                 }
               },
-              {signal}
+              {signal},
             )
           }
         }


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

There was [an incident](https://github.com/github/availability/issues/2935) last week that resulted in dotcom's global nav list appearing to load forever. The issue was caused by adding a `stopPropagation()` call to the dialog invoker's `click` event handler, which prevented dotcom's own `click` handler from running.

Except in very specific circumstances, we should not be swallowing events using `stopPropagation`. See [this article](https://css-tricks.com/dangers-stopping-event-propagation/) for an explanation. This PR adds eslint rules for both `stopPropagation` and `stopImmediatePropagation`. The idea here isn't to stop us from ever using these functions, but to make sure we consider the ramifications of doing so before disabling the lint rule.

This PR also disables the lint rule for all the places we currently call `stopPropagation` and `stopImmediatePropagation`. I will file a separate issue for auditing these existing usages.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production; this change is dev-only.

#### List the issues that this change affects.

Fixes https://github.com/github/primer/issues/3034

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.