### PR TITLE
actionmenu: ensure focus falls back to invoking element when dialogs are closed

### DIFF
--- a/.changeset/brave-bugs-tap.md
+++ b/.changeset/brave-bugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure ActionMenu restores focus on close of a dialog, if a menu item opened that dialog

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -207,7 +207,7 @@ export class ActionMenuElement extends HTMLElement {
       if (dialogInvoker) {
         const dialog = this.ownerDocument.getElementById(dialogInvoker.getAttribute('data-show-dialog-id') || '')
 
-        if (dialog && this.contains(dialogInvoker) && this.contains(dialog)) {
+        if (dialog && this.contains(dialogInvoker)) {
           this.#handleDialogItemActivated(event, dialog)
           return
         }
@@ -243,20 +243,32 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #handleDialogItemActivated(event: Event, dialog: HTMLElement) {
-    this.querySelector<HTMLElement>('.ActionListWrap')!.style.display = 'none'
+    if (this.contains(dialog)) {
+      this.querySelector<HTMLElement>('.ActionListWrap')!.style.display = 'none'
+    }
     const dialog_controller = new AbortController()
     const {signal} = dialog_controller
     const handleDialogClose = () => {
       dialog_controller.abort()
-      this.querySelector<HTMLElement>('.ActionListWrap')!.style.display = ''
-      if (this.#isOpen()) {
-        this.#hide()
+      if (this.contains(dialog)) {
+        this.querySelector<HTMLElement>('.ActionListWrap')!.style.display = ''
+        if (this.#isOpen()) {
+          this.#hide()
+        }
       }
       const activeElement = this.ownerDocument.activeElement
       const lostFocus = this.ownerDocument.activeElement === this.ownerDocument.body
       const focusInClosedMenu = this.contains(activeElement)
       if (lostFocus || focusInClosedMenu) {
-        setTimeout(() => this.invokerElement?.focus(), 0)
+        setTimeout(() => {
+          // if the activeElement has changed after a task, then it's likely
+          // that other JS has tried to shift focus. We should respect that
+          // focus shift as long as it's not back at the document.
+          const newActiveElement = this.ownerDocument.activeElement
+          if (newActiveElement === activeElement || newActiveElement === this.ownerDocument.body) {
+            this.invokerElement?.focus()
+          }
+        }, 0)
       }
     }
     // a modal <dialog> element will close all popovers

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -259,7 +259,8 @@ export class ActionMenuElement extends HTMLElement {
       const activeElement = this.ownerDocument.activeElement
       const lostFocus = this.ownerDocument.activeElement === this.ownerDocument.body
       const focusInClosedMenu = this.contains(activeElement)
-      if (lostFocus || focusInClosedMenu) {
+      const focusInDialog = dialog.contains(activeElement)
+      if (lostFocus || focusInClosedMenu || focusInDialog) {
         setTimeout(() => {
           // if the activeElement has changed after a task, then it's likely
           // that other JS has tried to shift focus. We should respect that

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -56,6 +56,10 @@ module Alpha
       click_on_item(4)
     end
 
+    def close_dialog
+      find("[data-close-dialog-id][aria-label=Close]").click
+    end
+
     def focus_on_invoker_button
       page.evaluate_script(<<~JS)
         document.querySelector('action-menu button[aria-controls]').focus()
@@ -338,6 +342,19 @@ module Alpha
 
       # opening the dialog should close the menu
       refute_selector "action-menu ul li"
+    end
+
+    def test_open_then_closing_dialog_restores_focus
+      visit_preview(:opens_dialog)
+
+      click_on_invoker_button
+      click_on_second_item
+
+      assert_selector "dialog[open]"
+
+      close_dialog
+
+      assert_equal page.evaluate_script("document.activeElement").text, "Menu"
     end
 
     def test_opens_dialog_on_keydown


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Currently if an actionmenu opens a dialog, and that dialog is subsequently closed, focus is _not_ automatically restored to the action menu invoker. It should be.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
Gosh if I had time in my day to make a video...

### Integration
<!-- Does this change require any updates to code in production? -->
Shouldn't need to.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/3491, https://github.com/github/accessibility-audits/issues/7683

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
I used the existing dialog close behaviour, which was only triggered if the dialog was a _descendant_ of the menu. This guard got moved to the relevant parts which hide the actionmenu wrapper, but it retains the focus move code.

I've also added extra guards around the focus code to ensure we're not overriding focus changes for instances that shift focus on dialog close.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] ~~Added/updated documentation~~ N/A
- [x] ~~Added/updated previews (Lookbook)~~ N/A
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
