### PR TITLE
Remove OpenStruct from primer_octicon cop

### DIFF
--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -200,7 +200,7 @@ module RuboCop
         def kwargs(node)
           return node.arguments.last if node.arguments.size > 1
 
-          OpenStruct.new(keys: [], pairs: [], type: :hash)
+          RuboCop::AST::HashNode.new("hash")
         end
 
         def icon(node)

--- a/test/lib/rubocop/primer_octicon_test.rb
+++ b/test/lib/rubocop/primer_octicon_test.rb
@@ -273,4 +273,12 @@ class RubocopPrimerOcticonTest < CopTestCase
 
     assert_correction "primer_octicon(:icon, size: :medium)"
   end
+
+  def test_no_args
+    investigate(cop, <<-RUBY)
+      octicon
+    RUBY
+
+    assert_correction "primer_octicon"
+  end
 end


### PR DESCRIPTION
OpenStruct will not be included in modern Ruby versions, so we should not rely on it being there. This removes usage and instead builds the same class instance that is returned above.

```
irb(main):003> h = RuboCop::AST::HashNode.new(hash) => s(:hash)
irb(main):004> h.keys
=> []
irb(main):005> h.pairs
=> []
irb(main):006> h.type
=> :hash
```
