### PR TITLE
Fix caption templates

### DIFF
--- a/app/forms/caption_template_form.rb
+++ b/app/forms/caption_template_form.rb
@@ -18,5 +18,11 @@ class CaptionTemplateForm < ApplicationForm
       age_radios.radio_button(value: "young", label: "10-15")
       age_radios.radio_button(value: "middle_aged", label: "16-21")
     end
+
+    name_form.check_box_group(name: "places", label: "Cool places") do |check_group|
+      check_group.check_box(value: "lopez", label: "Lopez Island")
+      check_group.check_box(value: "bellevue", label: "Bellevue")
+      check_group.check_box(value: "seattle", label: "Seattle")
+    end
   end
 end

--- a/app/forms/caption_template_form/places_bellevue_caption.html.erb
+++ b/app/forms/caption_template_form/places_bellevue_caption.html.erb
@@ -1,0 +1,1 @@
+<span>Bellevue caption</span>

--- a/app/forms/caption_template_form/places_lopez_caption.html.erb
+++ b/app/forms/caption_template_form/places_lopez_caption.html.erb
@@ -1,0 +1,1 @@
+<span>Lopez caption</span>

--- a/app/forms/caption_template_form/places_seattle_caption.html.erb
+++ b/app/forms/caption_template_form/places_seattle_caption.html.erb
@@ -1,0 +1,1 @@
+<span>Seattle caption</span>

--- a/app/lib/primer/forms/dsl/check_box_input.rb
+++ b/app/lib/primer/forms/dsl/check_box_input.rb
@@ -50,14 +50,10 @@ module Primer
           false
         end
 
-        private
-
-        def caption_template_name
-          @caption_template_name ||= if @scheme == :array
-                                       :"#{name}_#{value}"
-                                     else
-                                       name.to_sym
-                                     end
+        def values_disambiguate_template_names?
+          # Check boxes submitted as an array all have the same name, so we return true here
+          # to ensure different caption templates can be attached to individual check box inputs.
+          @scheme == :array
         end
       end
     end

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -300,6 +300,14 @@ module Primer
           ""
         end
 
+        # Whether or not the `value:` argument should be used to determine the caption template
+        # for a given field. This is useful in especially radio button groups where each option
+        # has the same name but a different value. Check box groups where the values are submitted
+        # as an array also use this feature, since each check box also has the same name.
+        def values_disambiguate_template_names?
+          false
+        end
+
         private
 
         def input_data
@@ -309,7 +317,7 @@ module Primer
         def caption_template_name
           return nil unless name
 
-          @caption_template_name ||= if respond_to?(:value) && value.present?
+          @caption_template_name ||= if values_disambiguate_template_names? && respond_to?(:value) && value.present?
                                        :"#{name}_#{value}"
                                      else
                                        name.to_sym

--- a/app/lib/primer/forms/dsl/radio_button_input.rb
+++ b/app/lib/primer/forms/dsl/radio_button_input.rb
@@ -42,6 +42,10 @@ module Primer
         def supports_validation?
           false
         end
+
+        def values_disambiguate_template_names?
+          true
+        end
       end
     end
   end

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -61,10 +61,13 @@ class Primer::FormsTest < Minitest::Test
     assert_selector ".FormControl-caption .color-fg-danger", text: "Check only if you are cool."
     assert_selector ".FormControl-caption .color-fg-danger", text: "A young thing."
     assert_selector ".FormControl-caption .color-fg-danger", text: "No longer a spring chicken."
+    assert_selector ".FormControl-caption", text: "Lopez caption"
+    assert_selector ".FormControl-caption", text: "Bellevue caption"
+    assert_selector ".FormControl-caption", text: "Seattle caption"
   end
 
-  def test_the_input_is_described_by_the_caption_when_caption_templates_are_used
-    num_inputs = 4
+  def test_inputs_are_described_by_their_captions_when_caption_templates_are_used
+    num_inputs = 7
     render_preview :caption_template_form
 
     caption_ids = page


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

A [recent PR](https://github.com/primer/view_components/pull/3141) broke caption templates for certain types of form inputs, causing them not to render at all. The issue was caused by always using the input's configured `value:` to determine the caption template path, where previously only the `name:` was used. In cases where the `value:` was provided for eg. a text input, the code would look for the wrong caption template and, finding no template, would render no caption.

#### Context

There are two input types for which disambiguating caption template paths by using the `value:` is necessary: radio button groups and check box groups (but only check box groups submitted as an array). This is because, in each of these cases, the same name is used for each check box or radio button element. In order to know which caption template to render, we also take the `value:` into consideration when determining the caption template path. For example, a radio button group named "places" that has a child radio button with a value of "seattle" will look for a caption template named places_seattle_caption.html.erb.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Rather than use the `value:` to determine the caption template unconditionally, I added the `values_disambiguate_template_names?` method to all `Input` classes. This method is called by `caption_template_name` to determine if the caption template path should be constructed using the `value:` argument. Doing so should preserve the behavior introduced in https://github.com/primer/view_components/pull/3141 that allows submit buttons to be configured with a value while also only allowing value-based template caption paths to be used for the appropriate input types.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.