### PR TITLE
use ViewComponent 4.0.0.rc1

### DIFF
--- a/.changeset/mighty-cobras-bake.md
+++ b/.changeset/mighty-cobras-bake.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Use ViewComponent 4.0.0.alpha7

--- a/.changeset/mighty-cobras-bake.md
+++ b/.changeset/mighty-cobras-bake.md
@@ -2,4 +2,4 @@
 "@primer/view-components": patch
 ---
 
-Use ViewComponent 4.0.0.alpha7
+Use ViewComponent 4.0.0.rc1

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "lookbook", "~> 2.3.11"
 if ENV["VIEW_COMPONENT_PATH"]
   gem "view_component", path: ENV["VIEW_COMPONENT_PATH"]
 else
-  gem "view_component", "4.0.0.alpha7"
+  gem "view_component", "4.0.0.rc1"
 end
 
 gem "kramdown", "~> 2.5"

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "lookbook", "~> 2.3.11"
 if ENV["VIEW_COMPONENT_PATH"]
   gem "view_component", path: ENV["VIEW_COMPONENT_PATH"]
 else
-  gem "view_component", "4.0.0.alpha6"
+  gem "view_component", "4.0.0.alpha7"
 end
 
 gem "kramdown", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
-    view_component (4.0.0.alpha6)
+    view_component (4.0.0.alpha7)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
     vite_rails (3.0.19)
@@ -349,7 +349,7 @@ DEPENDENCIES
   sprockets-rails
   thor
   timecop
-  view_component (= 4.0.0.alpha6)
+  view_component (= 4.0.0.alpha7)
   vite_rails (~> 3.0)
   webmock
   yard (~> 0.9.37)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,7 +282,7 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
-    view_component (4.0.0.alpha7)
+    view_component (4.0.0.rc1)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
     vite_rails (3.0.19)
@@ -349,7 +349,7 @@ DEPENDENCIES
   sprockets-rails
   thor
   timecop
-  view_component (= 4.0.0.alpha7)
+  view_component (= 4.0.0.rc1)
   vite_rails (~> 3.0)
   webmock
   yard (~> 0.9.37)

--- a/app/lib/primer/experimental_slot_helpers.rb
+++ b/app/lib/primer/experimental_slot_helpers.rb
@@ -22,7 +22,7 @@ module Primer
         registered_slots[slot_name][:renderable_hash][type] = poly_def
 
         define_method(:"with_#{type}") do |**system_arguments, &block|
-          set_slot(slot_name, poly_def, **system_arguments, &block)
+          __vc_set_slot(slot_name, poly_def, **system_arguments, &block)
         end
       end
     end

--- a/app/lib/primer/experimental_slot_helpers.rb
+++ b/app/lib/primer/experimental_slot_helpers.rb
@@ -13,7 +13,7 @@ module Primer
         slot_def = registered_slots[slot_name]
         raise "Unknown slot '#{slot_name}'" unless slot_def
 
-        poly_def = define_slot(
+        poly_def = __vc_define_slot(
           type,
           collection: slot_def[:collection],
           callable: callable

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.6.0"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", "4.0.0.alpha6"
+gem "view_component", "4.0.0.alpha7"
 gem "lookbook", "~> 2.3.11" unless rails_version.to_f < 7
 
 gem "vite_rails", "~> 3.0"

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -37,7 +37,7 @@ gem "puma", "~> 6.6.0"
 gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
-gem "view_component", "4.0.0.alpha7"
+gem "view_component", "4.0.0.rc1"
 gem "lookbook", "~> 2.3.11" unless rails_version.to_f < 7
 
 gem "vite_rails", "~> 3.0"

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    view_component (4.0.0.alpha7)
+    view_component (4.0.0.rc1)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
     vite_rails (3.0.19)
@@ -401,7 +401,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  view_component (= 4.0.0.alpha7)
+  view_component (= 4.0.0.rc1)
   vite_rails (~> 3.0)
 
 BUNDLED WITH

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -346,7 +346,7 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    view_component (4.0.0.alpha6)
+    view_component (4.0.0.alpha7)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
     vite_rails (3.0.19)
@@ -401,7 +401,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   turbo-rails
-  view_component (= 4.0.0.alpha6)
+  view_component (= 4.0.0.alpha7)
   vite_rails (~> 3.0)
 
 BUNDLED WITH

--- a/demo/config/application.rb
+++ b/demo/config/application.rb
@@ -34,7 +34,6 @@ module Demo
     config.view_component.previews.enabled = true
     config.view_component.previews.controller = "PreviewController"
     config.view_component.previews.paths << Rails.root.join("..", "previews")
-    config.view_component.show_previews = true
 
     config.autoload_paths << Rails.root.join("..", "test", "test_helpers", "components")
 


### PR DESCRIPTION
### What are you trying to accomplish?

This PR integrates PVC with ViewComponent 4.0.0.rc1. This should be released in GitHub.com in concert with the ViewComponent release.

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.