### PR TITLE
Creating a workflow that will assign the release conductor to the release pull request when it's opened

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -47,6 +47,7 @@
     "memory": "8gb"
   },
   "features": {
-    "sshd": "latest"
+    "sshd": "latest",
+    "ghcr.io/devcontainers/features/github-cli:1": {}
   }
 }

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pagerduty:
     name: PagerDuty Oncall
-    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+    uses: primer/.github/.github/actions/pagerduty/action.yml@release_conductor_script
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
     secrets:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -1,8 +1,7 @@
 name: Assign Release Conductor
 
 on:
-  push:
-  workflow_dispatch:
+  pull_request:
 
 jobs:
   pagerduty:
@@ -24,11 +23,9 @@ jobs:
       - name: Get Release PR
         id: release-pr
         run: |
-          PR_NUMBER=$(gh pr list --head changeset-release/main --json number --jq '.[].number')
-          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "assignees=$(gh pr view $PR_NUMBER --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
-          echo "reviews=$(gh pr view $PR_NUMBER --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+          echo "assignees=$(gh pr view ${{ github.event.number }} --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+          echo "reviews=$(gh pr view ${{ github.event.number }} --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
       - name: Reset Assignees & Reviewers
         run: |
-          gh pr edit ${{ steps.release-pr.outputs.number }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
-          gh pr edit ${{ steps.release-pr.outputs.number }} --add-reviewer ${{ needs.pagerduty.outputs.user }} --add-assignee ${{ needs.pagerduty.outputs.user }}
+          gh pr edit ${{ github.event.number }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
+          gh pr edit ${{ github.event.number }} --add-reviewer ${{ needs.pagerduty.outputs.user }} --add-assignee ${{ needs.pagerduty.outputs.user }}

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -1,4 +1,4 @@
-name: Get Oncall username
+name: Assign Release Conductor
 
 on:
   push:
@@ -17,19 +17,14 @@ jobs:
     needs: pagerduty
     steps:
       - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
-
-      # - name: Get Release PR
-      #   id: release-pr
-      #   run: |
-      #     PR_NUMBER=$(gh pr list -R ${{ matrix.repo }} --head changeset-release/main --json number --jq '.[].number')
-      #     echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
-      #     echo "assignees=$(gh pr view $PR_NUMBER -R ${{ matrix.repo }} --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
-      #     echo "reviews=$(gh pr view $PR_NUMBER -R ${{ matrix.repo }} --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      # - name: Reset Assignees & Reviewers
-      #   run: |
-      #     gh pr edit ${{ steps.release-pr.outputs.number }} -R ${{ matrix.repo }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
-      #     gh pr edit ${{ steps.release-pr.outputs.number }} -R ${{ matrix.repo }} --add-reviewer ${{ steps.pagerduty.outputs.user }} --add-assignee ${{ steps.pagerduty.outputs.user }}
-      #   env:
-      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Get Release PR
+        id: release-pr
+        run: |
+          PR_NUMBER=$(gh pr list --head changeset-release/main --json number --jq '.[].number')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "assignees=$(gh pr view $PR_NUMBER --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+          echo "reviews=$(gh pr view $PR_NUMBER --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+      - name: Reset Assignees & Reviewers
+        run: |
+          gh pr edit ${{ steps.release-pr.outputs.number }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
+          gh pr edit ${{ steps.release-pr.outputs.number }} --add-reviewer ${{ needs.pagerduty.outputs.user }} --add-assignee ${{ needs.pagerduty.outputs.user }}

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -5,13 +5,15 @@ on:
 
 jobs:
   pagerduty:
-    - name: PagerDuty Oncall
-      id: pagerduty
-      uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
-      with:
-        schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
-        token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
-    - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
+    steps:
+      - name: PagerDuty Oncall
+        id: pagerduty
+        uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+        with:
+          schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
+        secrets:
+          token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
+      - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
 
       # - name: Get Release PR
       #   id: release-pr

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -4,9 +4,6 @@ on:
   push:
   workflow_dispatch:
 
-permissions:
-  pull-requests: write
-
 jobs:
   pagerduty:
     name: PagerDuty Oncall

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -2,6 +2,7 @@ name: Get Oncall username
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   pagerduty:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,7 +6,6 @@ on:
 jobs:
   pagerduty:
     name: PagerDuty Oncall
-    id: pagerduty
     uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -5,13 +5,13 @@ on:
 
 jobs:
   pagerduty:
-  - name: PagerDuty Oncall
-    id: pagerduty
-    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
-    with:
-      schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
-      token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
-  - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
+    - name: PagerDuty Oncall
+      id: pagerduty
+      uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+      with:
+        schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
+        token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
+    - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
 
       # - name: Get Release PR
       #   id: release-pr

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pagerduty:
     name: PagerDuty Oncall
-    uses: primer/.github/.github/actions/pagerduty/action.yml@release_conductor_script
+    uses: primer/.github/.github/workflows/pagerduty/action.yml@release_conductor_script
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
     secrets:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pagerduty:
     name: PagerDuty Oncall
-    uses: primer/.github/.github/workflows/pagerduty/action.yml@release_conductor_script
+    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
     secrets:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -5,15 +5,18 @@ on:
 
 jobs:
   pagerduty:
+    name: PagerDuty Oncall
+    id: pagerduty
+    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+    with:
+      schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
+    secrets:
+      token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
+  schedule:
+    runs-on: ubuntu-latest
+    needs: pagerduty
     steps:
-      - name: PagerDuty Oncall
-        id: pagerduty
-        uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
-        with:
-          schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
-        secrets:
-          token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
-      - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
+      - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
 
       # - name: Get Release PR
       #   id: release-pr

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -4,6 +4,9 @@ on:
   push:
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 jobs:
   pagerduty:
     name: PagerDuty Oncall
@@ -16,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: pagerduty
     env:
-      GH_TOKEN: ${{ github.token }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
       - name: Get Release PR

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -5,13 +5,14 @@ on:
 
 jobs:
   pagerduty:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'changeset-release/main'
     name: PagerDuty Oncall
     uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
     secrets:
       token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
-  schedule:
+  update-assignee:
     runs-on: ubuntu-latest
     needs: pagerduty
     env:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -1,0 +1,29 @@
+name: Get Oncall username
+
+on:
+  push:
+
+jobs:
+  pagerduty:
+  - name: PagerDuty Oncall
+    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+    with:
+      schedule-id: 'PCCKSZ5'
+      token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
+  - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
+
+      # - name: Get Release PR
+      #   id: release-pr
+      #   run: |
+      #     PR_NUMBER=$(gh pr list -R ${{ matrix.repo }} --head changeset-release/main --json number --jq '.[].number')
+      #     echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+      #     echo "assignees=$(gh pr view $PR_NUMBER -R ${{ matrix.repo }} --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+      #     echo "reviews=$(gh pr view $PR_NUMBER -R ${{ matrix.repo }} --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      # - name: Reset Assignees & Reviewers
+      #   run: |
+      #     gh pr edit ${{ steps.release-pr.outputs.number }} -R ${{ matrix.repo }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
+      #     gh pr edit ${{ steps.release-pr.outputs.number }} -R ${{ matrix.repo }} --add-reviewer ${{ steps.pagerduty.outputs.user }} --add-assignee ${{ steps.pagerduty.outputs.user }}
+      #   env:
+      #     GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,13 +6,14 @@ on:
 jobs:
   pagerduty:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.ref == 'changeset-release/main'
-    name: PagerDuty Oncall
-    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
+    name: Lookup who is oncall from pagerduty
+    uses: primer/.github/.github/workflows/pagerduty_oncall.yml@v2.2.0
     with:
       schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
     secrets:
       token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
   update-assignee:
+    name: Update assignee and review requests
     runs-on: ubuntu-latest
     needs: pagerduty
     steps:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -1,4 +1,4 @@
-name: Assign Release Condu
+name: Assign Release Conductor
 
 on:
   push:

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -1,4 +1,4 @@
-name: Assign Release Conductor
+name: Assign Release Condu
 
 on:
   push:
@@ -15,6 +15,8 @@ jobs:
   schedule:
     runs-on: ubuntu-latest
     needs: pagerduty
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
       - name: Get Release PR

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -15,18 +15,26 @@ jobs:
   update-assignee:
     runs-on: ubuntu-latest
     needs: pagerduty
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
       - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
+      - name: Get App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PRIMER_APP_ID_SHARED }}
+          owner: primer
+          private-key: ${{ secrets.PRIMER_APP_PRIVATE_KEY_SHARED }}
+      - uses: actions/checkout@v4
       - name: Get Release PR
         id: release-pr
         run: |
           echo "assignees=$(gh pr view ${{ github.event.number }} --json assignees --jq ".assignees[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
           echo "reviews=$(gh pr view ${{ github.event.number }} --json reviewRequests  --jq ".reviewRequests[].login" | tr '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Reset Assignees & Reviewers
         run: |
           gh pr edit ${{ github.event.number }} --remove-reviewer "${{ steps.release-pr.outputs.reviews }}" --remove-assignee "${{ steps.release-pr.outputs.assignees }}"
           gh pr edit ${{ github.event.number }} --add-reviewer ${{ needs.pagerduty.outputs.user }} --add-assignee ${{ needs.pagerduty.outputs.user }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -21,6 +21,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
       - run: echo ${{ needs.pagerduty.outputs.user }} is the Release conductor
       - name: Get Release PR
         id: release-pr

--- a/.github/workflows/release_conductor.yml
+++ b/.github/workflows/release_conductor.yml
@@ -6,9 +6,10 @@ on:
 jobs:
   pagerduty:
   - name: PagerDuty Oncall
+    id: pagerduty
     uses: primer/.github/.github/workflows/pagerduty_oncall.yml@release_conductor_script
     with:
-      schedule-id: 'PCCKSZ5'
+      schedule-id: ${{ vars.PAGERDUTY_RELEASE_CONDUCTOR_SCHEDULE }}
       token: ${{ secrets.PAGERDUTY_TOKEN_SHARED }}
   - run: echo ${{ steps.pagerduty.outputs.user }} is the Release conductor
 


### PR DESCRIPTION
This workflow will lookup the current on call release conductor and assign them to the release pull request. This uses the script being added here https://github.com/primer/.github/pull/48