### PR TITLE
Add "action" to the list of data attributes that accept multiple values

### DIFF
--- a/.changeset/lemon-kiwis-learn.md
+++ b/.changeset/lemon-kiwis-learn.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Add "action" to the list of data attributes that accept multiple values in the `merge_data` helper

--- a/app/lib/primer/attributes_helper.rb
+++ b/app/lib/primer/attributes_helper.rb
@@ -4,7 +4,7 @@ module Primer
   # :nodoc:
   module AttributesHelper
     PLURAL_ARIA_ATTRIBUTES = %i[describedby labelledby].freeze
-    PLURAL_DATA_ATTRIBUTES = %i[target targets].freeze
+    PLURAL_DATA_ATTRIBUTES = %i[target targets action].freeze
 
     def aria(val, system_arguments)
       system_arguments[:"aria-#{val}"] || system_arguments.dig(:aria, val.to_sym)


### PR DESCRIPTION
### What are you trying to accomplish?
The current attribtue helper method `merge_data` has defined some keys that accept multiple values and adds some after each other devided by a space. This PR adds `action` to the list of the allowed keys.


### Integration
No


#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
