### PR TITLE
[SelectPanel] Don't clear selection if input field doesn't exist

### DIFF
--- a/.changeset/silent-wasps-peel.md
+++ b/.changeset/silent-wasps-peel.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+[SelectPanel] Don't clear selection if input field doesn't exist

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -465,10 +465,13 @@ export class SelectPanelElement extends HTMLElement {
       this.dialog.removeAttribute('data-ready')
       this.invokerElement?.setAttribute('aria-expanded', 'false')
       // When we close the dialog, clear the filter input
-      const fireSearchEvent = this.filterInputTextField.value.length > 0
-      this.filterInputTextField.value = ''
-      if (fireSearchEvent) {
-        this.filterInputTextField.dispatchEvent(new Event('input'))
+
+      if (this.filterInputTextField) {
+        const fireSearchEvent = this.filterInputTextField.value.length > 0
+        this.filterInputTextField.value = ''
+        if (fireSearchEvent) {
+          this.filterInputTextField.dispatchEvent(new Event('input'))
+        }
       }
 
       this.dispatchEvent(


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

We tried to ship v0.35 yesterday and ran into a few javascript errors caused by https://github.com/primer/view_components/pull/3095. This PR addresses the problem.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production - this is a bugfix for the current release.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I added a guard to make sure the filter input text field exists.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.