### PR TITLE
Add `role="radiogroup"` to fieldset in Radio group component

### DIFF
--- a/.changeset/sharp-jokes-notice.md
+++ b/.changeset/sharp-jokes-notice.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Adds `role="radiogroup"` on `fieldset` in radio group component

--- a/app/lib/primer/forms/radio_button_group.html.erb
+++ b/app/lib/primer/forms/radio_button_group.html.erb
@@ -1,5 +1,5 @@
 <div class="FormControl-radio-group-wrap">
-  <%= content_tag(:fieldset, **@input.input_arguments) do %>
+  <%= content_tag(:fieldset, role: 'radiogroup', **@input.input_arguments) do %>
     <% if @input.label %>
       <%= content_tag(:legend, **@input.label_arguments) do %>
         <%= @input.label %>


### PR DESCRIPTION
_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Adds `role="radiogroup"` to fieldset. This resolves https://github.com/github/primer/issues/4311, by ensuring that the position of each radio option is announced in NVDA.

Context for this fix: https://github.com/github/accessibility-audits/issues/8985#issuecomment-2447957210

### Integration
<!-- Does this change require any updates to code in production? -->

No

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/4311

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->
     
Add `role` to `<fieldset>` in our Radio Group component. 

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
