### PR TITLE
Add `align-self: flex-start` to group heading directly

### DIFF
--- a/.changeset/wild-onions-explode.md
+++ b/.changeset/wild-onions-explode.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Replace `align-items` with `align-self` and apply it on `ActionList` group headings directly.

--- a/app/components/primer/alpha/action_list.pcss
+++ b/app/components/primer/alpha/action_list.pcss
@@ -642,7 +642,6 @@ nav-list {
   /* with children */
   &:not(:empty) {
     display: flex;
-    align-items: flex-start;
     padding-inline: var(--actionListContent-paddingBlock);
     padding-block: var(--base-size-8);
     font-size: var(--text-body-size-small);
@@ -669,6 +668,7 @@ nav-list {
     font-size: var(--text-body-size-small);
     font-weight: var(--base-text-weight-semibold);
     color: var(--fgColor-muted);
+    align-self: flex-start;
   }
 }
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Applies `flex-start` directly to the group heading in `ActionList`. This ensures that anything inside of `.ActionList-sectionDivider` that isn't the group heading won't receive the `align-items` style.

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->
     

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
