### PR TITLE
Fix `NoMethodError` when checking if `ActionList::Divider`s are active

### DIFF
--- a/.changeset/cyan-moons-run.md
+++ b/.changeset/cyan-moons-run.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix `NoMethodError` when checking if `ActionList::Divider`s are active

--- a/app/components/primer/alpha/action_list/divider.rb
+++ b/app/components/primer/alpha/action_list/divider.rb
@@ -29,6 +29,10 @@ module Primer
         def call
           render(Primer::BaseComponent.new(**@system_arguments)) { content }
         end
+
+        def active?
+          false
+        end
       end
     end
   end

--- a/test/components/alpha/action_list_test.rb
+++ b/test/components/alpha/action_list_test.rb
@@ -226,6 +226,7 @@ module Primer
         error = assert_raises ArgumentError do
           render_inline(Primer::Alpha::ActionList.new(aria: { label: "List" }, select_variant: :single)) do |component|
             component.with_item(label: "Item 1", active: true)
+            component.with_divider
             component.with_item(label: "Item 2", active: true)
           end
         end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This change adds an `active?` method to `ActionList::Divider`. This is necessary so all types of item implement the same interface.

For additional background, the `items` slot on `ActionList` is polymorphic, i.e. allows multiple kinds of item. Currently supported items are 1) regular 'ol items, 2) avatar items, and 3) dividers. Both regular and avatar items define `active?`, but `Divider` does not. In at least one place we iterate over all items, attempting to call `active?` on each of them. If one is a `Divider`, Ruby raises a `NoMethodError`.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
~- [ ] Added/updated previews (Lookbook)~
~- [ ] Tested in Chrome~
~- [ ] Tested in Firefox~
~- [ ] Tested in Safari~
~- [ ] Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
