### PR TITLE
Enable multi-select behavior in Select playground

### DIFF
--- a/previews/primer/alpha/select_preview.rb
+++ b/previews/primer/alpha/select_preview.rb
@@ -11,6 +11,7 @@ module Primer
       # @param label text
       # @param caption text
       # @param required toggle
+      # @param multiple toggle
       # @param visually_hide_label toggle
       # @param size [Symbol] select [small, medium, large]
       # @param full_width toggle
@@ -23,6 +24,7 @@ module Primer
         label: "Favorite place to visit",
         caption: "They're all good",
         required: false,
+        multiple: false,
         visually_hide_label: false,
         size: Primer::Forms::Dsl::Input::DEFAULT_SIZE.to_s,
         full_width: true,
@@ -36,6 +38,7 @@ module Primer
           label: label,
           caption: caption,
           required: required,
+          multiple: multiple,
           visually_hide_label: visually_hide_label,
           size: size,
           full_width: full_width,


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR adds the ability to toggle multi-select behavior on and off in the playground preview for the `Select` component. It should have been added in https://github.com/primer/view_components/pull/2627, but was overlooked.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.