### PR TITLE
All requests from `ToggleSwitch` are being made with a Turbo Accept header

### DIFF
--- a/.changeset/quick-falcons-cheat.md
+++ b/.changeset/quick-falcons-cheat.md
@@ -1,0 +1,6 @@
+---
+"@primer/view-components": patch
+---
+
+Fix a bug where all requests from the `ToggleSwitch` view component are being made with a Turbo Accept header.
+This started happening after the change in #2964 because `data-turbo=false` gets interpreted as a truthy value.

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -84,8 +84,9 @@ module Primer
 
         @system_arguments[:data] = merge_data(
           @system_arguments,
-          { data: { csrf: @csrf_token, turbo: @turbo } }
+          { data: { csrf: @csrf_token } }
         )
+        @system_arguments[:data][:turbo] = true if @turbo
       end
     end
   end

--- a/test/components/alpha/toggle_switch_test.rb
+++ b/test/components/alpha/toggle_switch_test.rb
@@ -69,6 +69,12 @@ module Primer
         assert_selector("[data-csrf]")
       end
 
+      def test_turbo_default
+        render_inline(Primer::Alpha::ToggleSwitch.new(src: "/foo"))
+
+        refute_selector("[data-turbo]")
+      end
+
       def test_turbo
         render_inline(Primer::Alpha::ToggleSwitch.new(src: "/foo", turbo: true))
 

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -100,7 +100,17 @@ module Alpha
       assert_equal "text/vnd.turbo-stream.html", ToggleSwitchController.last_request.headers["HTTP_ACCEPT"]
     end
 
+    def test_fetch_made_without_turbo
+      visit_preview(:default)
 
+      refute_selector(".ToggleSwitch--checked")
+      find("toggle-switch").click
+      assert_selector(".ToggleSwitch--checked")
+
+      wait_for_request
+
+      assert_equal "*/*", ToggleSwitchController.last_request.headers["HTTP_ACCEPT"]
+    end
 
     private
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fix a bug where all requests from the `ToggleSwitch` view component are being made with a Turbo `Accept` header. This started happening after the change in https://github.com/primer/view_components/pull/2964 because `data-turbo=false` gets interpreted as a truthy value.
It also kind of says that in https://catalyst.rocks/guide/attrs/#boolean-attributes but it's not totally clear IMO.

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Conditionally set `data-turbo`, instead of always.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
