### PR TITLE
Provide a default id for clear buttons in TextFields

### DIFF
--- a/.changeset/new-ravens-unite.md
+++ b/.changeset/new-ravens-unite.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Provide default id for clear button in text fields

--- a/app/lib/primer/forms/dsl/text_field_input.rb
+++ b/app/lib/primer/forms/dsl/text_field_input.rb
@@ -20,7 +20,7 @@ module Primer
           @leading_visual = system_arguments.delete(:leading_visual)
           @trailing_visual = system_arguments.delete(:trailing_visual)
           @leading_spinner = !!system_arguments.delete(:leading_spinner)
-          @clear_button_id = system_arguments.delete(:clear_button_id)
+          @clear_button_id = system_arguments.delete(:clear_button_id) || SecureRandom.uuid
           @inset = system_arguments.delete(:inset)
           @monospace = system_arguments.delete(:monospace)
           @auto_check_src = system_arguments.delete(:auto_check_src)


### PR DESCRIPTION
### What are you trying to accomplish?
Provide a default id for the clear button wihtin TextFields if `clear_button_id` is empty

### Integration
I don't think so..

#### List the issues that this change affects.
Closes #3482 

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
I used `SecureRandom.uuid` to provide a randomized ID. The `generate_id` method is only available in the scope of `Primer::Component` but not in `Primer::Forms::Dsl` 

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

