### PR TITLE
Ensure `full_width:` option is respected by the auto_complete input

### DIFF
--- a/.changeset/seven-experts-return.md
+++ b/.changeset/seven-experts-return.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure `full_width:` option is respected by the auto_complete input

--- a/app/lib/primer/forms/auto_complete.rb
+++ b/app/lib/primer/forms/auto_complete.rb
@@ -40,7 +40,8 @@ module Primer
             input_name: all_args[:name],
             input_id: all_args[:id],
             label_text: @input.label,
-            list_id: "#{all_args[:id]}-list"
+            list_id: "#{all_args[:id]}-list",
+            full_width: @input.full_width?
           )
       end
 

--- a/test/lib/primer/forms/auto_complete_input_test.rb
+++ b/test/lib/primer/forms/auto_complete_input_test.rb
@@ -36,4 +36,28 @@ class Primer::Forms::AutoCompleteInputTest < Minitest::Test
     # no rails error markup
     refute_selector ".field_with_errors", visible: :all
   end
+
+  def test_full_width_by_default
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |auto_complete_form|
+          auto_complete_form.auto_complete(name: :foo, label: "Foo", src: "/foo")
+        end
+      end
+    end
+
+    assert_selector ".FormControl--fullWidth"
+  end
+
+  def test_full_width_can_be_disabled
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |auto_complete_form|
+          auto_complete_form.auto_complete(name: :foo, label: "Foo", src: "/foo", full_width: false)
+        end
+      end
+    end
+
+    refute_selector ".FormControl--fullWidth"
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR passes the `full_width:` option through to the auto complete component from the form input. The `AutoComplete` component accepts the `full_width:` option, but that's also a shared/common option that all form controls accept. The `Input` base class deletes it from the hash of `system_arguments`, meaning it does not then get passed to the `AutoComplete` component. I believe `full_width:` is the only attribute with this problem, as other shared attributes are not deleted from `system_arguments`.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

The `AutoComplete` component uses the same CSS classes for the `<input>` element as the rest of the forms framework. Take a look at the text field input or the `TextField` component to preview the effect of the `full_width:` option.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production. I should note however that `full_width: true` is the default for all form inputs, which now includes `AutoComplete`. The `AutoComplete` component itself however defaults to `full_width: false`, meaning this PR will effectively change the default from `false` to `true`. Dotcom does not appear to use the auto complete input at all, so changing the default should have no practical effect in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/3195

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
