### PR TITLE
fix: Fix NVDA menu item counts that are broken by `<form>`

### DIFF
--- a/.changeset/gorgeous-turtles-agree.md
+++ b/.changeset/gorgeous-turtles-agree.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix NVDA menu item counts that are broken by using '<form>' inside an 'ActionMenu'.

--- a/app/components/primer/alpha/action_list/form_wrapper.html.erb
+++ b/app/components/primer/alpha/action_list/form_wrapper.html.erb
@@ -1,5 +1,5 @@
 <% if form_required? %>
-  <%= form_with(url: @action, method: @http_method, **@form_arguments) do %>
+  <%= form_with(url: @action, method: @http_method, html: { role: :none }, **@form_arguments) do %>
     <% if render_inputs? %>
       <% @inputs.each do |input_arguments| %>
         <%= render(Primer::BaseComponent.new(tag: :input, **input_arguments)) %>

--- a/app/components/primer/alpha/action_list/form_wrapper.html.erb
+++ b/app/components/primer/alpha/action_list/form_wrapper.html.erb
@@ -1,5 +1,5 @@
 <% if form_required? %>
-  <%= form_with(url: @action, method: @http_method, html: { role: :none }, **@form_arguments) do %>
+  <%= form_with(url: @action, method: @http_method, **@form_arguments) do %>
     <% if render_inputs? %>
       <% @inputs.each do |input_arguments| %>
         <%= render(Primer::BaseComponent.new(tag: :input, **input_arguments)) %>

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -89,6 +89,12 @@ module Primer
         def organize_arguments(data: {}, **system_arguments)
           content_arguments = system_arguments.delete(:content_arguments) || {}
 
+          # When a form is inside a menu, suppress form semantics.
+          # Otherwise, NVDA will miscount menu items.
+          form_arguments = system_arguments.delete(:form_arguments) || {}
+          form_arguments[:html] = form_arguments[:html] || {}
+          form_arguments[:html][:role] = :none
+
           if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
             content_arguments[:tag] = system_arguments[:tag]
           end
@@ -115,7 +121,7 @@ module Primer
             )
           end
 
-          { data: data, **system_arguments, content_arguments: content_arguments }
+          { data: data, **system_arguments, content_arguments: content_arguments, form_arguments: form_arguments }
         end
       end
     end


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes https://github.com/github/accessibility-audits/issues/7582 (Hubber login required)

When a `role="menu"` element contains a `<form>`, NVDA skips over that `<form>`’s `role="menuitem"` children.

NVDA generally announces “menu item _i_ of _t_” for every menu item. However, NVDA neither announces an “_i_” (item index), nor sums in “_t_” (total item count), any `role="menuitem"` element inside a `<form>`.

Here are two examples:

- NVDA announces that [this menu](https://view-components-storybook.eastus.cloudapp.azure.com/view-components/lookbook/inspect/primer/alpha/action_menu/with_actions) has 3 items, but it has 4. If, using browser devtools, you add `role="none"` to the `<form>`, then NVDA correctly detects the 4 menu items.

- This occurs on https://github.com/orgs/github/projects (Hubber login required). Under “Recently viewed” projects, in the three-dot “More project options” menu (to the right of each project), NVDA doesn’t count “Close project” and “Remove from recently viewed” as menu items. Both are forms-inside-menu.

#### List the issues that this change affects.

Closes https://github.com/github/accessibility-audits/issues/7582 (Hubber login required)

#### Risk Assessment

- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.

I’m rating this as medium risk, because I don’t know how likely we are to detect unintended side-effects of this change. I don’t know the relevant components’ test coverage.

### What approach did you choose and why?

I chose to suppress the `<form>` element’s implicit `role="form"` using `role="none"`. This makes its child `role="menuitem"` element become a direct child of the `role="menu"` element in the accessibility tree. This makes NVDA announce the child menu item properly.

I asked if this would break anything, in [#accessibility](https://github.slack.com/archives/C0FSWLQ0Y/p1714760746055849) (Hubber login required). `@zersiax` said: “…nulling the form semantics is what people generally do in this case…carry on.”

Notably, as of https://github.com/primer/view_components/pull/2822/commits/418b6cc1868c42270796505daa1c2599ffc375f2, `role="none"` is only applied for `<form>`s inside `ActionMenu`s, _not_ `<form>`s inside `ActionList`s generally.

### Anything you want to highlight for special attention from reviewers?

- Do we have adequate test coverage to feel safe from unintended side-effects?

- Do I need to update any docs?

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
