### PR TITLE
Fix asset compilation in test environment

### DIFF
--- a/Procfile.test
+++ b/Procfile.test
@@ -1,0 +1,2 @@
+vite: cd demo; bin/vite build -- --watch
+css: cd demo; exec npm run build:css -- --watch

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -15,7 +15,11 @@ namespace :test do
   namespace :build do
     task :css do
       Dir.chdir("demo/") do
-        system "npm run build:css"
+        # if vite is running in prod mode, we're probably running tests, see script/test-setup
+        if ENV["VITE_RUBY_MODE"] != "production"
+          system "npm run build:css"
+          system "bin/vite build"
+        end
       end
     end
   end

--- a/script/test
+++ b/script/test
@@ -5,6 +5,15 @@
 #/ 1. `script/test 'GLOB'` runs all tests for matching glob.
 #/     * make sure to wrap the `GLOB` in single quotes `''`.
 
+status=`overmind status --socket ./overmind-test.sock`
+
+if [[ $? > 0 || "$status" =~ dead ]]; then
+  echo "It looks like one or more supporting processes are not running. While not essential, you may want to run ./script/test-setup to start these processes."
+else
+  # tell vite-ruby we're using prod-ready assets instead of the dev server or dev build
+  export VITE_RUBY_MODE="production"
+fi
+
 if ! [ $# -eq 0 ]; then
   export TEST=$(echo "$1" | cut -d ":" -f 1)
 

--- a/script/test-setup
+++ b/script/test-setup
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+overmind start --daemonize --procfile Procfile.test --socket ./overmind-test.sock

--- a/script/test-teardown
+++ b/script/test-teardown
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+overmind stop --socket ./overmind-test.sock
+rm ./overmind-test.sock


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I have consistently observed system tests failing unexpectedly because of stale assets left behind in the demo app's public/ directory. Since tests don't recompile JavaScript assets (only CSS), tests run against whatever assets were last built by the dev server, which could be quite out-of-date, from a different branch, etc.

This PR adds a few scripts that start test versions of both vite and postcss. If these processes aren't running, we fall back to compiling both JavaScript and CSS before every test run.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production - these changes are test-only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.