### PR TITLE
Track and stop running processes to make it easier to run Playwright in dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
     - name: Run Playwright tests
       id: playwright-run
       continue-on-error: true
-      run: npx playwright test --workers 6
+      run: ./script/run-playwright
     - id: auto-commit
       uses: stefanzweifel/git-auto-commit-action@v5
       with:

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-vite: cd demo; bin/vite dev
-css: cd demo; npm run build:css -- --watch
+vite: cd demo; script/start-vite
+css: cd demo; script/start-css
 web: cd demo; bin/rails s -p 4000

--- a/demo/script/start-css
+++ b/demo/script/start-css
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+echo $$ > tmp/pids/css.pid
+exec npm run build:css -- --watch

--- a/demo/script/start-vite
+++ b/demo/script/start-vite
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+echo $$ > tmp/pids/vite.pid
+exec bin/vite dev

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,15 +23,15 @@ const config: PlaywrightTestConfig = {
     baseURL: 'http://127.0.0.1:4000',
     browserName: 'chromium',
     headless: true,
-    screenshot: 'only-on-failure'
+    screenshot: 'only-on-failure',
   },
   expect: {
     toHaveScreenshot: {
-      animations: 'disabled'
+      animations: 'disabled',
     },
     toMatchSnapshot: {
-      threshold: 0.1
-    }
+      threshold: 0.1,
+    },
   },
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
@@ -39,13 +39,13 @@ const config: PlaywrightTestConfig = {
   reporter: [
     ['line'],
     ['html', {open: 'never', outputFolder: path.join(__dirname, '.playwright/report')}],
-    ['json', {outputFile: path.join(__dirname, '.playwright', 'results.json')}]
+    ['json', {outputFile: path.join(__dirname, '.playwright', 'results.json')}],
   ],
 
   webServer: {
-    command: 'overmind start',
-    port: 4000
-  }
+    command: 'script/dev',
+    port: 4000,
+  },
 }
 
 export default config

--- a/script/dev
+++ b/script/dev
@@ -18,6 +18,8 @@ bundle check || bundle install
 npm install --ignore-scripts
 popd
 
+./script/stop-existing-processes
+
 while [[ "$#" > 0 ]]; do case $1 in
   -d|--debug) debug="1"; shift;;
 esac; done

--- a/script/run-playwright
+++ b/script/run-playwright
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+./script/stop-existing-processes
+exec npx playwright test --workers 6

--- a/script/stop-existing-processes
+++ b/script/stop-existing-processes
@@ -1,0 +1,17 @@
+#! /bin/bash
+
+overmind stop
+rm .overmind.sock
+
+pidfiles=(demo/tmp/pids/css.pid demo/tmp/pids/vite.pid demo/tmp/pids/server.pid)
+
+for pidfile in "${pidfiles[@]}"
+do
+  if [ -f $pidfile ]; then
+    pid=$(cat $pidfile)
+    name=$(basename "$pidfile" .pid)
+    echo "Stopping existing $name process with pid $pid"
+    kill -9 $pid
+    rm $pidfile
+  fi
+done


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I have continually been annoyed that Playwright doesn't shut down the web server correctly and leaves zombie processes lying around. This PR adds several scripts that track the PIDs of the vite, css, and rails processes, then another to stop them before running Playwright tests. This is much easier than finding and killing zombie processes with `lsof`.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production, this change is dev-only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.