### PR TITLE
Increase the default space between form elements

### DIFF
--- a/.changeset/tricky-foxes-train.md
+++ b/.changeset/tricky-foxes-train.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Increase space between form elements

--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -60,7 +60,7 @@
 .FormControl-spacingWrapper {
   display: flex;
   flex-direction: column;
-  row-gap: 0.5rem;
+  row-gap: var(--stack-gap-normal);
 }
 
 .FormControl-horizontalGroup {


### PR DESCRIPTION
### What are you trying to accomplish?
Currently, long forms are very hard to grasp. The elements are all very close together making it hard to recognize which text belongs to which input field. In this PR, I slightly increased the space between individual elements in a form to create a clearer visual differentiation.

### Screenshots
| Before | After |
|---|---|
| <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 15 40" src="https://github.com/user-attachments/assets/dcfd6cd8-a0d9-4e42-b2e2-2df3a6c39a31"> | <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 12 34" src="https://github.com/user-attachments/assets/1aed8cb8-a94b-4398-a550-129e8c319222"> |
| <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 15 04" src="https://github.com/user-attachments/assets/84045d9d-7bbc-4337-8bb0-72104bbe4803"> | <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 18 38" src="https://github.com/user-attachments/assets/f94e030f-2ad1-4417-84dd-04f2797299bf"> |
| <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 16 33" src="https://github.com/user-attachments/assets/61eab2b3-8498-460e-a0f0-5f62792f652f">  | <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 13 07" src="https://github.com/user-attachments/assets/32c6dca7-f22e-45b9-a0bb-31f9cba06700"> |
| <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 14 39" src="https://github.com/user-attachments/assets/b45db885-1245-44b2-8a56-7d71bcfe511f"> | <img width="400" alt="Bildschirmfoto 2024-09-13 um 09 13 41" src="https://github.com/user-attachments/assets/b41a273a-2b3f-46cd-b8d0-755fd726e46a"> |


### Integration
No

#### List the issues that this change affects.
Closes #3042

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?
Increase the space between form elements by using the `--stack-gap-normal` variable for the `.FormControl-spacingWrapper` instead of a custom space. 

In the linked issue it was discussed whether we should touch the spacings on the form groups instead. I decided to not touch the groups here, as imho the framework should be able to render a good looking form without needing to wrap every element into an individual group.


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
