### PR TITLE
Publish routes in packaged gem

### DIFF
--- a/.changeset/shiny-experts-accept.md
+++ b/.changeset/shiny-experts-accept.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Publish config folder in packaged gem

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/**/*", "previews/**/*"] - Dir["lib/**/*.rake"]
+  spec.files         = Dir["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/**/*", "app/**/*", "static/**/*", "previews/**/*", "config/**/*"] - Dir["lib/**/*.rake"]
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency     "actionview", ">= 7.1.0"


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

In a [recent PR](https://github.com/primer/view_components/pull/3501), controllers and views serving Lookbook previews were moved from the Rails app in the demo/ directory into the main PVC Rails engine. This appeared to work well when depending on a local copy of PVC, but the OpenProject team ran into an issue when attempting to use the published gem. It appears gem releases do not contain the contents of the config/ directory, and therefore cannot access the routes defined in config/routes.rb. Correspondingly, this PR adds config/ to the list of files included in gem releases.

### Integration
<!-- Does this change require any updates to code in production? -->

No changes necessary in production, this change is dev/test-only.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.