### PR TITLE
Do not close dialog when clicking on the backdrop when it contains a form

### DIFF
--- a/.changeset/no-close-dialog-with-form.md
+++ b/.changeset/no-close-dialog-with-form.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Do not close dialogs when clicking on the backdrop if the dialog contains a form

--- a/app/components/primer/dialog_helper.ts
+++ b/app/components/primer/dialog_helper.ts
@@ -111,6 +111,9 @@ export class DialogHelperElement extends HTMLElement {
     // The click target _must_ be the dialog element itself, and not elements underneath or inside.
     if (target !== dialog || !dialog?.open) return
 
+    // If the dialog contains a form, do not close the dialog when clicking outside of the dialog
+    if (dialog.querySelector('form')) return
+
     const rect = dialog.getBoundingClientRect()
     const clickWasInsideDialog =
       rect.top <= event.clientY &&

--- a/test/system/alpha/dialog_test.rb
+++ b/test/system/alpha/dialog_test.rb
@@ -89,6 +89,15 @@ module Alpha
       refute_selector "dialog[open]"
     end
 
+    def test_outside_click_does_not_close_dialog_with_form
+      visit_preview(:with_form)
+
+      click_button("Show Dialog")
+      mouse.click(x: 0, y: 0)
+
+      assert_selector "dialog[open]"
+    end
+
     def test_outside_menu_click_does_not_close_dialog
       visit_preview(:with_auto_complete)
 


### PR DESCRIPTION
### What are you trying to accomplish?
The [docs](https://primer.style/components/dialog/#backdrop) state that dialogs should not be closed when clicking on the backdrop, when the dialog contains a form:

> By default, clicking on the backdrop will dismiss the dialog. However, if the dialog contains a form that can have unsaved changes, the backdrop won't dismiss the dialog, regardless of the state of the form.

This behavior was not implemented yet. The PR adds the check to the mouse click handler for the dialog that it is not automatically closed, when the dialog contains a form.

### Screenshots

https://github.com/user-attachments/assets/188cbd16-0711-4a88-a6ea-f2e26aec44d4

### Integration
As this fix implenents behavior that is already documented, IMHO no change to documentation is needed.

#### List the issues that this change affects.

Fixes #3214

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
As the docs state that regardless of the state of the form the dialog should not be closed, I did not implement any logic to do dirty tracking of the form or similar, instead I just check for existance of a form within the dialog and thus prevent the auto closing logic.

> the backdrop won't dismiss the dialog, **regardless of the state of the form**.

### Anything you want to highlight for special attention from reviewers?
no

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
