### PR TITLE
Primitives v8 bug fix: `invisible` button hover state in high contrast themes

### DIFF
--- a/.changeset/cyan-hotels-double.md
+++ b/.changeset/cyan-hotels-double.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Primitives v8 bug fix: `invisible` button hover state in high contrast themes

--- a/app/components/primer/beta/button.pcss
+++ b/app/components/primer/beta/button.pcss
@@ -247,11 +247,7 @@ summary.Button {
   }
 
   &:hover:not(:disabled, .Button--inactive) {
-    background-color: var(--button-invisible-bgColor-hover);
-
-    & .Button-visual {
-      color: var(--button-invisible-iconColor-hover, var(--color-fg-default));
-    }
+    background-color: var(--control-transparent-bgColor-hover, var(--color-action-list-item-default-hover-bg));
   }
 
   &[aria-pressed='true'],

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "demo",
       "version": "0.1.0",
       "dependencies": {
         "@primer/css": "^21.2.0",


### PR DESCRIPTION
Before:
<img width="140" alt="button before fix" src="https://github.com/primer/view_components/assets/18661030/e7396fb4-c88d-41fb-878d-91f41d9673e2">

After:
<img width="163" alt="button after fix" src="https://github.com/primer/view_components/assets/18661030/f1bdce21-1f0c-4075-ad27-5770411db3ec">
