### PR TITLE
[ActionMenuForm] ActionMenuForm button should include aria-describedby={abel_id}

### DIFF
--- a/.changeset/rich-mugs-float.md
+++ b/.changeset/rich-mugs-float.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+[ActionMenuForm] Add aria-describedby to the ActionMenuForm's button so that the label is describing the button

--- a/app/lib/primer/forms/action_menu.html.erb
+++ b/app/lib/primer/forms/action_menu.html.erb
@@ -1,6 +1,6 @@
 <%= render(FormControl.new(input: @input)) do %>
   <%= render(Primer::Alpha::ActionMenu.new(**@input.input_arguments)) do |menu| %>
-    <% menu.with_show_button { "Select..." } %>
+    <% menu.with_show_button("aria-describedby": @label_id) { "Select..." } %>
     <% @input.block.call(menu) if @input.block %>
   <% end %>
 <% end %>

--- a/app/lib/primer/forms/action_menu.rb
+++ b/app/lib/primer/forms/action_menu.rb
@@ -8,6 +8,7 @@ module Primer
 
       def initialize(input:)
         @input = input
+        @input.label_arguments[:id] = label_id
 
         @input.input_arguments[:form_arguments] = {
           name: @input.name,
@@ -19,6 +20,10 @@ module Primer
         unless @input.input_arguments.include?(:dynamic_label)
           @input.input_arguments[:dynamic_label] = true
         end
+      end
+
+      def label_id
+        @label_id ||= "label-#{@input.base_id}"
       end
     end
   end

--- a/test/lib/primer/forms/action_menu_test.rb
+++ b/test/lib/primer/forms/action_menu_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "lib/test_helper"
+require_relative "models/trip"
+
+class Primer::Forms::ActionMenuTest < Minitest::Test
+  include Primer::ComponentTestHelpers
+
+  def test_label_aria_describes_button
+    render_in_view_context do
+      primer_form_with(url: "/foo") do |f|
+        render_inline_form(f) do |action_menu_form|
+          action_menu_form.action_menu(name: "city", label: "Favorite city", caption: "Select your favorite!") do |city_list|
+            city_list.with_item(label: "Lopez Island", data: { value: "lopez_island" }) do |item|
+              item.with_leading_visual_icon(icon: :log)
+            end
+            city_list.with_item(label: "Bellevue", data: { value: "bellevue" }) do |item|
+              item.with_leading_visual_icon(icon: :paste)
+            end
+            city_list.with_item(label: "Seattle", data: { value: "seattle" }) do |item|
+              item.with_leading_visual_icon(icon: :"device-camera")
+            end
+          end 
+        end
+      end
+    end
+
+    assert_selector "button[aria-describedby='Favorite city']"
+  end
+
+
+end

--- a/test/lib/primer/forms/action_menu_test.rb
+++ b/test/lib/primer/forms/action_menu_test.rb
@@ -1,32 +1,12 @@
 # frozen_string_literal: true
+require "system/test_case"
 
-require "lib/test_helper"
-require_relative "models/trip"
+module Forms
+  class ActionMenuTest < System::TestCase
 
-class Primer::Forms::ActionMenuTest < Minitest::Test
-  include Primer::ComponentTestHelpers
-
-  def test_label_aria_describes_button
-    render_in_view_context do
-      primer_form_with(url: "/foo") do |f|
-        render_inline_form(f) do |action_menu_form|
-          action_menu_form.action_menu(name: "city", label: "Favorite city", caption: "Select your favorite!") do |city_list|
-            city_list.with_item(label: "Lopez Island", data: { value: "lopez_island" }) do |item|
-              item.with_leading_visual_icon(icon: :log)
-            end
-            city_list.with_item(label: "Bellevue", data: { value: "bellevue" }) do |item|
-              item.with_leading_visual_icon(icon: :paste)
-            end
-            city_list.with_item(label: "Seattle", data: { value: "seattle" }) do |item|
-              item.with_leading_visual_icon(icon: :"device-camera")
-            end
-          end 
-        end
-      end
+    def test_label_aria_describes_button
+      visit_preview(:action_menu_form)
+      assert_equal(find("label")["id"], find("button", text: "Select...")["aria-describedby"])
     end
-
-    assert_selector "button[aria-describedby='Favorite city']"
   end
-
-
 end


### PR DESCRIPTION
closes: https://github.com/github/accessibility-audits/issues/10133

### What are you trying to accomplish?

Adds an `aria-describedby` to the ActionMenuForm's button.


### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
