### PR TITLE
Update lookbook example to use href when tag is anchor

### DIFF
--- a/previews/primer/beta/label_preview.rb
+++ b/previews/primer/beta/label_preview.rb
@@ -9,7 +9,7 @@ module Primer
       # @param size [Symbol] select [medium, large]
       # @param tag [Symbol] select [span, summary, a, div]
       # @param inline [Boolean] toggle
-      # @param href [String] URL to be used with a tag
+      # @param href [String] URL to be used with an anchor tag
       def playground(size: :medium, tag: :span, inline: false, href: nil)
         if tag == :a
           render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline, href: href || "#")) { "Link label" }

--- a/previews/primer/beta/label_preview.rb
+++ b/previews/primer/beta/label_preview.rb
@@ -9,8 +9,13 @@ module Primer
       # @param size [Symbol] select [medium, large]
       # @param tag [Symbol] select [span, summary, a, div]
       # @param inline [Boolean] toggle
-      def playground(size: :medium, tag: :span, inline: false)
-        render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
+      # @param href [String] URL to be used with a tag
+      def playground(size: :medium, tag: :span, inline: false, href: nil)
+        if tag == :a
+          render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline, href: href || "#")) { "Link label" }
+        else
+          render(Primer::Beta::Label.new(tag: tag, size: size, inline: inline)) { "Label" }
+        end
       end
 
       # @label Default Options


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

This PR updates the `Label` example in Lookbook to render an `href` when the tag is set to `:a`.

#### List the issues that this change affects.
Fixes: https://github.com/github/accessibility-audits/issues/5403

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
