### PR TITLE
Improve template path detection for forms

### DIFF
--- a/.changeset/khaki-seals-battle.md
+++ b/.changeset/khaki-seals-battle.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Improve template path detection for forms

--- a/app/lib/primer/forms/acts_as_component.rb
+++ b/app/lib/primer/forms/acts_as_component.rb
@@ -50,8 +50,6 @@ module Primer
       TemplateGlob = Struct.new(:glob_pattern, :method_name, :on_compile_callback)
       TemplateParams = Struct.new(:source, :identifier, :type, :format, keyword_init: true)
 
-      attr_accessor :template_root_path
-
       def renders_templates(glob_pattern, method_name = nil, &block)
         template_globs << TemplateGlob.new(glob_pattern, method_name, block)
       end
@@ -69,6 +67,15 @@ module Primer
       end
 
       private
+
+      def template_root_path
+        return @template_root_path if defined?(@template_root_path)
+
+        form_path = Utils.const_source_location(self.name)
+        @template_root_path = if form_path
+          File.join(File.dirname(form_path), self.name.demodulize.underscore)
+        end
+      end
 
       def template_globs
         @template_globs ||= []

--- a/app/lib/primer/forms/base.rb
+++ b/app/lib/primer/forms/base.rb
@@ -29,11 +29,6 @@ module Primer
         end
 
         def inherited(base)
-          form_path = Utils.const_source_location(base.name)
-          return unless form_path
-
-          base.template_root_path = File.join(File.dirname(form_path), base.name.demodulize.underscore)
-
           base.renders_template "after_content.html.erb" do
             base.instance_variable_set(:@has_after_content, true)
           end

--- a/app/lib/primer/forms/base_component.rb
+++ b/app/lib/primer/forms/base_component.rb
@@ -7,8 +7,8 @@ module Primer
       include Primer::ClassNameHelper
       extend ActsAsComponent
 
-      def self.inherited(base)
-        base_path = Utils.const_source_location(base.name)
+      def self.compile!
+        base_path = Utils.const_source_location(self.name)
 
         unless base_path
           warn "Could not identify the template for #{base}"
@@ -16,7 +16,9 @@ module Primer
         end
 
         dir = File.dirname(base_path)
-        base.renders_template File.join(dir, "#{base.name.demodulize.underscore}.html.erb"), :render_template
+        renders_template File.join(dir, "#{self.name.demodulize.underscore}.html.erb"), :render_template
+
+        super
       end
 
       delegate :required?, :disabled?, :hidden?, to: :@input

--- a/app/lib/primer/forms/utils.rb
+++ b/app/lib/primer/forms/utils.rb
@@ -14,6 +14,9 @@ module Primer
       # for the file in the configured autoload paths. Doing so relies on Rails' autoloading
       # conventions, so it should work ok. Zeitwerk also has this information but lacks a
       # public API to map constants to source files.
+      #
+      # Now that the Ruby bug above has been fixed and released, this method should be used only
+      # as a fallback for older Rubies.
       def const_source_location(class_name)
         return nil unless class_name
 
@@ -24,6 +27,8 @@ module Primer
         # NOTE: underscore respects namespacing, i.e. will convert Foo::Bar to foo/bar.
         class_path = "#{class_name.underscore}.rb"
 
+        # Prefer Zeitwerk-managed paths, falling back to ActiveSupport::Dependencies if Zeitwerk
+        # is disabled or not in use (i.e. the case for older Rails versions).
         autoload_paths = if Rails.respond_to?(:autoloaders) && Rails.autoloaders.zeitwerk_enabled?
           Rails.autoloaders.main.dirs
         else

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -33,7 +33,7 @@ module Demo
     config.view_component.preview_controller = "PreviewController"
     config.view_component.preview_paths << Rails.root.join("..", "previews")
 
-    config.autoload_paths << Rails.root.join("..", "test", "forms")
+    config.autoload_paths << Rails.root.join("..", "test", "lib")
     config.autoload_paths << Rails.root.join("..", "test", "test_helpers", "components")
 
     config.action_dispatch.default_headers.clear

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -33,7 +33,6 @@ module Demo
     config.view_component.preview_controller = "PreviewController"
     config.view_component.preview_paths << Rails.root.join("..", "previews")
 
-    config.autoload_paths << Rails.root.join("..", "test", "lib")
     config.autoload_paths << Rails.root.join("..", "test", "test_helpers", "components")
 
     config.action_dispatch.default_headers.clear

--- a/test/lib/primer/forms/const_src.rb
+++ b/test/lib/primer/forms/const_src.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Used in utils_test.rb
+module Primer
+  module Forms
+    class ConstSrc
+    end
+  end
+end

--- a/test/lib/primer/forms/utils_test.rb
+++ b/test/lib/primer/forms/utils_test.rb
@@ -7,9 +7,7 @@ class Primer::Forms::UtilsTest < Minitest::Test
   # https://github.com/ruby/ruby/pull/5646 and Rubies that do not. Ruby versions 2.7 to 3.1
   # (inclusive) are affected. See also https://bugs.ruby-lang.org/issues/18624.
   def test_const_source_location
-    # Load the constant so const_source_location will return the correct path instead of
-    # the path to the internal Zeitwerk file that defines the autoload.
-    Primer::Forms.const_get(:ConstSrc)
+    ensure_autoload!
 
     actual_loc = Primer::Forms::Utils.const_source_location("Primer::Forms::ConstSrc")
     expected_loc = File.join(File.dirname(__FILE__), "const_src.rb")
@@ -18,6 +16,11 @@ class Primer::Forms::UtilsTest < Minitest::Test
   end
 
   def test_const_source_location_falls_back_to_enumerating_load_path
+    # Normally this would be dangerous since test/lib isn't Zeitwerk-friendly, but because
+    # we're doing it after Zeitwerk setup, it will essentially have no effect.
+    Rails.autoloaders.main.push_dir(Rails.root.join("..", "test", "lib"))
+    ensure_autoload!
+
     called = false
 
     Object.stub(:const_source_location, [false, 0]) do
@@ -28,5 +31,18 @@ class Primer::Forms::UtilsTest < Minitest::Test
     end
 
     assert called, "Object.const_source_location was not called"
+  end
+
+  private
+
+  def ensure_autoload!
+    # Load the constant so const_source_location will return the correct path instead of
+    # the path to the file that defines the autoload (which is this file, see below).
+    Primer::Forms.const_get(:ConstSrc)
+  rescue NameError
+    # We unfortunately can't add test/lib to the load path because it's not Zeitwerk-friendly,
+    # so we fake it by setting up the autoload to our test file manually.
+    Primer::Forms.autoload :ConstSrc, File.join(File.dirname(__FILE__), "const_src")
+    Primer::Forms.const_get(:ConstSrc)
   end
 end

--- a/test/lib/primer/forms/utils_test.rb
+++ b/test/lib/primer/forms/utils_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+
+class Primer::Forms::UtilsTest < Minitest::Test
+  # This should pass under both Rubies that have the bug fix described in
+  # https://github.com/ruby/ruby/pull/5646 and Rubies that do not. Ruby versions 2.7 to 3.1
+  # (inclusive) are affected. See also https://bugs.ruby-lang.org/issues/18624.
+  def test_const_source_location
+    # Load the constant so const_source_location will return the correct path instead of
+    # the path to the internal Zeitwerk file that defines the autoload.
+    Primer::Forms.const_get(:ConstSrc)
+
+    actual_loc = Primer::Forms::Utils.const_source_location("Primer::Forms::ConstSrc")
+    expected_loc = File.join(File.dirname(__FILE__), "const_src.rb")
+
+    assert actual_loc == expected_loc
+  end
+
+  def test_const_source_location_falls_back_to_enumerating_load_path
+    called = false
+
+    Object.stub(:const_source_location, [false, 0]) do
+      actual_loc = Primer::Forms::Utils.const_source_location("Primer::Forms::ConstSrc")
+      expected_loc = File.join(File.dirname(__FILE__), "const_src.rb")
+      assert actual_loc == expected_loc
+      called = true
+    end
+
+    assert called, "Object.const_source_location was not called"
+  end
+end


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR adjusts the logic for detecting template paths for Rails forms. Like ViewComponents, Rails forms allow templates that follow specific naming conventions to be located adjacent to the form's .rb file. These templates enable two pieces of functionality:

1. **Caption templates** allow rendering more complicated field captions, i.e. captions that require more than simple plain text. Caption templates follow the naming convention <form path>/<field name>_caption.html.erb. For example, a form at foo_form.rb containing a field named `bar` would render a caption template at foo_form/bar_caption.html.erb.
2. **After content** allows rendering a template _after_ the form, usually for complicated description text that explains how the form should be used, how it's validated, general warnings, etc. These templates must be named after_content.html.erb. For example, a form at foo_form.rb would render an after content template at foo_form/after_content.html.erb.

When I originally added support for separate template files, I tried to use the new-ish `Module.const_source_location` method, which returns the absolute path to the file a particular constant was defined in. Doing so allows us to construct the template path for each form .rb file. Unfortunately, due to a [bug](https://github.com/ruby/ruby/pull/5646) in Ruby itself, this method returned `false` if the file was autoloaded, eg. by [Zeitwerk](https://github.com/fxn/zeitwerk), the Rails autoload system. The bug has since been fixed in newer versions of Ruby, but at the time was a blocker. To work around the problem, I introduced the `Primer::Forms::Utils.const_source_location` method that exploits the Zeitwerk requirement that files are named after the constants they define. In other words, `FooForm` is required to live in foo_form.rb somewhere on the Rails load path. The workaround therefore was able to loop over each path in the Rails load path looking for a file with the same name as the given constant. This approach seemed to work fine.

Before the advent of Zeitwerk, Rails used to manage autoloads via the `ActiveSupport::Dependencies` module, which still exists to this day. When adding support for template files, I noticed that `ActiveSupport::Dependencies.autoload_paths` seemed to contain all the right autoload paths, including the very important app/forms directory. Unfortunately, as I have now learned, it does not contain all the autoload paths that may have been added eg. in application.rb. Dotcom does in fact add autoload paths in application.rb, but these paths are added to a Zeitwerk-specific data structure, i.e. _not_ `ActiveSupport::Dependencies.autoload_paths`. Instead, Primer forms should iterate over `Rails.autoloaders.main.dirs`. I modified the code to do so, falling back to `ActiveSupport::Dependencies.autoload_paths` if Zeitwerk is not enabled (after all, PVC is used by apps outside of the GitHub monolith).

I can hear you asking, "Why do this at all? Can't we just use `Module.const_source_location` now that Ruby bug has been fixed and released?" Wow, I can see you were paying attention. You're absolutely right! That's where the second change in this PR comes from - using `Module.const_source_location` and falling back to `Primer::Forms::Utils.const_source_location` when necessary. Doing so should work for a sufficiently large matrix of Ruby and Rails versions.

Finally, this PR also contains a bit of a refactoring to prevent calling `Module.const_source_location` before the constant has been defined and the old autoload replaced. Calling `Module.const_source_location` too early (i.e. in `included` callbacks) will return the path to an internal Zeitwerk file (cref.rb), which I assume is the file that defines the autoload. The autoload has not been cleaned up by the time `included` is called, so we have to do it later. This turns out to be a cleaner approach anyway, as it does not require us to set `template_root_path` on form classes. Nice.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production, everything in this PR should be backwards-compatible.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes: https://github.com/github/primer/issues/4500

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

See above.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.