### PR TITLE
Give ownership of screenshots to design-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 * @primer/engineer-reviewers
 
+# Design changes
+.playwright/screenshots/ @primer/design-reviewers
+
 # Component CSS files
 app/components/**/*.pcss @primer/css-reviewers
 


### PR DESCRIPTION
Follow up to https://github.com/primer/view_components/pull/2664

This gives the playwright screenshots ownership to @primer/design-reviewers My thoughts are that if the style changes then design should 👓 