### PR TITLE
Add missing if statement in #waitForCondition

### DIFF
--- a/.changeset/rotten-apples-greet.md
+++ b/.changeset/rotten-apples-greet.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure condition is checked when mutations occur in SelectPanelElement.

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -250,8 +250,10 @@ export class SelectPanelElement extends HTMLElement {
       body()
     } else {
       const mutationObserver = new MutationObserver(() => {
-        body()
-        mutationObserver.disconnect()
+        if (condition()) {
+          body()
+          mutationObserver.disconnect()
+        }
       })
 
       mutationObserver.observe(this, {childList: true, subtree: true})


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

When refactoring our usage of `MutationObserver`s in `SelectPanelElement`, I completely forgot a necessary `if` statement that guards against the possibility that the condition has still not been met when the contents of the component's DOM tree change.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.