### PR TITLE
Allow ActionList item content to be supplied by positional arg

### DIFF
--- a/.changeset/brown-fireants-reflect.md
+++ b/.changeset/brown-fireants-reflect.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow ActionList item content to be supplied by positional arg

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -41,9 +41,12 @@ module Primer
         # Description content that complements the item's label, with optional test_selector.
         # See `ActionList`'s `description_scheme` argument for layout options.
         #
+        # @param legacy_content [String] Slot content, provided for backwards-compatibility. Pass a content block instead, or call `with_content`, eg. `component.with_description { "My description" }` or `component.with_description.with_content("My description")`.
         # @param test_selector [String] The value of this argument is set as the value of a `data-test-selector` HTML attribute on the description element.
-        renders_one :description, -> (test_selector: nil) do
-          Primer::BaseComponent.new(tag: "span", classes: "ActionListItem-description", test_selector: test_selector) { content }
+        renders_one :description, -> (legacy_content = nil, test_selector: nil) do
+          Primer::BaseComponent.new(tag: "span", classes: "ActionListItem-description", test_selector: test_selector).tap do |desc|
+            desc.with_content(legacy_content) if legacy_content
+          end
         end
 
         # An icon, avatar, SVG, or custom content that will render to the left of the label.

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -39,6 +39,16 @@ module Primer
         assert_selector(".ActionListItem-description[data-test-selector='foo']", text: "My description")
       end
 
+      def test_item_description_legacy_content
+        render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" })) do |component|
+          component.with_item(label: "Item 1", href: "/item1") do |item|
+            item.with_description("My description")
+          end
+        end
+
+        assert_selector(".ActionListItem-description", text: "My description")
+      end
+
       def test_item_trailing_visual_text
         render_preview(:item, params: { trailing_visual_text: "trailing visual text" })
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In attempting to upgrade PVC in dotcom, I ran into a number of test failures around a [seemingly innocuous change](https://github.com/primer/view_components/pull/2984) that allows adding a test selector to `ActionList` item descriptions. This change turned out to be a breaking change for the `ActionList` component, as it now requires passing a content block instead of a positional argument string to the `description` slot. This PR updates the `description` slot to accept content as a positional argument for backwards-compatibility with the previous version.

### Integration
<!-- Does this change require any updates to code in production? -->

This change is being made to address an integration incompatibility with dotcom production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I updated the description slot to accept a positional `legacy_content` argument that simply calls `#with_content` for you.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.