### PR TITLE
Prevent Scroll on `ActionMenu`

### DIFF
--- a/.changeset/kind-shirts-shout.md
+++ b/.changeset/kind-shirts-shout.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Add preventScroll to focus call in Action Menu

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -205,7 +205,9 @@ export class ActionMenuElement extends HTMLElement {
     const eventIsActivation = this.#isActivation(event)
 
     if (event.type === 'toggle' && (event as ToggleEvent).newState === 'open') {
-      this.#firstItem?.focus({preventScroll: true})
+      window.requestAnimationFrame(() => {
+        this.#firstItem?.focus()
+      })
     }
 
     if (targetIsInvoker && event.type === 'mousedown') {
@@ -371,7 +373,10 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #handleIncludeFragmentReplaced() {
-    if (this.#firstItem) this.#firstItem.focus()
+    window.requestAnimationFrame(() => {
+      this.#firstItem?.focus()
+    })
+
     this.#softDisableItems()
 
     // async items have loaded, so component is ready

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -205,7 +205,9 @@ export class ActionMenuElement extends HTMLElement {
     const eventIsActivation = this.#isActivation(event)
 
     if (event.type === 'toggle' && (event as ToggleEvent).newState === 'open') {
-      this.#firstItem?.focus()
+      window.requestAnimationFrame(() => {
+        this.#firstItem?.focus({preventScroll: true})
+      })
     }
 
     if (targetIsInvoker && event.type === 'mousedown') {

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -205,9 +205,7 @@ export class ActionMenuElement extends HTMLElement {
     const eventIsActivation = this.#isActivation(event)
 
     if (event.type === 'toggle' && (event as ToggleEvent).newState === 'open') {
-      window.requestAnimationFrame(() => {
-        this.#firstItem?.focus({preventScroll: true})
-      })
+      this.#firstItem?.focus({preventScroll: true})
     }
 
     if (targetIsInvoker && event.type === 'mousedown') {

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -373,10 +373,7 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   #handleIncludeFragmentReplaced() {
-    window.requestAnimationFrame(() => {
-      this.#firstItem?.focus()
-    })
-
+    this.#firstItem?.focus()
     this.#softDisableItems()
 
     // async items have loaded, so component is ready

--- a/script/test-setup
+++ b/script/test-setup
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+bundle
+pushd demo; bundle; popd
 overmind start --daemonize --procfile Procfile.test --socket ./overmind-test.sock

--- a/test/system/alpha/action_bar_test.rb
+++ b/test/system/alpha/action_bar_test.rb
@@ -44,7 +44,10 @@ class IntegrationAlphaActionBarTest < System::TestCase
 
       # We want to ensure that we're within the ActionMenu assert_selector("action-bar") do
       keyboard.type(:enter)
-      assert_equal page.evaluate_script("document.activeElement.classList.contains('ActionListContent')"), true
+
+      assert_selector ".ActionListContent" do |content|
+        page.evaluate_script("document.activeElement === arguments[0]", content)
+      end
     end
 
     def test_escape_in_overflow_menu_sets_focus_back
@@ -58,7 +61,9 @@ class IntegrationAlphaActionBarTest < System::TestCase
       assert_equal page.evaluate_script("!!document.activeElement.closest('action-menu')"), true
 
       keyboard.type(:enter)
-      assert_equal page.evaluate_script("document.activeElement.classList.contains('ActionListContent')"), true
+      assert_selector ".ActionListContent" do |content|
+        page.evaluate_script("document.activeElement === arguments[0]", content)
+      end
 
       keyboard.type(:escape)
 
@@ -75,7 +80,10 @@ class IntegrationAlphaActionBarTest < System::TestCase
       keyboard.type(:tab, :left)
 
       keyboard.type(:enter)
-      assert_equal page.evaluate_script("document.activeElement.classList.contains('ActionListContent')"), true
+
+      assert_selector ".ActionListContent" do |content|
+        page.evaluate_script("document.activeElement === arguments[0]", content)
+      end
 
       mouse.click(x: 0, y: 0)
       keyboard.type(:tab)

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -76,6 +76,7 @@ module Alpha
         keyboard.type(:enter)
         assert_selector "anchored-position:popover-open" # wait for menu to open
 
+        # make sure the first list item is the active element
         assert_selector "button[role=menuitem], button[role=menuitemradio], button[role=menuitemcheckbox]" do |button|
           page.evaluate_script("document.activeElement === arguments[0]", button)
         end

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -75,6 +75,10 @@ module Alpha
         # open menu, "click" on first item
         keyboard.type(:enter)
         assert_selector "anchored-position:popover-open" # wait for menu to open
+
+        assert_selector "button[role=menuitem], button[role=menuitemradio], button[role=menuitemcheckbox]" do |button|
+          page.evaluate_script("document.activeElement === arguments[0]", button)
+        end
       end
     end
 


### PR DESCRIPTION
### What are you trying to accomplish?
This code change attempts to fix an issue our team was seeing with the `ActionMenu`.  After selecting some menus, the page would sometimes jump to the top of the webpage (example seen below).  After some investigating, it looks like this was related to the `focus()` method leveraged within the `handleEvent` function.  

(More investigation info in [this Slack thread](https://github.slack.com/archives/CGJTTJ738/p1739206015740219)).

In this PR, we add the `preventScroll` option to the `focus()` call, and wrap that within the `window.requestAnimationFrame()` method.

### Screenshots
https://github.com/user-attachments/assets/9aeac72f-a6d2-4f4b-84d1-ddd7c49e209e

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->
- https://github.com/github/ecosystem-apps/issues/6557#issuecomment-2640696718

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
