### PR TITLE
Remove OpenStruct from primer_octicon cop

### DIFF
--- a/.changeset/olive-hats-applaud.md
+++ b/.changeset/olive-hats-applaud.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove OpenStruct from primer_octicon cop

--- a/lib/rubocop/cop/primer/primer_octicon.rb
+++ b/lib/rubocop/cop/primer/primer_octicon.rb
@@ -200,7 +200,7 @@ module RuboCop
         def kwargs(node)
           return node.arguments.last if node.arguments.size > 1
 
-          OpenStruct.new(keys: [], pairs: [], type: :hash)
+          RuboCop::AST::HashNode.new("hash")
         end
 
         def icon(node)


### PR DESCRIPTION
Shamelessly copy/pasting what @HParker wrote in https://github.com/primer/view_components/pull/3052

OpenStruct will not be included in modern Ruby versions, so we should not rely on it being there. This removes usage and instead builds the same class instance that is returned above.

```
irb(main):003> h = RuboCop::AST::HashNode.new(hash) => s(:hash)
irb(main):004> h.keys
=> []
irb(main):005> h.pairs
=> []
irb(main):006> h.type
=> :hash
```
