### PR TITLE
Do not populate dynamic label with active item in multi-select mode

### DIFF
--- a/.changeset/stale-fishes-begin.md
+++ b/.changeset/stale-fishes-begin.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Do not populate dynamic label with active item in multi-select mode

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -143,6 +143,12 @@ export class ActionMenuElement extends HTMLElement {
       () => Boolean(this.invokerElement),
       () => this.#intersectionObserver.observe(this.invokerElement!),
     )
+
+    // If there's no include fragment, then no async fetching will occur and we can
+    // mark the component as ready.
+    if (!this.includeFragment) {
+      this.setAttribute('data-ready', 'true')
+    }
   }
 
   disconnectedCallback() {
@@ -367,6 +373,9 @@ export class ActionMenuElement extends HTMLElement {
   #handleIncludeFragmentReplaced() {
     if (this.#firstItem) this.#firstItem.focus()
     this.#softDisableItems()
+
+    // async items have loaded, so component is ready
+    this.setAttribute('data-ready', 'true')
   }
 
   // Close when focus leaves menu
@@ -387,6 +396,7 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #setDynamicLabel() {
+    if (this.selectVariant !== 'single') return
     if (!this.dynamicLabel) return
     const invokerLabel = this.invokerLabel
     if (!invokerLabel) return

--- a/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
+++ b/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
@@ -3,7 +3,7 @@
     <% menu.with_show_button { "Strategy" } %>
     <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
     <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
-    <% menu.with_item(label: "Ours", data: { value: "ours" }) %>
+    <% menu.with_item(label: "Ours", data: { value: "ours" }, active: true) %>
     <% menu.with_item(label: "Resolve") %>
   <% end %>
   <hr>

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -436,7 +436,9 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal %w[fast_forward recursive], response["value"]
+
+      # "ours" is pre-selected
+      assert_equal %w[fast_forward recursive ours], response["value"]
     end
 
     def test_multiple_select_form_uses_label_if_no_value_provided
@@ -453,7 +455,14 @@ module Alpha
 
       # for some reason the JSON response is wrapped in HTML, I have no idea why
       response = JSON.parse(find("pre").text)
-      assert_equal %w[fast_forward Resolve], response["value"]
+
+      # "ours" is pre-selected
+      assert_equal %w[fast_forward ours Resolve], response["value"]
+    end
+
+    def test_multiple_select_does_not_set_dynamic_label_for_preselected_item
+      visit_preview(:multiple_select_form, route_format: :json)
+      assert_selector("action-menu[data-ready='true'] button[aria-controls]", exact_text: "Strategy")
     end
 
     def test_individual_items_can_submit_post_requests_via_forms


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR fixes an issue causing the `ActionMenu`'s dynamic label from being set to one of the selected items on page load. For single-select mode, this behavior is desirable, but the dynamic label feature is not supported in multi-select mode and should not appear on page load.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

See linked issue.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Fixes https://github.com/github/primer/issues/3082

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
~- [ ] Added/updated documentation~
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
