### PR TITLE
Fixing bug in the select panel that pushes the page when it is open

### DIFF
--- a/.changeset/sweet-mugs-invent.md
+++ b/.changeset/sweet-mugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fixing bug in the select panel that pushes the page when any `:modal` is open.

--- a/app/components/primer/alpha/dialog.pcss
+++ b/app/components/primer/alpha/dialog.pcss
@@ -21,11 +21,8 @@
   syntax: "<length>";
 }
 
-body:has(:modal) {
-  padding-right: var(--dialog-scrollgutter) !important;
-}
-
 body:has(dialog:modal.Overlay--disableScroll) {
+  padding-right: var(--dialog-scrollgutter) !important;
   overflow: hidden !important;
 }
 


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/4834

### What are you trying to accomplish?

The selector `body:has(:modal)` was causing the page to push when the dialog was open. This is because there's more than one modal on the page and not all of them have the Overflow scroll logic.

To fix the issue I combined the selectors to only apply this padding if the modal has the `.Overlay-disableScroll` class.

### Integration

No

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
