### PR TITLE
Add support for target on links inside Breadcrumbs

### DIFF
--- a/.changeset/orange-countries-try.md
+++ b/.changeset/orange-countries-try.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Add support for `target` attribute on links of Primer::Beta::Breadcrumbs

--- a/app/components/primer/beta/breadcrumbs.rb
+++ b/app/components/primer/beta/breadcrumbs.rb
@@ -48,8 +48,9 @@ module Primer
       class Item < Primer::Component
         attr_accessor :selected, :href
 
-        def initialize(href:, **system_arguments)
+        def initialize(href:, target: "_self", **system_arguments)
           @href = href
+          @target = target
           @system_arguments = deny_tag_argument(**system_arguments)
           @selected = false
 
@@ -58,7 +59,7 @@ module Primer
         end
 
         def call
-          link_arguments = { href: @href }
+          link_arguments = { href: @href, target: @target }
 
           if selected
             link_arguments[:"aria-current"] = "page"

--- a/previews/primer/beta/breadcrumbs_preview.rb
+++ b/previews/primer/beta/breadcrumbs_preview.rb
@@ -38,6 +38,15 @@ module Primer
       def with_deprecated_truncate
         render_with_template
       end
+
+      # @label With a specific link target
+      def with_link_target(number_of_links: 2)
+        render(Primer::Beta::Breadcrumbs.new) do |component|
+          Array.new(number_of_links&.to_i || 3) do |i|
+            component.with_item(href: "##{i}", target: "_blank") { "Breadcrumb Item #{i + 1}" }
+          end
+        end
+      end
     end
   end
 end

--- a/test/components/breadcrumbs_test.rb
+++ b/test/components/breadcrumbs_test.rb
@@ -68,6 +68,16 @@ class PrimerBreadcrumbsTest < Minitest::Test
     assert_selector("li.breadcrumb-item-selected a[aria-current='page']", text: "About")
   end
 
+  def test_renders_target_attribute
+    render_inline(Primer::Beta::Breadcrumbs.new) do |component|
+      component.with_item(href: "/", target: "_blank") { "Home" }
+      component.with_item(href: "/about") { "About" }
+    end
+
+    assert_selector(".breadcrumb-item a[target='_blank']", text: "Home")
+    assert_selector(".breadcrumb-item a[target='_self']", text: "About")
+  end
+
   def test_status
     assert_component_state(Primer::Beta::Breadcrumbs, :beta)
   end


### PR DESCRIPTION
### What are you trying to accomplish?
This adds the support for `target` attributes on the links of a `Primer::Beta::Breadcrumbs`.


#### List the issues that this change affects.

Closes #2886 

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
