### PR TITLE
Formatting tweak in NavList methods docs

### DIFF
--- a/app/components/primer/beta/nav_list.rb
+++ b/app/components/primer/beta/nav_list.rb
@@ -168,7 +168,7 @@ module Primer
         end
       end
 
-      # Lists that contain top-level items (i.e. items outside of a group) should be wrapped in a <ul>
+      # Lists that contain top-level items (i.e. items outside of a group) should be wrapped in a `<ul>`
       def render_outer_list?
         items.any? { |item| !group?(item) }
       end


### PR DESCRIPTION
### What are you trying to accomplish?

I was getting an error because the primer-docs Markdown parser was interpreting `'<ul>'` as HTML.
