### PR TITLE
[SelectPanel] Fix tab index issue in multi-select mode

### DIFF
--- a/.changeset/curly-phones-burn.md
+++ b/.changeset/curly-phones-burn.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+[SelectPanel] Fix tab index issue in multi-select mode

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -738,6 +738,8 @@ export class SelectPanelElement extends HTMLElement {
       return true
     }
 
+    if (!this.bannerErrorElement) return false
+
     return !this.bannerErrorElement.hasAttribute('hidden')
   }
 

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -314,11 +314,7 @@ export class SelectPanelElement extends HTMLElement {
         const itemContent = this.#getItemContent(item)
         if (!itemContent) continue
 
-        if (!this.isItemHidden(item) && !setZeroTabIndex) {
-          setZeroTabIndex = true
-        } else {
-          itemContent.setAttribute('tabindex', '-1')
-        }
+        itemContent.setAttribute('tabindex', '-1')
 
         // <li> elements should not themselves be tabbable
         item.removeAttribute('tabindex')

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -1052,6 +1052,8 @@ module Alpha
       end
     end
 
+    ########## FORM TESTS ############
+
     def test_single_select_form
       visit_preview(:single_select_form, route_format: :json)
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

@kendallgassner discovered a bug in the `SelectPanel` component affecting keyboard navigation for multi-select panels. Steps to reproduce:

1. Open the panel and focus on the filter input. Press <kbd>Tab</kbd>.
2. Observe that focus moves to the first item.
3. Focus on the filter input and enter text that causes the _first item_ to be hidden, i.e. be filtered out.
4. Clear the filter input and press <kbd>Tab</kbd>.
5. Observe that focus does not move to the first item (which is unexpected).

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Video alt: A screen recording demonstrating that the first item is initially tabbable but cannot be reached after filtering.

https://github.com/user-attachments/assets/037251a6-57d8-4bc7-b123-dee36f97b344

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
