### PR TITLE
Updates Button and ButtonMarketing playground previews with tag param

### DIFF
--- a/previews/primer/alpha/button_marketing_preview.rb
+++ b/previews/primer/alpha/button_marketing_preview.rb
@@ -7,10 +7,15 @@ module Primer
       # @label Playground
       # @param scheme [Symbol] select [default, primary, outline, transparent]
       # @param variant [Symbol] select [default, large]
+      # @param tag [Symbol] select [button, a]
       # @param type [Symbol] select [button, submit]
       # @param disabled [Boolean]
-      def playground(tag: :button, type: :button, scheme: :default, variant: :default, disabled: false)
-        render(Primer::Alpha::ButtonMarketing.new(tag: tag, type: type, scheme: scheme, variant: variant, disabled: disabled)) { "Default" }
+      def playground(tag: :button, type: :button, scheme: :default, variant: :default, disabled: false, href: nil)
+        # Sets default href to `a`, to ensure it's keyboard interactive and proper markup
+        if tag == :a && href.nil?
+          href = "#"
+        end
+        render(Primer::Alpha::ButtonMarketing.new(tag: tag, type: type, scheme: scheme, variant: variant, disabled: disabled, href: href)) { "Default" }
       end
 
       # @label Default options

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -20,6 +20,7 @@ module Primer
       # @param disabled toggle
       # @param inactive toggle
       # @param align_content select [center, start]
+      # @param tag select [a, button]
       # @param label_wrap toggle
       def playground(
         scheme: :default,
@@ -30,19 +31,25 @@ module Primer
         tag: :button,
         disabled: false,
         inactive: false,
-        label_wrap: false
+        label_wrap: false,
+        href: nil
       )
+        # Sets default href to `a`, to ensure it's keyboard interactive and proper markup
+        if tag == :a && href.nil?
+          href = "#"
+        end
         render(Primer::Beta::Button.new(
-                 scheme: scheme,
-                 size: size,
-                 block: block,
-                 id: id,
-                 align_content: align_content,
-                 tag: tag,
-                 disabled: disabled,
-                 inactive: inactive,
-                 label_wrap: label_wrap
-               )) do |_c|
+                  scheme: scheme,
+                  size: size,
+                  block: block,
+                  id: id,
+                  align_content: align_content,
+                  tag: tag,
+                  disabled: disabled,
+                  inactive: inactive,
+                  label_wrap: label_wrap,
+                  href: href
+                )) do |_c|
           "Button"
         end
       end

--- a/previews/primer/beta/button_preview.rb
+++ b/previews/primer/beta/button_preview.rb
@@ -39,16 +39,16 @@ module Primer
           href = "#"
         end
         render(Primer::Beta::Button.new(
-                  scheme: scheme,
-                  size: size,
-                  block: block,
-                  id: id,
-                  align_content: align_content,
-                  tag: tag,
-                  disabled: disabled,
-                  inactive: inactive,
-                  label_wrap: label_wrap,
-                  href: href
+                 scheme: scheme,
+                 size: size,
+                 block: block,
+                 id: id,
+                 align_content: align_content,
+                 tag: tag,
+                 disabled: disabled,
+                 inactive: inactive,
+                 label_wrap: label_wrap,
+                 href: href
                 )) do |_c|
           "Button"
         end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Follow up from https://github.com/primer/view_components/pull/2802#discussion_r1579609153, adds back the `tag` param with `button` and `a` options. Adds the `href` dynamically if the `a` is selected.

### Integration
<!-- Does this change require any updates to code in production? -->
No

#### List the issues that this change affects.

* https://github.com/github/primer/issues/2188
* https://github.com/github/primer/issues/2189

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Added back the `tag` option to playground previews and adds an `href` dynamically to ensure proper attributes are added based on the markup.

### Anything you want to highlight for special attention from reviewers?

No

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
