### PR TITLE
[Alpha][SelectPanel] Remove tabindex="-1" from `li` elements labelled as `role="none"`

### DIFF
--- a/.changeset/spotty-kings-whisper.md
+++ b/.changeset/spotty-kings-whisper.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove tabindex="-1" from li elements labelled as role="none" since tabindex's remove/negate role presentation

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -307,7 +307,7 @@ export class SelectPanelElement extends HTMLElement {
         }
 
         // <li> elements should not themselves be tabbable
-        item.setAttribute('tabindex', '-1')
+        item.removeAttribute('tabindex')
       }
     } else {
       for (const item of this.items) {

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -321,7 +321,7 @@ export class SelectPanelElement extends HTMLElement {
         }
 
         // <li> elements should not themselves be tabbable
-        item.setAttribute('tabindex', '-1')
+        item.removeAttribute('tabindex')
       }
     }
 


### PR DESCRIPTION
### What are you trying to accomplish?

Axe logs a few errors on the SelectPanel component...
- [Certain ARIA roles must be contained by particular parents](https://dequeuniversity.com/rules/axe/4.9/aria-required-parent?application=AxeChrome)
- [Ensure elements marked as presentational are consistently ignored](https://dequeuniversity.com/rules/axe/4.9/presentation-role-conflict?application=AxeChrome)
- [Certain ARIA roles must contain particular children](https://dequeuniversity.com/rules/axe/4.9/aria-required-children?application=AxeChrome)

Initially I thought these violations were false positives because our markup:

```html
<ul role="listbox">
  <li role="none">
    <button role="option"></button>
 ```
used `role='none'` to ignore the `li` element.
 

However, After investigating axe-core a bit, I discovered that I was in fact wrong and these violations are not a false positive. Someone asked a similar [question](https://github.com/dequelabs/axe-core/issues/4246) a while back in axe-core and based on a code-owners [response](https://github.com/dequelabs/axe-core/issues/4246#issuecomment-1816749240) it seems that tabindexes (even if always set to -1) remove or negate role='none' / role='presentation'.


### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
