### PR TITLE
Emit an input event primer-text-field#clearContents.

### DIFF
--- a/.changeset/quiet-vans-unite.md
+++ b/.changeset/quiet-vans-unite.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Trigger an input event when the primer-text-field clear button is pressed.

--- a/lib/primer/forms/primer_text_field.ts
+++ b/lib/primer/forms/primer_text_field.ts
@@ -57,6 +57,7 @@ export class PrimerTextFieldElement extends HTMLElement {
   clearContents() {
     this.inputElement.value = ''
     this.inputElement.focus()
+    this.inputElement.dispatchEvent(new Event('input', { bubbles: true, cancelable: true}))
   }
 
   clearError(): void {

--- a/lib/primer/forms/primer_text_field.ts
+++ b/lib/primer/forms/primer_text_field.ts
@@ -57,7 +57,7 @@ export class PrimerTextFieldElement extends HTMLElement {
   clearContents() {
     this.inputElement.value = ''
     this.inputElement.focus()
-    this.inputElement.dispatchEvent(new Event('input', { bubbles: true, cancelable: true}))
+    this.inputElement.dispatchEvent(new Event('input', { bubbles: true, cancelable: false }))
   }
 
   clearError(): void {

--- a/test/system/alpha/text_field_test.rb
+++ b/test/system/alpha/text_field_test.rb
@@ -12,8 +12,20 @@ module Alpha
       find("input[type=text]").fill_in(with: "foobar")
       assert_equal find("input[type=text]").value, "foobar"
 
+      evaluate_multiline_script(<<~JS)
+        window.inputTriggeredV = false
+
+        document.querySelector('input[type=text]').addEventListener('input', (_event) => {
+          window.inputTriggered = true
+        })
+      JS
+
+      refute page.evaluate_script("window.inputTriggered")
+
       find("button").click
       assert_equal find("input[type=text]").value, ""
+
+      assert page.evaluate_script("window.inputTriggered")
     end
 
     def test_auto_check_error

--- a/test/system/alpha/text_field_test.rb
+++ b/test/system/alpha/text_field_test.rb
@@ -13,7 +13,7 @@ module Alpha
       assert_equal find("input[type=text]").value, "foobar"
 
       evaluate_multiline_script(<<~JS)
-        window.inputTriggeredV = false
+        window.inputTriggered = false
 
         document.querySelector('input[type=text]').addEventListener('input', (_event) => {
           window.inputTriggered = true


### PR DESCRIPTION
### What are you trying to accomplish?
I want to make the [`primer-text-field`](https://github.com/primer/view_components/blob/main/lib/primer/forms/text_field.html.erb) clear button to trigger an `input` event in the field. This makes the clear button logic to behave the same way as it was deleted by the user manually.

A good example for this behaviour is to use the `primer-text-field` as a search field, triggering a background request to refresh the results when its value is changed. Without emitting the `input` event on the [`#clearContents`](https://github.com/primer/view_components/blob/96b42db2e0c0402008d2e00851e481d993b1506e/lib/primer/forms/primer_text_field.ts#L57-L60), refreshing the results would not be triggered.

A possible workaround would be to bind the background request directly on the clear button too. Unfortunately there is no simple way to bind events to the clear button, because event binding to the clear button is not possible via the [`primer-text-field`](https://github.com/primer/view_components/blob/96b42db2e0c0402008d2e00851e481d993b1506e/lib/primer/forms/text_field.html.erb#L15-L19) component declaration.

### Integration
Does not require any code change in production.

#### List the issues that this change affects.
Closes #3061

#### Risk Assessment
- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
The solution is trigger an `input` event when the `primer-text-field` clear button is clicked.

- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [X] Added/updated tests
- [ ] ~~Added/updated documentation~~
- [ ] ~~Added/updated previews (Lookbook)~~
- [X] Tested in Chrome
- [X] Tested in Firefox
- [X] Tested in Safari
- [X] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
