### PR TITLE
Set `role=none` in different place for ActionMenu form items

### DIFF
--- a/.changeset/rotten-socks-appear.md
+++ b/.changeset/rotten-socks-appear.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix issue with ActionMenu form items which would prevent a wrapping form if form_arguments: was passed

--- a/app/components/primer/alpha/action_list/form_wrapper.rb
+++ b/app/components/primer/alpha/action_list/form_wrapper.rb
@@ -19,6 +19,11 @@ module Primer
           @list = list
           @form_arguments = form_arguments
 
+          # When a form is inside a menu, suppress form semantics.
+          # Otherwise, NVDA will miscount menu items.
+          @form_arguments[:html] ||= {}
+          @form_arguments[:html][:role] = :none
+
           @action = action
           @http_method = extract_http_method(@form_arguments)
 

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -89,12 +89,6 @@ module Primer
         def organize_arguments(data: {}, **system_arguments)
           content_arguments = system_arguments.delete(:content_arguments) || {}
 
-          # When a form is inside a menu, suppress form semantics.
-          # Otherwise, NVDA will miscount menu items.
-          form_arguments = system_arguments.delete(:form_arguments) || {}
-          form_arguments[:html] = form_arguments[:html] || {}
-          form_arguments[:html][:role] = :none
-
           if system_arguments[:tag] && ITEM_TAG_OPTIONS.include?(system_arguments[:tag])
             content_arguments[:tag] = system_arguments[:tag]
           end
@@ -121,7 +115,7 @@ module Primer
             )
           end
 
-          { data: data, **system_arguments, content_arguments: content_arguments, form_arguments: form_arguments }
+          { data: data, **system_arguments, content_arguments: content_arguments }
         end
       end
     end

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -189,6 +189,13 @@ module Primer
 
         assert @rendered_content.scan("test").size == 1, "The show button rendered its content more than once"
       end
+
+      def test_single_select_form_items_have_role_none
+        render_preview(:single_select_form_items)
+
+        # one form per item
+        assert_selector "form[role=none]", count: 2
+      end
     end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A recent PR added `role="none"` to forms that wrap `ActionMenu` items. Unfortunately this caused a few [dotcom tests to fail](https://github.com/github/github/actions/runs/9007935746/job/24748898425?pr=322793) because it appeared to supersede form arguments passed to individual items. I'm still not sure why, but moving the code into the `FormWrapper` fixed the problem.

### Integration
<!-- Does this change require any updates to code in production? -->

No additional changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.