### PR TITLE
Action list description test selector

### DIFF
--- a/.changeset/loud-shoes-enjoy.md
+++ b/.changeset/loud-shoes-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Add ability to attach a test selector to ActionList items

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -40,6 +40,8 @@ module Primer
 
         # Description content that complements the item's label, with optional test_selector.
         # See `ActionList`'s `description_scheme` argument for layout options.
+        #
+        # @param test_selector [String] The value of this argument is set as the value of a `data-test-selector` HTML attribute on the description element.
         renders_one :description, -> (test_selector: nil) do
           Primer::BaseComponent.new(tag: "span", classes: "ActionListItem-description", test_selector: test_selector) { content }
         end

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import resolve from "@rollup/plugin-node-resolve"
 import typescript from "@rollup/plugin-typescript"
-// import { terser } from "rollup-plugin-terser"
+import { terser } from "rollup-plugin-terser"
 import pkg from "./package.json"
 
 export default {
@@ -13,7 +13,7 @@ export default {
   plugins: [
     resolve(),
     typescript(),
-    // terser({keep_classnames: /Element$/}) // comment out terser in dev if you want debugger statements
+    terser({keep_classnames: /Element$/}) // comment out terser in dev if you want debugger statements
   ],
   onwarn: (warning, warn) => {
     if (warning.code === "THIS_IS_UNDEFINED") return

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import resolve from "@rollup/plugin-node-resolve"
 import typescript from "@rollup/plugin-typescript"
-import { terser } from "rollup-plugin-terser"
+// import { terser } from "rollup-plugin-terser"
 import pkg from "./package.json"
 
 export default {
@@ -13,7 +13,7 @@ export default {
   plugins: [
     resolve(),
     typescript(),
-    terser({keep_classnames: /Element$/}) // comment out terser in dev if you want debugger statements
+    // terser({keep_classnames: /Element$/}) // comment out terser in dev if you want debugger statements
   ],
   onwarn: (warning, warn) => {
     if (warning.code === "THIS_IS_UNDEFINED") return

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -29,6 +29,16 @@ module Primer
         assert_selector(".ActionListItem-description", text: "Bruce Banner")
       end
 
+      def test_item_description_test_selector
+        render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |component|
+          component.with_item(label: "Item 1", href: "/item1") do |item|
+            item.with_description(test_selector: "foo") { "My description" }
+          end
+        end
+
+        assert_selector(".ActionListItem-description[data-test-selector='foo']", text: "My description")
+      end
+
       def test_item_trailing_visual_text
         render_preview(:item, params: { trailing_visual_text: "trailing visual text" })
 


### PR DESCRIPTION
See: https://github.com/primer/view_components/pull/2971 (thanks @sampart!)

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Make it possible to set a `test_selector` on `Primer::Alpha::ActionList::Item#description`.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

![screenshot with devtools open, showing the test selector](https://github.com/user-attachments/assets/6215a3fd-ccb4-4d8c-9ff5-0c8c73714112)

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes #2970

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

After discussing with `@camertron` (thank you!) I went for switching from a passthrough slot to a lambda slot, returning a `Primer::BaseComponent` so that it can be used with `with_content` as well as with a block.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
