### PR TITLE
Allow setting custom values on submit buttons

### DIFF
--- a/.changeset/cuddly-games-prove.md
+++ b/.changeset/cuddly-games-prove.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Allow setting custom values on submit buttons.

--- a/app/lib/primer/forms/button.rb
+++ b/app/lib/primer/forms/button.rb
@@ -54,11 +54,14 @@ module Primer
       private
 
       def tag_attributes
+        attrs = { name: @input.name }
+        attrs[:value] = @input.value if @input.value
+
         case @type
         when :submit
-          ButtonAttributeGenerator.submit_tag_attributes(@input.label, name: @input.name)
+          ButtonAttributeGenerator.submit_tag_attributes(@input.label, **attrs)
         else
-          ButtonAttributeGenerator.button_tag_attributes(@input.label, name: @input.name)
+          ButtonAttributeGenerator.button_tag_attributes(@input.label, **attrs)
         end
       end
     end

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -246,6 +246,10 @@ module Primer
           @input_arguments[:id]
         end
 
+        def value
+          @input_arguments[:value]
+        end
+
         # :nocov:
         def name
           raise_for_abstract_method!(__method__)

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -309,7 +309,7 @@ module Primer
         def caption_template_name
           return nil unless name
 
-          @caption_template_name ||= if respond_to?(:value)
+          @caption_template_name ||= if respond_to?(:value) && value.present?
                                        :"#{name}_#{value}"
                                      else
                                        name.to_sym

--- a/test/lib/primer/forms/submit_button_input_test.rb
+++ b/test/lib/primer/forms/submit_button_input_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::SubmitButtonInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_uses_name_as_value_by_default
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |submit_button_form|
+          submit_button_form.submit(name: :foo, label: "Foo")
+        end
+      end
+    end
+
+    assert_selector "button[type=submit][value=Foo]"
+  end
+
+  def test_allows_overriding_value
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |submit_button_form|
+          submit_button_form.submit(name: :foo, label: "Foo", value: "bar")
+        end
+      end
+    end
+
+    assert_selector "button[type=submit][value=bar]"
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?

It's currently not possible to set a custom value on a submit button in the Primer forms framework, an oversight this PR addresses.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/3129

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.