### PR TITLE
Add subtitle slot to the Primer::Alpha::Overlay::Header and Primer::Alpha::Dialog::Header

### DIFF
--- a/.changeset/forty-rings-chew.md
+++ b/.changeset/forty-rings-chew.md
@@ -2,4 +2,4 @@
 "@primer/view-components": minor
 ---
 
-Adds a subtitle slot to the Primer::Alpha::Overlay::Header
+Adds a subtitle slot to the Primer::Alpha::Overlay::Header and Primer::Alpha::Dialog::Header

--- a/.changeset/forty-rings-chew.md
+++ b/.changeset/forty-rings-chew.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Adds a subtitle slot to the Primer::Alpha::Overlay::Header

--- a/app/components/primer/alpha/dialog/header.html.erb
+++ b/app/components/primer/alpha/dialog/header.html.erb
@@ -8,6 +8,8 @@
         <%= content %>
       <% elsif @subtitle.present? %>
         <h2 id="<%= @id %>-description" class="Overlay-description"><%= @subtitle %></h2>
+      <% else %>
+        <%= subtitle %>
       <% end %>
     </div>
     <div class="Overlay-actionWrap">

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -28,6 +28,20 @@ module Primer
           Primer::BaseComponent.new(**system_arguments)
         }
 
+                # Optional subtitle slot for adding a subtitle to the header.
+        #
+        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+        renders_one :subtitle, lambda { |**system_arguments|
+          raise ArgumentError, "Do not use the subtitle slot if you are passing subtitle in as an argument" if @subtitle.present? && !Rails.env.production?
+
+          system_arguments[:tag] = :h2
+          system_arguments[:classes] = class_names(
+            "Overlay-description",
+            system_arguments[:classes]
+          )
+          Primer::BaseComponent.new(**system_arguments)
+        }
+
         # @param id [String] The HTML element's ID value.
         # @param title [String] Describes the content of the dialog.
         # @param subtitle [String] Provides additional context for the dialog, also setting the `aria-describedby` attribute.

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -28,7 +28,7 @@ module Primer
           Primer::BaseComponent.new(**system_arguments)
         }
 
-                # Optional subtitle slot for adding a subtitle to the header.
+        # Optional subtitle slot for adding a subtitle to the header.
         #
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         renders_one :subtitle, lambda { |**system_arguments|

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -6,6 +6,8 @@
         <%= content %>
       <% elsif @subtitle.present? %>
         <h2 class="Overlay-description"><%= @subtitle %></h2>
+      <% else %>
+        <%= subtitle %>
       <% end %>
     </div>
     <% if @overlay_id %>

--- a/app/components/primer/alpha/overlay/header.rb
+++ b/app/components/primer/alpha/overlay/header.rb
@@ -25,6 +25,21 @@ module Primer
           Primer::BaseComponent.new(**system_arguments)
         }
 
+
+        # Optional subtitle slot for adding a subtitle to the header.
+        #
+        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+        renders_one :subtitle, lambda { |**system_arguments|
+          raise ArgumentError, "Do not use the subtitle slot if you are passing subtitle in as an argument" if @subtitle.present? && !Rails.env.production?
+
+          system_arguments[:tag] = :h2
+          system_arguments[:classes] = class_names(
+            "Overlay-description",
+            system_arguments[:classes]
+          )
+          Primer::BaseComponent.new(**system_arguments)
+        }
+
         # @param title [String] Describes the content of the Overlay.
         # @param subtitle [String] Provides additional context for the Overlay, also setting the `aria-describedby` attribute.
         # @param overlay_id [String] Provides the id of the overlay element so the close button can close it

--- a/previews/primer/alpha/overlay_preview.rb
+++ b/previews/primer/alpha/overlay_preview.rb
@@ -184,6 +184,17 @@ module Primer
         render_with_template(locals: {})
       end
 
+      def overlay_with_header_subtitle
+        render(Primer::Alpha::Overlay.new(title: "Dialog", role: :dialog, size: :large, padding: :condensed)) do |d|
+          d.with_header(title: "Large Dialog Header", divider: true) do |h|
+            h.with_subtitle {"A subtitle"}
+          end
+          d.with_show_button { "Show Overlay" }
+          d.with_footer { "Large Dialog Footer" }
+          d.with_body { "This is a long body for the overlay dialog. <br>".html_safe * 20 }
+        end
+      end
+
       def overlay_with_three_bodies
         render_with_template(locals: {})
       end

--- a/static/previews.json
+++ b/static/previews.json
@@ -4967,6 +4967,19 @@
         }
       },
       {
+        "preview_path": "primer/alpha/overlay/overlay_with_header_subtitle",
+        "name": "overlay_with_header_subtitle",
+        "snapshot": "false",
+        "skip_rules": {
+          "wont_fix": [
+            "region"
+          ],
+          "will_fix": [
+            "color-contrast"
+          ]
+        }
+      },
+      {
         "preview_path": "primer/alpha/overlay/overlay_with_three_bodies",
         "name": "overlay_with_three_bodies",
         "snapshot": "false",

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -91,6 +91,12 @@ module Primer
         end
       end
 
+      def test_renders_header_subtitle
+        render_inline(Primer::Alpha::Dialog::Header.new(id: "1", title: "Header")) do |component|
+          component.with_subtitle { "subtitle" }
+        end
+      end
+    
       def test_renders_header_with_filter
         render_preview(:with_header_filter)
 

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -97,7 +97,7 @@ module Primer
         end
         assert_selector(".Overlay-header .Overlay-description")
       end
-    
+
       def test_renders_header_with_filter
         render_preview(:with_header_filter)
 

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -95,6 +95,7 @@ module Primer
         render_inline(Primer::Alpha::Dialog::Header.new(id: "1", title: "Header")) do |component|
           component.with_subtitle { "subtitle" }
         end
+        assert_selector(".Overlay-header .Overlay-description")
       end
     
       def test_renders_header_with_filter

--- a/test/components/primer/alpha/overlay_test.rb
+++ b/test/components/primer/alpha/overlay_test.rb
@@ -125,6 +125,14 @@ class PrimerAlphaOverlayTest < Minitest::Test
     assert_selector(".Overlay-header .Overlay-headerContentWrap + .Overlay-headerFilter")
   end
 
+  def test_renders_header_subtitle
+    render_inline(Primer::Alpha::Overlay::Header.new(id: "1", title: "Header")) do |component|
+      component.with_subtitle { "subtitle" }
+    end
+
+    assert_selector(".Overlay-header .Overlay-description")
+  end
+
   def test_renders_multiple_bodies_as_tabpanels
     render_inline(Primer::Alpha::Overlay.new(title: "Title", role: :dialog)) do |component|
       component.with_header


### PR DESCRIPTION
### What are you trying to accomplish?

I would like to add a link inside of a subtitle. In order to do this I need the subtitle field to be a slot.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
