### PR TITLE
update ToggleSwitch to support autofocus

### DIFF
--- a/.changeset/late-jobs-think.md
+++ b/.changeset/late-jobs-think.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Adds optional autofocus to ToggleSwitch

--- a/app/components/primer/alpha/toggle_switch.html.erb
+++ b/app/components/primer/alpha/toggle_switch.html.erb
@@ -8,7 +8,16 @@
     <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content("Off")) %>
   <% end %>
 
-  <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@aria_arguments)) do %>
+  <%= render(Primer::BaseComponent.new(
+    tag: :button,
+    classes: "ToggleSwitch-track",
+    disabled: disabled?,
+    data: {
+      target: "toggle-switch.switch", action: "click:toggle-switch#toggle"
+    },
+    **@aria_arguments,
+    **@button_arguments,
+  )) do %>
     <%= render(Primer::Box.new(classes: "ToggleSwitch-icons", aria: { hidden: true })) do %>
       <%= render(Primer::Box.new(classes: "ToggleSwitch-lineIcon")) do %>
         <%= render(Primer::BaseComponent.new(

--- a/app/components/primer/alpha/toggle_switch.html.erb
+++ b/app/components/primer/alpha/toggle_switch.html.erb
@@ -8,16 +8,7 @@
     <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content("Off")) %>
   <% end %>
 
-  <%= render(Primer::BaseComponent.new(
-    tag: :button,
-    classes: "ToggleSwitch-track",
-    disabled: disabled?,
-    data: {
-      target: "toggle-switch.switch", action: "click:toggle-switch#toggle"
-    },
-    **@aria_arguments,
-    **@button_arguments,
-  )) do %>
+  <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@aria_arguments)) do %>
     <%= render(Primer::Box.new(classes: "ToggleSwitch-icons", aria: { hidden: true })) do %>
       <%= render(Primer::Box.new(classes: "ToggleSwitch-lineIcon")) do %>
         <%= render(Primer::BaseComponent.new(

--- a/app/components/primer/alpha/toggle_switch.html.erb
+++ b/app/components/primer/alpha/toggle_switch.html.erb
@@ -8,7 +8,7 @@
     <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content("Off")) %>
   <% end %>
 
-  <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@aria_arguments)) do %>
+  <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@button_arguments)) do %>
     <%= render(Primer::Box.new(classes: "ToggleSwitch-icons", aria: { hidden: true })) do %>
       <%= render(Primer::Box.new(classes: "ToggleSwitch-lineIcon")) do %>
         <%= render(Primer::BaseComponent.new(

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -28,23 +28,12 @@ module Primer
       # @param status_label_position [Symbol] Which side of the toggle switch to render the status label. <%= one_of(Primer::Alpha::ToggleSwitch::STATUS_LABEL_POSITION_OPTIONS) %>
       # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(
-        src: nil,
-        csrf_token: nil,
-        checked: false,
-        enabled: true,
-        size: SIZE_DEFAULT,
-        status_label_position: STATUS_LABEL_POSITION_DEFAULT,
-        turbo: false,
-        button_arguments: {},
-        **system_arguments
-      )
+      def initialize(src: nil, csrf_token: nil, checked: false, enabled: true, size: SIZE_DEFAULT, status_label_position: STATUS_LABEL_POSITION_DEFAULT, turbo: false, **system_arguments)
         @src = src
         @csrf_token = csrf_token
         @checked = checked
         @enabled = enabled
         @turbo = turbo
-        @button_arguments = button_arguments
         @system_arguments = system_arguments
 
         @size = fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -27,8 +27,19 @@ module Primer
       # @param size [Symbol] What size toggle switch to render. <%= one_of(Primer::Alpha::ToggleSwitch::SIZE_OPTIONS) %>
       # @param status_label_position [Symbol] Which side of the toggle switch to render the status label. <%= one_of(Primer::Alpha::ToggleSwitch::STATUS_LABEL_POSITION_OPTIONS) %>
       # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
+      # @param autofocus [Boolean] Whether switch should be autofocused when rendered.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(src: nil, csrf_token: nil, checked: false, enabled: true, size: SIZE_DEFAULT, status_label_position: STATUS_LABEL_POSITION_DEFAULT, turbo: false, **system_arguments)
+      def initialize(
+        src: nil,
+        csrf_token: nil,
+        checked: false,
+        enabled: true,
+        size: SIZE_DEFAULT,
+        status_label_position: STATUS_LABEL_POSITION_DEFAULT,
+        turbo: false,
+        autofocus: nil,
+        **system_arguments
+      )
         @src = src
         @csrf_token = csrf_token
         @checked = checked
@@ -50,12 +61,13 @@ module Primer
           SIZE_MAPPINGS[@size]
         )
 
-        @aria_arguments = {
+        @button_arguments = {
           aria: merge_aria(
             @system_arguments,
             aria: { pressed: on? }
           )
         }
+        @button_arguments[:autofocus] = true if autofocus
 
         @system_arguments[:src] = @src if @src
       end

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -28,12 +28,23 @@ module Primer
       # @param status_label_position [Symbol] Which side of the toggle switch to render the status label. <%= one_of(Primer::Alpha::ToggleSwitch::STATUS_LABEL_POSITION_OPTIONS) %>
       # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(src: nil, csrf_token: nil, checked: false, enabled: true, size: SIZE_DEFAULT, status_label_position: STATUS_LABEL_POSITION_DEFAULT, turbo: false, **system_arguments)
+      def initialize(
+        src: nil,
+        csrf_token: nil,
+        checked: false,
+        enabled: true,
+        size: SIZE_DEFAULT,
+        status_label_position: STATUS_LABEL_POSITION_DEFAULT,
+        turbo: false,
+        button_arguments: {},
+        **system_arguments
+      )
         @src = src
         @csrf_token = csrf_token
         @checked = checked
         @enabled = enabled
         @turbo = turbo
+        @button_arguments = button_arguments
         @system_arguments = system_arguments
 
         @size = fetch_or_fallback(SIZE_OPTIONS, size, SIZE_DEFAULT)

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -62,6 +62,10 @@ module Primer
       def with_turbo
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, turbo: true))
       end
+
+      def with_autofocus
+        render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, autofocus: true))
+      end
     end
   end
 end

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -62,6 +62,11 @@ module Primer
       def with_turbo
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, turbo: true))
       end
+
+      def with_button_arguments
+        button_arguments = { id: 'foo', data: { turbo_permanent: true } }
+        render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, button_arguments: button_arguments))
+      end
     end
   end
 end

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -62,11 +62,6 @@ module Primer
       def with_turbo
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, turbo: true))
       end
-
-      def with_button_arguments
-        button_arguments = { id: 'foo', data: { turbo_permanent: true } }
-        render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.toggle_switch_index_path, button_arguments: button_arguments))
-      end
     end
   end
 end

--- a/test/components/alpha/toggle_switch_test.rb
+++ b/test/components/alpha/toggle_switch_test.rb
@@ -80,6 +80,12 @@ module Primer
 
         assert_selector("[data-turbo]")
       end
+
+      def test_autofocus
+        render_inline(Primer::Alpha::ToggleSwitch.new(src: "/foo", autofocus: true))
+
+        assert_selector(".ToggleSwitch-track[autofocus]")
+      end
     end
   end
 end


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans. Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

Related to https://github.com/github/accessibility-audits/issues/10006
Required by https://github.com/github/github/pull/361376

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR updates the ToggleSwitch component to allow the `autofocus` property to be applied to its button element. Doing so will allow this component to be fully accessible when used in conjunction with the [Rails turbo framework](https://github.com/hotwired/turbo-rails). See https://github.com/github/accessibility-audits/issues/10006 for more context.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

https://github.com/user-attachments/assets/bc33f286-983f-4180-b086-3fc6537fb099

### Integration
<!-- Does this change require any updates to code in production? -->

No prod changes required.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

* Helps with https://github.com/github/accessibility-audits/issues/10006

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

I explored two approaches for allowing users to optionally apply the `autofocus` attribute to the ToggleSwitch button element:
1. [Add generic `button_arguments` argument](https://github.com/primer/view_components/pull/3319/commits/bb0c6cdd245561575e37a59aa9d96fefdb1bebfc), allowing users to pass any supported attribute to the button
2. [Add specific `autofocus` argument](https://github.com/primer/view_components/pull/3319/commits/bb05db7199a348fa6397e8ad755ae55ec254cc8c), so users can apply this single attribute directly

I opted to use the second approach, as it is the minimum viable change required to make this component accessible when used with [turbo-rails](https://github.com/hotwired/turbo-rails). Using a more surgical, targeted approach seemed safer and easier to maintain/test than the more permissive, open-ended first approach. This also seemed more in line with Primer view component design principles.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

* What do reviewers think of the two approaches described above? Would folks prefer to ship the more permissive `button_arguments` approach? 🤔  I didn't see this kind of argument in many existing components; however, it does resemble generic system arguments, which are allowed for all components (if not the child elements they render, necessarily).
* Are there any concerns around supporting `autofocus` on a toggle switch button? It is an allowed attribute for buttons in general, but I wasn't sure if there was some reason we didn't already support it here.
* Should this be a minor release instead of a patch?

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
