### PR TITLE
Ensure Enter, Down, Home, and End behave as expected when a SelectPanel's input field has focus

### DIFF
--- a/.changeset/warm-gorillas-beg.md
+++ b/.changeset/warm-gorillas-beg.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Ensure Down, Home, and End behave as expected when a SelectPanel's input field has focus

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -623,7 +623,13 @@ export class SelectPanelElement extends HTMLElement {
     if (event.type === 'keydown') {
       const key = (event as KeyboardEvent).key
 
-      if (key === 'ArrowDown') {
+      if (key === 'Enter') {
+        const item = this.visibleItems[0] as HTMLLIElement | null
+
+        if (item) {
+          this.#handleItemActivated(item, false)
+        }
+      } else if (key === 'ArrowDown') {
         const item = (this.focusableItem || this.visibleItems[0]) as HTMLLIElement
 
         if (item) {
@@ -823,7 +829,7 @@ export class SelectPanelElement extends HTMLElement {
     dialog.addEventListener('cancel', handleDialogClose, {signal})
   }
 
-  #handleItemActivated(item: SelectPanelItem) {
+  #handleItemActivated(item: SelectPanelItem, shouldClose: boolean = true) {
     // Hide popover after current event loop to prevent changes in focus from
     // altering the target of the event. Not doing this specifically affects
     // <a> tags. It causes the event to be sent to the currently focused element
@@ -832,7 +838,7 @@ export class SelectPanelElement extends HTMLElement {
     // works fine.
     if (this.selectVariant !== 'multiple') {
       setTimeout(() => {
-        if (this.open) {
+        if (this.open && shouldClose) {
           this.hide()
         }
       })

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -224,8 +224,6 @@ export class SelectPanelElement extends HTMLElement {
           }
 
           // signal that any focus hijinks are finished (thanks Safari)
-          // eslint-disable-next-line no-console
-          console.log('Setting data-ready')
           this.dialog.setAttribute('data-ready', 'true')
 
           this.updateAnchorPosition()

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -606,12 +606,31 @@ export class SelectPanelElement extends HTMLElement {
   }
 
   #handleSearchFieldEvent(event: Event) {
-    if (event.type === 'keydown' && (event as KeyboardEvent).key === 'ArrowDown') {
-      if (this.focusableItem) {
-        this.focusableItem.focus()
-        event.preventDefault()
+    if (event.type === 'keydown') {
+      const key = (event as KeyboardEvent).key
+
+      if (key === 'ArrowDown') {
+        const item = this.focusableItem || this.visibleItems[0]
+
+        if (item) {
+          item.focus()
+          event.preventDefault()
+        }
+      } else if (key === 'Home') {
+        const item = this.visibleItems[0]
+
+        if (item) {
+          item.focus()
+          event.preventDefault()
+        }
+      } else if (key === 'End') {
+        if (this.visibleItems.length > 0) {
+          this.visibleItems[this.visibleItems.length - 1].focus()
+          event.preventDefault()
+        }
       }
     }
+
     if (event.type !== 'input') return
 
     // remote-input-element does not trigger another loadstart event if a request is
@@ -952,6 +971,7 @@ export class SelectPanelElement extends HTMLElement {
       element => element.parentElement! as SelectPanelItem,
     )
   }
+
   get focusableItem(): HTMLElement | undefined {
     for (const item of this.items) {
       const itemContent = this.#getItemContent(item)

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -212,6 +212,12 @@ export class SelectPanelElement extends HTMLElement {
     )
 
     this.#dialogIntersectionObserver = new IntersectionObserver(entries => {
+      // Focus on the filter input when the dialog opens to work around a Safari limitation
+      // that prevents the autofocus attribute from working as it does in other browsers
+      if (this.filterInputTextField) {
+        this.filterInputTextField.focus()
+      }
+
       for (const entry of entries) {
         const elem = entry.target
         if (entry.isIntersecting && elem === this.dialog) {
@@ -610,22 +616,23 @@ export class SelectPanelElement extends HTMLElement {
       const key = (event as KeyboardEvent).key
 
       if (key === 'ArrowDown') {
-        const item = this.focusableItem || this.visibleItems[0]
+        const item = (this.focusableItem || this.visibleItems[0]) as HTMLLIElement
 
         if (item) {
-          item.focus()
+          this.#getItemContent(item)!.focus()
           event.preventDefault()
         }
       } else if (key === 'Home') {
-        const item = this.visibleItems[0]
+        const item = this.visibleItems[0] as HTMLLIElement | null
 
         if (item) {
-          item.focus()
+          this.#getItemContent(item)!.focus()
           event.preventDefault()
         }
       } else if (key === 'End') {
         if (this.visibleItems.length > 0) {
-          this.visibleItems[this.visibleItems.length - 1].focus()
+          const item = this.visibleItems[this.visibleItems.length - 1] as HTMLLIElement
+          this.#getItemContent(item)!.focus()
           event.preventDefault()
         }
       }

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -72,6 +72,14 @@ module Alpha
       assert_selector "select-panel[data-ready=true]", wait: 5
     end
 
+    def wait_for_dialog_ready
+      begin
+        assert_selector "dialog[data-ready]"
+      rescue Minitest::Assertion
+        # if we've waited this long, assume everything is fine
+      end
+    end
+
     def filter_results(query:)
       find("input").fill_in(with: query)
     end
@@ -255,15 +263,29 @@ module Alpha
 
       focus_on_invoker_button
 
-      # open panel, "click" on first item
-      keyboard.type(:enter, :tab, :enter)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # "click" on first item
+      keyboard.type(:tab, :enter)
 
       # activating item closes panel, so checked item is hidden
       assert_selector "[aria-selected=true]", text: "Item 1", visible: :hidden
 
       focus_on_invoker_button
 
-      keyboard.type(:enter, :tab, :down, :enter)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # "click" on second item
+      keyboard.type(:tab, :down, :enter)
+
       assert_selector "[aria-selected=true]", text: "Item 2", visible: :hidden
       refute_selector "[aria-checked]", visible: :hidden
     end
@@ -273,15 +295,29 @@ module Alpha
 
       focus_on_invoker_button
 
-      # open panel, "click" on first item
-      keyboard.type(:enter, :tab, :space)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # "click" on first item
+      keyboard.type(:tab, :space)
 
       # activating item closes panel, so checked item is hidden
       assert_selector "[aria-selected=true]", text: "Item 1", visible: :hidden
 
       focus_on_invoker_button
 
-      keyboard.type(:enter, :tab, :down, :space)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # "click" second item
+      keyboard.type(:tab, :down, :space)
+
       assert_selector "[aria-selected=true]", text: "Item 2", visible: :hidden
       refute_selector "[aria-checked]", visible: :hidden
     end
@@ -348,8 +384,14 @@ module Alpha
 
       focus_on_invoker_button
 
-      # open panel, select first item
-      keyboard.type(:enter, :tab, :enter)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # select first item
+      keyboard.type(:tab, :enter)
 
       assert_selector "[aria-checked=true]", count: 1
       assert_selector "[aria-checked=true]", text: "Item 1"
@@ -369,8 +411,14 @@ module Alpha
 
       focus_on_invoker_button
 
-      # open panel, select first item
-      keyboard.type(:enter, :tab, :space)
+      # open panel
+      keyboard.type(:enter)
+
+      # wait for the panel to adjust focus (to work around a Safari issue)
+      wait_for_dialog_ready
+
+      # select first item
+      keyboard.type(:tab, :space)
 
       assert_selector "[aria-checked=true]", count: 1
       assert_selector "[aria-checked=true]", text: "Item 1"

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -196,7 +196,7 @@ module Alpha
 
       keyboard.type(:down)
 
-      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.tag_name, "button"
       assert_equal active_element.text, "Item 1"
     end
 
@@ -209,7 +209,7 @@ module Alpha
 
       keyboard.type(:home)
 
-      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.tag_name, "button"
       assert_equal active_element.text, "Item 1"
     end
 
@@ -222,7 +222,7 @@ module Alpha
 
       keyboard.type(:end)
 
-      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.tag_name, "button"
       assert_equal active_element.text, "Item 4"
     end
 

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -234,6 +234,24 @@ module Alpha
       assert_equal active_element.text, "Item 4"
     end
 
+    def test_pressing_enter_in_filter_input_checks_first_item
+      visit_preview(:default)
+
+      click_on_invoker_button
+
+      # nothing is checked initially
+      refute_selector "[aria-checked=true]"
+      refute_selector "[aria-selected=true]"
+
+      assert_equal active_element.tag_name, "input"
+
+      keyboard.type(:enter)
+
+      # pressing enter in the filter input does not close the panel
+      assert_selector "[aria-checked=true]", text: "Item 1"
+      refute_selector "[aria-selected]"
+    end
+
     ########## SINGLE SELECT TESTS ############
 
     def test_single_select_item_checked

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -84,6 +84,10 @@ module Alpha
       end
     end
 
+    def active_element
+      page.evaluate_script("document.activeElement")
+    end
+
     ########## TESTS ############
 
     def test_invoker_opens_panel
@@ -143,9 +147,7 @@ module Alpha
 
       click_on_invoker_button
 
-      active_element = page.evaluate_script("document.activeElement")
-
-      assert active_element.tag_name, "Alert"
+      assert_equal active_element.tag_name, "input"
       assert_includes active_element["class"], "FormControl-input"
     end
 
@@ -161,7 +163,7 @@ module Alpha
 
       keyboard.type(:tab)
 
-      assert_includes page.evaluate_script("document.activeElement").text, "Item 2"
+      assert_includes active_element.text, "Item 2"
     end
 
     def test_remembers_selections_on_filter
@@ -183,6 +185,45 @@ module Alpha
       end
 
       assert_selector "[aria-checked=true]", count: 2
+    end
+
+    def test_pressing_down_arrow_in_filter_input_focuses_first_item
+      visit_preview(:default)
+
+      click_on_invoker_button
+
+      assert_equal active_element.tag_name, "input"
+
+      keyboard.type(:down)
+
+      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.text, "Item 1"
+    end
+
+    def test_pressing_home_in_filter_input_focuses_first_item
+      visit_preview(:default)
+
+      click_on_invoker_button
+
+      assert_equal active_element.tag_name, "input"
+
+      keyboard.type(:home)
+
+      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.text, "Item 1"
+    end
+
+    def test_pressing_end_in_filter_input_focuses_first_item
+      visit_preview(:default)
+
+      click_on_invoker_button
+
+      assert_equal active_element.tag_name, "input"
+
+      keyboard.type(:end)
+
+      assert_equal active_element.tag_name, "li"
+      assert_equal active_element.text, "Item 4"
     end
 
     ########## SINGLE SELECT TESTS ############
@@ -650,15 +691,14 @@ module Alpha
       # tab to list
       keyboard.type(:tab)
 
-      active_element = page.evaluate_script("document.activeElement")
-      assert active_element.tag_name == "button"
+      assert_equal active_element.tag_name, "button"
       assert_includes active_element["class"], "ActionListContent"
 
       # tab out of list
       keyboard.type(:tab)
 
       # focus is no longer on the list
-      assert page.evaluate_script("document.activeElement").tag_name == "body"
+      assert_equal active_element.tag_name, "body"
     end
 
     def test_arrowing_through_items
@@ -668,7 +708,7 @@ module Alpha
       keyboard.type(:tab)  # tab to list
 
       1.upto(4) do |i|
-        assert page.evaluate_script("document.activeElement").text == "Item #{i}"
+        assert_equal active_element.text, "Item #{i}"
         keyboard.type(:down)
       end
     end
@@ -681,11 +721,11 @@ module Alpha
       # tab to list and down to 4th item
       keyboard.type(:tab, :down, :down, :down)
 
-      assert page.evaluate_script("document.activeElement").text == "Item 4"
+      assert_equal active_element.text, "Item 4"
 
       keyboard.type(:down)
 
-      assert page.evaluate_script("document.activeElement").text == "Item 1"
+      assert_equal active_element.text, "Item 1"
     end
 
     def test_arrowing_up_on_first_item_wraps_to_bottom
@@ -696,11 +736,11 @@ module Alpha
       # tab to list and down to 4th item
       keyboard.type(:tab)
 
-      assert page.evaluate_script("document.activeElement").text == "Item 1"
+      assert_equal active_element.text, "Item 1"
 
       keyboard.type(:up)
 
-      assert page.evaluate_script("document.activeElement").text == "Item 4"
+      assert_equal active_element.text, "Item 4"
     end
 
     def test_arrowing_skips_filtered_items
@@ -724,7 +764,7 @@ module Alpha
       # Note that the controller renders items in a predictable order.
       2.times do |i|
         ["Photon torpedo", "Phaser"].each do |item_text|
-          assert_includes page.evaluate_script("document.activeElement").text, item_text
+          assert_includes active_element.text, item_text
           keyboard.type(:down)
         end
       end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR addresses feedback from the projects/memex team around pressing the <kbd>Down</kbd> arrow when the filter input field has focus: https://github.com/github/accessibility/discussions/6500#discussioncomment-10124428

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I made these changes in accordance with our API docs for `SelectPanel (internal-only): https://github.com/github/primer/blob/90ca31f40b92b4365a01b64325f8fdf93f80725b/apis/select-panel-api.md. In addition to fixing the behavior of the <kbd>Down</kbd> key, I also added behavior for the <kbd>Home</kbd> and <kbd>End</kbd> keys.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
