### PR TITLE
Upgrade kuby-core

### DIFF
--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/getkuby/kuby-core.git
-  revision: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
-  ref: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
-  specs:
-    kuby-core (0.20.1)
-      colorize (~> 0.8)
-      docker-remote (~> 0.8)
-      gli (~> 2.21)
-      helm-cli (~> 0.3)
-      krane (~> 2.0)
-      kube-dsl (~> 0.7)
-      kubernetes-cli (~> 0.4)
-      kuby-cert-manager (~> 0.4)
-      kuby-crdb (~> 0.2)
-      railties (>= 5.1)
-      rake
-      rouge (~> 3.0)
-
 PATH
   remote: ..
   specs:
@@ -194,6 +175,19 @@ GEM
       kube-dsl (~> 0.1)
     kuby-cert-manager (0.4.0)
       kube-dsl (~> 0.1)
+    kuby-core (0.20.2)
+      colorize (~> 0.8)
+      docker-remote (~> 0.8)
+      gli (~> 2.21)
+      helm-cli (~> 0.3)
+      krane (~> 2.0)
+      kube-dsl (~> 0.7)
+      kubernetes-cli (~> 0.4)
+      kuby-cert-manager (~> 0.4)
+      kuby-crdb (~> 0.2)
+      railties (>= 5.1)
+      rake
+      rouge (~> 3.0)
     kuby-crdb (0.3.0)
       kube-dsl (~> 0.7)
     kuby-kind (0.2.3)
@@ -372,7 +366,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.4)
   kind-rb (~> 0.1)
   kuby-azure (~> 0.4.0)
-  kuby-core!
+  kuby-core (~> 0.20)
   kuby-kind (~> 0.2)
   listen
   lookbook (~> 2.3.2)

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: https://github.com/getkuby/kuby-core.git
+  revision: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
+  ref: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
+  specs:
+    kuby-core (0.20.1)
+      colorize (~> 0.8)
+      docker-remote (~> 0.8)
+      gli (~> 2.21)
+      helm-cli (~> 0.3)
+      krane (~> 2.0)
+      kube-dsl (~> 0.7)
+      kubernetes-cli (~> 0.4)
+      kuby-cert-manager (~> 0.4)
+      kuby-crdb (~> 0.2)
+      railties (>= 5.1)
+      rake
+      rouge (~> 3.0)
+
 PATH
   remote: ..
   specs:
@@ -175,19 +194,6 @@ GEM
       kube-dsl (~> 0.1)
     kuby-cert-manager (0.4.0)
       kube-dsl (~> 0.1)
-    kuby-core (0.20.1)
-      colorize (~> 0.8)
-      docker-remote (~> 0.8)
-      gli (~> 2.21)
-      helm-cli (~> 0.3)
-      krane (~> 2.0)
-      kube-dsl (~> 0.7)
-      kubernetes-cli (~> 0.4)
-      kuby-cert-manager (~> 0.4)
-      kuby-crdb (~> 0.2)
-      railties (>= 5.1)
-      rake
-      rouge (~> 3.0)
     kuby-crdb (0.3.0)
       kube-dsl (~> 0.7)
     kuby-kind (0.2.3)
@@ -366,7 +372,7 @@ DEPENDENCIES
   hotwire-livereload (~> 1.4)
   kind-rb (~> 0.1)
   kuby-azure (~> 0.4.0)
-  kuby-core (~> 0.20)
+  kuby-core!
   kuby-kind (~> 0.2)
   listen
   lookbook (~> 2.3.2)

--- a/demo/gemfiles/kuby.gemfile
+++ b/demo/gemfiles/kuby.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "kuby-core", github: "getkuby/kuby-core", ref: "20df458e8e9679d52f7da8f7e0f756d9a087b21e" # "~> 0.20"
+gem "kuby-core", "~> 0.20"
 gem "kuby-azure", "~> 0.4.0"
 gem "kuby-kind", "~> 0.2"
 gem "kind-rb", "~> 0.1"

--- a/demo/gemfiles/kuby.gemfile
+++ b/demo/gemfiles/kuby.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "kuby-core", "~> 0.20"
+gem "kuby-core", github: "getkuby/kuby-core", ref: "20df458e8e9679d52f7da8f7e0f756d9a087b21e" # "~> 0.20"
 gem "kuby-azure", "~> 0.4.0"
 gem "kuby-kind", "~> 0.2"
 gem "kind-rb", "~> 0.1"

--- a/demo/gemfiles/kuby.gemfile.lock
+++ b/demo/gemfiles/kuby.gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: https://github.com/getkuby/kuby-core.git
+  revision: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
+  ref: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
+  specs:
+    kuby-core (0.20.1)
+      colorize (~> 0.8)
+      docker-remote (~> 0.8)
+      gli (~> 2.21)
+      helm-cli (~> 0.3)
+      krane (~> 2.0)
+      kube-dsl (~> 0.7)
+      kubernetes-cli (~> 0.4)
+      kuby-cert-manager (~> 0.4)
+      kuby-crdb (~> 0.2)
+      railties (>= 5.1)
+      rake
+      rouge (~> 3.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -123,19 +142,6 @@ GEM
       kube-dsl (~> 0.1)
     kuby-cert-manager (0.4.0)
       kube-dsl (~> 0.1)
-    kuby-core (0.20.1)
-      colorize (~> 0.8)
-      docker-remote (~> 0.8)
-      gli (~> 2.21)
-      helm-cli (~> 0.3)
-      krane (~> 2.0)
-      kube-dsl (~> 0.7)
-      kubernetes-cli (~> 0.4)
-      kuby-cert-manager (~> 0.4)
-      kuby-crdb (~> 0.2)
-      railties (>= 5.1)
-      rake
-      rouge (~> 3.0)
     kuby-crdb (0.2.0)
       kube-dsl (~> 0.7)
     kuby-kind (0.2.1)
@@ -228,7 +234,7 @@ PLATFORMS
 DEPENDENCIES
   kind-rb (~> 0.1)
   kuby-azure (~> 0.4.0)
-  kuby-core (~> 0.20)
+  kuby-core!
   kuby-kind (~> 0.2)
   pry-byebug
 

--- a/demo/gemfiles/kuby.gemfile.lock
+++ b/demo/gemfiles/kuby.gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: https://github.com/getkuby/kuby-core.git
-  revision: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
-  ref: 20df458e8e9679d52f7da8f7e0f756d9a087b21e
-  specs:
-    kuby-core (0.20.1)
-      colorize (~> 0.8)
-      docker-remote (~> 0.8)
-      gli (~> 2.21)
-      helm-cli (~> 0.3)
-      krane (~> 2.0)
-      kube-dsl (~> 0.7)
-      kubernetes-cli (~> 0.4)
-      kuby-cert-manager (~> 0.4)
-      kuby-crdb (~> 0.2)
-      railties (>= 5.1)
-      rake
-      rouge (~> 3.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -142,6 +123,19 @@ GEM
       kube-dsl (~> 0.1)
     kuby-cert-manager (0.4.0)
       kube-dsl (~> 0.1)
+    kuby-core (0.20.2)
+      colorize (~> 0.8)
+      docker-remote (~> 0.8)
+      gli (~> 2.21)
+      helm-cli (~> 0.3)
+      krane (~> 2.0)
+      kube-dsl (~> 0.7)
+      kubernetes-cli (~> 0.4)
+      kuby-cert-manager (~> 0.4)
+      kuby-crdb (~> 0.2)
+      railties (>= 5.1)
+      rake
+      rouge (~> 3.0)
     kuby-crdb (0.2.0)
       kube-dsl (~> 0.7)
     kuby-kind (0.2.1)
@@ -234,7 +228,7 @@ PLATFORMS
 DEPENDENCIES
   kind-rb (~> 0.1)
   kuby-azure (~> 0.4.0)
-  kuby-core!
+  kuby-core (~> 0.20)
   kuby-kind (~> 0.2)
   pry-byebug
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR bumps kuby-core so preview deploys work again.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Bumped to v0.20.2, which includes this fix: https://github.com/getkuby/kuby-core/pull/138

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.