### PR TITLE
Allow Banner component to receive focus, adds optional `id` parameter

### DIFF
--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -68,13 +68,15 @@ module Primer
       # @param description [String] Description text rendered underneath the message.
       # @param icon [Symbol] The name of an <%= link_to_octicons %> icon to use. If no icon is provided, a default one will be chosen based on the scheme.
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::Banner::SCHEME_MAPPINGS.keys) %>
+      # @param id [String] an optional ID a user can pass in to target the `x-banner` component.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, **system_arguments)
+      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, id: nil, **system_arguments)
         @scheme = fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)
         @icon = icon || DEFAULT_ICONS[@scheme]
         @dismiss_scheme = dismiss_scheme
         @dismiss_label = dismiss_label
         @description = description
+        @id = id
 
         @system_arguments = system_arguments
         @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
@@ -96,6 +98,7 @@ module Primer
 
         @wrapper_arguments = {
           tag: custom_element_name,
+          id: @id,
           data: { dismiss_scheme: @dismiss_scheme }
         }
       end

--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -99,6 +99,7 @@ module Primer
           data: { dismiss_scheme: @dismiss_scheme }
         }
       end
+
       private
 
       def custom_element_name

--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -69,13 +69,12 @@ module Primer
       # @param icon [Symbol] The name of an <%= link_to_octicons %> icon to use. If no icon is provided, a default one will be chosen based on the scheme.
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::Banner::SCHEME_MAPPINGS.keys) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, focus_on_show: false, **system_arguments)
+      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, **system_arguments)
         @scheme = fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)
         @icon = icon || DEFAULT_ICONS[@scheme]
         @dismiss_scheme = dismiss_scheme
         @dismiss_label = dismiss_label
         @description = description
-        @focus_on_show = focus_on_show
 
         @system_arguments = system_arguments
         @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
@@ -97,12 +96,8 @@ module Primer
 
         @wrapper_arguments = {
           tag: custom_element_name,
-          data: { dismiss_scheme: @dismiss_scheme, focus_on_show: @focus_on_show }
+          data: { dismiss_scheme: @dismiss_scheme }
         }
-
-        # if @focus_on_show
-        #   @wrapper_arguments[:tabindex] = -1
-        # end
       end
       private
 

--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -69,12 +69,13 @@ module Primer
       # @param icon [Symbol] The name of an <%= link_to_octicons %> icon to use. If no icon is provided, a default one will be chosen based on the scheme.
       # @param scheme [Symbol] <%= one_of(Primer::Alpha::Banner::SCHEME_MAPPINGS.keys) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, **system_arguments)
+      def initialize(tag: DEFAULT_TAG, full: false, full_when_narrow: false, dismiss_scheme: DEFAULT_DISMISS_SCHEME, dismiss_label: DEFAULT_DISMISS_LABEL, description: nil, icon: nil, scheme: DEFAULT_SCHEME, focus_on_show: false, **system_arguments)
         @scheme = fetch_or_fallback(SCHEME_MAPPINGS.keys, scheme, DEFAULT_SCHEME)
         @icon = icon || DEFAULT_ICONS[@scheme]
         @dismiss_scheme = dismiss_scheme
         @dismiss_label = dismiss_label
         @description = description
+        @focus_on_show = focus_on_show
 
         @system_arguments = system_arguments
         @system_arguments[:tag] = fetch_or_fallback(TAG_OPTIONS, tag, DEFAULT_TAG)
@@ -89,6 +90,10 @@ module Primer
           "Banner--full-whenNarrow": full_when_narrow
         )
 
+        if @focus_on_show
+          @system_arguments[:tabindex] = -1
+        end
+
         @message_arguments = {
           tag: :div,
           classes: "Banner-message"
@@ -96,7 +101,7 @@ module Primer
 
         @wrapper_arguments = {
           tag: custom_element_name,
-          data: { dismiss_scheme: @dismiss_scheme }
+          data: { dismiss_scheme: @dismiss_scheme, focus_on_show: @focus_on_show }
         }
       end
 

--- a/app/components/primer/alpha/banner.rb
+++ b/app/components/primer/alpha/banner.rb
@@ -90,10 +90,6 @@ module Primer
           "Banner--full-whenNarrow": full_when_narrow
         )
 
-        if @focus_on_show
-          @system_arguments[:tabindex] = -1
-        end
-
         @message_arguments = {
           tag: :div,
           classes: "Banner-message"
@@ -103,8 +99,11 @@ module Primer
           tag: custom_element_name,
           data: { dismiss_scheme: @dismiss_scheme, focus_on_show: @focus_on_show }
         }
-      end
 
+        # if @focus_on_show
+        #   @wrapper_arguments[:tabindex] = -1
+        # end
+      end
       private
 
       def custom_element_name

--- a/app/components/primer/alpha/x_banner.ts
+++ b/app/components/primer/alpha/x_banner.ts
@@ -4,6 +4,12 @@ import {controller, target} from '@github/catalyst'
 class XBannerElement extends HTMLElement {
   @target titleText: HTMLElement
 
+  // connectedCallback() {
+  //   if (this.#focusOnShow === 'true') {
+  //     this.focus()
+  //   }
+  // }
+
   dismiss() {
     const parentElement = this.parentElement
     if (!parentElement) return
@@ -15,11 +21,13 @@ class XBannerElement extends HTMLElement {
     }
   }
 
+  focusBanner() {
+    this.setAttribute('tabindex', '-1')
+    this.focus()
+  }
+
   show() {
     this.style.setProperty('display', 'initial')
-    if (this.#focusOnShow === 'true') {
-      this.focus()
-    }
   }
 
   hide() {
@@ -28,10 +36,6 @@ class XBannerElement extends HTMLElement {
 
   get #dismissScheme(): string {
     return this.getAttribute('data-dismiss-scheme')!
-  }
-
-  get #focusOnShow(): string {
-    return this.getAttribute('data-focus-on-show')!
   }
 }
 

--- a/app/components/primer/alpha/x_banner.ts
+++ b/app/components/primer/alpha/x_banner.ts
@@ -4,12 +4,6 @@ import {controller, target} from '@github/catalyst'
 class XBannerElement extends HTMLElement {
   @target titleText: HTMLElement
 
-  // connectedCallback() {
-  //   if (this.#focusOnShow === 'true') {
-  //     this.focus()
-  //   }
-  // }
-
   dismiss() {
     const parentElement = this.parentElement
     if (!parentElement) return

--- a/app/components/primer/alpha/x_banner.ts
+++ b/app/components/primer/alpha/x_banner.ts
@@ -17,6 +17,9 @@ class XBannerElement extends HTMLElement {
 
   show() {
     this.style.setProperty('display', 'initial')
+    if (this.#focusOnShow === 'true') {
+      this.focus()
+    }
   }
 
   hide() {
@@ -25,6 +28,10 @@ class XBannerElement extends HTMLElement {
 
   get #dismissScheme(): string {
     return this.getAttribute('data-dismiss-scheme')!
+  }
+
+  get #focusOnShow(): string {
+    return this.getAttribute('data-focus-on-show')!
   }
 }
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

**Note: I am mostly looking for feedback on this approach before I test it fully 🙏🏻** 

On the Accessibility team, we've discovered a few audit issues are marked as blocked by Primer. After more investigation, we realized this is not the case, and that in some scenarios, we want to move focus to the Banner component when a user takes an action. We can do this in dotcom with JS, as most consumers have logic to show/hide the banners based on certain conditions.

This PR adds a `focusBanner()` method to allow consumers to hook into to focus the banner in certain scenarios. The element we want to focus on in a Banner is subject to change, so this approach allows that element to be managed at the Primer level. It also allows an optional `id` parameter to be passed in which is applied to the `<x-banner>` element (currently passing in `id` as a system arg applies it to the nested `<div>` under `x-banner`, so calling a method on the ID won't work).

### Integration
<!-- Does this change require any updates to code in production? -->

No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

* https://github.com/github/accessibility-audits/issues/5108
* https://github.com/github/accessibility-audits/issues/5090
* https://github.com/github/accessibility-audits/issues/5492

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I chose to add a method to add the `tabindex` and `.focus()` functionality to focus the banner. @khiga8 and I considered adding a parameter to the ruby component, such as `focus_on_show`, that would hide the banner by default, and when shown, it would focus the banner.

The reasons we didn't go with this approach right now (it may be a good thing to discuss in the future!):

* Consumers currently handle the logic for hiding/showing the banner. We'd need to build this in at the component-level and update instances where a consumer is showing/hiding their banner
* It'd be more work to implement on the dotcom consumer end
* It'd be a larger time commitment on our end and Primer's (for testing, reviewing, validating, etc)
* It'd be a more risky change

### Anything you want to highlight for special attention from reviewers?

A consumer could use this new functionality by calling the method this way:

```js
document.querySelector("#banner_id").focusBanner();
```

Is this an anti-pattern? Should we invest more time in allowing a consumer to do something like:

```rb
<%= render(Primer::Alpha::Banner.new(hidden: :true, focus_on_show: :true)) do %>
  Please update your billing information in order to add a payment method.
<% end %>
```

and then the component would be responsible for showing/hiding itself? I think we'd still need to have an event listener present to know when to show/hide the component... Open to other ideas here!

### Accessibility

Allows the banner to be focusable, which will ensure screen reader announcements are consistent in certain scenarios when relevant

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
