### PR TITLE
Add support for trailing and leading visual icons in Primer::Beta::Link

### DIFF
--- a/.changeset/odd-dots-laugh.md
+++ b/.changeset/odd-dots-laugh.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Support leading and trailing icons for Links

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -170,7 +170,7 @@ module Primer
       if SELF_CLOSING_TAGS.include?(@tag)
         tag(@tag, @content_tag_args.merge(@result))
       else
-        content_tag(@tag, trimmed_content(trim: @trim), @content_tag_args.merge(@result))
+        content_tag(@tag, @trim ? trimmed_content : content, @content_tag_args.merge(@result))
       end
     end
   end

--- a/app/components/primer/base_component.rb
+++ b/app/components/primer/base_component.rb
@@ -151,12 +151,15 @@ module Primer
     # | :- | :- | :- |
     # | classes | String | CSS class name value to be concatenated with generated Primer CSS classes. |
     # | test_selector | String | Adds `data-test-selector='given value'` in non-Production environments for testing purposes. |
+    # | trim | Boolean | Calls `strip` on the content to remove trailing and leading white spaces. |
     def initialize(tag:, classes: nil, **system_arguments)
       @tag = tag
 
       @system_arguments = validate_arguments(tag: tag, **system_arguments)
 
       @result = Primer::Classify.call(**@system_arguments.merge(classes: classes))
+
+      @trim = !!@system_arguments.delete(:trim)
 
       @system_arguments[:"data-view-component"] = true
       # Filter out Primer keys so they don't get assigned as HTML attributes
@@ -167,7 +170,7 @@ module Primer
       if SELF_CLOSING_TAGS.include?(@tag)
         tag(@tag, @content_tag_args.merge(@result))
       else
-        content_tag(@tag, content, @content_tag_args.merge(@result))
+        content_tag(@tag, trimmed_content(trim: @trim), @content_tag_args.merge(@result))
       end
     end
   end

--- a/app/components/primer/beta/link.html.erb
+++ b/app/components/primer/beta/link.html.erb
@@ -1,4 +1,4 @@
-<% link_content = capture do %>
+<%= render Primer::ConditionalWrapper.new(condition: tooltip?, tag: :span, position: :relative) do %>
   <%= render(Primer::BaseComponent.new(**@system_arguments)) do -%>
     <% if leading_visual %>
       <span class="Link-visual Link-leadingVisual">
@@ -12,13 +12,5 @@
       </span>
     <% end %>
   <% end -%>
-<% end %>
-
-<% if tooltip.present? %>
-  <%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
-    <%= link_content %>
-    <%= tooltip %>
-  <% end %>
-<% else %>
-  <%= link_content %>
+  <%= tooltip %>
 <% end %>

--- a/app/components/primer/beta/link.html.erb
+++ b/app/components/primer/beta/link.html.erb
@@ -1,16 +1,16 @@
-<%= render Primer::ConditionalWrapper.new(condition: tooltip?, tag: :span, position: :relative) do %>
-  <%= render(Primer::BaseComponent.new(**@system_arguments)) do -%>
+<%= render Primer::ConditionalWrapper.new(condition: tooltip?, trim: true, tag: :span, position: :relative) do %>
+  <%= render(Primer::BaseComponent.new(trim: true, **@system_arguments)) do %>
     <% if leading_visual %>
       <span class="Link-visual Link-leadingVisual">
         <%= leading_visual %>
       </span>
     <% end %>
-    <%= trimmed_content -%>
+    <%= content %>
     <% if trailing_visual %>
       <span class="Link-visual Link-trailingVisual">
         <%= trailing_visual %>
       </span>
     <% end %>
-  <% end -%>
-  <%= tooltip %>
+  <% end %>
+  <%= tooltip if tooltip? %>
 <% end %>

--- a/app/components/primer/beta/link.html.erb
+++ b/app/components/primer/beta/link.html.erb
@@ -1,13 +1,13 @@
 <%= render Primer::ConditionalWrapper.new(condition: tooltip?, trim: true, tag: :span, position: :relative) do %>
   <%= render(Primer::BaseComponent.new(trim: true, **@system_arguments)) do %>
     <% if leading_visual %>
-      <span class="Link-visual Link-leadingVisual">
+      <span>
         <%= leading_visual %>
       </span>
     <% end %>
     <%= content %>
     <% if trailing_visual %>
-      <span class="Link-visual Link-trailingVisual">
+      <span>
         <%= trailing_visual %>
       </span>
     <% end %>

--- a/app/components/primer/beta/link.html.erb
+++ b/app/components/primer/beta/link.html.erb
@@ -1,0 +1,24 @@
+<% link_content = capture do %>
+  <%= render(Primer::BaseComponent.new(**@system_arguments)) do -%>
+    <% if leading_visual %>
+      <span class="Link-visual Link-leadingVisual">
+        <%= leading_visual %>
+      </span>
+    <% end %>
+    <%= trimmed_content -%>
+    <% if trailing_visual %>
+      <span class="Link-visual Link-trailingVisual">
+        <%= trailing_visual %>
+      </span>
+    <% end %>
+  <% end -%>
+<% end %>
+
+<% if tooltip.present? %>
+  <%= render Primer::BaseComponent.new(tag: :span, position: :relative) do %>
+    <%= link_content %>
+    <%= tooltip %>
+  <% end %>
+<% else %>
+  <%= link_content %>
+<% end %>

--- a/app/components/primer/beta/link.rb
+++ b/app/components/primer/beta/link.rb
@@ -80,19 +80,6 @@ module Primer
       def before_render
         raise ArgumentError, "href is required" if @system_arguments[:href].nil? && !Rails.env.production?
       end
-
-      private
-
-      def trimmed_content
-        return if content.blank?
-
-        trimmed_content = content.strip
-
-        return trimmed_content unless content.html_safe?
-
-        # strip unsets `html_safe`, so we have to set it back again to guarantee that HTML blocks won't break
-        trimmed_content.html_safe # rubocop:disable Rails/OutputSafety
-      end
     end
   end
 end

--- a/app/components/primer/beta/link.rb
+++ b/app/components/primer/beta/link.rb
@@ -30,6 +30,32 @@ module Primer
         Primer::Alpha::Tooltip.new(**system_arguments)
       }
 
+      # Leading visuals appear to the left of the link text.
+      #
+      # Use:
+      #
+      # - `leading_visual_icon` which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Octicon) %>.
+      #
+      # @param system_arguments [Hash] Same arguments as <%= link_to_component(Primer::Beta::Octicon) %>.
+      renders_one :leading_visual, types: {
+        icon: lambda { |**system_arguments|
+          Primer::Beta::Octicon.new(**system_arguments)
+        }
+      }
+
+      # Trailing visuals appear to the right of the link text.
+      #
+      # Use:
+      #
+      # - `trailing_visual_icon` which accepts the arguments accepted by <%= link_to_component(Primer::Beta::Octicon) %>.
+      #
+      # @param system_arguments [Hash] Same arguments as <%= link_to_component(Primer::Beta::Octicon) %>.
+      renders_one :trailing_visual, types: {
+        icon: lambda { |**system_arguments|
+          Primer::Beta::Octicon.new(**system_arguments)
+        }
+      }
+
       # @param href [String] URL to be used for the Link. Required. If the requirements are not met an error will be raised in non production environments. In production, an empty link element will be rendered.
       # @param scheme [Symbol] <%= one_of(Primer::Beta::Link::SCHEME_MAPPINGS.keys) %>
       # @param muted [Boolean] Uses light gray for Link color, and blue on hover.
@@ -55,18 +81,17 @@ module Primer
         raise ArgumentError, "href is required" if @system_arguments[:href].nil? && !Rails.env.production?
       end
 
-      def call
-        if tooltip.present?
-          render Primer::BaseComponent.new(tag: :span, position: :relative) do
-            render(Primer::BaseComponent.new(**@system_arguments)) do
-              content
-            end.to_s + tooltip.to_s
-          end
-        else
-          render(Primer::BaseComponent.new(**@system_arguments)) do
-            content
-          end
-        end
+      private
+
+      def trimmed_content
+        return if content.blank?
+
+        trimmed_content = content.strip
+
+        return trimmed_content unless content.html_safe?
+
+        # strip unsets `html_safe`, so we have to set it back again to guarantee that HTML blocks won't break
+        trimmed_content.html_safe # rubocop:disable Rails/OutputSafety
       end
     end
   end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -144,5 +144,12 @@ module Primer
     def should_raise_aria_error?
       !Rails.env.production? && raise_on_invalid_aria? && !ENV["PRIMER_WARNINGS_DISABLED"]
     end
+
+    def trimmed_content(trim: false)
+      return content unless trim && content.present?
+
+       # strip unsets `html_safe`, so we have to set it back again to guarantee that HTML blocks won't break
+      content.html_safe? ? content.strip.html_safe : content.strip # rubocop:disable Rails/OutputSafety
+    end
   end
 end

--- a/app/components/primer/component.rb
+++ b/app/components/primer/component.rb
@@ -145,10 +145,10 @@ module Primer
       !Rails.env.production? && raise_on_invalid_aria? && !ENV["PRIMER_WARNINGS_DISABLED"]
     end
 
-    def trimmed_content(trim: false)
-      return content unless trim && content.present?
+    def trimmed_content
+      return content unless content.present?
 
-       # strip unsets `html_safe`, so we have to set it back again to guarantee that HTML blocks won't break
+      # strip unsets `html_safe`, so we have to set it back again to guarantee that HTML blocks won't break
       content.html_safe? ? content.strip.html_safe : content.strip # rubocop:disable Rails/OutputSafety
     end
   end

--- a/app/components/primer/conditional_wrapper.rb
+++ b/app/components/primer/conditional_wrapper.rb
@@ -10,12 +10,13 @@ module Primer
     def initialize(condition:, **base_component_arguments)
       @condition = condition
       @base_component_arguments = base_component_arguments
+      @trim = !!@base_component_arguments.delete(:trim)
     end
 
     def call
-      return content unless @condition
+      return trimmed_content(trim: @trim) unless @condition
 
-      BaseComponent.new(**@base_component_arguments).render_in(self) { content }
+      BaseComponent.new(trim: @trim, **@base_component_arguments).render_in(self) { content }
     end
   end
 end

--- a/app/components/primer/conditional_wrapper.rb
+++ b/app/components/primer/conditional_wrapper.rb
@@ -14,7 +14,9 @@ module Primer
     end
 
     def call
-      return trimmed_content(trim: @trim) unless @condition
+      unless @condition
+        return @trim ? trimmed_content : content
+      end
 
       BaseComponent.new(trim: @trim, **@base_component_arguments).render_in(self) { content }
     end

--- a/previews/primer/beta/link_preview.rb
+++ b/previews/primer/beta/link_preview.rb
@@ -9,8 +9,14 @@ module Primer
       # @param underline [Boolean]
       # @param muted [Boolean]
       # @param scheme [Symbol] select [default, primary, secondary]
-      def playground(scheme: :default, muted: false, underline: true)
-        render(Primer::Beta::Link.new(href: "#", scheme: scheme, muted: muted, underline: underline)) { "This is a link!" }
+      # @param leading_visual_icon [Symbol] octicon
+      # @param trailing_visual_icon [Symbol] octicon
+      def playground(scheme: :default, muted: false, underline: true, leading_visual_icon: nil, trailing_visual_icon: nil)
+        render(Primer::Beta::Link.new(href: "#", scheme: scheme, muted: muted, underline: underline)) do |link|
+          link.with_leading_visual_icon(icon: leading_visual_icon) if leading_visual_icon && leading_visual_icon != :none
+          link.with_trailing_visual_icon(icon: trailing_visual_icon) if trailing_visual_icon && trailing_visual_icon != :none
+          "This is a link!"
+        end
       end
 
       # @label Default Options
@@ -66,6 +72,22 @@ module Primer
         render(Primer::Beta::Link.new(href: "#", scheme: :secondary, muted: true)) { "This is a muted secondary link color." }
       end
       # @!endgroup
+
+      # @label With leading icon
+      def with_leading_icon
+        render(Primer::Beta::Link.new(href: "#")) do |component|
+          component.with_leading_visual_icon(icon: :"mark-github")
+          "Link with leading icon"
+        end
+      end
+
+      # @label With trailing icon
+      def with_trailing_icon
+        render(Primer::Beta::Link.new(href: "#")) do |component|
+          component.with_trailing_visual_icon(icon: :"link-external")
+          "Link with trailing icon"
+        end
+      end
     end
   end
 end

--- a/test/components/beta/link_test.rb
+++ b/test/components/beta/link_test.rb
@@ -100,16 +100,18 @@ class PrimerBetaLinkTest < Minitest::Test
     end
 
     assert_selector("a[href='http://google.com']")
-    assert_selector(".Link-visual.Link-leadingVisual .octicon-plus")
+    assert_selector(".octicon-plus")
   end
 
   def test_renders_trailing_visual_icon
     render_inline(Primer::Beta::Link.new(href: "http://google.com")) do |component|
-      component.with_trailing_visual_icon(icon: "plus")
+      component.with_leading_visual_icon(icon: "plus")
+      component.with_trailing_visual_icon(icon: "alert")
       "content"
     end
 
     assert_selector("a[href='http://google.com']")
-    assert_selector(".Link-visual.Link-trailingVisual .octicon-plus")
+    assert_selector("a span:first-child .octicon-plus")
+    assert_selector("a span:nth-child(2) .octicon-alert")
   end
 end

--- a/test/components/beta/link_test.rb
+++ b/test/components/beta/link_test.rb
@@ -92,4 +92,24 @@ class PrimerBetaLinkTest < Minitest::Test
 
     assert_selector("a[href='http://google.com'] + tool-tip", text: "Tooltip text", visible: false)
   end
+
+  def test_renders_leading_visual_icon
+    render_inline(Primer::Beta::Link.new(href: "http://google.com")) do |component|
+      component.with_leading_visual_icon(icon: "plus")
+      "content"
+    end
+
+    assert_selector("a[href='http://google.com']")
+    assert_selector(".Link-visual.Link-leadingVisual .octicon-plus")
+  end
+
+  def test_renders_trailing_visual_icon
+    render_inline(Primer::Beta::Link.new(href: "http://google.com")) do |component|
+      component.with_trailing_visual_icon(icon: "plus")
+      "content"
+    end
+
+    assert_selector("a[href='http://google.com']")
+    assert_selector(".Link-visual.Link-trailingVisual .octicon-plus")
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
This PR adds slots for  a `trailing_visual` and a `leading_visual`. As of now, only Icons are supported as types.

### Screenshots
<img width="191" alt="Bildschirmfoto 2024-07-30 um 14 19 42" src="https://github.com/user-attachments/assets/53601bf7-e28f-4a62-aa2a-dafc2744c3d1">
<img width="198" alt="Bildschirmfoto 2024-07-30 um 14 19 37" src="https://github.com/user-attachments/assets/aa81611d-38be-4f0b-bc3b-bd7dcf85b661">



#### List the issues that this change affects.

Closes #2981 

#### Risk Assessment

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
I limited the visual to icons for now, as I did not know, which other types (avatar, svg, ...) shall be supported.

### Anything you want to highlight for special attention from reviewers?
I extracted the code of the `call` method to a html.erb template because of the increased complexity of the template. In there I used a `capture` block to avoid the previous duplication depending on the existance of a tooltip.


### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
