### PR TITLE
Introduce demo cleanup action

### DIFF
--- a/.github/workflows/demo-preview-cleanup.rb
+++ b/.github/workflows/demo-preview-cleanup.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "json"
+
+puts "Querying for open pull requests..."
+open_pr_ids = JSON.parse(`gh pr list --repo primer/view_components --state open --json number`)
+open_pr_ids.map! { |data| data["number"] }
+puts "Found #{open_pr_ids.size} open pull requests"
+
+puts "Querying for existing preview environments..."
+preview_envs = JSON.parse(`az container list -g primer`)
+preview_env_ids =
+  preview_envs
+    .select { |data| data["name"].start_with?("primer-view-components-preview-") }
+    .map { |data| data["name"].split("-").last.to_i }
+puts "Found #{preview_env_ids.size} existing preview environments"
+
+preview_env_ids_to_delete = preview_env_ids - open_pr_ids
+puts "Identified #{preview_env_ids_to_delete.size} preview environments to delete:"
+puts preview_env_ids_to_delete.map { |pr_id| "- primer-view-components-preview-#{pr_id}" }.join("\n")
+
+preview_env_ids_to_delete.each_with_index do |pr_id, index|
+  puts "Deleting preview environment #{index + 1}/#{preview_env_ids_to_delete.size}"
+  system "az container delete -n 'primer-view-components-preview-#{pr_id}' -g primer -y &> /dev/null"
+end
+
+puts "Deleted #{preview_env_ids_to_delete.size} preview environments"

--- a/.github/workflows/demo-preview-cleanup.yml
+++ b/.github/workflows/demo-preview-cleanup.yml
@@ -1,0 +1,47 @@
+name: Demo Preview Cleanup
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # every day at noon
+
+permissions:
+  id-token: write      # This is required for requesting the OIDC JWT for authing with Azure
+  contents: read       # This is required for actions/checkout
+  pull-requests: read  # Required to list PRs
+
+# This allows one deploy workflow to interrupt another
+concurrency:
+  group: 'preview-env-cleanup @ ${{ github.head_ref || github.run_id }} for ${{ github.event.inputs.PR_NUMBER }}'
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Cleanup
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: preview
+
+    steps:
+      - uses: Azure/login@v2
+        with:
+          # excluding a client secret here will cause a login via OpenID Connect (OIDC),
+          # which prevents us from having to rotate client credentials, etc
+          client-id: "5ad1a188-b944-40eb-a2f8-cc683a6a65a0"
+          tenant-id: "398a6654-997b-47e9-b12b-9515b896b4de"
+          subscription-id: "550eb99d-d0c7-4651-a337-f53fa6520c4f"
+
+      # Do this before repo checkout to prevent running bundle install
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      # Delete web app (which will also delete the App Service plan)
+      # This will succeed even if the app doesn't exist / has already been deleted
+      - name: 'Delete App Service Apps for closed PRs'
+        run: ruby ./.github/workflows/demo-preview-cleanup.rb
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR introduces an Actions workflow that cleans up old preview environments. We delete preview envs automatically when PRs are closed or merged, but we still had a number of old ones hanging around, ostensibly from before we implemented the auto-delete Action. These old preview envs were getting [flagged](https://github.com/github/vuln-mgmt/issues/118286) by our automated security tooling. I tried to delete them manually via the Azure console but didn't have permission (what a surprise), so I decided to put in the effort to create this cleanup Action. It runs at 12 noon every day (5am PT).

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.