### PR TITLE
Don't instantiate or use Regexp when `string.start_with?` will do

### DIFF
--- a/.changeset/chilly-rocks-compare.md
+++ b/.changeset/chilly-rocks-compare.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Switch Ruby match from Regexps to String's starts_with method

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -18,18 +18,18 @@ module Primer
 
       # Replacements for some classnames that end up being a different argument key
       REPLACEMENT_KEYS = {
-        Regexp.new("^f") => "font_size",
-        Regexp.new("^anim") => "animation",
-        Regexp.new("^v-align") => "vertical_align",
-        Regexp.new("^d") => "display",
-        Regexp.new("^wb") => "word_break",
-        Regexp.new("^v") => "visibility",
-        Regexp.new("^width") => "w",
-        Regexp.new("^height") => "h",
-        Regexp.new("^color-bg") => "bg",
-        Regexp.new("^color-border") => "border_color",
-        Regexp.new("^color-fg") => "color",
-        Regexp.new("^rounded") => "border_radius"
+        "f" => "font_size",
+        "anim" => "animation",
+        "v-align" => "vertical_align",
+        "d" => "display",
+        "wb" => "word_break",
+        "v" => "visibility",
+        "width" => "w",
+        "height" => "h",
+        "color-bg" => "bg",
+        "color-border" => "border_color",
+        "color-fg" => "color",
+        "rounded" => "border_radius"
       }.freeze
 
       SUPPORTED_KEY_CACHE = Hash.new { |h, k| h[k] = !UTILITIES[k].nil? }
@@ -190,7 +190,7 @@ module Primer
 
         def infer_selector_key(selector)
           REPLACEMENT_KEYS.each do |k, v|
-            return v.to_sym if selector.match?(k)
+            return v.to_sym if selector.starts_with?(k)
           end
           selector.split("-").first.to_sym
         end

--- a/lib/primer/classify/utilities.rb
+++ b/lib/primer/classify/utilities.rb
@@ -190,7 +190,7 @@ module Primer
 
         def infer_selector_key(selector)
           REPLACEMENT_KEYS.each do |k, v|
-            return v.to_sym if selector.starts_with?(k)
+            return v.to_sym if selector.start_with?(k)
           end
           selector.split("-").first.to_sym
         end

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -55,7 +55,7 @@ namespace :utilities do
         next unless classname.start_with?(k)
 
         key = v
-        classname.sub!(Regexp.new("#{k}-"), "")
+        classname.sub!(Regexp.new("\A#{k}-"), "")
       end
 
       # If we didn't find a replacement, grab the first text before hyphen

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -52,7 +52,7 @@ namespace :utilities do
 
       # Look for a replacement key
       Primer::Classify::Utilities::REPLACEMENT_KEYS.each do |k, v|
-        next unless classname.match?(Regexp.new(k))
+        next unless classname.start_with?(k)
 
         key = v
         classname.sub!(Regexp.new("#{k}-"), "")

--- a/test/lib/css_coverage_test.rb
+++ b/test/lib/css_coverage_test.rb
@@ -29,7 +29,7 @@ class CssCoverageTest < Minitest::Test
     # Cleanup the data to make sure it's only one selector per item
     @css_data = @css_data
                 .flat_map { |c| c.gsub(/(\w)\./, '\1 .').split(/[\s:\[+>]+/) }
-                .select { |c| c.starts_with?(".") }
+                .select { |c| c.start_with?(".") }
                 .uniq
   end
 


### PR DESCRIPTION
### What are you trying to accomplish?

While doing some unrelated profiling work in GitHub, I noticed `infer_selector_key` coming up often. I looked at the source because I was curious, and saw it was using this `Hash` of a bunch of `Regexp`. At first I though the goal in `infer_selector_key` was to gsub (replace) the contents of `selector`, but it looks like it just returns the value of the hash if it matches. `Regexp` instances have a little bit more overhead than Strings, especially when String's `start_with?` is written all in C. 

Generally, we don't need to wrap things in Regexp unless we want to do something complex with capture groups, etc., in Ruby.

Before making a change, I wrote a benchmark using benchmark-ips (which figures out how many Iterations-Per-Second the blocks of code can do, on its own, so I didn't have to pick statistically-significant iteration counts) and this script just isolates out the logic of the change we want to use --

```ruby
require "benchmark/ips"

REPLACEMENT_KEYS = {
  # NOTE: Copied from `lib/primer/classify/utilities.r`
  # Elided here for brevity
}.freeze

Benchmark.ips do |x|
  x.report("regexp match - case matches") do
    "rounded_border".match?(REPLACEMENT_KEYS.keys.last)
  end

  x.report("regexp match - case does not match") do
    "font".match?(REPLACEMENT_KEYS.keys.last)
  end

  x.report("string starts_with - case matches") do
    "rounded_border".start_with?("rounded")
  end

  x.report("string starts_with - case does not match") do
    "font".start_with?("rounded")
  end

  x.compare!
end
```

And the outputs:
```
$ safe-ruby script/benchmark-matt.rb
ruby 3.3.5 (2024-09-04 revision 4f143c3038) [x86_64-linux]
Warming up --------------------------------------
regexp match - case matches
                       382.111k i/100ms
regexp match - case does not match
                       480.783k i/100ms
string starts_with - case matches
                       613.842k i/100ms
string starts_with - case does not match
                       663.965k i/100ms
Calculating -------------------------------------
regexp match - case matches
                          3.887M (± 2.2%) i/s -     19.488M in   5.015503s
regexp match - case does not match
                          4.770M (± 1.7%) i/s -     24.039M in   5.040564s
string starts_with - case matches
                          6.336M (± 1.7%) i/s -     31.920M in   5.039189s
string starts_with - case does not match
                          6.641M (± 2.0%) i/s -     33.862M in   5.100539s

Comparison:
string starts_with - case does not match:  6641407.3 i/s
string starts_with - case matches:  6336044.9 i/s - 1.05x  slower
regexp match - case does not match:  4770427.1 i/s - 1.39x  slower
regexp match - case matches:  3887307.8 i/s - 1.71x  slower
```

As you can see, switching to a string and using `start_with` is faster when we isolate out looping over the Hash, etc.

On the code I was looking at, the `start_with?` version getting called 1306 times should result in roughly a 3ms faster execution. Not huge, but since I could see this improvement, I made it.

The only place where Regexp.new was actually needed as in `lib/tasks/utilities.rake` where we do a sub, but it was also essentially wrapping the keys and therefore calling `Regexp.new(Regexp.new("^f"))` (or whatever the value inside was. The rake task probably doesn't get called as much as the class is used, but we should still benefit here.

### Integration

No, this should not change any usage of `infer_selector_key`.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/primer/view_components/issues/3176

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?

See above with benchmarks.

### Anything you want to highlight for special attention from reviewers?

### Accessibility

N/A should not change functionality so should not affect accessibility

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
