### PR TITLE
Prevent an empty list of custom regexes in the DetailsMenuMigration linter from reporting false positives

### DIFF
--- a/.changeset/metal-shirts-sparkle.md
+++ b/.changeset/metal-shirts-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prevent an empty list of custom regexes in the DetailsMenuMigration linter from reporting false-positives

--- a/lib/primer/view_components/linters/details_menu_migration.rb
+++ b/lib/primer/view_components/linters/details_menu_migration.rb
@@ -32,8 +32,30 @@ module ERBLint
             # ERB nodes
             erb_nodes(processed_source).each do |node|
               code = extract_ruby_from_erb_node(node)
-              generate_node_offense(self.class, processed_source, node, MIGRATE_FROM_DETAILS_MENU) if (code.match?(DETAILS_MENU_RUBY_PATTERN) || code.match?(Regexp.new(@config.custom_erb_pattern.join("|"), true)))
+
+              if contains_offense?(code)
+                generate_node_offense(self.class, processed_source, node, MIGRATE_FROM_DETAILS_MENU)
+              end
             end
+          end
+
+          def contains_offense?(code)
+            return true if code.match?(DETAILS_MENU_RUBY_PATTERN)
+            return code.match?(custom_erb_pattern) if custom_erb_pattern
+            false
+          end
+
+          def custom_erb_pattern
+            unless defined?(@custom_erb_pattern)
+              @custom_erb_pattern =
+                if @config.custom_erb_pattern.empty?
+                  nil
+                else
+                  Regexp.new(@config.custom_erb_pattern.join("|"), true)
+                end
+            end
+
+            @custom_erb_pattern
           end
         end
       end

--- a/test/lib/erblint/details_menu_migration_test.rb
+++ b/test/lib/erblint/details_menu_migration_test.rb
@@ -38,6 +38,12 @@ class DetailsMenuMigrationTest < ErblintTestCase
     assert_match(/.<details-menu> has been deprecated./, @linter.offenses.first.message)
   end
 
+  def test_does_not_warn_if_no_details_menu_used
+    @file = "<% component.with_body('foo') %>"
+    @linter.run(processed_source)
+    assert_equal 0, @linter.offenses.count
+  end
+
   def test_does_not_warn_if_inline_disable_comment
     @file = <<~HTML
       <%= render SomeComponent.new(tag: :"details-menu") do %><%# erblint:disable Primer::Accessibility::DetailsMenuMigration %>


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A [recent PR](https://github.com/primer/view_components/pull/2985) introduced the ability to add custom regexes to the `DetailsMenuMigration` linter to provide 3rd-party code a way to customize how the linter identifies violations. Unfortunately if the list of custom regexes is empty, the linter checks all code against an empty regex (eg. `//i`), which matches every string and therefore always returns `true`. This results in false-positives for every line of code in the file.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I modified the linter to skip matching with the custom regexes if the list of custom regexes is empty.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
