### PR TITLE
When hiding a `Spinner`, also hide its screen reader text

### DIFF
--- a/.changeset/neat-pumpkins-appear.md
+++ b/.changeset/neat-pumpkins-appear.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+When hiding a `Spinner`, also hide its screen reader text

--- a/app/components/primer/beta/spinner.html.erb
+++ b/app/components/primer/beta/spinner.html.erb
@@ -1,7 +1,9 @@
-<%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" fill="none" />
-  <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
-<% end %>
-<% if no_aria_label? %>
-  <span class="spinner-screenreader-text sr-only"><%= @sr_text %></span>
+<%= render(Primer::BaseComponent.new(tag: :span, hidden: @hidden, data: { target: @target })) do %>
+  <%= render Primer::BaseComponent.new(**@system_arguments) do %>
+    <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-opacity="0.25" stroke-width="2" vector-effect="non-scaling-stroke" fill="none" />
+    <path d="M15 8a7.002 7.002 0 00-7-7" stroke="currentColor" stroke-width="2" stroke-linecap="round" vector-effect="non-scaling-stroke" />
+  <% end %>
+  <% if no_aria_label? %>
+    <span class="sr-only"><%= @sr_text %></span>
+  <% end %>
 <% end %>

--- a/app/components/primer/beta/spinner.rb
+++ b/app/components/primer/beta/spinner.rb
@@ -40,6 +40,9 @@ module Primer
         else
           @system_arguments[:role] = "img"
         end
+
+        @target = extract_data(:target, @system_arguments)
+        @hidden = @system_arguments.delete(:hidden)
       end
 
       def no_aria_label?

--- a/app/lib/primer/attributes_helper.rb
+++ b/app/lib/primer/attributes_helper.rb
@@ -14,6 +14,16 @@ module Primer
       system_arguments[:"data-#{val}"] || system_arguments.dig(:data, val.to_sym)
     end
 
+    def extract_data(val, system_arguments)
+      if system_arguments.include?(:"data-#{val}")
+        system_arguments.delete(:"data-#{val}")
+      else
+        if system_arguments.include?(:data) && system_arguments[:data][val.to_sym]
+          system_arguments[:data].delete(val.to_sym)
+        end
+      end
+    end
+
     # Merges hashes that contain "aria-*" keys and nested aria: hashes. Removes keys from
     # each hash and returns them in the new hash.
     #

--- a/lib/primer/forms/primer_text_field.ts
+++ b/lib/primer/forms/primer_text_field.ts
@@ -11,7 +11,6 @@ declare global {
   }
 }
 
-const SCREENREADER_TEXT_CLASSNAME = 'spinner-screenreader-text'
 @controller
 export class PrimerTextFieldElement extends HTMLElement {
   @target inputElement: HTMLInputElement
@@ -99,13 +98,11 @@ export class PrimerTextFieldElement extends HTMLElement {
 
   showLeadingSpinner(): void {
     this.leadingSpinner?.removeAttribute('hidden')
-    this.leadingSpinner?.querySelector(SCREENREADER_TEXT_CLASSNAME)?.removeAttribute('hidden')
     this.leadingVisual?.setAttribute('hidden', '')
   }
 
   hideLeadingSpinner(): void {
     this.leadingSpinner?.setAttribute('hidden', '')
-    this.leadingSpinner?.querySelector(SCREENREADER_TEXT_CLASSNAME)?.setAttribute('hidden', '')
     this.leadingVisual?.removeAttribute('hidden')
   }
 }

--- a/test/components/alpha/text_field_test.rb
+++ b/test/components/alpha/text_field_test.rb
@@ -92,7 +92,7 @@ class PrimerAlphaTextFieldTest < Minitest::Test
       Primer::Alpha::TextField.new(**@default_params, leading_visual: { icon: :search }, leading_spinner: true)
     )
 
-    assert_selector "svg[data-target='primer-text-field.leadingSpinner']", visible: :hidden
+    assert_selector "[data-target='primer-text-field.leadingSpinner']", visible: :hidden
   end
 
   def test_enforces_leading_visual_when_spinner_requested

--- a/test/system/alpha/text_field_test.rb
+++ b/test/system/alpha/text_field_test.rb
@@ -80,5 +80,23 @@ module Alpha
       assert_selector "[data-target='primer-text-field.leadingVisual']"
       refute_selector "[data-target='primer-text-field.leadingSpinner']"
     end
+
+    def test_shows_and_hides_screenreader_text
+      visit_preview(:playground, leading_spinner: true)
+
+      evaluate_multiline_script(<<~JS)
+        const textField = document.querySelector('primer-text-field')
+        textField.showLeadingSpinner()
+      JS
+
+      assert_selector "[data-target='primer-text-field.leadingSpinner'] .sr-only", text: "Loading"
+
+      evaluate_multiline_script(<<~JS)
+        const textField = document.querySelector('primer-text-field')
+        textField.hideLeadingSpinner()
+      JS
+
+      refute_selector "[data-target='primer-text-field.leadingSpinner'] .sr-only"
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Unfortunately I merged https://github.com/primer/view_components/pull/3011 a little too fast. This is a follow-up PR that adjusts the approach taken in the original PR by hiding/showing the entire `Spinner`, including the screen reader text.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

This doesn't fix an axe scan violation, but it does address the following accessibility issue: https://github.com/github/primer/issues/3690

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
