### PR TITLE
Explicitly convert params to integers where needed in previews

### DIFF
--- a/.changeset/dirty-parents-sneeze.md
+++ b/.changeset/dirty-parents-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Explicitly convert params to integers where needed for several previews

--- a/previews/primer/alpha/tab_nav_preview.rb
+++ b/previews/primer/alpha/tab_nav_preview.rb
@@ -11,7 +11,7 @@ module Primer
       # @param with_counters [Boolean] toggle
       def playground(number_of_tabs: 3, with_icons: false, with_counters: false)
         render(Primer::Alpha::TabNav.new(label: "label")) do |component|
-          Array.new(number_of_tabs || 3) do |i|
+          Array.new(number_of_tabs&.to_i || 3) do |i|
             component.with_tab(selected: i.zero?, href: "##{i + 1}") do |tab|
               tab.with_icon(icon: :star) if with_icons
               tab.with_text { "Tab #{i + 1}" }

--- a/previews/primer/alpha/tab_panels_preview.rb
+++ b/previews/primer/alpha/tab_panels_preview.rb
@@ -10,7 +10,7 @@ module Primer
       # @param align [Symbol] select [left, right]
       def playground(number_of_panels: 3, align: :left)
         render(Primer::Alpha::TabPanels.new(label: "label", align: align)) do |component|
-          Array.new(number_of_panels || 3) do |i|
+          Array.new(number_of_panels&.to_i || 3) do |i|
             component.with_tab(selected: i.zero?, id: "tab-#{i + 1}") do |tab|
               tab.with_panel { "Panel #{i + 1}" }
               tab.with_text { "Tab #{i + 1}" }
@@ -26,7 +26,7 @@ module Primer
       # @snapshot
       def default(number_of_panels: 3, align: :left)
         render(Primer::Alpha::TabPanels.new(label: "label", align: align)) do |component|
-          Array.new(number_of_panels || 3) do |i|
+          Array.new(number_of_panels&.to_i || 3) do |i|
             component.with_tab(selected: i.zero?, id: "tab-#{i + 1}") do |tab|
               tab.with_panel { "Panel #{i + 1}" }
               tab.with_text { "Tab #{i + 1}" }

--- a/previews/primer/alpha/underline_nav_preview.rb
+++ b/previews/primer/alpha/underline_nav_preview.rb
@@ -15,7 +15,7 @@ module Primer
                                label: label,
                                tag: tag,
                                align: align,
-                               number_of_panels: number_of_panels
+                               number_of_panels: number_of_panels.to_i,
                              })
       end
 
@@ -31,7 +31,7 @@ module Primer
                                label: label,
                                tag: tag,
                                align: align,
-                               number_of_panels: number_of_panels
+                               number_of_panels: number_of_panels.to_i,
                              })
       end
 
@@ -44,7 +44,7 @@ module Primer
       # @param number_of_panels [Integer] number
       def with_icons_and_counters(label: "With icons and counters", number_of_panels: 3, align: :left, tag: :nav)
         render(Primer::Alpha::UnderlineNav.new(label: label, tag: tag, align: align)) do |component|
-          Array.new(number_of_panels || 3) do |i|
+          Array.new(number_of_panels.to_i || 3) do |i|
             component.with_tab(href: "#", selected: i.zero?) do |tab|
               tab.with_icon(icon: :star)
               tab.with_text { "Item #{i + 1}" }

--- a/previews/primer/alpha/underline_panels_preview.rb
+++ b/previews/primer/alpha/underline_panels_preview.rb
@@ -25,7 +25,7 @@ module Primer
       # @param align [Symbol] select [left, right]
       def default(number_of_panels: 3, align: :left)
         render(Primer::Alpha::UnderlinePanels.new(label: "Test navigation", align: align)) do |component|
-          Array.new(number_of_panels || 3) do |i|
+          Array.new(number_of_panels&.to_i || 3) do |i|
             component.with_tab(selected: i.zero?, id: "tab-#{i + 1}") do |tab|
               tab.with_panel { "Panel #{i + 1}" }
               tab.with_text { "Tab #{i + 1}" }

--- a/previews/primer/beta/avatar_stack_preview.rb
+++ b/previews/primer/beta/avatar_stack_preview.rb
@@ -13,7 +13,7 @@ module Primer
       # @param tooltip_label text
       def playground(number_of_avatars: 1, tag: :div, align: :left, tooltipped: false, tooltip_label: "This is a tooltip!")
         render(Primer::Beta::AvatarStack.new(tag: tag, align: align, tooltipped: tooltipped, body_arguments: { label: tooltip_label })) do |component|
-          Array.new(number_of_avatars || 1) do
+          Array.new(number_of_avatars&.to_i || 1) do
             component.with_avatar(src: Primer::ExampleImage::BASE64_SRC, alt: "@kittenuser")
           end
         end

--- a/previews/primer/beta/breadcrumbs_preview.rb
+++ b/previews/primer/beta/breadcrumbs_preview.rb
@@ -9,7 +9,7 @@ module Primer
       # @param number_of_links [Integer] number
       def playground(number_of_links: 2)
         render(Primer::Beta::Breadcrumbs.new) do |component|
-          Array.new(number_of_links || 3) do |i|
+          Array.new(number_of_links&.to_i || 3) do |i|
             component.with_item(href: "##{i}") { "Breadcrumb Item #{i + 1}" }
           end
         end
@@ -21,7 +21,7 @@ module Primer
       # @snapshot
       def default(number_of_links: 2)
         render(Primer::Beta::Breadcrumbs.new) do |component|
-          Array.new(number_of_links || 3) do |i|
+          Array.new(number_of_links&.to_i || 3) do |i|
             component.with_item(href: "##{i}") { "Breadcrumb Item #{i + 1}" }
           end
         end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Fixes https://github.com/primer/view_components/issues/2734.

When you change a param in lookbook, that value gets sent as a string, even if it is a number. We have different components where we allow changing the number of things rendered, and if you try to change the number, it errors currently because we are passing in a string instead of an integer.

This PR just updates those previews to call `.to_i`, if the param is present. I've confirmed that this fixes changing the params for these previews in lookbook.

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
