### PR TITLE
Fix anchor escaping in call to `Regexp.new`

### DIFF
--- a/.changeset/nice-suns-fold.md
+++ b/.changeset/nice-suns-fold.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix incorrect classname keys when generating `lib/primer/classify/utilities.yml` with `bundle exec rake utilities:build`.

--- a/lib/tasks/utilities.rake
+++ b/lib/tasks/utilities.rake
@@ -55,7 +55,7 @@ namespace :utilities do
         next unless classname.start_with?(k)
 
         key = v
-        classname.sub!(Regexp.new("\A#{k}-"), "")
+        classname.sub!(Regexp.new("\\A#{k}-"), "")
       end
 
       # If we didn't find a replacement, grab the first text before hyphen


### PR DESCRIPTION
### What are you trying to accomplish?

* Fix broken *Generate static files* workflow on `main` due to a regression introduced in #3177 (308a56b3a7fe3e29bb12aec0c3cf05a3bb7e32f4).
* Fix running `bundle exec rake utilities:build static:dump`

### Integration

Not AFAICT.

#### List the issues that this change affects.

Closes #3263

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Fixes classname keys when generating `lib/primer/classify/utilities.yml` with `bundle exec rake utilities:build`.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] ~Added/updated previews (Lookbook)~
- [ ] ~Tested in Chrome~
- [ ] ~Tested in Firefox~
- [ ] ~Tested in Safari~
- [ ] ~Tested in Edge~

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
