### PR TITLE
Add live region to announce "Copied!" on ClipboardCopy component

### DIFF
--- a/.changeset/afraid-shoes-taste.md
+++ b/.changeset/afraid-shoes-taste.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Adds live region to announce "Copied!" on ClipboardCopy component

--- a/.changeset/eight-paws-jump.md
+++ b/.changeset/eight-paws-jump.md
@@ -1,5 +1,0 @@
----
-"@primer/view-components": minor
----
-
-Adds live region to announce "Copied!" on ClipboardCopy component

--- a/.changeset/eight-paws-jump.md
+++ b/.changeset/eight-paws-jump.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+Adds live region to announce "Copied!" on ClipboardCopy component

--- a/app/components/primer/beta/clipboard_copy.html.erb
+++ b/app/components/primer/beta/clipboard_copy.html.erb
@@ -5,4 +5,5 @@
     <%= render Primer::Beta::Octicon.new(:copy) %>
     <%= render Primer::Beta::Octicon.new(:check, color: :success, style: "display: none;") %>
   <% end %>
+  <div aria-live="polite" aria-atomic="true" class="sr-only" data-clipboard-copy-live-region></div>
 <% end %>

--- a/app/components/primer/beta/clipboard_copy.html.erb
+++ b/app/components/primer/beta/clipboard_copy.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(tag: :span, classes: "ClipboardCopyWrapper") do %>
+<%= render Primer::BaseComponent.new(tag: :span) do %>
   <%= render Primer::BaseComponent.new(**@system_arguments) do %>
     <% if content.present? %>
       <%= content %>

--- a/app/components/primer/beta/clipboard_copy.html.erb
+++ b/app/components/primer/beta/clipboard_copy.html.erb
@@ -1,9 +1,11 @@
-<%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <% if content.present? %>
-    <%= content %>
-  <% else %>
-    <%= render Primer::Beta::Octicon.new(:copy) %>
-    <%= render Primer::Beta::Octicon.new(:check, color: :success, style: "display: none;") %>
+<div>
+  <%= render Primer::BaseComponent.new(**@system_arguments) do %>
+    <% if content.present? %>
+      <%= content %>
+    <% else %>
+      <%= render Primer::Beta::Octicon.new(:copy) %>
+      <%= render Primer::Beta::Octicon.new(:check, color: :success, style: "display: none;") %>
+    <% end %>
   <% end %>
-  <div aria-live="polite" aria-atomic="true" class="sr-only" data-clipboard-copy-live-region></div>
-<% end %>
+  <div aria-live="polite" aria-atomic="true" class="sr-only" data-clipboard-copy-feedback></div>
+</div>

--- a/app/components/primer/beta/clipboard_copy.html.erb
+++ b/app/components/primer/beta/clipboard_copy.html.erb
@@ -1,4 +1,4 @@
-<%= render Primer::BaseComponent.new(tag: :div) do %>
+<%= render Primer::BaseComponent.new(tag: :span, classes: "ClipboardCopyWrapper") do %>
   <%= render Primer::BaseComponent.new(**@system_arguments) do %>
     <% if content.present? %>
       <%= content %>

--- a/app/components/primer/beta/clipboard_copy.html.erb
+++ b/app/components/primer/beta/clipboard_copy.html.erb
@@ -1,4 +1,4 @@
-<div>
+<%= render Primer::BaseComponent.new(tag: :div) do %>
   <%= render Primer::BaseComponent.new(**@system_arguments) do %>
     <% if content.present? %>
       <%= content %>
@@ -8,4 +8,4 @@
     <% end %>
   <% end %>
   <div aria-live="polite" aria-atomic="true" class="sr-only" data-clipboard-copy-feedback></div>
-</div>
+<% end %>

--- a/app/components/primer/beta/clipboard_copy.rb
+++ b/app/components/primer/beta/clipboard_copy.rb
@@ -10,6 +10,8 @@ module Primer
     #
     # @accessibility
     #   Always set an accessible label to help the user interact with the component.
+    #
+    #   This component has a built-in `aria-live` region that announces "Copied!" when the copy element is pressed.
     class ClipboardCopy < Primer::Component
       status :beta
 

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -37,7 +37,7 @@ document.addEventListener('clipboard-copy', ({target}) => {
   if (!target.hasAttribute('data-view-component')) return
 
   const currentTimeout = clipboardCopyElementTimers.get(target)
-  const clipboardCopyLiveRegion = document.querySelector<HTMLDivElement>('[data-clipboard-copy-feedback]')
+  const clipboardCopyLiveRegion = target.parentNode?.querySelector<HTMLDivElement>('[data-clipboard-copy-feedback]')
   const copiedAnnouncement = 'Copied!'
 
   if (currentTimeout) {

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -37,7 +37,7 @@ document.addEventListener('clipboard-copy', ({target}) => {
   if (!target.hasAttribute('data-view-component')) return
 
   const currentTimeout = clipboardCopyElementTimers.get(target)
-  const clipboardCopyLiveRegion = target.parentNode?.querySelector<HTMLDivElement>('[data-clipboard-copy-feedback]')
+  const clipboardCopyLiveRegion = target.parentNode?.querySelector<HTMLElement>('[data-clipboard-copy-feedback]')
   const copiedAnnouncement = 'Copied!'
 
   if (currentTimeout) {

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -37,18 +37,35 @@ document.addEventListener('clipboard-copy', ({target}) => {
   if (!target.hasAttribute('data-view-component')) return
 
   const currentTimeout = clipboardCopyElementTimers.get(target)
+  const clipboardCopyLiveRegion = document.querySelector<HTMLDivElement>('[data-clipboard-copy-live-region]')
+  const copiedAnnouncement = 'Copied!'
 
   if (currentTimeout) {
     clearTimeout(currentTimeout)
     clipboardCopyElementTimers.delete(target)
   } else {
     showCheck(target)
+    if (clipboardCopyLiveRegion) {
+      if (clipboardCopyLiveRegion.textContent === copiedAnnouncement) {
+        /* This is a hack due to the way the aria live API works.
+    A screen reader will not read a live region again
+    if the text is the same. Adding a space character tells
+    the browser that the live region has updated,
+    which will cause it to read again, but with no audible difference. */
+        clipboardCopyLiveRegion.textContent = `${copiedAnnouncement}\u00A0`
+      } else {
+        clipboardCopyLiveRegion.textContent = copiedAnnouncement
+      }
+    }
   }
 
   clipboardCopyElementTimers.set(
     target,
     setTimeout(() => {
       showCopy(target)
+      // if (clipboardCopyLiveRegion) {
+      //   clipboardCopyLiveRegion.textContent = ''
+      // }
       clipboardCopyElementTimers.delete(target)
     }, CLIPBOARD_COPY_TIMER_DURATION),
   )

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -48,10 +48,10 @@ document.addEventListener('clipboard-copy', ({target}) => {
     if (clipboardCopyLiveRegion) {
       if (clipboardCopyLiveRegion.textContent === copiedAnnouncement) {
         /* This is a hack due to the way the aria live API works.
-    A screen reader will not read a live region again
-    if the text is the same. Adding a space character tells
-    the browser that the live region has updated,
-    which will cause it to read again, but with no audible difference. */
+       A screen reader will not read a live region again
+       if the text is the same. Adding a space character tells
+       the browser that the live region has updated,
+       which will cause it to read again, but with no audible difference. */
         clipboardCopyLiveRegion.textContent = `${copiedAnnouncement}\u00A0`
       } else {
         clipboardCopyLiveRegion.textContent = copiedAnnouncement

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -48,10 +48,10 @@ document.addEventListener('clipboard-copy', ({target}) => {
     if (clipboardCopyLiveRegion) {
       if (clipboardCopyLiveRegion.textContent === copiedAnnouncement) {
         /* This is a hack due to the way the aria live API works.
-       A screen reader will not read a live region again
-       if the text is the same. Adding a space character tells
-       the browser that the live region has updated,
-       which will cause it to read again, but with no audible difference. */
+        A screen reader will not read a live region again
+        if the text is the same. Adding a space character tells
+        the browser that the live region has updated,
+        which will cause it to read again, but with no audible difference. */
         clipboardCopyLiveRegion.textContent = `${copiedAnnouncement}\u00A0`
       } else {
         clipboardCopyLiveRegion.textContent = copiedAnnouncement

--- a/app/components/primer/beta/clipboard_copy.ts
+++ b/app/components/primer/beta/clipboard_copy.ts
@@ -37,7 +37,7 @@ document.addEventListener('clipboard-copy', ({target}) => {
   if (!target.hasAttribute('data-view-component')) return
 
   const currentTimeout = clipboardCopyElementTimers.get(target)
-  const clipboardCopyLiveRegion = document.querySelector<HTMLDivElement>('[data-clipboard-copy-live-region]')
+  const clipboardCopyLiveRegion = document.querySelector<HTMLDivElement>('[data-clipboard-copy-feedback]')
   const copiedAnnouncement = 'Copied!'
 
   if (currentTimeout) {
@@ -63,9 +63,6 @@ document.addEventListener('clipboard-copy', ({target}) => {
     target,
     setTimeout(() => {
       showCopy(target)
-      // if (clipboardCopyLiveRegion) {
-      //   clipboardCopyLiveRegion.textContent = ''
-      // }
       clipboardCopyElementTimers.delete(target)
     }, CLIPBOARD_COPY_TIMER_DURATION),
   )

--- a/app/components/primer/beta/clipboard_copy_button.rb
+++ b/app/components/primer/beta/clipboard_copy_button.rb
@@ -5,6 +5,8 @@ module Primer
     # `ClipboardCopyButton` uses the `ClipboardCopy` component to copy text to the clipboard,
     # styled as a Primer button. It can be used wherever a button is desired, and works well
     # with components like `ButtonGroup`.
+    # @accessibility
+    #   This component has a built-in `aria-live` region that announces "Copied!" when the copy button is pressed.
     class ClipboardCopyButton < Primer::Beta::Button
       # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Beta::Button) %> and <%= link_to_component(Primer::Beta::ClipboardCopy) %>.
       def initialize(**system_arguments)

--- a/test/components/beta/clipboard_copy_test.rb
+++ b/test/components/beta/clipboard_copy_test.rb
@@ -40,4 +40,10 @@ class PrimerBetaClipboardCopyTest < Minitest::Test
       assert_selector("svg.octicon.octicon-check.color-fg-success", visible: false)
     end
   end
+
+  def test_renders_aria_live_region
+    render_inline Primer::Beta::ClipboardCopy.new(value: "my-branch-name", "aria-label": "Copy branch name to clipboard")
+
+    assert_selector("[data-clipboard-copy-feedback]")
+  end
 end

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -16,6 +16,18 @@ module Beta
       assert_equal "Text to copy", clipboard_text
     end
 
+    def test_populates_live_region
+      visit_preview(:playground)
+
+      clipboard_text = capture_clipboard do
+        find("#clipboard-button").click
+      end
+
+      assert_selector("[data-clipboard-copy-feedback]") do |node|
+        assert_equal(node.text.strip, "Copied!")
+      end
+    end
+
     def test_includes_tooltip
       visit_preview(:with_tooltip)
 

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -19,9 +19,7 @@ module Beta
     def test_populates_live_region
       visit_preview(:playground)
 
-      clipboard_text = capture_clipboard do
-        find("#clipboard-button").click
-      end
+      find("#clipboard-button").click
 
       assert_selector("[data-clipboard-copy-feedback]") do |node|
         assert_equal(node.text.strip, "Copied!")

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -19,7 +19,7 @@ module Beta
     def test_includes_tooltip
       visit_preview(:with_tooltip)
 
-      assert_selector ".Button + tool-tip", visible: :all
+      assert_selector ".ClipboardCopyWrapper + tool-tip", visible: :all
     end
   end
 end

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -19,7 +19,7 @@ module Beta
     def test_includes_tooltip
       visit_preview(:with_tooltip)
 
-      assert_selector ".ClipboardCopyWrapper + tool-tip", visible: :all
+      assert_selector "tool-tip[for='clipboard-button']", visible: :all
     end
   end
 end

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -9,6 +9,8 @@ module Beta
     def test_copies_text
       visit_preview(:playground)
 
+      assert_selector("[data-clipboard-copy-feedback]", text: "", visible: :false)
+
       clipboard_text = capture_clipboard do
         find("#clipboard-button").click
       end

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -6,16 +6,6 @@ module Beta
   class IntegrationClipboardCopyButtonTest < System::TestCase
     include Primer::ClipboardTestHelpers
 
-    def test_copies_text
-      visit_preview(:playground)
-
-      clipboard_text = capture_clipboard do
-        find("#clipboard-button").click
-      end
-
-      assert_equal "Text to copy", clipboard_text
-    end
-
     def test_populates_live_region
       visit_preview(:playground)
 
@@ -24,6 +14,16 @@ module Beta
       assert_selector("[data-clipboard-copy-feedback]") do |node|
         assert_equal(node.text.strip, "Copied!")
       end
+    end
+
+    def test_copies_text
+      visit_preview(:playground)
+
+      clipboard_text = capture_clipboard do
+        find("#clipboard-button").click
+      end
+
+      assert_equal "Text to copy", clipboard_text
     end
 
     def test_includes_tooltip

--- a/test/system/beta/clipboard_copy_button_test.rb
+++ b/test/system/beta/clipboard_copy_button_test.rb
@@ -6,16 +6,6 @@ module Beta
   class IntegrationClipboardCopyButtonTest < System::TestCase
     include Primer::ClipboardTestHelpers
 
-    def test_populates_live_region
-      visit_preview(:playground)
-
-      find("#clipboard-button").click
-
-      assert_selector("[data-clipboard-copy-feedback]") do |node|
-        assert_equal(node.text.strip, "Copied!")
-      end
-    end
-
     def test_copies_text
       visit_preview(:playground)
 
@@ -24,6 +14,7 @@ module Beta
       end
 
       assert_equal "Text to copy", clipboard_text
+      assert_selector("[data-clipboard-copy-feedback]", text: "Copied!", visible: :false)
     end
 
     def test_includes_tooltip


### PR DESCRIPTION
### What are you trying to accomplish?

Adds a live region to the ClipboardCopy component so that by default, "Copied!" is announced when a user successfully copies something.

### Screenshots

#### Before
Screen recording of the ClipboardCopy button on Lookbook, when pressing "Enter" or "Control + Option + Space", no feedback is announced but there is a visual icon change from 2 pages stacked on top of each other to a green check mark

https://github.com/primer/view_components/assets/35239154/5221b6e6-f399-461c-92f2-9f1cf512e2b9


#### After
Screen recording of the ClipboardCopy button on Lookbook, when pressing "Enter" or "Control + Option + Space", "Copied!" is announced

https://github.com/primer/view_components/assets/35239154/3f6db4af-c313-4aa9-bd5e-1a33b630059e


### Integration

No

#### List the issues that this change affects.

Related to https://github.com/github/accessibility-audits/issues/6469 & https://github.com/github/accessibility/issues/6096.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

I am adding a live region to the ClipboardCopy button so that, by default, screen reader feedback will be announced.

I considered adding a live region to the [`clipboard-copy-element` web component](https://github.com/github/clipboard-copy-element) which is used under the hood, but changing that component to include a live region would be a breaking change since we'd need to wrap the current inner text with another element so that we can have a live region as a sibling. [Nesting a live region inside of a `<button>` element has poor support](https://github.com/github/accessibility/blob/main/docs/wiki/screen-reader-testing/dynamically-updated-buttons-support-april-2024.md#6-bonus-setting-a-nested-polite-span-live-region-inside-the-button) and is not recommended.

### Anything you want to highlight for special attention from reviewers?

* Is there a better way to wrap the component?
* Is there a better way than looking for the `parentNode` of the `target` element to target the specific aria-live region for one component (thinking if there are multiple ClipboardCopy elements on the page and not wanting them to conflict)? I didn't want to change the API too much by making the wrapper I added the new `<clipboard-copy>` component but maybe it's ok?

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
