### PR TITLE
Mark `Flash` as deprecated

### DIFF
--- a/.changeset/mighty-poems-know.md
+++ b/.changeset/mighty-poems-know.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Mark `Flash` as deprecated

--- a/.changeset/mighty-poems-know.md
+++ b/.changeset/mighty-poems-know.md
@@ -1,5 +1,5 @@
 ---
-"@primer/view-components": patch
+"@primer/view-components": minor
 ---
 
 Mark `Flash` as deprecated

--- a/app/components/primer/beta/flash.rb
+++ b/app/components/primer/beta/flash.rb
@@ -2,6 +2,8 @@
 
 module Primer
   module Beta
+    # This component has been deprecated. Use [Banner](<%= link_to_component(Primer::Alpha::Banner) %>) instead.
+    #
     # Use `Flash` to inform users of successful or pending actions.
     class Flash < Primer::Component
       status :deprecated

--- a/app/components/primer/beta/flash.rb
+++ b/app/components/primer/beta/flash.rb
@@ -4,7 +4,7 @@ module Primer
   module Beta
     # Use `Flash` to inform users of successful or pending actions.
     class Flash < Primer::Component
-      status :beta
+      status :deprecated
 
       # Optional action content showed on the right side of the component.
       #

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -63,3 +63,7 @@ deprecations:
     autocorrect: false
     replacement: "Primer::Beta::Truncate"
     guide: "https://primer.style/guides/rails/migration-guides/primer-truncate"
+
+  - component: "Primer::Beta::Flash"
+    autocorrect: false
+    replacement: "Primer::Alpha::Banner"

--- a/lib/primer/deprecations.yml
+++ b/lib/primer/deprecations.yml
@@ -33,6 +33,11 @@ deprecations:
     autocorrect: true
     replacement: "Primer::Beta::AutoComplete::Item"
 
+  - component: "Primer::Beta::Flash"
+    autocorrect: false
+    replacement: "Primer::Alpha::Banner"
+    guide: "https://primer.style/components/banner/rails/alpha"
+
   - component: "Primer::BlankslateComponent"
     autocorrect: true
     replacement: "Primer::Beta::Blankslate"
@@ -63,7 +68,3 @@ deprecations:
     autocorrect: false
     replacement: "Primer::Beta::Truncate"
     guide: "https://primer.style/guides/rails/migration-guides/primer-truncate"
-
-  - component: "Primer::Beta::Flash"
-    autocorrect: false
-    replacement: "Primer::Alpha::Banner"

--- a/test/components/beta/flash_test.rb
+++ b/test/components/beta/flash_test.rb
@@ -69,6 +69,6 @@ class PrimerFlashTest < Minitest::Test
   end
 
   def test_status
-    assert_component_state(Primer::Beta::Flash, :beta)
+    assert_component_state(Primer::Beta::Flash, :deprecated)
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Formally deprecates `Flash` in favor of `Banner`.

[Related slack thread](https://github.slack.com/archives/CGJTTJ738/p1707774059572439?thread_ts=1707524004.597779&cid=CGJTTJ738)

### Integration
This may require the `DeprecatedComponentsCounter` to be updated.

#### List the issues that this change affects.
Fixes: https://github.com/primer/view_components/issues/2599

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Anything you want to highlight for special attention from reviewers?

Do I need to do anything else?