### PR TITLE
Prevent hidden inputs from taking up space on the page

### DIFF
--- a/.changeset/two-badgers-suffer.md
+++ b/.changeset/two-badgers-suffer.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Prevent hidden inputs from taking up space on the page

--- a/app/forms/horizontal_form.rb
+++ b/app/forms/horizontal_form.rb
@@ -3,6 +3,8 @@
 # :nodoc:
 class HorizontalForm < ApplicationForm
   form do |my_form|
+    my_form.hidden(name: :token, value: "abc123")
+
     my_form.group(layout: :horizontal) do |name_group|
       name_group.text_field(
         name: :first_name,

--- a/app/lib/primer/forms/dsl/hidden_input.rb
+++ b/app/lib/primer/forms/dsl/hidden_input.rb
@@ -27,6 +27,10 @@ module Primer
         def supports_validation?
           false
         end
+
+        def hidden?
+          true
+        end
       end
     end
   end

--- a/app/lib/primer/forms/group.rb
+++ b/app/lib/primer/forms/group.rb
@@ -18,9 +18,12 @@ module Primer
         @layout = layout
         @system_arguments = system_arguments
 
+        @system_arguments[:display] = :none if inputs.all?(&:hidden?)
+
         @system_arguments[:classes] = class_names(
           @system_arguments.delete(:classes),
-          "FormControl-horizontalGroup" => horizontal?
+          "FormControl-horizontalGroup" => horizontal?,
+          "FormControl-spacingWrapper" => !horizontal? && inputs.size > 1
         )
       end
 

--- a/test/lib/primer/forms_test.rb
+++ b/test/lib/primer/forms_test.rb
@@ -172,6 +172,12 @@ class Primer::FormsTest < Minitest::Test
     assert_selector ".FormControl-horizontalGroup .FormControl", count: 2
   end
 
+  def test_hidden_items_wrapped_in_display_none
+    render_preview :horizontal_form
+
+    assert_selector ".d-none input[type=hidden]", visible: :hidden
+  end
+
   def test_renders_multi_input
     render_preview :multi_input_form
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes an issue where hidden inputs created with the forms framework would take up vertical/horizontal space on the page. Depending on the form, this can lead to weird visual spacing issues. This has been a problem for a while, but was recently exacerbated by https://github.com/primer/view_components/pull/3087 (merged as https://github.com/primer/view_components/pull/3159).

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

This is difficult to show in a screenshot because the input itself is not visible.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/3194

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

All inputs are wrapped in the `Group` component, so I added some logic that adds `display: none` to groups that contain only hidden inputs.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
