### PR TITLE
Update workflow deps on primer/.github to use tag

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -10,7 +10,7 @@ jobs:
   release-canary:
     name: npm
     if: ${{ github.repository == 'primer/view_components' }}
-    uses: primer/.github/.github/workflows/release_canary.yml@main
+    uses: primer/.github/.github/workflows/release_canary.yml@v1.0.0
     with:
       install: npm i
     secrets:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -9,7 +9,7 @@ jobs:
   release-candidate:
     name: npm
     if: ${{ github.repository == 'primer/view_components' }}
-    uses: primer/.github/.github/workflows/release_candidate.yml@main
+    uses: primer/.github/.github/workflows/release_candidate.yml@v1.0.0
     secrets:
       gh_token: ${{ secrets.GITHUB_TOKEN }}
       npm_token: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
This PR updates the workflows to use a tagged version of primer/.github/.github/workflows/ as we are updating them and relying on `@main` is bad for us and a security risk.

_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Fix actions to use tagged versions

### Integration
No

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
