### PR TITLE
Remove importmap-rails dependency

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -48,8 +48,6 @@ group :development do
   gem "spring", "~> 4.2"
   gem "spring-watcher-listen", "~> 2.1"
   gem "hotwire-livereload", "~> 1.4"
-  # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-  gem "importmap-rails"
 
   # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
   gem "turbo-rails"

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -136,10 +136,6 @@ GEM
     http-form_data (2.3.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    importmap-rails (2.0.1)
-      actionpack (>= 6.0.0)
-      activesupport (>= 6.0.0)
-      railties (>= 6.0.0)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -368,7 +364,6 @@ DEPENDENCIES
   cssbundling-rails (~> 1.4)
   foreman
   hotwire-livereload (~> 1.4)
-  importmap-rails
   kind-rb (~> 0.1)
   kuby-azure (~> 0.4.0)
   kuby-core (~> 0.20)


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Remove the `importmap-rails` dependency, since we don't use import maps.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.