### PR TITLE
Align group headers in `Primer::Alpha::ActionMenu`

### DIFF
--- a/.changeset/khaki-suits-lay.md
+++ b/.changeset/khaki-suits-lay.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Always align group headers of a `Primer::Alpha::ActionMenu` at the beginning of the line

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -642,6 +642,7 @@ nav-list {
   /* with children */
   &:not(:empty) {
     display: flex;
+    align-items: flex-start;
     padding-inline: var(--actionListContent-paddingBlock);
     padding-block: var(--base-size-8);
     font-size: var(--text-body-size-small);


### PR DESCRIPTION
### What are you trying to accomplish?
Group headers inside ActionMenus should always be left aligned, no matter how the menu itself is positioned.

### Screenshots
**Before**

<img width="320" alt="Bildschirmfoto 2024-07-17 um 13 23 21" src="https://github.com/user-attachments/assets/5a0ae810-f6e2-4ca1-9e55-5312b29e0b86">


**After**

<img width="320" alt="Bildschirmfoto 2024-07-17 um 13 22 52" src="https://github.com/user-attachments/assets/ec6e9449-9f9a-4de9-9115-2155de282ec9">

#### List the issues that this change affects.

Closes #2950

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
