### PR TITLE
Add trailing visuals to the text field

### DIFF
--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -121,6 +121,8 @@
 ** .FormControl
 ** ├─ .FormControl-label
 ** │  ├─ .FormControl-input-wrap
+** │  │  ├─ .FormControl-input-trailingVisualWrap
+** │  │  │  ├─ .FormControl-input-trailingVisual
 ** │  │  ├─ .FormControl-input-leadingVisualWrap
 ** │  │  │  ├─ .FormControl-input-leadingVisual
 ** │  │  ├─ .FormControl-input
@@ -253,6 +255,23 @@
     }
   }
 
+  & .FormControl-input-trailingVisualWrap {
+    position: absolute;
+    top: var(--base-size-8);
+    right: var(--base-size-8);
+    display: block;
+    width: var(--base-size-16);
+    height: var(--base-size-16);
+    color: var(--fgColor-muted);
+    pointer-events: none;
+
+    /* octicon */
+    & .FormControl-input-trailingVisual {
+      display: block;
+      user-select: none;
+    }
+  }
+
   /* TODO: replace with new Button component */
   & .FormControl-input-trailingAction {
     position: absolute;
@@ -333,10 +352,28 @@
     }
   }
 
+  /* if trailingVisual is present */
+
   /*
 	┌──────────────────┬──32px──┐
 	╎  ┌──────────────┐  ┌────┐ ╎
-	╎   24px               24px   ╎
+	╎   24px               24px ╎
+	╎  └──────────────┘  └────┘ ╎
+	└──────────────────┴────────┘
+  */
+
+  &.FormControl-input-wrap--trailingVisual {
+    & .FormControl-input {
+      padding-inline-end: calc(
+              var(--control-medium-paddingInline-condensed) + var(--base-size-16) + var(--control-medium-gap)
+      ); /* 32px */
+    }
+  }
+
+  /*
+	┌──────────────────┬──32px──┐
+	╎  ┌──────────────┐  ┌────┐ ╎
+	╎   24px               24px ╎
 	╎  └──────────────┘  └────┘ ╎
 	└──────────────────┴────────┘
   */
@@ -376,6 +413,10 @@
     & .FormControl-input-leadingVisualWrap {
       top: calc(var(--control-medium-paddingInline-condensed) - var(--base-size-2)); /* 6px */
       left: calc(var(--control-medium-paddingInline-condensed) - var(--base-size-2)); /* 6px */
+    }
+    & .FormControl-input-trailingVisualWrap {
+      top: calc(var(--control-medium-paddingInline-condensed) - var(--base-size-2)); /* 6px */
+      right: calc(var(--control-medium-paddingInline-condensed) - var(--base-size-2)); /* 6px */
     }
 
     /*
@@ -427,6 +468,10 @@
       top: var(--control-medium-paddingInline-normal);
       left: var(--control-medium-paddingInline-normal);
     }
+    & .FormControl-input-trailingVisualWrap {
+      top: var(--control-medium-paddingInline-normal);
+      right: var(--control-medium-paddingInline-normal);
+    }
 
     /*
     ┌──36px──┬───12px padding──────┐
@@ -440,6 +485,13 @@
       & .FormControl-input.FormControl-large {
         padding-inline-start: calc(
           var(--control-large-paddingInline-normal) + var(--base-size-16) + var(--control-large-gap)
+        ); /* 36px */
+      }
+    }
+    &.FormControl-input-wrap--trailingVisual {
+      & .FormControl-input.FormControl-large {
+        padding-inline-end: calc(
+                var(--control-large-paddingInline-normal) + var(--base-size-16) + var(--control-large-gap)
         ); /* 36px */
       }
     }

--- a/app/lib/primer/forms/dsl/text_field_input.rb
+++ b/app/lib/primer/forms/dsl/text_field_input.rb
@@ -7,7 +7,7 @@ module Primer
       class TextFieldInput < Input
         attr_reader(
           *%i[
-            name label show_clear_button leading_visual leading_spinner clear_button_id
+            name label show_clear_button leading_visual leading_spinner trailing_visual clear_button_id
             visually_hide_label inset monospace field_wrap_classes auto_check_src
           ]
         )
@@ -20,6 +20,7 @@ module Primer
 
           @show_clear_button = system_arguments.delete(:show_clear_button)
           @leading_visual = system_arguments.delete(:leading_visual)
+          @trailing_visual = system_arguments.delete(:trailing_visual)
           @leading_spinner = !!system_arguments.delete(:leading_spinner)
           @clear_button_id = system_arguments.delete(:clear_button_id)
           @inset = system_arguments.delete(:inset)
@@ -30,6 +31,13 @@ module Primer
             @leading_visual[:classes] = class_names(
               "FormControl-input-leadingVisual",
               @leading_visual[:classes]
+            )
+          end
+
+          if @trailing_visual
+            @trailing_visual[:classes] = class_names(
+              "FormControl-input-trailingVisual",
+              @trailing_visual[:classes]
             )
           end
 
@@ -48,6 +56,14 @@ module Primer
         alias inset? inset
         alias monospace? monospace
 
+        def trailing_visual?
+          !!@trailing_visual
+        end
+
+        def leading_visual?
+          !!@leading_visual
+        end
+
         def to_component
           TextField.new(input: self)
         end
@@ -58,10 +74,6 @@ module Primer
 
         def focusable?
           true
-        end
-
-        def leading_visual?
-          !!@leading_visual
         end
 
         def validation_arguments

--- a/app/lib/primer/forms/text_field.html.erb
+++ b/app/lib/primer/forms/text_field.html.erb
@@ -17,5 +17,12 @@
         <%= render(Primer::Beta::Octicon.new(icon: :"x-circle-fill")) %>
       </button>
     <% end %>
+    <% if @input.trailing_visual%>
+      <span class="FormControl-input-trailingVisualWrap">
+        <% if @input.trailing_visual %>
+          <%= render(Primer::Beta::Octicon.new(**@input.trailing_visual, data: { target: "primer-text-field.trailingVisual" })) %>
+        <% end %>
+      </span>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/lib/primer/forms/text_field.rb
+++ b/app/lib/primer/forms/text_field.rb
@@ -24,6 +24,7 @@ module Primer
             "FormControl-input-wrap",
             INPUT_WRAP_SIZE[input.size],
             "FormControl-input-wrap--trailingAction": @input.show_clear_button?,
+            "FormControl-input-wrap--trailingVisual": @input.trailing_visual?,
             "FormControl-input-wrap--leadingVisual": @input.leading_visual?
           ),
 

--- a/previews/primer/alpha/text_field_preview.rb
+++ b/previews/primer/alpha/text_field_preview.rb
@@ -172,6 +172,12 @@ module Primer
         render(Primer::Alpha::TextField.new(monospace: true, name: "my-text-field", label: "My text field"))
       end
 
+      # @label With trailing visual
+      # @snapshot
+      def with_trailing_visual
+        render(Primer::Alpha::TextField.new(trailing_visual: { icon: :search }, name: "my-text-field", label: "My text field"))
+      end
+
       # @label With leading visual
       # @snapshot
       def with_leading_visual


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Like leading visuals in a text-field, add trailing visuals to it. As explained [here](https://primer.style/components/text-input/#with-leading-and-trailing-visuals). 

### Screenshots
![Screenshot 2024-12-10 at 07 43 30](https://github.com/user-attachments/assets/168fb56a-3d80-4718-ac84-b88075db9e2f)

Closes #3218 

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
Like leading visuals in text field, we add a section for trailing visuals:

- [ ] Icon
- [ ] Text

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
