### PR TITLE
[Alpha][SelectPanel] Fix single select remote loading bug

### DIFF
--- a/.changeset/dull-knives-leave.md
+++ b/.changeset/dull-knives-leave.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fixes Alpha::SelectPanel remote loading bug where items from the server were overriding the users selections. Additionally, update the #removeSelectedItem function to grab the data-value from the correct element.

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -701,7 +701,11 @@ export class SelectPanelElement extends HTMLElement {
 
       const value = itemContent.getAttribute('data-value')
 
-      if (value && !this.#selectedItems.has(value) && this.isItemChecked(item)) {
+      if (this.selectVariant === 'single' && this.selectedItems.length !== 0) {
+        if (this.selectedItems[0].value !== value) {
+          itemContent.setAttribute(this.ariaSelectionType, 'false')
+        }
+      } else if (value && !this.#selectedItems.has(value) && this.isItemChecked(item)) {
         this.#addSelectedItem(item)
       }
     }

--- a/demo/app/controllers/select_panel_items_controller.rb
+++ b/demo/app/controllers/select_panel_items_controller.rb
@@ -42,6 +42,12 @@ class SelectPanelItemsController < ApplicationController
                 []
               end
 
+    if unselect_items?
+      results.map! do |result|
+        result.merge(selected: false)
+      end
+    end
+
     clean_up_old_uuids(uuid)
 
     respond_to do |format|
@@ -83,5 +89,13 @@ class SelectPanelItemsController < ApplicationController
 
   def key_for(uuid)
     "#{COOKIE_PREFIX}#{uuid}"
+  end
+
+  def select_items?
+    params.fetch(:select_items, "true") == "true"
+  end
+
+  def unselect_items?
+    !select_items?
   end
 end

--- a/previews/primer/alpha/select_panel_preview.rb
+++ b/previews/primer/alpha/select_panel_preview.rb
@@ -18,6 +18,7 @@ module Primer
       # @param open_on_load toggle
       # @param anchor_align [Symbol] select [start, center, end]
       # @param anchor_side [Symbol] select [outside_bottom, outside_top, outside_left, outside_right]
+      # @param select_items toggle
       def playground(
         title: "Sci-fi equipment",
         subtitle: "Various tools from your favorite shows",
@@ -31,10 +32,12 @@ module Primer
         show_filter: true,
         open_on_load: false,
         anchor_align: :start,
-        anchor_side: :outside_bottom
+        anchor_side: :outside_bottom,
+        select_items: true
       )
         render_with_template(locals: {
           subtitle: subtitle,
+          select_items: select_items,
           system_arguments: {
             title: title,
             size: size,

--- a/previews/primer/alpha/select_panel_preview/playground.html.erb
+++ b/previews/primer/alpha/select_panel_preview/playground.html.erb
@@ -8,7 +8,8 @@
   src: select_panel_items_path(
     select_variant: :single,
     show_results: !simulate_no_results,
-    fail: simulate_failure
+    fail: simulate_failure,
+    select_items: select_items
   ),
   select_variant: :single,
   fetch_strategy: :remote,

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 require "system/test_case"
@@ -182,11 +183,12 @@ module Alpha
       end
 
       # Phaser should already be selected
-      assert_selector "[aria-checked=true]", count: 1
+      assert_selector "[aria-checked=true]", text: "Phaser"
 
       click_on "Photon torpedo"
 
-      assert_selector "[aria-checked=true]", count: 2
+      assert_selector "[aria-checked=true]", text: "Phaser"
+      assert_selector "[aria-checked=true]", text: "Photon torpedo"
 
       wait_for_items_to_load do
         filter_results(query: "ph")
@@ -382,6 +384,100 @@ module Alpha
       refute_selector "[aria-selected=true]"
     end
 
+    def test_single_select_does_not_allow_server_to_check_items_on_filter_if_selections_already_made
+      # playground is single-select
+      visit_preview(:playground)
+
+      wait_for_items_to_load do
+        click_on_invoker_button
+      end
+
+      # Phaser should already be selected
+      assert_selector "[aria-selected=true]", text: "Phaser"
+
+      click_on "Photon torpedo"
+      click_on_invoker_button
+
+      wait_for_items_to_load do
+        filter_results(query: "ph")
+      end
+
+      # server will render this item checked, but since the user has already made selections,
+      # the server-rendered selections should be ignored
+      refute_selector "[aria-selected=true]", text: "Phaser"
+      assert_selector "[aria-selected=true]", text: "Photon torpedo"
+    end
+
+    def test_single_select_remembers_only_one_checked_item_and_ignores_checked_items_from_server
+      # playground is single-select
+      visit_preview(:playground)
+
+      wait_for_items_to_load do
+        click_on_invoker_button
+      end
+
+      # Phaser should already be selected
+      assert_selector "[aria-selected=true]", text: "Phaser"
+
+      wait_for_items_to_load do
+        filter_results(query: "light")
+      end
+
+      click_on "Lightsaber"
+
+      click_on_invoker_button
+
+      wait_for_items_to_load do
+        filter_results(query: "")
+      end
+
+      refute_selector "[aria-selected=true]", text: "Phaser"
+      assert_selector "[aria-selected=true]", text: "Lightsaber"
+    end
+
+    def test_single_select_handles_all_options_unselected_by_default
+      # playground is single-select
+      visit_preview(:playground, select_items: false)
+
+      wait_for_items_to_load do
+        click_on_invoker_button
+      end
+
+      # Phaser should note already be selected
+      refute_selector "[aria-selected=true]", text: "Phaser"
+
+      wait_for_items_to_load do
+        filter_results(query: "light")
+      end
+
+      click_on "Lightsaber"
+
+      click_on_invoker_button
+
+      wait_for_items_to_load do
+        filter_results(query: "")
+      end
+
+      refute_selector "[aria-selected=true]", text: "Phaser"
+      assert_selector "[aria-selected=true]", text: "Lightsaber"
+
+
+      wait_for_items_to_load do
+        filter_results(query: "ph")
+      end
+
+      click_on "Phaser"
+
+      click_on_invoker_button
+
+      wait_for_items_to_load do
+        filter_results(query: "")
+      end
+
+      assert_selector "[aria-selected=true]", text: "Phaser"
+      refute_selector "[aria-selected=true]", text: "Lightsaber"
+    end
+
     ########## MULTISELECT TESTS ############
 
     def test_multi_select_items_checked
@@ -476,6 +572,32 @@ module Alpha
 
       refute_selector "[aria-checked=true]"
     end
+
+    def test_multi_select_does_not_allow_server_to_check_items_on_filter_if_selections_already_made
+      # remote_fetch is multi-select
+      visit_preview(:remote_fetch)
+
+      wait_for_items_to_load do
+        click_on_invoker_button
+      end
+
+      # Phaser should already be selected
+      assert_selector "[aria-checked=true]", text: "Phaser"
+
+      # check torpedo, uncheck phaser
+      click_on "Photon torpedo"
+      click_on "Phaser"
+
+      wait_for_items_to_load do
+        filter_results(query: "ph")
+      end
+
+      # server will render phaser checked, but since the user has already made selections,
+      # the server-rendered selections should be ignored
+      refute_selector "[aria-checked=true]", text: "Phaser"
+      assert_selector "[aria-checked=true]", text: "Photon torpedo"
+    end
+    
 
     ########## JAVASCRIPT API TESTS ############
 

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -597,7 +597,6 @@ module Alpha
       refute_selector "[aria-checked=true]", text: "Phaser"
       assert_selector "[aria-checked=true]", text: "Photon torpedo"
     end
-    
 
     ########## JAVASCRIPT API TESTS ############
 


### PR DESCRIPTION
### What

Fixes a remote single-select filtering has a bug where ...

When a user clicks an item `handleItemActivated `is called. In single select mode this function de-selects all items stored in `this.items`.

However, `this.items` contains only SelectPanel items that the server has returned to the SelectPanel. Meaning, if a user filters items using the input field the server may have returned a subset of items and therefore, we cannot deselect all items.

A similar problem will occur if a server has a limit and only returns a subset of the results to begin with.

Additionally, I fixed `removeSelecteditems` as it was checking for the `data-value` on the li as opposed to the button which has the actual value.

#### List the issues that this change affects.
- https://github.com/github/primer/issues/3694
- 
Closes # (type the GitHub issue number after #)
- https://github.com/github/primer/issues/3694

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

Added test cases to test functionality and mitgate regression 

### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [X] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
