### PR TITLE
Ensure ActionMenu's itemActivated event bubbles

### DIFF
--- a/.changeset/perfect-carpets-joke.md
+++ b/.changeset/perfect-carpets-joke.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Ensure ActionMenu's itemActivated event bubbles

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -358,6 +358,7 @@ export class ActionMenuElement extends HTMLElement {
 
     this.dispatchEvent(
       new CustomEvent('itemActivated', {
+        bubbles: true,
         detail: {item: item.parentElement, checked: this.isItemChecked(item.parentElement)},
       }),
     )


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

The `ActionMenu`'s `itemActivated` event does not bubble, making it more difficult to use than necessary. `SelectPanel`, which was based on `ActionMenu`, also features an `itemActivated` event. `SelectPanel`'s event bubbles, so `ActionMenu`'s probably should too.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/primer/view_components/issues/3269

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.