### PR TITLE
Add `Dialog::Header` `close_button` slot [WIP]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 18.0.0)
-      view_component (>= 3.1, < 4.0)
+      view_component (>= 3.14, < 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/app/components/primer/alpha/dialog/header.html.erb
+++ b/app/components/primer/alpha/dialog/header.html.erb
@@ -12,9 +12,11 @@
         <%= subtitle %>
       <% end %>
     </div>
-    <div class="Overlay-actionWrap">
-      <%= render Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "data-close-dialog-id": @id) %>
-    </div>
+    <% if close_button? %>
+      <div class="Overlay-actionWrap">
+        <%= close_button %>
+      </div>
+    <% end %>
   </div>
   <%= filter %>
 <% end %>

--- a/app/components/primer/alpha/dialog/header.rb
+++ b/app/components/primer/alpha/dialog/header.rb
@@ -6,6 +6,8 @@ module Primer
       # A `Dialog::Header` is a compositional component, used to render the
       # Header of a dialog. See <%= link_to_component(Primer::Alpha::Dialog) %>.
       class Header < Primer::Component
+        include ViewComponent::SlotableDefault
+
         status :alpha
         audited_at "2022-10-10"
 
@@ -42,6 +44,8 @@ module Primer
           Primer::BaseComponent.new(**system_arguments)
         }
 
+        renders_one :close_button
+
         # @param id [String] The HTML element's ID value.
         # @param title [String] Describes the content of the dialog.
         # @param subtitle [String] Provides additional context for the dialog, also setting the `aria-describedby` attribute.
@@ -71,6 +75,10 @@ module Primer
             { "Overlay-header--divided": show_divider },
             system_arguments[:classes]
           )
+        end
+
+        def default_close_button
+          Primer::Beta::CloseButton.new(classes: "Overlay-closeButton", "data-close-dialog-id": @id)
         end
       end
     end

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.6.0"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", '>= 3.11.0'
+gem "view_component", '>= 3.14.0'
 gem "lookbook", "~> 2.3.5" unless rails_version.to_f < 7
 
 gem "vite_rails", "~> 3.0"

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
       octicons (>= 18.0.0)
-      view_component (>= 3.1, < 4.0)
+      view_component (>= 3.14, < 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -363,6 +363,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21
@@ -396,7 +397,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  view_component (>= 3.11.0)
+  view_component (>= 3.14.0)
   vite_rails (~> 3.0)
 
 BUNDLED WITH

--- a/previews/primer/alpha/dialog_preview.rb
+++ b/previews/primer/alpha/dialog_preview.rb
@@ -302,6 +302,36 @@ module Primer
       def with_header_filter
         render_with_template(locals: {})
       end
+
+      # @label Custom Header Close Button
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      def with_header_close_button(title: "Test Dialog", subtitle: nil, button_text: "Show Dialog", show_divider: true)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               button_text: button_text,
+                               show_divider: show_divider
+                             })
+      end
+
+      # @label No Header Close Button
+      #
+      # @param title [String] text
+      # @param subtitle [String] text
+      # @param button_text [String] text
+      # @param show_divider [Boolean] toggle
+      def with_no_header_close_button(title: "Test Dialog", subtitle: nil, button_text: "Show Dialog", show_divider: true)
+        render_with_template(locals: {
+                               title: title,
+                               subtitle: subtitle,
+                               button_text: button_text,
+                               show_divider: show_divider
+                             })
+      end
     end
   end
 end

--- a/previews/primer/alpha/dialog_preview/with_header_close_button.html.erb
+++ b/previews/primer/alpha/dialog_preview/with_header_close_button.html.erb
@@ -1,0 +1,9 @@
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: title, subtitle: subtitle, visually_hide_title: false)) do |dialog| %>
+  <% dialog.with_header(show_divider: show_divider) do |header| %>
+    <% header.with_close_button(bg: :danger) do %>
+      <%= render(Primer::Beta::CloseButton.new(bg: :accent, classes: "Overlay-closeButton", data: { close_dialog_id: dialog.id })) %>
+    <% end %>
+  <% end %>
+  <% dialog.with_show_button_content(button_text) %>
+  <% dialog.with_body_content("Hello World") %>
+<% end %>

--- a/previews/primer/alpha/dialog_preview/with_no_header_close_button.html.erb
+++ b/previews/primer/alpha/dialog_preview/with_no_header_close_button.html.erb
@@ -1,0 +1,10 @@
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: title, subtitle: subtitle, visually_hide_title: false)) do |dialog| %>
+  <% dialog.with_header(show_divider: show_divider) do |header| %>
+    <% header.with_close_button %>
+  <% end %>
+  <% dialog.with_show_button_content(button_text) %>
+  <% dialog.with_body_content("Hello World") %>
+  <% dialog.with_footer do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Close" } %>
+  <% end %>
+<% end %>

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "actionview", ">= 5.0.0"
   spec.add_runtime_dependency     "activesupport", ">= 5.0.0"
   spec.add_runtime_dependency     "octicons", ">= 18.0.0"
-  spec.add_runtime_dependency     "view_component", [">= 3.1", "< 4.0"]
+  spec.add_runtime_dependency     "view_component", [">= 3.14", "< 4.0"]
 end

--- a/test/components/primer/alpha/dialog_test.rb
+++ b/test/components/primer/alpha/dialog_test.rb
@@ -98,6 +98,13 @@ module Primer
         assert_selector(".Overlay-header .Overlay-description")
       end
 
+      def test_renders_header_close_button
+        render_inline(Primer::Alpha::Dialog::Header.new(id: "1", title: "Header")) do |component|
+          component.with_close_button { "subtitle" }
+        end
+        assert_selector(".Overlay-header")
+      end
+
       def test_renders_header_with_filter
         render_preview(:with_header_filter)
 


### PR DESCRIPTION
### What are you trying to accomplish?

The same as #3373 - this is an alternate implementation.

### Screenshots

See #3373 


### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

See #3373 for why this approach might be sub-optimal.

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
