### PR TITLE
Bug Fix: anchored-position re-calculate position on scroll

### DIFF
--- a/.changeset/brown-buckets-sell.md
+++ b/.changeset/brown-buckets-sell.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix: Re-calculate anchored-position on scroll

--- a/app/components/primer/anchored_position.ts
+++ b/app/components/primer/anchored_position.ts
@@ -68,10 +68,6 @@ export default class AnchoredPositionElement extends HTMLElement implements Posi
     this.setAttribute('side', `${value}`)
   }
 
-  get open(): boolean {
-    return this.matches(':popover-open')
-  }
-
   get anchorOffset(): number {
     const alias = this.getAttribute('anchor-offset')
     if (alias === 'spacious' || alias === '8') return 8

--- a/app/components/primer/anchored_position.ts
+++ b/app/components/primer/anchored_position.ts
@@ -13,6 +13,8 @@ const updateWhenVisible = (() => {
   return (el: AnchoredPositionElement) => {
     // eslint-disable-next-line github/prefer-observers
     window.addEventListener('resize', updateVisibleAnchors)
+    // eslint-disable-next-line github/prefer-observers
+    window.addEventListener('scroll', updateVisibleAnchors)
     intersectionObserver ||= new IntersectionObserver(entries => {
       for (const entry of entries) {
         const target = entry.target as AnchoredPositionElement
@@ -64,6 +66,10 @@ export default class AnchoredPositionElement extends HTMLElement implements Posi
 
   set side(value: AnchorSide) {
     this.setAttribute('side', `${value}`)
+  }
+
+  get open(): boolean {
+    return this.matches(':popover-open')
   }
 
   get anchorOffset(): number {

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -187,6 +187,10 @@ module Primer
       def overlay_with_three_bodies
         render_with_template(locals: {})
       end
+
+      def in_a_sticky_container
+        render_with_template(locals: {})
+      end
     end
   end
 end

--- a/previews/primer/alpha/overlay_preview/in_a_sticky_container.html.erb
+++ b/previews/primer/alpha/overlay_preview/in_a_sticky_container.html.erb
@@ -1,0 +1,19 @@
+<div style="position:sticky;top:0;" class="color-bg-accent">
+  <%= render(Primer::Alpha::Overlay.new(title: "Dialog", role: :dialog, size: :large, padding: :condensed)) do |d| %>
+    <% d.with_header(title: "Large Dialog Header", divider: true) do |header| %>
+      <% header.with_filter do %>
+        <%= render Primer::Alpha::TextField.new(
+          autofocus: true,
+          visually_hide_label:
+          true,
+          name: "filter",
+          label: "Filter Overlay"
+        ) %>
+      <% end %>
+    <% end %>
+    <% d.with_show_button { "Show Overlay" } %>
+    <% d.with_footer { "Large Dialog Footer" } %>
+    <% d.with_body { "This is a long body for the overlay dialog. <br>".html_safe * 20 } %>
+  <% end %>
+</div>
+<div style="height:3000px;"></div>


### PR DESCRIPTION
### What are you trying to accomplish?

Fix an issue with `anchored-position` where the component doesn't stay with the anchor if it's in a sticky container. 

### Screenshots

**Before**

https://github.com/primer/view_components/assets/54012/d58d80e8-a17d-4a42-a2ec-24b987c88c7f

**After**


https://github.com/primer/view_components/assets/54012/c736d80e-0b4f-4435-aea2-d37a57a63a8a

http://primer-view-components-preview-2794.eastus.azurecontainer.io/view-components/lookbook/inspect/primer/alpha/overlay/in_a_sticky_container

### Integration

No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

The recalculating was already there, I just added a scroll event listener

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
