### PR TITLE
[SelectPanel] Fix issue causing no error banner to appear when there are no matches

### DIFF
--- a/.changeset/quiet-fans-repeat.md
+++ b/.changeset/quiet-fans-repeat.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+[SelectPanel] Fix issue causing no error banner to appear when there are no matches

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -752,8 +752,8 @@ export class SelectPanelElement extends HTMLElement {
   #setErrorState(type: ErrorStateType) {
     let errorElement = this.fragmentErrorElement
 
-    if (type === ErrorStateType.BODY) {
-      this.fragmentErrorElement?.removeAttribute('hidden')
+    if (type === ErrorStateType.BODY && this.fragmentErrorElement) {
+      this.fragmentErrorElement.removeAttribute('hidden')
       this.bannerErrorElement.setAttribute('hidden', '')
     } else {
       errorElement = this.bannerErrorElement

--- a/previews/primer/alpha/select_panel_preview.rb
+++ b/previews/primer/alpha/select_panel_preview.rb
@@ -227,12 +227,15 @@ module Primer
       # @snapshot interactive
       # @param open_on_load toggle
       # @param banner_scheme [Symbol] select [danger, warning]
+      # @param show_results toggle
       def remote_fetch_filter_failure(
         open_on_load: false,
-        banner_scheme: :danger
+        banner_scheme: :danger,
+        show_results: true
       )
         render_with_template(locals: {
           open_on_load: open_on_load,
+          show_results: show_results,
           system_arguments: {
             # .to_sym workaround for https://github.com/lookbook-hq/lookbook/issues/640
             banner_scheme: banner_scheme.to_sym

--- a/previews/primer/alpha/select_panel_preview/remote_fetch_filter_failure.html.erb
+++ b/previews/primer/alpha/select_panel_preview/remote_fetch_filter_failure.html.erb
@@ -3,7 +3,8 @@
 <%= render(Primer::Alpha::SelectPanel.new(
   data: { interaction_subject: subject_id },
   # passing a uuid here causes the request to succeed the first time and fail all subsequent times
-  src: select_panel_items_path(fail: "true", uuid: SecureRandom.uuid),
+  # set show_results to false to simulate an initial load with no items
+  src: select_panel_items_path(show_results: show_results.to_s, fail: "true", uuid: SecureRandom.uuid),
   fetch_strategy: :remote,
   open_on_load: open_on_load,
   **system_arguments

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -1046,6 +1046,25 @@ module Alpha
       refute_selector "[data-target='select-panel.fragmentErrorElement']"
     end
 
+    def test_no_results_filter_failure
+      visit_preview(:remote_fetch_filter_failure, show_results: false)
+
+      wait_for_items_to_load do
+        click_on_invoker_button
+      end
+
+      # no items on initial load
+      assert_selector "select-panel", text: "No results found"
+
+      wait_for_items_to_load do
+        filter_results(query: "foobar")
+      end
+
+      # only the banner-based error message should appear
+      assert_selector "[data-target='select-panel.bannerErrorElement']", text: "Sorry, something went wrong"
+      refute_selector "[data-target='select-panel.fragmentErrorElement']"
+    end
+
     def test_remote_fetch_clears_input_on_close
       visit_preview(:remote_fetch)
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The `SelectPanel` component has a bug preventing the error banner from appearing if the previous filter operation produced no results.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

#### Before

https://github.com/user-attachments/assets/3f73858c-3391-4be3-9a95-31a72522c832

#### After

https://github.com/user-attachments/assets/8029dbc0-840e-478e-9462-59e8fa368197

### Integration

<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/4260

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.