### PR TITLE
Revert popover-polyfill back to v0.3.8

### DIFF
--- a/.changeset/violet-coats-marry.md
+++ b/.changeset/violet-coats-marry.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Revert popover-polyfill to v0.3.8

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@github/include-fragment-element": "^6.1.1",
         "@github/relative-time-element": "^4.0.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.4.0",
+        "@oddbird/popover-polyfill": "^0.3.8",
         "@primer/behaviors": "^1.3.4"
       },
       "devDependencies": {
@@ -2539,9 +2539,9 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.4.0.tgz",
-      "integrity": "sha512-jrqoTI8lk5UziDsDPJ2Y+nmXYCcRhmr6uMARr3v/W6AMxRgsnRLWJyWKYr6FjaGMgbyxXG+OkCUPQY4Xl3toGg=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3046,12 +3046,6 @@
         "@oddbird/popover-polyfill": "^0.3.2",
         "@primer/behaviors": "^1.3.4"
       }
-    },
-    "node_modules/@primer/view-components/node_modules/@oddbird/popover-polyfill": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
-      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g==",
-      "dev": true
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.2.3",
@@ -13845,9 +13839,9 @@
       }
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.4.0.tgz",
-      "integrity": "sha512-jrqoTI8lk5UziDsDPJ2Y+nmXYCcRhmr6uMARr3v/W6AMxRgsnRLWJyWKYr6FjaGMgbyxXG+OkCUPQY4Xl3toGg=="
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
+      "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -14195,14 +14189,6 @@
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.3.2",
         "@primer/behaviors": "^1.3.4"
-      },
-      "dependencies": {
-        "@oddbird/popover-polyfill": {
-          "version": "0.3.8",
-          "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.3.8.tgz",
-          "integrity": "sha512-+aK7EHL3VggfsWGVqUwvtli2+kP5OWyseAsrefhzR2XWoi2oALUCeoDn63i5WS3ZOmLiXHRNBwHPeta8w+aM1g==",
-          "dev": true
-        }
       }
     },
     "@rollup/plugin-node-resolve": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@github/include-fragment-element": "^6.1.1",
     "@github/relative-time-element": "^4.0.0",
     "@github/tab-container-element": "^3.1.2",
-    "@oddbird/popover-polyfill": "^0.4.0",
+    "@oddbird/popover-polyfill": "^0.3.8",
     "@primer/behaviors": "^1.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Unfortunately v0.4.0 of popover-polyfill references `window`, which breaks React SSR in github dotcom.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.