### PR TITLE
add support for Ruby 3.4 in tests

### DIFF
--- a/.changeset/two-rings-jog.md
+++ b/.changeset/two-rings-jog.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+add support for Ruby 3.4 in test suite

--- a/test/performance/bench_classify.rb
+++ b/test/performance/bench_classify.rb
@@ -40,7 +40,7 @@ class BenchClassify < Minitest::Benchmark
   end
 
   def bench_allocations
-    assert_allocations "3.3" => 7, "3.2" => 6, "3.1" => 6, "3.0" => 6, "2.7" => 4 do
+    assert_allocations "3.4" => 7, "3.3" => 7, "3.2" => 6, "3.1" => 6, "3.0" => 6, "2.7" => 4 do
       Primer::Classify.call(**@values)
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

In order to update ViewComponent's CI to run Ruby 3.4 when testing against Primer ViewComponents, we need to add support for Ruby 3.4 in tests here. This is probably a good idea regardless due to GitHub.com using Ruby 3.4.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
