### PR TITLE
Missing space between Dialog Header and Body

### DIFF
--- a/.changeset/slow-impalas-relate.md
+++ b/.changeset/slow-impalas-relate.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add top spacing to Dialog::Body to avoid it being glued to the divider

--- a/app/components/primer/alpha/dialog.pcss
+++ b/app/components/primer/alpha/dialog.pcss
@@ -231,10 +231,6 @@ dialog.Overlay:not([open]) {
     padding-bottom: var(--stack-padding-condensed);
     /* stylelint-disable-next-line primer/box-shadow */
     box-shadow: inset 0 calc(var(--borderWidth-thin) * -1) var(--borderColor-default);
-
-    & + .Overlay-body {
-      padding-top: var(--stack-padding-normal);
-    }
   }
 
   &.Overlay-header--large {
@@ -296,7 +292,6 @@ dialog.Overlay:not([open]) {
 /* generic body content slot */
 .Overlay-body {
   padding: var(--stack-padding-normal);
-  padding-top: 0;
   overflow-y: auto;
   scrollbar-width: thin;
   font-size: var(--text-body-size-medium);


### PR DESCRIPTION
### What are you trying to accomplish?
Add top-padding for the Dialog body to move it closer to the React component and avoid it being glued to the divider.

### Screenshots
|  | Before | After |
|---|---|---|
| Default | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 43 59" src="https://github.com/user-attachments/assets/a7aa3e35-d731-47c5-8cdd-33f6bffc4db2"> | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 43 21" src="https://github.com/user-attachments/assets/91e483d2-deb0-4f8e-b7d9-4f5809a7b427"> |
| With large header and divider | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 44 29" src="https://github.com/user-attachments/assets/e952ab2d-7ef8-4b4a-b415-7aef7a8a4b9f"> | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 37 02" src="https://github.com/user-attachments/assets/6fc125cd-1da3-489d-b8ac-4d1872339319"> |
| Custom header | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 45 33" src="https://github.com/user-attachments/assets/90b63f0d-8178-4bc9-8f62-56bdf4170d5b"> | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 36 42" src="https://github.com/user-attachments/assets/c53ea5cf-1cdb-421b-acf8-56554991ceb7"> |
| Header filter | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 45 12" src="https://github.com/user-attachments/assets/e158979f-8888-42f8-a5cf-7378257944da"> | <img width="250" alt="Bildschirmfoto 2024-08-30 um 14 36 31" src="https://github.com/user-attachments/assets/52ff04eb-3d0a-4766-9818-280fef64959b"> |



#### List the issues that this change affects.

Closes #3008 

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
* Looking at the [React component](https://primer.style/react/storybook/?path=/story/components-dialog--default), which always has a padding-top for the body of a dialog
* In Rails this was explicitly canceled (probably because the divider is not always visible as in React??). However, this results in the body being glued to the header which looks super strange
* I am aware that the spacings are sill not optimal and consistent with the React component, however I think that this might already be a good improvement and would fix the related issue.


### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
