### PR TITLE
Add `Dialog::Header` `close_scheme`, `close_label` params

### DIFF
--- a/app/components/primer/alpha/dialog/header.html.erb
+++ b/app/components/primer/alpha/dialog/header.html.erb
@@ -12,9 +12,17 @@
         <%= subtitle %>
       <% end %>
     </div>
-    <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "data-close-dialog-id": @id) %>
-    </div>
+    <% if @close_scheme != :none %>
+      <div class="Overlay-actionWrap">
+        <%= render(
+          Primer::Beta::CloseButton.new(
+            classes: "Overlay-closeButton",
+            aria: { label: @close_label },
+            data: { close_dialog_id: @id }
+          )
+        ) %>
+      </div>
+    <% end %>
   </div>
   <%= filter %>
 <% end %>

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -16,6 +16,14 @@ module Primer
         }.freeze
         VARIANT_OPTIONS = VARIANT_MAPPINGS.keys
 
+        DEFAULT_CLOSE_SCHEME = :close
+        CLOSE_SCHEMES = [
+          DEFAULT_CLOSE_SCHEME,
+          :none
+        ].freeze
+
+        DEFAULT_CLOSE_LABEL = "Close"
+
         # Optional filter slot for adding a filter input to the header.
         #
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
@@ -48,6 +56,8 @@ module Primer
         # @param show_divider [Boolean] Show a divider between the header and body.
         # @param visually_hide_title [Boolean] Visually hide the `title` while maintaining a label for assistive technologies.
         # @param variant [Symbol] <%= one_of(Primer::Alpha::Dialog::Header::VARIANT_OPTIONS) %>
+        # @param close_scheme [Symbol] Whether the component can be closed with an "x" button. <%= one_of(Primer::Alpha::Banner::CLOSE_SCHEMES) %>
+        # @param close_label [String] The aria-label text of the close "x" button.
         # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
         def initialize(
           id:,
@@ -56,12 +66,16 @@ module Primer
           show_divider: false,
           visually_hide_title: false,
           variant: DEFAULT_VARIANT,
+          close_scheme: DEFAULT_CLOSE_SCHEME,
+          close_label: DEFAULT_CLOSE_LABEL,
           **system_arguments
         )
           @id = id
           @title = title
           @subtitle = subtitle
           @visually_hide_title = visually_hide_title
+          @close_scheme = close_scheme
+          @close_label = close_label
           @system_arguments = deny_tag_argument(**system_arguments)
           @system_arguments[:tag] = :div
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -363,6 +363,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -302,6 +302,38 @@ module Primer
       def with_header_filter
         render_with_template(locals: {})
       end
+
+      # @label With Header Close Button label
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      # @param close_label [String] text
+      def with_header_close_button_label(title: "Test Dialog", subtitle: nil, button_text: "Show Dialog", show_divider: true, close_label: "Close me!")
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               button_text: button_text,
+                               show_divider: show_divider,
+                               close_label: close_label
+                             })
+      end
+
+      # @label Without Header Close Button
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      def without_header_close_button(title: "Test Dialog", subtitle: nil, button_text: "Show Dialog", show_divider: true)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               button_text: button_text,
+                               show_divider: show_divider
+                             })
+      end
     end
   end
 end

--- a/previews/primer/alpha/dialog_preview/with_header_close_button_label.html.erb
+++ b/previews/primer/alpha/dialog_preview/with_header_close_button_label.html.erb
@@ -1,0 +1,5 @@
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: title, subtitle: subtitle, visually_hide_title: false)) do |dialog| %>
+  <% dialog.with_header(show_divider: show_divider, close_label: close_label) %>
+  <% dialog.with_show_button_content(button_text) %>
+  <% dialog.with_body_content("Hello World") %>
+<% end %>

--- a/previews/primer/alpha/dialog_preview/without_header_close_button.html.erb
+++ b/previews/primer/alpha/dialog_preview/without_header_close_button.html.erb
@@ -1,0 +1,8 @@
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: title, subtitle: subtitle, visually_hide_title: false)) do |dialog| %>
+  <% dialog.with_header(show_divider: show_divider, close_scheme: :none) %>
+  <% dialog.with_show_button_content(button_text) %>
+  <% dialog.with_body_content("Hello World") %>
+  <% dialog.with_footer do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Close" } %>
+  <% end %>
+<% end %>

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -98,6 +98,34 @@ module Primer
         assert_selector(".Overlay-header .Overlay-description")
       end
 
+      def test_renders_header_with_close_label
+        render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog")) do |component|
+          component.with_body { "content" }
+          component.with_header(close_label: "Close me!") { "header" }
+        end
+
+        assert_selector("dialog") do
+          assert_selector(".Overlay-header") do
+            assert_selector(".Overlay-actionWrap")
+            assert_selector("button[data-close-dialog-id][aria-label='Close me!']")
+          end
+        end
+      end
+
+      def test_renders_header_with_close_scheme_none
+        render_inline(Primer::Alpha::Dialog.new(title: "Title", id: "my-dialog")) do |component|
+          component.with_body { "content" }
+          component.with_header(close_scheme: :none) { "header" }
+        end
+
+        assert_selector("dialog") do
+          assert_selector(".Overlay-header") do
+            refute_selector(".Overlay-actionWrap")
+            refute_selector("button[data-close-dialog-id]")
+          end
+        end
+      end
+
       def test_renders_header_with_filter
         render_preview(:with_header_filter)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Currently it is not possible to specify a custom ARIA label for the Dialog close button. This is problematic for apps (like OpenProject) with fully localized UIs.

This PR adds two new params to `Primer::Alpha::Dialog::Header#initialize`:
- `@param close_scheme [Symbol]` Whether the component can be closed with an "x" button. Either `:close` or `:none`.
- `@param close_label [String]` The `aria-label` text of the close "x" button.

This allows for a few new scenarios:
- localization: the caller can pass a localized string as `close_label:` argument (e.g. with `I18n.t`).
- completely hiding the close button: this may be desirable from a UX perspective if the caller renders a close button elsewhere in the dialog (e.g. the footer).

### Screenshots

custom close label:

<img width="504" alt="Screenshot 2025-03-10 at 08 03 24" src="https://github.com/user-attachments/assets/d0d46309-3993-406c-bb41-b2c33a8e4bae" />

without a header close button:

<img width="498" alt="Screenshot 2025-03-10 at 08 03 31" src="https://github.com/user-attachments/assets/e5e9e0ba-a239-47da-b221-a67d8a16dca4" />

the initial focussed element is the footer close button.

### Integration

This should not be a breaking change.

#### List the issues that this change affects.

Closes # (type the GitHub issue number after #)

Related OpenProject Work Package: https://community.openproject.org/wp/61631

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

This API is modelled on the `Primer::Alpha::Banner` component, which accepts `dismiss_scheme` and `dismiss_label` arguments.

My initial approach was to create a `close_button` slot - I went ahead and pushed that work (see #3374) but wasn't happy with the API. For example, in order the hide the close button, you would need to call `with_close_button` without a block.

### Anything you want to highlight for special attention from reviewers?



### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
