### PR TITLE
Prevent rounded corners in the middle of a BorderBox

### DIFF
--- a/.changeset/proud-pens-dress.md
+++ b/.changeset/proud-pens-dress.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Prevent rounded corners in the middle of a Primer::Beta::BorderBox

--- a/app/components/primer/beta/border_box.pcss
+++ b/app/components/primer/beta/border_box.pcss
@@ -89,7 +89,7 @@
   border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
 
   /* Ensures bottom-border doesn't poke out when .Box-body used without box-footer */
-  &:last-of-type {
+  &:last-child {
     margin-bottom: calc(var(--borderWidth-thin) * -1);
     border-bottom-right-radius: var(--borderRadius-medium);
     border-bottom-left-radius: var(--borderRadius-medium);
@@ -106,8 +106,7 @@
   border-top-width: var(--borderWidth-thin);
 
   &:first-of-type {
-    border-top-left-radius: var(--borderRadius-medium);
-    border-top-right-radius: var(--borderRadius-medium);
+    border-top-width: 0;
   }
 
   &:last-of-type {


### PR DESCRIPTION
### What are you trying to accomplish?
In a `Primer::Beta::BorderBox` there are constellations in which there are rounded corners somewhere in the middle. For example 

```
render(Primer::Beta::BorderBox.new) do |component|
  component.with_header { "Header" }
  component.with_body { "Body" }
  component.with_row { "Row one" }
  component.with_row { "Row two" }
end
```

### Screenshots
<img width="400" alt="Bildschirmfoto 2024-03-12 um 08 57 25" src="https://github.com/primer/view_components/assets/7457313/2f4edb21-466a-42e6-9fef-07efe1936717">


#### List the issues that this change affects.

Closes #2684 

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
