### PR TITLE
Fix memory leak in forms framework

### DIFF
--- a/.changeset/tall-cats-cry.md
+++ b/.changeset/tall-cats-cry.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix memory leak in forms framework causing form templates to be compiled on each render in development

--- a/app/lib/primer/forms/base_component.rb
+++ b/app/lib/primer/forms/base_component.rb
@@ -7,18 +7,11 @@ module Primer
       include Primer::ClassNameHelper
       extend ActsAsComponent
 
-      def self.compile!
-        base_path = Utils.const_source_location(self.name)
-
-        unless base_path
-          warn "Could not identify the template for #{base}"
-          return
-        end
-
-        dir = File.dirname(base_path)
-        renders_template File.join(dir, "#{self.name.demodulize.underscore}.html.erb"), :render_template
-
-        super
+      def self.inherited(base)
+        base.renders_template(
+          File.join("%{base_template_path}", "#{base.name.demodulize.underscore}.html.erb"),
+          :render_template
+        )
       end
 
       delegate :required?, :disabled?, :hidden?, to: :@input


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes an issue introduced in https://github.com/primer/view_components/pull/3236 that causes templates to be compiled more than once, i.e. every time a component is rendered. While definitely a problem, there should be no negative effects aside from extra computation time and memory usage. The problem should only happen in development, i.e. not production.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/3259

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

Based on the excellent description in https://github.com/primer/view_components/issues/3259, I moved the code that registers the component's template from the `compile!` method to to a `self.inherited` callback. This should result in only compiling the template a single time when the component class is first loaded.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.