### PR TITLE
Remove non-existing argument in Banner preview

### DIFF
--- a/.changeset/ten-wombats-beg.md
+++ b/.changeset/ten-wombats-beg.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Remove non-existing argument in Banner preview

--- a/previews/primer/alpha/banner_preview.rb
+++ b/previews/primer/alpha/banner_preview.rb
@@ -55,7 +55,7 @@ module Primer
       # @label Dismissable
       # @snapshot
       def dismissible
-        render(Primer::Alpha::Banner.new(dismiss_scheme: :hide, reappear: true)) { "This is a dismissable banner." }
+        render(Primer::Alpha::Banner.new(dismiss_scheme: :hide)) { "This is a dismissable banner." }
       end
 
       # @!group Full Width


### PR DESCRIPTION
This has been removed in https://github.com/primer/view_components/pull/2186