### PR TITLE
Allow form groups to accept system arguments

### DIFF
--- a/.changeset/hip-deers-rhyme.md
+++ b/.changeset/hip-deers-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Allow form groups to accept system arguments

--- a/app/lib/primer/forms/base_component.rb
+++ b/app/lib/primer/forms/base_component.rb
@@ -61,14 +61,6 @@ module Primer
         self.class.compile! unless self.class.instance_methods(false).include?(:render_template)
         render_template
       end
-
-      def content_tag_if(condition, tag, **kwargs, &block)
-        if condition
-          content_tag(tag, **kwargs, &block)
-        else
-          capture(&block)
-        end
-      end
     end
   end
 end

--- a/app/lib/primer/forms/group.html.erb
+++ b/app/lib/primer/forms/group.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag_if(horizontal?, :div, class: "FormControl-horizontalGroup") do %>
+<%= render(Primer::Box.new(**@system_arguments)) do %>
   <% @inputs.each do |input| %>
     <%= render(input.to_component) %>
   <% end %>

--- a/app/lib/primer/forms/group.rb
+++ b/app/lib/primer/forms/group.rb
@@ -17,6 +17,11 @@ module Primer
         @form = form
         @layout = layout
         @system_arguments = system_arguments
+
+        @system_arguments[:classes] = class_names(
+          @system_arguments.delete(:classes),
+          "FormControl-horizontalGroup" => horizontal?
+        )
       end
 
       def horizontal?

--- a/test/lib/primer/forms/group_input_test.rb
+++ b/test/lib/primer/forms/group_input_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::GroupInputTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_group_accepts_system_arguments
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |sys_args_form|
+          sys_args_form.group(layout: :horizontal, border: true, p: 1) do |group|
+            group.text_field(name: :first_name, label: "First name")
+            group.text_field(name: :last_name, label: "Last name")
+          end
+        end
+      end
+    end
+
+    assert_selector ".FormControl-horizontalGroup.border.p-1"
+  end
+end

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -297,12 +297,6 @@ class Primer::FormsTest < Minitest::Test
     assert_selector "primer-text-field.FormControl"
   end
 
-  def test_siblings_are_form_controls_when_including_a_multi_input
-    render_preview :multi_input_form
-
-    assert_selector ".FormControl-radio-group-wrap + .FormControl"
-  end
-
   def test_toggle_switch_button_labelled_by_label
     render_preview(:example_toggle_switch_form)
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR modifies Primer forms' group component to accept system arguments.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/primer/view_components/issues/3142

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
