### PR TITLE
Allow `Primer::Alpha::ActionList::Item#description` to take a `test_selector`

### DIFF
--- a/app/components/primer/alpha/action_list/item.html.erb
+++ b/app/components/primer/alpha/action_list/item.html.erb
@@ -28,11 +28,7 @@
         <%= render(Primer::BaseComponent.new(tag: :span, **@label_arguments)) do %>
           <%= @label || content %>
         <% end %>
-        <% if description? %>
-          <span class="ActionListItem-description">
-            <%= description %>
-          </span>
-        <% end %>
+      <%= description if description? %>
       <% end %>
       <% if trailing_visual %>
         <span class="ActionListItem-visual ActionListItem-visual--trailing">

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -40,7 +40,9 @@ module Primer
 
         # Description content that complements the item's label. See `ActionList`'s `description_scheme` argument
         # for layout options.
-        renders_one :description
+        renders_one :description, -> (test_selector: nil) do
+          Primer::BaseComponent.new(tag: "span", test_selector: test_selector) { content }
+        end
 
         # An icon, avatar, SVG, or custom content that will render to the left of the label.
         #

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -38,8 +38,8 @@ module Primer
         }
         TRUNCATION_BEHAVIOR_OPTIONS = TRUNCATION_BEHAVIOR_MAPPINGS.keys.freeze
 
-        # Description content that complements the item's label. See `ActionList`'s `description_scheme` argument
-        # for layout options.
+        # Description content that complements the item's label, with optional test_selector.
+        # See `ActionList`'s `description_scheme` argument for layout options.
         renders_one :description, -> (test_selector: nil) do
           Primer::BaseComponent.new(tag: "span", classes: "ActionListItem-description", test_selector: test_selector) { content }
         end

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -41,7 +41,7 @@ module Primer
         # Description content that complements the item's label. See `ActionList`'s `description_scheme` argument
         # for layout options.
         renders_one :description, -> (test_selector: nil) do
-          Primer::BaseComponent.new(tag: "span", test_selector: test_selector) { content }
+          Primer::BaseComponent.new(tag: "span", classes: "ActionListItem-description", test_selector: test_selector) { content }
         end
 
         # An icon, avatar, SVG, or custom content that will render to the left of the label.

--- a/previews/primer/alpha/action_list_preview.rb
+++ b/previews/primer/alpha/action_list_preview.rb
@@ -380,7 +380,7 @@ module Primer
                  aria: { label: "List heading" }
                )) do |component|
           component.with_item(label: "Default item", href: "/") do |item|
-            item.with_description.with_content("This is a description")
+            item.with_description(test_selector: "some-selector").with_content("This is a description")
           end
         end
       end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Make it possible to set a `test_selector` on `Primer::Alpha::ActionList::Item#description`.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

After:

![screenshot with devtools open, showing the test selector](https://github.com/user-attachments/assets/6215a3fd-ccb4-4d8c-9ff5-0c8c73714112)

### Integration
<!-- Does this change require any updates to code in production? -->

No, but I intend to make of use of it to improve some tests.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes #2970

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

After discussing with `@camertron` (thank you!) I went for switching from a passthrough slot to a lambda slot, returning a `Primer::BaseComponent` so that it can be used with `with_content` as well as with a block.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

Don't think so.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests -- does this need a test?
- [x] Added/updated documentation (assuming c9c82571edbd746c5e064d6dfa5a8408e967cb83 is enough)
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge -- I don't have easy access to Edge. I presume this change is simple enough that not testing in Edge is okay?

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
