### PR TITLE
Removing minitest dependency line from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,11 +46,6 @@ gem "sourcemap", "~> 0.1"
 
 group :test do
   gem "webmock"
-
-  # Disallow v5.19 for now since it breaks mocha.
-  # See: https://github.com/freerange/mocha/issues/614
-  # Remove this line when mocha has fixed the issue
-  gem "minitest", "< 5.22"
 end
 
 # development dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,6 @@ DEPENDENCIES
   listen (~> 3.0)
   lookbook (~> 2.2.1)
   matrix (~> 0.4.2)
-  minitest (< 5.22)
   mocha
   primer_view_components!
   pry


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Cleaning up the Gemfile noticed this line was meant to be temporary. The issue is resolved so removing the line https://github.com/freerange/mocha/issues/614

```rb
  # Disallow v5.19 for now since it breaks mocha.
  # See: https://github.com/freerange/mocha/issues/614
  # Remove this line when mocha has fixed the issue
  gem "minitest", "< 5.22"
```


