### PR TITLE
[Primer::Alpha::FormControl] Remove required example for SegmentedControl

### DIFF
--- a/previews/primer/alpha/form_control_preview.rb
+++ b/previews/primer/alpha/form_control_preview.rb
@@ -74,19 +74,6 @@ module Primer
         )
       end
 
-      # @label Required
-      def required
-        render_with_template(
-          template: "primer/alpha/form_control_preview/playground",
-          locals: {
-            system_arguments: {
-              label: "Best character",
-              required: true
-            }
-          }
-        )
-      end
-
       # @label With visually hidden label
       def with_visually_hidden_label
         render_with_template(

--- a/test/components/alpha/form_control_test.rb
+++ b/test/components/alpha/form_control_test.rb
@@ -29,14 +29,6 @@ module Primer
         assert_includes(described_by_ids, validation_id)
       end
 
-      def test_required
-        render_preview(:required)
-
-        assert_selector(".FormControl-label", text: "Best character") do
-          assert_selector("[aria-hidden=true]", text: "*")
-        end
-      end
-
       def test_visually_hidden_label
         render_preview(:with_visually_hidden_label)
 


### PR DESCRIPTION
Relates to: https://github.com/github/accessibility-audits/issues/10021

A SegmentedControl cannot have a required state so this example doesn't make sense:
* The `<ul>` role, `list`, doesn't support a required state. We could try to set `aria-required="true"` but that's considered invalid HTML.
* SegmentedControl will never have an empty state so marking as required doesnt make sense.

⚠️ **I'm confused on how this component is meant to be used and wondering if it should be deprecated or have clearer guidance? Advice needed!**  

Currently:
* This component is not shown on the Docs page for [FormControl](https://primer.style/components/form-control). The overview for FormControl claims that `required` will be forwarded to the input, but that's not what happens here. In fact, there's an [explicit note in the code](https://github.com/primer/view_components/blob/main/app/components/primer/alpha/form_control.rb#L16) saying this component only visually renders an asterisk.
* Consumers are able to pass in any arbitrary component as a child to give this child a label, caption, required asterisk.
   * BUT even though labels and required asterisks are visually rendered, there's actually no programmatic association which is problematic accessibility wise since consumers might set `label:` expecting the component to handle things appropriately (when it actually doesn't).
  * We could try to have the component handle setting `id`/`for` or `aria-labelledby`, but it depends on what's being passed in, and there doesn't seem to be any restrictions.

### Integration
<!-- Does this change require any updates to code in production? -->

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
