### PR TITLE
Update Markdown preview examples to include tabindex

### DIFF
--- a/app/components/primer/beta/markdown.rb
+++ b/app/components/primer/beta/markdown.rb
@@ -3,6 +3,7 @@
 module Primer
   module Beta
     # Use `Markdown` to wrap markdown content.
+    # @accessibility This component is purely presentational. Consumers should handle accessibility expectations, such as ensuring that an overflowing, scrollable code block or table is keyboard accessible.
     class Markdown < Primer::Component
       status :beta
 

--- a/previews/primer/beta/markdown_preview.rb
+++ b/previews/primer/beta/markdown_preview.rb
@@ -47,7 +47,7 @@ module Primer
 
       <h6>Header 6</h6>
 
-      <table>
+      <table tabindex="0">
         <thead>
           <tr>
             <th>What</th>
@@ -147,7 +147,7 @@ module Primer
 
       <p>Tables should have bold headings and alternating shaded rows.</p>
 
-      <table>
+      <table tabindex="0">
         <thead>
           <tr>
             <th>Artist</th>
@@ -181,7 +181,7 @@ module Primer
 
       <p>If a table is too wide, it should condense down and/or scroll horizontally.</p>
 
-      <table>
+      <table tabindex="0">
         <thead>
           <tr>
             <th>Artist</th>
@@ -237,13 +237,13 @@ module Primer
 
       <pre><code>var foo = \"bar\";</code></pre>
 
-      <pre><code>Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. This line should be long enough to demonstrate this.</code></pre>
+      <pre tabindex="0"><code>Long, single-line code blocks should not wrap. They should horizontally scroll if they are too long. They should also have a tabindex=0 to ensure keyboard accessibility. This line should be long enough to demonstrate this.</code></pre>
 
-      <pre><code>var foo = \"The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.\";</code></pre>
+      <pre tabindex="0"><code>var foo = \"The same thing is true for code with syntax highlighting. A single line of code should horizontally scroll if it is really long.\";</code></pre>
 
       <p>Inline code inside table cells should still be distinguishable.</p>
 
-      <table>
+      <table tabindex="0">
         <thead>
           <tr>
             <th>Language</th>

--- a/previews/primer/beta/markdown_preview.rb
+++ b/previews/primer/beta/markdown_preview.rb
@@ -47,7 +47,7 @@ module Primer
 
       <h6>Header 6</h6>
 
-      <table tabindex="0">
+      <table>
         <thead>
           <tr>
             <th>What</th>
@@ -147,7 +147,7 @@ module Primer
 
       <p>Tables should have bold headings and alternating shaded rows.</p>
 
-      <table tabindex="0">
+      <table>
         <thead>
           <tr>
             <th>Artist</th>

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -14500,7 +14500,7 @@
   {
     "fully_qualified_name": "Primer::Beta::Markdown",
     "description": "Use `Markdown` to wrap markdown content.",
-    "accessibility_docs": null,
+    "accessibility_docs": "This component is purely presentational. Consumers should handle accessibility expectations, such as ensuring that an overflowing, scrollable code block or table is keyboard accessible.",
     "is_form_component": false,
     "is_published": true,
     "requires_js": false,


### PR DESCRIPTION
### What are you trying to accomplish?

* Updates Markdown preview examples to include tabindex to ensure horizontal overflow region can be scrolled with keyboard.
* Adds a note that this component is purely presentational.

#### List the issues that this change affects.

Relates to:
* https://github.com/github/accessibility-audits/issues/10053
* https://github.com/github/accessibility-audits/issues/10132

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Given this component is purely presentational, I hesitate to add JS behaviors to it since it's already used in places that might already be providing JS behaviors. I opted to add a warning to have the consumer handle adding JS behaviors. For example, dotcom has a JS script to handle overflowing tables. (Note: we are still not handling overflow code blocks and I've started a convo with the relevant team. See [this discussion thread](https://github.com/github/accessibility-audits/issues/10053#issuecomment-2654953629)).

### Anything you want to highlight for special attention from reviewers?

Does this approach sound reasonable? 


### Merge checklist

- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
