### PR TITLE
Update app to use actions/create-github-app-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,13 @@ jobs:
 
       # Use the primer GitHub App for authentication.
       # See: https://github.com/organizations/primer/settings/apps/primer
-      - id: get-access-token
-        uses: camertron/github-app-installation-auth-action@v1
+      - name: Get App Token
+        uses: actions/create-github-app-token@v1
+        id: get-access-token
         with:
           app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
+          owner: primer
           private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
-          client-id: ${{ vars.PRIMER_APP_CLIENT_ID_SHARED }}
-          client-secret: ${{ secrets.PRIMER_APP_CLIENT_SECRET_SHARED }}
-          installation-id: ${{ vars.PRIMER_APP_INSTALLATION_ID_SHARED }}
 
       - name: Create release pull request or publish to npm
         id: changesets
@@ -52,5 +51,5 @@ jobs:
           version: npm run changeset:version
           publish: script/changeset-publish
         env:
-          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.access-token }}
+          GITHUB_TOKEN: ${{ steps.get-access-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}


### PR DESCRIPTION
Update the release workflow to use the `actions/create-github-app-token` action instead of `camertron/github-app-installation-auth-action`.