### PR TITLE
refactor dialog-helper to use toggle events

### DIFF
--- a/.changeset/green-sloths-press.md
+++ b/.changeset/green-sloths-press.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Improve performance of Dialog element

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -14,11 +14,15 @@ function dialogToggleHandler(event: Event) {
   if (newState !== 'open') return
   if (target.closest('dialog-helper')?.dialog !== target) return
   // We don't want to show the Dialog component as non-modal
-  if (target.matches('[open]:not(:modal)')) {
+  forceDialogToOpenAsModal(target)
+}
+
+function forceDialogToOpenAsModal(dialog: HTMLDialogElement) {
+  if (dialog.matches('[open]:not(:modal)')) {
     // eslint-disable-next-line no-restricted-syntax
-    target.addEventListener('close', e => e.stopImmediatePropagation(), {once: true})
-    target.close()
-    target.showModal()
+    dialog.addEventListener('close', e => e.stopImmediatePropagation(), {once: true})
+    dialog.close()
+    dialog.showModal()
   }
 }
 
@@ -102,6 +106,8 @@ export class DialogHelperElement extends HTMLElement {
     document.addEventListener('click', this, {signal})
     document.addEventListener('beforetoggle', dialogBeforeToggleHandler, true)
     document.addEventListener('toggle', dialogToggleHandler, true)
+    const {dialog} = this
+    if (dialog.open) forceDialogToOpenAsModal(dialog)
   }
 
   disconnectedCallback() {

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -107,7 +107,7 @@ export class DialogHelperElement extends HTMLElement {
     document.addEventListener('beforetoggle', dialogBeforeToggleHandler, true)
     document.addEventListener('toggle', dialogToggleHandler, true)
     const {dialog} = this
-    if (dialog.open) forceDialogToOpenAsModal(dialog)
+    if (dialog?.open) forceDialogToOpenAsModal(dialog)
   }
 
   disconnectedCallback() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "@github/tab-container-element": "^3.1.2",
         "@oddbird/popover-polyfill": "^0.5.2",
         "@primer/behaviors": "^1.3.4",
-        "@primer/live-region-element": "^0.7.1"
+        "@primer/live-region-element": "^0.7.1",
+        "dialog-toggle-events-polyfill": "^1.0.1"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",
@@ -4715,6 +4716,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dialog-toggle-events-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dialog-toggle-events-polyfill/-/dialog-toggle-events-polyfill-1.0.1.tgz",
+      "integrity": "sha512-wS8Ku4Z+BNdDoOEkAow/8c7Ilip/hHmV+75WhRxkWghbM8f909F4+vn+p63SE3Waq9K/nEt0gQrX+zUMVV0Kew==",
+      "license": "MIT"
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -14985,6 +14992,11 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "dev": true
+    },
+    "dialog-toggle-events-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dialog-toggle-events-polyfill/-/dialog-toggle-events-polyfill-1.0.1.tgz",
+      "integrity": "sha512-wS8Ku4Z+BNdDoOEkAow/8c7Ilip/hHmV+75WhRxkWghbM8f909F4+vn+p63SE3Waq9K/nEt0gQrX+zUMVV0Kew=="
     },
     "diff": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
     "@github/relative-time-element": "^4.0.0",
     "@github/remote-input-element": "^0.4.0",
     "@github/tab-container-element": "^3.1.2",
-    "@primer/live-region-element": "^0.7.1",
     "@oddbird/popover-polyfill": "^0.5.2",
-    "@primer/behaviors": "^1.3.4"
+    "@primer/behaviors": "^1.3.4",
+    "@primer/live-region-element": "^0.7.1",
+    "dialog-toggle-events-polyfill": "^1.0.1"
   },
   "peerDependencies": {
     "@primer/primitives": "9.x || 10.x"


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In https://github.com/primer/view_components/pull/3144 we managed to reduce the cost of an expensive recalc by using `@property --dialog-scrollgutter { inherits: false }`. This dramatically reduced the recalc cost of this particular bit of code.

However one thing we wanted to do - but failed to achieve in that PR - was to perform this calc as _late as possible_. Right now every page load (or thereabouts) that features a dialog causes this recalc. In https://github.com/primer/view_components/pull/3144 we first tried to override the invoker function to do this during the click of the opener button, however there are callsites in the monolith that don't use the opener button, and instead call `showModal` directly. We could have overridden that but it was deemed a risky change. This was discussed here: https://github.com/primer/view_components/pull/3144#discussion_r1793739156. In this discussion I pointed out that once https://github.com/whatwg/html/issues/9733 lands then we could use `beforetoggle` to reliably find a point in time _just before_ the dialog opens, but this is a more complex fix.

So, fast forward to today; `beforetoggle` and `toggle` exist in Chrome & Firefox, and have recently been merged in Safari. I have a [polyfill](https://github.com/keithamus/dialog-toggle-events-polyfill) available to support browsers which don't support these events, which works reliably. 

So this PR refactors the dialog helper to use `beforetoggle` to set the `--dialog-scrollgutter`.   It brings in the polyfill to ensure cross-browser-compat.

Additionally, our dialog-helper code uses a MutationObserver to force dialogs to be shown as modal, not as non-modal. This takes the opportunity to use the `toggle` event to do this instead. This will have a far smaller impact on performance than the change using `beforetoggle`, but it certainly helps and makes the code cleaner & more readable.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
