### PR TITLE
Update IncludeFragment to add data-nonce when a current nonce is present

### DIFF
--- a/.changeset/sour-beds-draw.md
+++ b/.changeset/sour-beds-draw.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Create Primer::CurrentAttributes allowing apps to set request specific context to components. Update IncludeFragment to add data-nonce when a current nonce is present.

--- a/app/components/primer/alpha/include_fragment.rb
+++ b/app/components/primer/alpha/include_fragment.rb
@@ -21,7 +21,7 @@ module Primer
         @system_arguments[:src] = src
 
         if loading
-          @system_arguments[:loading] = fetch_or_fallback(ALLOWED_LOADING_VALUES, loading, DEFAULT_LOADING)
+          @system_arguments[:loading] = fetch_or_fallback(ALLOWED_LOADING_VALUES, loading.to_sym, DEFAULT_LOADING)
         end
 
         if Primer::CurrentAttributes.nonce

--- a/app/components/primer/alpha/include_fragment.rb
+++ b/app/components/primer/alpha/include_fragment.rb
@@ -8,14 +8,25 @@ module Primer
     class IncludeFragment < Primer::Component
       status :alpha
 
+      ALLOWED_LOADING_VALUES = [:lazy, :eager].freeze
+      DEFAULT_LOADING = :eager
+
       # @param src [String] The URL  from which to retrieve an HTML element fragment.
       # @param loading [Symbol] <%= one_of([:lazy, :eager]) %>
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(src: nil, loading: :eager, **system_arguments)
+      def initialize(src: nil, loading: nil, **system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:tag] = "include-fragment"
         @system_arguments[:loading] = loading
         @system_arguments[:src] = src
+
+        if loading
+          @system_arguments[:loading] = fetch_or_fallback(ALLOWED_LOADING_VALUES, loading, DEFAULT_LOADING)
+        end
+
+        if Primer::CurrentAttributes.nonce
+          @system_arguments[:"data-nonce"] = Primer::CurrentAttributes.nonce
+        end
       end
 
       def call

--- a/app/components/primer/alpha/include_fragment.rb
+++ b/app/components/primer/alpha/include_fragment.rb
@@ -13,12 +13,14 @@ module Primer
 
       # @param src [String] The URL  from which to retrieve an HTML element fragment.
       # @param loading [Symbol] <%= one_of([:lazy, :eager]) %>
+      # @param accept [String] What to send as the Accept header.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
-      def initialize(src: nil, loading: nil, **system_arguments)
+      def initialize(src: nil, loading: nil, accept: nil, **system_arguments)
         @system_arguments = system_arguments
         @system_arguments[:tag] = "include-fragment"
         @system_arguments[:loading] = loading
         @system_arguments[:src] = src
+        @system_arguments[:accept] = accept if accept
 
         if loading
           @system_arguments[:loading] = fetch_or_fallback(ALLOWED_LOADING_VALUES, loading.to_sym, DEFAULT_LOADING)

--- a/app/lib/primer/current_attributes.rb
+++ b/app/lib/primer/current_attributes.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module Primer
-  # :nodoc:
+  # `Primer::CurrentAttributes` can be used by controllers to set request-bound data
+  # that can be propagated to components.
   class CurrentAttributes < ActiveSupport::CurrentAttributes
     attribute :nonce
   end

--- a/app/lib/primer/current_attributes.rb
+++ b/app/lib/primer/current_attributes.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Primer
+  # :nodoc:
+  class CurrentAttributes < ActiveSupport::CurrentAttributes
+    attribute :nonce
+  end
+end

--- a/test/components/primer/alpha/include_fragment_test.rb
+++ b/test/components/primer/alpha/include_fragment_test.rb
@@ -5,10 +5,15 @@ require "components/test_helper"
 class PrimerAlphaIncludeFragmentTest < Minitest::Test
   include Primer::ComponentTestHelpers
 
+  def setup
+    Primer::CurrentAttributes.reset
+  end
+
   def test_renders
     render_inline(Primer::Alpha::IncludeFragment.new)
 
-    assert_selector("include-fragment[loading='eager']")
+    assert_selector("include-fragment:not([loading])")
+    assert_selector("include-fragment:not([data-nonce])")
   end
 
   def test_renders_lazy
@@ -17,9 +22,22 @@ class PrimerAlphaIncludeFragmentTest < Minitest::Test
     assert_selector("include-fragment[loading='lazy']")
   end
 
+  def test_renders_eager
+    render_inline(Primer::Alpha::IncludeFragment.new(loading: :eager))
+
+    assert_selector("include-fragment[loading='eager']")
+  end
+
   def test_renders_with_src
     render_inline(Primer::Alpha::IncludeFragment.new(src: "/some/path"))
 
     assert_selector("include-fragment[src='/some/path']")
+  end
+
+  def test_renders_with_nonce
+    Primer::CurrentAttributes.nonce = "nonce-value"
+    render_inline(Primer::Alpha::IncludeFragment.new)
+
+    assert_selector("include-fragment[data-nonce='nonce-value']")
   end
 end

--- a/test/components/primer/alpha/include_fragment_test.rb
+++ b/test/components/primer/alpha/include_fragment_test.rb
@@ -34,6 +34,12 @@ class PrimerAlphaIncludeFragmentTest < Minitest::Test
     assert_selector("include-fragment[src='/some/path']")
   end
 
+  def test_renders_accept
+    render_inline(Primer::Alpha::IncludeFragment.new(accept: "text/fragment+html"))
+
+    assert_selector("include-fragment[accept='text/fragment+html']")
+  end
+
   def test_renders_with_nonce
     Primer::CurrentAttributes.nonce = "nonce-value"
     render_inline(Primer::Alpha::IncludeFragment.new)


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

I'm providing a new `Primer::CurrentAttributes` class that callers can use to set some request/context dependent information to be passed to components. The first use here is setting a unique `nonce` to all `IncludeFragment` components without having to manually add it as a prop in every use-case.

### Screenshots
No UI changes.

### Integration
This is totally optional.

#### List the issues that this change affects.
Part of #4942

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?
I'm using [ActiveSupport::CurrentAttributes](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) to create a new Primer specific class to hold data related to components. This class is request bound so it ensures we can share data across a single request.

### Accessibility

- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
