### PR TITLE
Add `turbo: true` as an option for ToggleSwitch

### DIFF
--- a/.changeset/hip-glasses-wave.md
+++ b/.changeset/hip-glasses-wave.md
@@ -1,0 +1,6 @@
+---
+"@primer/view-components": minor
+---
+
+Add `turbo: true` as an parameter for the `ToggleSwitch` component and treat the respoonse (when it has the correct MIME type) as a [Turbo Stream](https://turbo.hotwired.dev/handbook/streams). The new `turbo` paramater defaults to false
+and with that the HTTP response is simply ignored as is the current behavior.

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -26,12 +26,14 @@ module Primer
       # @param enabled [Boolean] Whether or not the toggle switch responds to user input.
       # @param size [Symbol] What size toggle switch to render. <%= one_of(Primer::Alpha::ToggleSwitch::SIZE_OPTIONS) %>
       # @param status_label_position [Symbol] Which side of the toggle switch to render the status label. <%= one_of(Primer::Alpha::ToggleSwitch::STATUS_LABEL_POSITION_OPTIONS) %>
+      # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(src: nil, csrf_token: nil, checked: false, enabled: true, size: SIZE_DEFAULT, status_label_position: STATUS_LABEL_POSITION_DEFAULT, **system_arguments)
+      def initialize(src: nil, csrf_token: nil, checked: false, enabled: true, size: SIZE_DEFAULT, status_label_position: STATUS_LABEL_POSITION_DEFAULT, turbo: false, **system_arguments)
         @src = src
         @csrf_token = csrf_token
         @checked = checked
         @enabled = enabled
+        @turbo = turbo
         @system_arguments = system_arguments
 
         @size = fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)
@@ -82,7 +84,7 @@ module Primer
 
         @system_arguments[:data] = merge_data(
           @system_arguments,
-          { data: { csrf: @csrf_token } }
+          { data: { csrf: @csrf_token, turbo: @turbo } }
         )
       end
     end

--- a/app/components/primer/alpha/toggle_switch.ts
+++ b/app/components/primer/alpha/toggle_switch.ts
@@ -182,7 +182,8 @@ class ToggleSwitchElement extends HTMLElement {
       throw new Error(await response.text())
     }
 
-    if (window.Turbo && this.turbo) {
+    const contentType = response.headers.get('Content-Type')
+    if (window.Turbo && this.turbo && contentType?.startsWith('text/vnd.turbo-stream.html')) {
       window.Turbo.renderStreamMessage(await response.text())
     }
   }

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -58,6 +58,10 @@ module Primer
       def with_bad_csrf_token
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, csrf_token: "i_am_a_criminal"))
       end
+
+      def with_turbo
+        render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, turbo: true))
+      end
     end
   end
 end

--- a/test/components/alpha/toggle_switch_test.rb
+++ b/test/components/alpha/toggle_switch_test.rb
@@ -68,6 +68,12 @@ module Primer
 
         assert_selector("[data-csrf]")
       end
+
+      def test_turbo
+        render_inline(Primer::Alpha::ToggleSwitch.new(src: "/foo", turbo: true))
+
+        assert_selector("[data-turbo]")
+      end
     end
   end
 end

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -88,6 +88,20 @@ module Alpha
       assert_equal "XMLHttpRequest", ToggleSwitchController.last_request.headers["HTTP_REQUESTED_WITH"]
     end
 
+    def test_fetch_made_with_turbo
+      visit_preview(:with_turbo)
+
+      refute_selector(".ToggleSwitch--checked")
+      find("toggle-switch").click
+      assert_selector(".ToggleSwitch--checked")
+
+      wait_for_request
+
+      assert_equal "text/vnd.turbo-stream.html", ToggleSwitchController.last_request.headers["HTTP_ACCEPT"]
+    end
+
+
+
     private
 
     def wait_for_spinner


### PR DESCRIPTION
### What are you trying to accomplish?

As described in #2940, we are using a `ToggleSwitchForm` and in our case the response is a turbo stream that should replace some other elements in the page. The current implementation does not allow for that as the `fetch` request does not trigger any behavior associated with Turbo. To do that we need to explicitly set the `Accept` header to allow `text/vnd.turbo-stream.html` and when the response comes back, we need to pass it to `Turbo.renderStreamMessage` to be rendered. 

In #2940 we also discussed making the `ToggleSwitch` have a proper form, but while experimenting with this I found that this completely changes the existing behavior and I wanted this change to be as unobstrusive as it could be.

### Integration

The default is `turbo: false`, so nothing changes in existing code.

#### List the issues that this change affects.

Closes #2940 

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

The code does not change any default behavior. One has to intentionally activate turbo with `turbo: true` as a param to the `ToggleSwitch` to get the new behavior. Also the response needs to provide the correct content type to be forwarded into the turbo renderer.

### What approach did you choose and why?
See above

### Anything you want to highlight for special attention from reviewers?
There are currently no tests for the call to `Turbo.renderStreamMessage`, would be interested in any pointers how to add proper tests.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
