### PR TITLE
Fix wrapping behavior of toggle switch label

### DIFF
--- a/.changeset/pretty-tables-grab.md
+++ b/.changeset/pretty-tables-grab.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix wrapping behavior of toggle switch label

--- a/app/forms/example_toggle_switch_form/example_field_caption.html.erb
+++ b/app/forms/example_toggle_switch_form/example_field_caption.html.erb
@@ -1,1 +1,1 @@
-My <em>favorite</em> caption.
+My <em>favorite</em> caption lorem ipsum dolor sit amet.

--- a/lib/primer/forms/toggle_switch.html.erb
+++ b/lib/primer/forms/toggle_switch.html.erb
@@ -7,8 +7,7 @@
     <%= content_tag(:div, data: { target: "toggle-switch-input.validationElement" }, **@input.validation_arguments) do %>
       <%= content_tag(:span, @input.validation_messages.first, data: { target: "toggle-switch-input.validationMessageElement" }, **@input.validation_message_arguments) %>
     <% end %>
-
-    <div><%= render(Caption.new(input: @input)) %></div>
   </span>
   <%= render(Primer::Alpha::ToggleSwitch.new(src: @input.src, csrf_token: @input.csrf, **@input.input_arguments)) %>
 <% end %>
+<div><%= render(Caption.new(input: @input)) %></div>


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes the wrapping behavior of toggle switch captions for consistency with our [documentation](https://primer.style/components/toggle-switch#label-and-description) on the subject.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

|Before|After|
|-|-|
|<img width="341" alt="A screenshot of an example toggle switch form showing the caption wrapped onto multiple lines. It appears to the right of the toggle switch itself." src="https://github.com/user-attachments/assets/5a9538e4-0f88-4d03-9bbd-e931cd1a0fa2">|<img width="340" alt="A screenshot of an example toggle switch form showing a caption that has not wrapped. It appears underneath the toggle switch." src="https://github.com/user-attachments/assets/fb7c025f-4317-4d53-9f4e-72ce03885981">|

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production - this change is purely visual.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/2943

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

~- [ ] Added/updated tests~
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
