### PR TITLE
Remove aria-disabled from dialogs

### DIFF
--- a/.changeset/fifty-items-explain.md
+++ b/.changeset/fifty-items-explain.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove aria-disabled from dialogs

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -131,7 +131,6 @@ module Primer
         @system_arguments[:aria] = merge_aria(
           @system_arguments, {
             aria: {
-              disabled: true,
               labelledby: labelledby,
               describedby: "#{@id}-description"
             }


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
In #1891 we added `aria-disabled=true` to `::Dialog`. This attribute makes the dialog and all children unavailable to ATs. This is far from ideal. In #1996 we changed this to ensure that the Dialog, when open, toggled its `aria-disabled` flag from `true` to `false`. This was better.

In #2364 we moved from our custom `<modal-dialog>` to native `<dialog>`, and somehow the `aria-disabled=true` fixed flag returned.

This PR removes it entirely. I do not know of a good reason to keep it, `<dialog>` should be AT friendly so we shouldn't need to do aria shenanigans. 

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
N/A

### Integration
<!-- Does this change require any updates to code in production? -->
N/A

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->
https://github.com/primer/view_components/issues/2578

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
Remove the aria attribute.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->
If you can think of a good reason to keep this attribute I'd love to know it!

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
