### PR TITLE
Make `ToolTipElement` `for` an observed attribute

### DIFF
--- a/.changeset/green-glasses-exist.md
+++ b/.changeset/green-glasses-exist.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Make `ToolTipElement` `for` an observed attribute

--- a/app/components/primer/alpha/tool_tip.ts
+++ b/app/components/primer/alpha/tool_tip.ts
@@ -234,28 +234,7 @@ class ToolTipElement extends HTMLElement {
     this.#update(false)
     this.#allowUpdatePosition = true
 
-    if (!this.control) return
-
-    this.setAttribute('role', 'tooltip')
-
-    this.#abortController?.abort()
-    this.#abortController = new AbortController()
-    const {signal} = this.#abortController
-
-    this.addEventListener('mouseleave', this, {signal})
-    this.addEventListener('toggle', this, {signal})
-    this.control.addEventListener('mouseenter', this, {signal})
-    this.control.addEventListener('mouseleave', this, {signal})
-    this.control.addEventListener('focus', this, {signal})
-    this.control.addEventListener('mousedown', this, {signal})
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore popoverTargetElement is not in the type definition
-    this.control.popoverTargetElement?.addEventListener('beforetoggle', this, {
-      signal,
-    })
-    this.ownerDocument.addEventListener('focusout', focusOutListener)
-    this.ownerDocument.addEventListener('focusin', focusInListener)
-    this.ownerDocument.addEventListener('keydown', this, {signal, capture: true})
+    this.#updateControl()
   }
 
   disconnectedCallback() {
@@ -303,7 +282,7 @@ class ToolTipElement extends HTMLElement {
     }
   }
 
-  static observedAttributes = ['data-type', 'data-direction', 'id']
+  static observedAttributes = ['data-type', 'data-direction', 'id', 'for']
 
   #update(isOpen: boolean) {
     if (isOpen) {
@@ -321,11 +300,38 @@ class ToolTipElement extends HTMLElement {
   attributeChangedCallback(name: string) {
     if (!this.isConnected) return
 
-    if (name === 'id' || name === 'data-type') {
+    if (name === 'for') {
+      this.#updateControl()
+    } else if (name === 'id' || name === 'data-type') {
       this.#updateControlReference()
     } else if (name === 'data-direction') {
       this.#updateDirection()
     }
+  }
+
+  #updateControl() {
+    if (!this.control) return
+
+    this.setAttribute('role', 'tooltip')
+
+    this.#abortController?.abort()
+    this.#abortController = new AbortController()
+    const {signal} = this.#abortController
+
+    this.addEventListener('mouseleave', this, {signal})
+    this.addEventListener('toggle', this, {signal})
+    this.control.addEventListener('mouseenter', this, {signal})
+    this.control.addEventListener('mouseleave', this, {signal})
+    this.control.addEventListener('focus', this, {signal})
+    this.control.addEventListener('mousedown', this, {signal})
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore popoverTargetElement is not in the type definition
+    this.control.popoverTargetElement?.addEventListener('beforetoggle', this, {
+      signal,
+    })
+    this.ownerDocument.addEventListener('focusout', focusOutListener)
+    this.ownerDocument.addEventListener('focusin', focusInListener)
+    this.ownerDocument.addEventListener('keydown', this, {signal, capture: true})
   }
 
   #updateControlReference() {


### PR DESCRIPTION
### What are you trying to accomplish?

Make `ToolTipElement` `for` an observed attribute.
    
Enables the for attribute (and associated control element) to be dynamically added or updated after the custom element is connected to the DOM, allowing event listeners to be attached accordingly.
    
This improves compatibility with frontend frameworks (e.g. Angular) that bind attributes post-instantiation.

### Integration

This change should not require any changes to production code.

#### List the issues that this change affects.

Closes #3557

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

N/A

### Anything you want to highlight for special attention from reviewers?

Tested with a recent version of Angular: https://github.com/opf/openproject/pull/19121

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

