### PR TITLE
reduce cost of style calc+layout in --dialog-scrollgutter

### DIFF
--- a/.changeset/wicked-bananas-tie.md
+++ b/.changeset/wicked-bananas-tie.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Remove dialog-scrollgutter setting from hot-path, for improved performance

--- a/app/components/primer/alpha/dialog.pcss
+++ b/app/components/primer/alpha/dialog.pcss
@@ -8,8 +8,22 @@
 
 /* Overlay */
 
+/* The --dialog-scrollgutter property is used only on the body element to
+ * simulate scrollbar-gutter:stable. This property is not and should not
+ * be used elsewhere in the DOM. There is a performance penalty to
+ * setting inherited properties which can cause a large style recalc to
+ * occur, so it benefits us to prevent inheritance for this property.
+ * See https://web.dev/blog/at-property-performance
+ */
+@property --dialog-scrollgutter {
+  initial-value: 0;
+  inherits: false;
+  syntax: "<length>";
+}
+
 /* TODO: One day this can be :has(:modal), when it is better supported */
 body.has-modal {
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   padding-right: var(--dialog-scrollgutter) !important;
   overflow: hidden !important;
 }
@@ -350,6 +364,7 @@ dialog.Overlay:not([open]) {
   &:hover,
   &:focus {
     background-color: var(--button-default-bgColor-hover);
+    /* stylelint-disable-next-line primer/colors */
     border: var(--borderWidth-thin) solid var(--control-bgColor-hover);
   }
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In our mob pairing session called "Making Dotcom Fast" we ran into an issue where the Primer Dialog component is causing an expensive recalc operation on every page load; this is due to it setting the `--dialog-scrollgutter` css property, which is a property derived from the `innerWidth` & `body.clientWidth` properties.

In order to prevent this cost on page load, we decided to move the operation to the first `click` event that can be handled by the `dialogInvokerButtonHandler`. This moves the cost of the recalc away from document load to document click:

![image](https://github.com/user-attachments/assets/2dcefeea-bd4a-431a-b69f-0cab3e7ff992)

![image](https://github.com/user-attachments/assets/e62ebc7d-0a04-4402-8e0e-e9c5a2f72fc4)

However this change alone still leaves the recalc cost during the first click event which is still costly and could impact INP. 

![image](https://github.com/user-attachments/assets/363414b9-ff6f-4775-a6b8-3b3f99abd7ff)

So we added some CSS - inspired by [this article on the `@property` rule and how it can lower recalc costs by disabling inheritance](https://web.dev/blog/at-property-performance) - which is perfect for this use case. This reduced recalc cost from ~70-90ms on my machine to under 2ms:

![image](https://github.com/user-attachments/assets/e9cc92e3-1ef1-4b1d-ac9b-f59a386c3f7b)

We've _not_ moved the code away from the hot-path, and into the click event listener, due to compat risk with the Dialog element and its use in dotcom. This can come at a later date, perhaps.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->
(See above perf traces)

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.

/cc the commit co-authors:
@ansballard, @AdamShwert, @arelia, @arielvalentin, @chrisgavin, @Cbodfield, @composerinteralia, @garman, @dgreif, @erinnachen, @georgebrock, @jibrang, @jfuchs, @khiga8, @manuelpuyol, @mattcosta7, @another-mattr, @MelissaPastore, @theinterned, @phillmv, @Raffo, @cheshire137, @srt32