### PR TITLE
use command/commandfor over custom data-(show|close|submit)-dialog-id

### DIFF
--- a/.changeset/happy-camels-march.md
+++ b/.changeset/happy-camels-march.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Deprecate `data-show-dialog-id` and `data-close-dialog-id`, use `commandfor` & `command` instead.

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -247,10 +247,10 @@ export class ActionMenuElement extends HTMLElement {
     if (targetIsItem && eventIsActivation) {
       if (this.#potentiallyDisallowActivation(event)) return
 
-      const dialogInvoker = item.closest('[data-show-dialog-id]')
+      const dialogInvoker = item.closest<HTMLButtonElement>('button[commandfor][command=show-modal]')
 
       if (dialogInvoker) {
-        const dialog = this.ownerDocument.getElementById(dialogInvoker.getAttribute('data-show-dialog-id') || '')
+        const dialog = dialogInvoker.commandForElement
 
         if (dialog && this.contains(dialogInvoker)) {
           this.#handleDialogItemActivated(event, dialog)

--- a/app/components/primer/alpha/dialog.rb
+++ b/app/components/primer/alpha/dialog.rb
@@ -62,7 +62,10 @@ module Primer
           system_arguments[:classes]
         )
         system_arguments[:id] = "dialog-show-#{@system_arguments[:id]}"
-        system_arguments[:data] = (system_arguments[:data] || {}).merge({ "show-dialog-id": @system_arguments[:id] })
+        system_arguments[:data] = (system_arguments[:data] || {})
+        system_arguments[:type] = :button
+        system_arguments[:commandfor] = @system_arguments[:id]
+        system_arguments[:command] = "show-modal"
         if icon.present?
           Primer::Beta::IconButton.new(icon: icon, **system_arguments)
         else

--- a/app/components/primer/alpha/dialog/header.html.erb
+++ b/app/components/primer/alpha/dialog/header.html.erb
@@ -13,7 +13,7 @@
       <% end %>
     </div>
     <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "data-close-dialog-id": @id) %>
+      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "type": :button, "commandfor": @id, "command": "close") %>
     </div>
   </div>
   <%= filter %>

--- a/app/components/primer/alpha/modal_dialog.ts
+++ b/app/components/primer/alpha/modal_dialog.ts
@@ -1,5 +1,6 @@
 import {focusTrap} from '@primer/behaviors'
 import {getFocusableChild} from '@primer/behaviors/utils'
+import 'invokers-polyfill'
 
 function focusIfNeeded(elem: HTMLElement | undefined | null) {
   if (document.activeElement !== elem) {
@@ -18,6 +19,8 @@ function clickHandler(event: Event) {
   // If the user is clicking a valid dialog trigger
   let dialogId = button?.getAttribute('data-show-dialog-id')
   if (dialogId) {
+    // eslint-disable-next-line no-console
+    console.warn('data-show-dialog-id is deprecated. Please use `commandfor` and `command=show-modal`')
     /* eslint-disable-next-line no-restricted-syntax */
     event.stopPropagation()
     const dialog = document.getElementById(dialogId)
@@ -36,6 +39,8 @@ function clickHandler(event: Event) {
 
   dialogId = button.getAttribute('data-close-dialog-id') || button.getAttribute('data-submit-dialog-id')
   if (dialogId) {
+    // eslint-disable-next-line no-console
+    console.warn('data-close-dialog-id is deprecated. Please use `commandfor` and `command=show-modal`')
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof ModalDialogElement) {
       const dialogIndex = overlayStack.findIndex(ele => ele.id === dialogId)

--- a/app/components/primer/alpha/overlay/header.html.erb
+++ b/app/components/primer/alpha/overlay/header.html.erb
@@ -12,7 +12,7 @@
     </div>
     <% if @overlay_id %>
       <div class="Overlay-actionWrap">
-        <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @overlay_id, "popovertargetaction": "hide", "data-close-dialog-id": @overlay_id) %>
+        <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "popovertarget": @overlay_id, "popovertargetaction": "hide") %>
       </div>
     <% end %>
   </div>

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -6,6 +6,7 @@ import type {AnchorAlignment, AnchorSide} from '@primer/behaviors'
 import type {LiveRegionElement} from '@primer/live-region-element'
 import '@primer/live-region-element'
 import '@oddbird/popover-polyfill'
+import 'invokers-polyfill'
 import {observeMutationsUntilConditionMet} from '../utils'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null
@@ -144,7 +145,7 @@ export class SelectPanelElement extends HTMLElement {
   }
 
   get closeButton(): HTMLButtonElement | null {
-    return this.querySelector('button[data-close-dialog-id]')
+    return this.querySelector('button[commandfor][command="close"]')
   }
 
   get invokerLabel(): HTMLElement | null {
@@ -483,10 +484,10 @@ export class SelectPanelElement extends HTMLElement {
     if (targetIsItem && eventIsActivation) {
       if (this.#potentiallyDisallowActivation(event)) return
 
-      const dialogInvoker = item.closest('[data-show-dialog-id]')
+      const dialogInvoker = item.closest<HTMLButtonElement>('button[commandfor][command="show-modal"]')
 
       if (dialogInvoker) {
-        const dialog = this.ownerDocument.getElementById(dialogInvoker.getAttribute('data-show-dialog-id') || '')
+        const dialog = dialogInvoker.commandForElement
 
         if (dialog && this.contains(dialogInvoker) && this.contains(dialog)) {
           this.#handleDialogItemActivated(event, dialog)

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -1,3 +1,5 @@
+import 'invokers-polyfill'
+
 function dialogInvokerButtonHandler(event: Event) {
   const target = event.target as HTMLElement
   const button = target?.closest('button')
@@ -7,6 +9,8 @@ function dialogInvokerButtonHandler(event: Event) {
   // If the user is clicking a valid dialog trigger
   let dialogId = button?.getAttribute('data-show-dialog-id')
   if (dialogId) {
+    // eslint-disable-next-line no-console
+    console.warn('data-show-dialog-id is deprecated. Please use `commandfor` and `command=show-modal`')
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof HTMLDialogElement) {
       dialog.showModal()
@@ -59,6 +63,8 @@ function dialogInvokerButtonHandler(event: Event) {
 
   dialogId = button.getAttribute('data-close-dialog-id') || button.getAttribute('data-submit-dialog-id')
   if (dialogId) {
+    // eslint-disable-next-line no-console
+    console.warn('data-close-dialog-id is deprecated. Please use `commandfor` and `command=close`')
     const dialog = document.getElementById(dialogId)
     if (dialog instanceof HTMLDialogElement && dialog.open) {
       dialog.close()

--- a/demo/app/views/action_menu/deferred.html.erb
+++ b/demo/app/views/action_menu/deferred.html.erb
@@ -5,7 +5,7 @@
   <% list.with_item(
     label: "Show dialog",
     tag: :button,
-    content_arguments: { "data-show-dialog-id": "my-dialog" },
+    content_arguments: { "type": :button, "commandfor": "my-dialog", "command": "show-modal" },
     value: "",
     scheme: :danger
   ) %>

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.5.2",
         "@primer/behaviors": "^1.3.4",
-        "@primer/live-region-element": "^0.7.1"
+        "@primer/live-region-element": "^0.7.1",
+        "invokers-polyfill": "^0.4.8"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
@@ -6562,6 +6563,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/invokers-polyfill": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/invokers-polyfill/-/invokers-polyfill-0.4.8.tgz",
+      "integrity": "sha512-M1injmSmfl2xKjlRaU/Ci6hk+Xma4IzjkTbrho5dacQNSVZMuXj/fNFGORU827+pIzfayPsk1iDAxmWWTzFh1Q==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -16296,6 +16303,11 @@
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
       }
+    },
+    "invokers-polyfill": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/invokers-polyfill/-/invokers-polyfill-0.4.8.tgz",
+      "integrity": "sha512-M1injmSmfl2xKjlRaU/Ci6hk+Xma4IzjkTbrho5dacQNSVZMuXj/fNFGORU827+pIzfayPsk1iDAxmWWTzFh1Q=="
     },
     "is-array-buffer": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "@github/relative-time-element": "^4.0.0",
     "@github/remote-input-element": "^0.4.0",
     "@github/tab-container-element": "^3.1.2",
-    "@primer/live-region-element": "^0.7.1",
     "@oddbird/popover-polyfill": "^0.5.2",
-    "@primer/behaviors": "^1.3.4"
+    "@primer/behaviors": "^1.3.4",
+    "@primer/live-region-element": "^0.7.1",
+    "invokers-polyfill": "^0.4.8"
   },
   "peerDependencies": {
     "@primer/primitives": "9.x || 10.x"

--- a/previews/primer/alpha/action_menu_preview/opens_dialog.html.erb
+++ b/previews/primer/alpha/action_menu_preview/opens_dialog.html.erb
@@ -4,7 +4,7 @@
   <% component.with_item(
     label: "Show dialog",
     tag: :button,
-    content_arguments: { "data-show-dialog-id": "my-dialog" },
+    content_arguments: { "type": :button, "commandfor": "my-dialog", "command": "show-modal" },
     value: "",
     scheme: :danger
   ) %>
@@ -15,7 +15,7 @@
     Are you sure you want to delete this?
   <% end %>
   <%= render(Primer::Alpha::Dialog::Footer.new()) do %>
-    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
+    <%= render(Primer::Beta::Button.new(data: { "type": :button, "commandfor": "my-dialog", "command": "close" })) { "Cancel" } %>
     <%= render(Primer::Beta::Button.new(scheme: :danger)) { "Delete" } %>
   <% end %>
 <% end %>

--- a/test/components/alpha/select_panel_test.rb
+++ b/test/components/alpha/select_panel_test.rb
@@ -115,7 +115,7 @@ module Primer
         render_preview(:default)
 
         panel_id = page.find_css("select-panel").first.attributes["id"].value
-        assert_selector "select-panel button[data-close-dialog-id='#{panel_id}-dialog']"
+        assert_selector "select-panel button[commandfor='#{panel_id}-dialog'][command=close]"
       end
 
       def test_raises_if_remote_strategy_and_hidden_filter_used_together

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -24,13 +24,13 @@ module Primer
           component.with_show_button { "Show" }
         end
 
-        assert_selector("[data-show-dialog-id]")
+        assert_selector("[commandfor][command='show-modal']")
       end
 
       def test_renders_icon_show_button
         render_preview :playground, params: { icon: :ellipsis }
 
-        assert_selector("button[data-show-dialog-id] svg.octicon.octicon-ellipsis")
+        assert_selector("button[commandfor][command='show-modal'] svg.octicon.octicon-ellipsis")
       end
 
       def test_raises_on_missing_title

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -84,7 +84,7 @@ module Alpha
     end
 
     def close_dialog
-      find("[data-close-dialog-id][aria-label=Close]").click
+      find("[commandfor][command=close][aria-label=Close]").click
     end
 
     def focus_on_invoker_button

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -9,12 +9,12 @@ module Alpha
     def click_on_initial_dialog_close_button
       # this simulates capybara's #trigger method, which isn't supported with selenium drivers
       page.evaluate_script(<<~JS)
-        document.querySelector("button[data-close-dialog-id='dialog-one']").dispatchEvent(new Event('click'))
+        document.querySelector("button[commandfor='dialog-one'][command=close]").dispatchEvent(new Event('click'))
       JS
     end
 
     def click_on_nested_dialog_close_button
-      find("button[data-close-dialog-id='dialog-two']").click
+      find("button[commandfor='dialog-two'][command=close]").click
     end
 
     def click_on_nested_dialog_button

--- a/test/system/alpha/select_panel_test.rb
+++ b/test/system/alpha/select_panel_test.rb
@@ -38,7 +38,7 @@ module Alpha
     end
 
     def click_on_x_button
-      find("[data-close-dialog-id]").click
+      find("[commandfor][command=close]").click
     end
 
     def click_on_item(idx)


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

I want to deprecate `data-show-dialog-id` and `data-close-dialog-id`. Doing this allows us to:

 - Reduce the amount of JS code required for primer functionality.
 - Reduce the _bespoke_ API surface of PVC; relying instead on web-platform features.
 - Rely more on the web-platform for mitigiating bugs an accessibility issues.

### Integration
<!-- Does this change require any updates to code in production? -->

No updates to production, but production will also want to migrate.

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->


#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
