### PR TITLE
Fix autofocus behavior for radio button and check box groups

### DIFF
--- a/.changeset/dry-radios-breathe.md
+++ b/.changeset/dry-radios-breathe.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix autofocus behavior for radio button and check box groups

--- a/lib/primer/forms/check_box_group.html.erb
+++ b/lib/primer/forms/check_box_group.html.erb
@@ -1,5 +1,5 @@
-<%= content_tag(:div, **@input.input_arguments) do %>
-  <fieldset>
+<div class="FormControl-check-group-wrap">
+  <%= content_tag(:fieldset, **@input.input_arguments) do %>
     <% if @input.label %>
       <%= content_tag(:legend, **@input.label_arguments) do %>
         <%= @input.label %>
@@ -10,11 +10,11 @@
         <%= render(check_box.to_component) %>
       <% end %>
     <% end %>
-  </fieldset>
+  <% end %>
   <div class="mt-2">
     <%= render(ValidationMessage.new(input: @input)) %>
   </div>
   <div class="mt-2">
     <%= render(Caption.new(input: @input)) %>
   </div>
-<% end %>
+</div>

--- a/lib/primer/forms/check_box_group.rb
+++ b/lib/primer/forms/check_box_group.rb
@@ -8,10 +8,7 @@ module Primer
 
       def initialize(input:)
         @input = input
-
         @input.add_label_classes("FormControl-label", "mb-2")
-        @input.add_input_classes("FormControl-check-group-wrap")
-
         Primer::Forms::Utils.classify(@input.input_arguments)
       end
     end

--- a/lib/primer/forms/dsl/check_box_group_input.rb
+++ b/lib/primer/forms/dsl/check_box_group_input.rb
@@ -25,6 +25,14 @@ module Primer
           :check_box_group
         end
 
+        def focusable?
+          true
+        end
+
+        def autofocus!
+          @check_boxes.first&.autofocus!
+        end
+
         def check_box(**system_arguments, &block)
           args = {
             name: @name,

--- a/lib/primer/forms/dsl/radio_button_group_input.rb
+++ b/lib/primer/forms/dsl/radio_button_group_input.rb
@@ -25,6 +25,14 @@ module Primer
           :radio_button_group
         end
 
+        def autofocus!
+          @radio_buttons.first&.autofocus!
+        end
+
+        def focusable?
+          true
+        end
+
         def radio_button(**system_arguments, &block)
           @radio_buttons << RadioButtonInput.new(
             builder: @builder, form: @form, name: @name, disabled: disabled?,

--- a/lib/primer/forms/radio_button_group.html.erb
+++ b/lib/primer/forms/radio_button_group.html.erb
@@ -1,5 +1,5 @@
-<%= content_tag(:div, **@input.input_arguments) do %>
-  <fieldset>
+<div class="FormControl-radio-group-wrap">
+  <%= content_tag(:fieldset, **@input.input_arguments) do %>
     <% if @input.label %>
       <%= content_tag(:legend, **@input.label_arguments) do %>
         <%= @input.label %>
@@ -10,11 +10,11 @@
         <%= render(radio_button.to_component) %>
       <% end %>
     <% end %>
-  </fieldset>
+  <% end %>
   <div class="mt-2">
     <%= render(ValidationMessage.new(input: @input)) %>
   </div>
   <div class="mt-2">
     <%= render(Caption.new(input: @input)) %>
   </div>
-<% end %>
+</div>

--- a/lib/primer/forms/radio_button_group.rb
+++ b/lib/primer/forms/radio_button_group.rb
@@ -8,10 +8,7 @@ module Primer
 
       def initialize(input:)
         @input = input
-
         @input.add_label_classes("FormControl-label", "mb-2")
-        @input.add_input_classes("FormControl-radio-group-wrap")
-
         Primer::Forms::Utils.classify(@input.input_arguments)
       end
     end

--- a/test/lib/primer/forms/checkbox_group_input_test.rb
+++ b/test/lib/primer/forms/checkbox_group_input_test.rb
@@ -60,10 +60,14 @@ class Primer::Forms::CheckboxGroupInputTest < Minitest::Test
     end
 
     # the wrapper should be marked invalid, but not individual check boxes
-    assert_selector ".FormControl-check-group-wrap[invalid=true][aria-invalid=true]"
+    assert_selector ".FormControl-check-group-wrap fieldset[invalid=true][aria-invalid=true]"
     refute_selector "input[type=checkbox][invalid]"
 
     # should have a validation message
-    assert_selector ".FormControl-inlineValidation", text: "Places must have at least two selections"
+    validation_id = page.find("fieldset")["aria-describedby"]
+    assert_selector ".FormControl-inlineValidation[id='#{validation_id}']", text: "Places must have at least two selections"
+
+    # first check box should have focus
+    assert_selector "input[type=checkbox][value=lopez][autofocus]"
   end
 end

--- a/test/lib/primer/forms/radio_button_group_input_test.rb
+++ b/test/lib/primer/forms/radio_button_group_input_test.rb
@@ -59,11 +59,15 @@ class Primer::Forms::RadioButtonGroupInputTest < Minitest::Test
       end
     end
 
-    # the wrapper should be marked invalid, but not individual check boxes
-    assert_selector ".FormControl-radio-group-wrap[invalid=true][aria-invalid=true]"
+    # the wrapper should be marked invalid, but not individual radio buttons
+    assert_selector ".FormControl-radio-group-wrap fieldset[invalid=true][aria-invalid=true]"
     refute_selector "input[type=radio][invalid]"
 
     # should have a validation message
-    assert_selector ".FormControl-inlineValidation", text: /Channel can['’]t be blank/
+    validation_id = page.find("fieldset")["aria-describedby"]
+    assert_selector ".FormControl-inlineValidation[id='#{validation_id}']", text: /Channel can['’]t be blank/
+
+    # first radio button should have focus
+    assert_selector "input[type=radio][value=online][autofocus]"
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes autofocus behavior for radio button and check box groups. According to [Primer's form guidelines](https://primer.style/ui-patterns/forms/overview#validation-on-submit), "the first invalid input should be focused and scrolled into the viewport". There are two problems with the current implementation:

1. The validation message is attached to a wrapping `<div>` element and should instead be attached to the wrapping `<fieldset>` element. This is causing screen readers to skip announcing the validation message.
2. The `autofocus` attribute is not present on any element.

This PR fixes both issues. See this [Slack discussion](https://github.slack.com/archives/CSGAVNZ19/p1708622152838609) (internal only) for additional details.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

See the linked Slack discussion above.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

This PR does not fix an axe scan violation, but it does address two accessibility audit issues, see (internal only):

1. https://github.com/github/accessibility-audits/issues/7568
2. https://github.com/github/accessibility-audits/issues/7569

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge