### PR TITLE
Add multiple body options to Overlay body slot

### DIFF
--- a/.changeset/wild-knives-notice.md
+++ b/.changeset/wild-knives-notice.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Update `Overlay.with_body` to allow multiple bodies. When the component has more than one we render in a `TabPanel`

--- a/app/components/primer/alpha/overlay.html.erb
+++ b/app/components/primer/alpha/overlay.html.erb
@@ -6,7 +6,20 @@
     <% if content.present? %>
       <%= content %>
     <% else %>
-      <%= body %>
+      <% if bodies.size == 1 %>
+        <%= bodies.first %>
+      <% else %>
+        <%= render(Primer::Alpha::TabPanels.new(label: "label", wrapper_arguments: { classes: "Overlay-tabPanels" })) do |component| %>
+          <% bodies.each do |body| %>
+            <% component.with_tab(**body.tab_arguments) do |tab| %>
+              <% tab.with_panel(classes: "Overlay-tabPanel") do %>
+                <%= body %>
+              <% end %>
+              <% tab.with_text { body.tab_label } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
       <%= footer %>
     <% end %>
   <% end %>

--- a/app/components/primer/alpha/overlay.html.erb
+++ b/app/components/primer/alpha/overlay.html.erb
@@ -6,9 +6,7 @@
     <% if content.present? %>
       <%= content %>
     <% else %>
-      <% if bodies.size == 1 %>
-        <%= bodies.first %>
-      <% else %>
+      <% if bodies.size > 1 %>
         <%= render(Primer::Alpha::TabPanels.new(label: "label", wrapper_arguments: { classes: "Overlay-tabPanels" })) do |component| %>
           <% bodies.each do |body| %>
             <% component.with_tab(**body.tab_arguments) do |tab| %>
@@ -19,6 +17,8 @@
             <% end %>
           <% end %>
         <% end %>
+      <% else %>
+        <%= bodies.first %>
       <% end %>
       <%= footer %>
     <% end %>

--- a/app/components/primer/alpha/overlay.pcss
+++ b/app/components/primer/alpha/overlay.pcss
@@ -24,3 +24,19 @@ anchored-position.not-anchored::backdrop, dialog::backdrop {
     outline: solid 1px transparent;
   }
 }
+
+.Overlay-tabPanels {
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
+
+  & > .tabnav {
+    margin: var(--base-size-8) 0;
+    padding: 0 var(--base-size-8);
+  }
+}
+
+.Overlay-tabPanel {
+  overflow: hidden;
+  display: flex;
+}

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -109,7 +109,7 @@ module Primer
       #
       # @param padding [Symbol] The padding. <%= one_of(Primer::Alpha::Overlay::PADDING_OPTIONS) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_one :body, lambda { |padding: @padding, **system_arguments|
+      renders_many :bodies, lambda { |padding: @padding, **system_arguments|
         Primer::Alpha::Overlay::Body.new(
           padding: padding,
           **system_arguments
@@ -185,7 +185,16 @@ module Primer
             @system_arguments[:aria][:label] = @title
           end
         end
-        with_body unless body?
+        if bodies?
+          if bodies.size > 1
+            # confirm all bodies have tab_label
+            bodies.each do |body|
+              raise ArgumentError, "Multiple with_body slots require `tab_label` to be passed." unless body.tab_label.present?
+            end
+          end
+        else
+          with_body
+        end
       end
 
       private

--- a/app/components/primer/alpha/overlay.rb
+++ b/app/components/primer/alpha/overlay.rb
@@ -106,6 +106,7 @@ module Primer
       }
 
       # Required body content.
+      # when multiple bodies are passed, they will be rendered in a TabPanels component.
       #
       # @param padding [Symbol] The padding. <%= one_of(Primer::Alpha::Overlay::PADDING_OPTIONS) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>

--- a/app/components/primer/alpha/overlay/body.rb
+++ b/app/components/primer/alpha/overlay/body.rb
@@ -6,8 +6,12 @@ module Primer
       # A `Overlay::Body` is a compositional component, used to render the
       # Body of an overlay. See <%= link_to_component(Primer::Alpha::Overlay) %>.
       class Body < Primer::Component
+
+        attr_reader :tab_arguments, :tab_label
+
+        # @param tab_arguments [Hash] Arguments passed to TabPanels component
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-        def initialize(padding: DEFAULT_PADDING, **system_arguments)
+        def initialize(padding: DEFAULT_PADDING, tab_label: nil, tab_arguments: {}, **system_arguments)
           @system_arguments = deny_tag_argument(**system_arguments)
           @system_arguments[:tag] = :div
           @system_arguments[:classes] = class_names(
@@ -15,6 +19,8 @@ module Primer
             PADDING_MAPPINGS[fetch_or_fallback(PADDING_OPTIONS, padding, DEFAULT_PADDING)],
             system_arguments[:classes]
           )
+          @tab_arguments = tab_arguments
+          @tab_label = tab_label
         end
 
         def call

--- a/app/components/primer/alpha/tab_panels.rb
+++ b/app/components/primer/alpha/tab_panels.rb
@@ -19,7 +19,7 @@ module Primer
       # @param id [String] Unique ID of tab.
       # @param selected [Boolean] Whether the tab is selected.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      renders_many :tabs, lambda { |id:, selected: false, **system_arguments|
+      renders_many :tabs, lambda { |id: self.class.generate_id, selected: false, **system_arguments|
         system_arguments[:id] = id
         system_arguments[:classes] = tab_nav_tab_classes(system_arguments[:classes])
 

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -183,6 +183,10 @@ module Primer
       def overlay_with_header_filter
         render_with_template(locals: {})
       end
+
+      def overlay_with_three_bodies
+        render_with_template(locals: {})
+      end
     end
   end
 end

--- a/previews/primer/alpha/overlay_preview/overlay_with_three_bodies.html.erb
+++ b/previews/primer/alpha/overlay_preview/overlay_with_three_bodies.html.erb
@@ -1,0 +1,18 @@
+<%= render(Primer::Alpha::Overlay.new(title: "Dialog", role: :dialog, size: :large, padding: :condensed)) do |d| %>
+  <% d.with_header(title: "Large Dialog Header", divider: true) do |header| %>
+    <% header.with_filter do %>
+      <%= render Primer::Alpha::TextField.new(
+        autofocus: true,
+        visually_hide_label:
+        true,
+        name: "filter",
+        label: "Filter Overlay"
+      ) %>
+    <% end %>
+  <% end %>
+  <% d.with_show_button { "Show Overlay" } %>
+  <% d.with_footer { "Large Dialog Footer" } %>
+  <% d.with_body(tab_label: "Tab 1", tab_arguments: { selected: true }) { "This is the first tab <br>".html_safe * 20 } %>
+  <% d.with_body(tab_label: "Tab 2") { "This is the second tab <br>".html_safe * 20 } %>
+  <% d.with_body(tab_label: "Tab 3") { "This is the third tab <br>".html_safe * 20 } %>
+<% end %>

--- a/static/classes.json
+++ b/static/classes.json
@@ -408,6 +408,12 @@
   "Overlay-headerFilter": [
     "Primer::Alpha::Dialog"
   ],
+  "Overlay-tabPanel": [
+    "Primer::Alpha::Overlay"
+  ],
+  "Overlay-tabPanels": [
+    "Primer::Alpha::Overlay"
+  ],
   "Popover": [
     "Primer::Beta::Popover"
   ],

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -124,4 +124,29 @@ class PrimerAlphaOverlayTest < Minitest::Test
 
     assert_selector(".Overlay-header .Overlay-headerContentWrap + .Overlay-headerFilter")
   end
+
+  def test_renders_multiple_bodies_as_tabpanels
+    render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
+      component.with_header
+      component.with_body(tab_label: "Tab 1") { "Hello" }
+      component.with_body(tab_label: "Tab 2") { "Hello" }
+    end
+
+    assert_selector("tab-container.Overlay-tabPanels") do
+      assert_selector(".tabnav-tab", count: 2)
+      assert_selector(".Overlay-tabPanel", count: 2, visible: :all)
+    end
+  end
+
+  def test_raises_argument_error_when_tab_label_is_missing
+    error = assert_raises(ArgumentError) do
+      render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
+        component.with_header
+        component.with_body { "Hello" }
+        component.with_body { "Hello" }
+      end
+    end
+
+    assert_includes(error.message, "Multiple with_body slots require `tab_label` to be passed.")
+  end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This enables more functionality on the Overlay component to add TabPanels when multiple bodies are rendered. In support of https://github.com/github/primer/issues/3083

My approach was to change the `with_body` slot to allow multiple bodies. When multiple bodies are passed we render TabPanels instead.

### Screenshots

<img width="676" alt="image" src="https://github.com/primer/view_components/assets/54012/379a5eab-d281-4a9e-8569-54e43dc61b32">

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
