### PR TITLE
Allow nested sub-menus in the ActionMenu component

### DIFF
--- a/.changeset/forty-ghosts-admire.md
+++ b/.changeset/forty-ghosts-admire.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': minor
+---
+
+Introduce nested menus for Primer::Alpha::ActionMenu

--- a/app/components/primer/alpha/action_menu.html.erb
+++ b/app/components/primer/alpha/action_menu.html.erb
@@ -1,28 +1,3 @@
 <%= render Primer::BaseComponent.new(**@system_arguments) do %>
-  <focus-group direction="vertical" mnemonics retain>
-    <%= render(@overlay) do |overlay| %>
-      <% overlay.with_body(padding: :none) do %>
-        <% if @src.present? %>
-          <%= render(Primer::Alpha::IncludeFragment.new(src: @src, loading: preload? ? :eager : :lazy, "data-target": "action-menu.includeFragment")) do %>
-            <%= render(Primer::Alpha::ActionMenu::List.new(id: "#{@menu_id}-list", menu_id: @menu_id)) do |list| %>
-              <% list.with_item(
-                aria: { disabled: true },
-                content_arguments: {
-                  display: :flex,
-                  align_items: :center,
-                  justify_content: :center,
-                  text_align: :center,
-                  autofocus: true
-                }
-              ) do %>
-                <%= render Primer::Beta::Spinner.new(aria: { label: "Loading content..." }) %>
-              <% end %>
-            <% end %>
-          <% end %>
-        <% else %>
-          <%= render(@list) %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </focus-group>
+  <%= render(@primary_menu) %>
 <% end %>

--- a/app/components/primer/alpha/action_menu.rb
+++ b/app/components/primer/alpha/action_menu.rb
@@ -171,143 +171,69 @@ module Primer
     class ActionMenu < Primer::Component
       status :alpha
 
-      DEFAULT_PRELOAD = false
+      delegate :preload, :preload?, :list, to: :@primary_menu
+      delegate :with_show_button, :with_item, :items, :with_divider, :with_avatar_item, :with_group, :with_sub_menu_item, to: :@primary_menu
 
-      DEFAULT_SELECT_VARIANT = :none
-      SELECT_VARIANT_OPTIONS = [
-        :single,
-        :multiple,
-        DEFAULT_SELECT_VARIANT
-      ].freeze
+      # @!parse
+      #   # Adds an item to the menu.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+      #   def with_item(**system_arguments)
+      #   end
+      #
+      #   # Adds an avatar item to the menu.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+      #   def with_avatar_item(**system_arguments)
+      #   end
+      #
+      #   # Adds a divider to the list. Dividers visually separate items.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
+      #   def with_divider(**system_arguments)
+      #   end
+      #
+      #   # Adds a group to the menu. Groups are a logical set of items with a header.
+      #   #
+      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::Group) %>.
+      #   def with_group(**system_arguments)
+      #   end
+      #
+      #   # Gets the list of configured menu items, which includes regular items, avatar items, groups, and dividers.
+      #   #
+      #   # @return [Array<ViewComponent::Slot>]
+      #   def items
+      #   end
 
-      attr_reader :list, :preload
-
-      alias preload? preload
-
-      # @param menu_id [String] Id of the menu.
-      # @param anchor_align [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_ALIGN_OPTIONS) %>.
-      # @param anchor_side [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_SIDE_OPTIONS) %>.
-      # @param size [Symbol] <%= one_of(Primer::Alpha::Overlay::SIZE_OPTIONS) %>.
-      # @param src [String] Used with an `include-fragment` element to load menu content from the given source URL.
-      # @param preload [Boolean] When true, and src is present, loads the `include-fragment` on trigger hover.
-      # @param dynamic_label [Boolean] Whether or not to display the text of the currently selected item in the show button.
-      # @param dynamic_label_prefix [String] If provided, the prefix is prepended to the dynamic label and displayed in the show button.
-      # @param select_variant [Symbol] <%= one_of(Primer::Alpha::ActionMenu::SELECT_VARIANT_OPTIONS) %>
-      # @param form_arguments [Hash] Allows an `ActionMenu` to act as a select list in multi- and single-select modes. Pass the `builder:` and `name:` options to this hash. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which are created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
-      # @param overlay_arguments [Hash] Arguments to pass to the underlying <%= link_to_component(Primer::Alpha::Overlay) %>
-      # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
-      def initialize(
-        menu_id: self.class.generate_id,
-        anchor_align: Primer::Alpha::Overlay::DEFAULT_ANCHOR_ALIGN,
-        anchor_side: Primer::Alpha::Overlay::DEFAULT_ANCHOR_SIDE,
-        size: Primer::Alpha::Overlay::DEFAULT_SIZE,
-        src: nil,
-        preload: DEFAULT_PRELOAD,
-        dynamic_label: false,
-        dynamic_label_prefix: nil,
-        select_variant: DEFAULT_SELECT_VARIANT,
-        form_arguments: {},
-        overlay_arguments: {},
-        **system_arguments
-      )
-        @menu_id = menu_id
-        @src = src
-        @preload = fetch_or_fallback_boolean(preload, DEFAULT_PRELOAD)
-        @system_arguments = deny_tag_argument(**system_arguments)
-
-        @system_arguments[:preload] = true if @src.present? && preload?
-
-        @select_variant = fetch_or_fallback(SELECT_VARIANT_OPTIONS, select_variant, DEFAULT_SELECT_VARIANT)
+      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::PrimaryMenu) %>.
+      def initialize(**system_arguments)
+        @primary_menu = PrimaryMenu.allocate
+        @system_arguments = @primary_menu.send(:initialize, **system_arguments)
 
         @system_arguments[:tag] = :"action-menu"
-        @system_arguments[:"data-select-variant"] = select_variant
-        @system_arguments[:"data-dynamic-label"] = "" if dynamic_label
-        @system_arguments[:"data-dynamic-label-prefix"] = dynamic_label_prefix if dynamic_label_prefix.present?
+        @system_arguments[:preload] = true if @primary_menu.preload?
 
-        overlay_arguments[:data] = merge_data(
-          overlay_arguments, data: {
-            target: "action-menu.overlay"
+        @system_arguments[:data] = merge_data(
+          @system_arguments, {
+            data: { "select-variant": @primary_menu.select_variant }
           }
         )
 
-        @overlay = Primer::Alpha::Overlay.new(
-          id: "#{@menu_id}-overlay",
-          title: "Menu",
-          visually_hide_title: true,
-          anchor_align: anchor_align,
-          anchor_side: anchor_side,
-          size: size,
-          **overlay_arguments
-        )
+        @system_arguments[:"data-dynamic-label"] = "" if @primary_menu.dynamic_label
 
-        @list = Primer::Alpha::ActionMenu::List.new(
-          menu_id: @menu_id,
-          select_variant: select_variant,
-          form_arguments: form_arguments
-        )
-      end
-
-      # @!parse
-      #   # Button to activate the menu.
-      #   #
-      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
-      #   renders_one(:show_button)
-
-      # Button to activate the menu.
-      #
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
-      def with_show_button(**system_arguments, &block)
-        @overlay.with_show_button(**system_arguments, id: "#{@menu_id}-button", controls: "#{@menu_id}-list") do |button|
-          evaluate_block(button, &block)
+        if @primary_menu.dynamic_label_prefix.present?
+          @system_arguments[:"data-dynamic-label-prefix"] = @primary_menu.dynamic_label_prefix
         end
-      end
-
-      # @!parse
-      #   # Adds a new item to the list.
-      #   #
-      #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      #   renders_many(:items)
-
-      # Adds a new item to the list.
-      #
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      def with_item(**system_arguments, &block)
-        @list.with_item(**system_arguments, &block)
-      end
-
-      # Adds a divider to the list.
-      #
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `divider` slot.
-      def with_divider(**system_arguments, &block)
-        @list.with_divider(**system_arguments, &block)
-      end
-
-      # Adds an avatar item to the list. Avatar items are a convenient way to accessibly add an item with a leading avatar image.
-      #
-      # @param src [String] The source url of the avatar image.
-      # @param username [String] The username associated with the avatar.
-      # @param full_name [String] Optional. The user's full name.
-      # @param full_name_scheme [Symbol] Optional. How to display the user's full name.
-      # @param avatar_arguments [Hash] Optional. The arguments accepted by <%= link_to_component(Primer::Beta::Avatar) %>.
-      # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Item) %>.
-      def with_avatar_item(**system_arguments, &block)
-        @list.with_avatar_item(**system_arguments, &block)
-      end
-
-      def with_group(**system_arguments, &block)
-        @list.with_group(**system_arguments, &block)
       end
 
       private
 
       def before_render
         content
-
-        raise ArgumentError, "`items` cannot be set when `src` is specified" if @src.present? && @list.items.any?
       end
 
       def render?
-        @list.items.any? || @src.present?
+        @primary_menu.items.any? || @primary_menu.src.present?
       end
     end
   end

--- a/app/components/primer/alpha/action_menu/action_menu_element.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_element.ts
@@ -3,6 +3,8 @@ import '@oddbird/popover-polyfill'
 import type {IncludeFragmentElement} from '@github/include-fragment-element'
 import AnchoredPositionElement from '../../anchored_position'
 import {observeMutationsUntilConditionMet} from '../../utils'
+import {ActionMenuFocusZoneStack} from './action_menu_focus_zone_stack'
+import {ClipboardCopyElement} from '@github/clipboard-copy-element'
 
 type SelectVariant = 'none' | 'single' | 'multiple' | null
 type SelectedItem = {
@@ -11,22 +13,22 @@ type SelectedItem = {
   element: Element
 }
 
-const validSelectors = ['[role="menuitem"]', '[role="menuitemcheckbox"]', '[role="menuitemradio"]']
-const menuItemSelectors = validSelectors.map(selector => `:not([hidden]) > ${selector}`)
-
 @controller
 export class ActionMenuElement extends HTMLElement {
-  @target
-  includeFragment: IncludeFragmentElement
-
-  @target
-  overlay: AnchoredPositionElement
+  @target includeFragment: IncludeFragmentElement
+  @target overlay: AnchoredPositionElement
+  @target list: HTMLElement
 
   #abortController: AbortController
   #originalLabel = ''
   #inputName = ''
   #invokerBeingClicked = false
   #intersectionObserver: IntersectionObserver
+  #focusZoneStack: ActionMenuFocusZoneStack
+
+  static validItemRoles = ['menuitem', 'menuitemcheckbox', 'menuitemradio']
+  static validSelectors = ActionMenuElement.validItemRoles.map(role => `[role="${role}"]`)
+  static menuItemSelectors = ActionMenuElement.validSelectors.map(selector => `:not([hidden]) > ${selector}`)
 
   get selectVariant(): SelectVariant {
     return this.getAttribute('data-select-variant') as SelectVariant
@@ -60,6 +62,11 @@ export class ActionMenuElement extends HTMLElement {
 
   get popoverElement(): HTMLElement | null {
     return (this.invokerElement?.popoverTargetElement as HTMLElement) || null
+  }
+
+  // i.e. sub-menus
+  get childPopoverElements(): HTMLElement[] {
+    return Array.from(this.overlay.querySelectorAll('anchored-position')) as AnchoredPositionElement[]
   }
 
   get invokerElement(): HTMLButtonElement | null {
@@ -102,7 +109,7 @@ export class ActionMenuElement extends HTMLElement {
     this.addEventListener('mouseover', this, {signal})
     this.addEventListener('focusout', this, {signal})
     this.addEventListener('mousedown', this, {signal})
-    this.popoverElement?.addEventListener('toggle', this, {signal})
+    this.addEventListener('toggle', this, {signal, capture: true})
     this.#setDynamicLabel()
     this.#updateInput()
     this.#softDisableItems()
@@ -149,6 +156,22 @@ export class ActionMenuElement extends HTMLElement {
     if (!this.includeFragment) {
       this.setAttribute('data-ready', 'true')
     }
+
+    const levelObserver = new MutationObserver(() => this.#updateLevels())
+    levelObserver.observe(this, {childList: true, subtree: true})
+
+    this.#updateLevels()
+
+    this.#focusZoneStack = new ActionMenuFocusZoneStack()
+  }
+
+  #updateLevels() {
+    let idx = 1
+
+    for (const menu of this.querySelectorAll('[role=menu]')) {
+      menu.setAttribute('data-level', idx.toString())
+      idx++
+    }
   }
 
   disconnectedCallback() {
@@ -158,7 +181,7 @@ export class ActionMenuElement extends HTMLElement {
   #softDisableItems() {
     const {signal} = this.#abortController
 
-    for (const item of this.querySelectorAll(validSelectors.join(','))) {
+    for (const item of this.querySelectorAll(ActionMenuElement.validSelectors.join(','))) {
       item.addEventListener('click', this.#potentiallyDisallowActivation.bind(this), {signal})
       item.addEventListener('keydown', this.#potentiallyDisallowActivation.bind(this), {signal})
     }
@@ -168,7 +191,7 @@ export class ActionMenuElement extends HTMLElement {
   #potentiallyDisallowActivation(event: Event): boolean {
     if (!this.#isActivation(event)) return false
 
-    const item = (event.target as HTMLElement).closest(menuItemSelectors.join(','))
+    const item = (event.target as HTMLElement).closest(ActionMenuElement.menuItemSelectors.join(','))
     if (!item) return false
 
     if (item.getAttribute('aria-disabled')) {
@@ -193,21 +216,34 @@ export class ActionMenuElement extends HTMLElement {
     )
   }
 
+  #isClipboardActivationViaKeyboard(event: Event): boolean {
+    return (
+      event.target instanceof ClipboardCopyElement &&
+      event instanceof KeyboardEvent &&
+      event.type === 'keydown' &&
+      !(event.ctrlKey || event.altKey || event.metaKey || event.shiftKey) &&
+      (event.key === ' ' || event.key === 'Enter')
+    )
+  }
+
   #isActivation(event: Event): boolean {
     // Some browsers fire MouseEvents (Firefox) and others fire PointerEvents (Chrome). Activating an item via
     // enter or space counterintuitively fires one of these rather than a KeyboardEvent. Since PointerEvent
     // inherits from MouseEvent, it is enough to check for MouseEvent here.
-    return (event instanceof MouseEvent && event.type === 'click') || this.#isAnchorActivationViaSpace(event)
+    return (
+      (event instanceof MouseEvent && event.type === 'click') ||
+      this.#isAnchorActivationViaSpace(event) ||
+      this.#isClipboardActivationViaKeyboard(event)
+    )
   }
 
   handleEvent(event: Event) {
     const targetIsInvoker = this.invokerElement?.contains(event.target as HTMLElement)
     const eventIsActivation = this.#isActivation(event)
 
-    if (event.type === 'toggle' && (event as ToggleEvent).newState === 'open') {
-      window.requestAnimationFrame(() => {
-        this.#firstItem?.focus()
-      })
+    if (event.type === 'toggle' && event instanceof ToggleEvent) {
+      this.#handleToggleEvent(event)
+      return
     }
 
     if (targetIsInvoker && event.type === 'mousedown') {
@@ -241,7 +277,7 @@ export class ActionMenuElement extends HTMLElement {
       return
     }
 
-    const item = (event.target as Element).closest(menuItemSelectors.join(','))
+    const item = (event.target as Element).closest(ActionMenuElement.menuItemSelectors.join(',')) as HTMLElement | null
     const targetIsItem = item !== null
 
     if (targetIsItem && eventIsActivation) {
@@ -262,7 +298,16 @@ export class ActionMenuElement extends HTMLElement {
       // We then click it manually to navigate.
       if (this.#isAnchorActivationViaSpace(event)) {
         event.preventDefault()
-        ;(item as HTMLElement).click()
+        item.click()
+      }
+
+      const subMenu = this.#subMenuForItem(item)
+
+      if (subMenu) {
+        // Prevent submitting a form when clicking on sub-menu items
+        event.preventDefault()
+        subMenu.showPopover()
+        return
       }
 
       this.#handleItemActivated(item)
@@ -272,6 +317,53 @@ export class ActionMenuElement extends HTMLElement {
 
     if (event.type === 'include-fragment-replaced') {
       this.#handleIncludeFragmentReplaced()
+      return
+    }
+
+    if (targetIsItem && event instanceof KeyboardEvent) {
+      this.#handleItemKeyboardEvent(event, item)
+    }
+  }
+
+  #handleItemKeyboardEvent(event: KeyboardEvent, item: HTMLElement) {
+    switch (event.key) {
+      case 'ArrowRight': {
+        const subMenu = this.#subMenuForItem(item)
+        subMenu?.showPopover()
+        break
+      }
+
+      case 'ArrowLeft':
+        if (item.closest('role[menu]') !== this.list) {
+          const overlay = item.closest('anchored-position') as AnchoredPositionElement | null
+          overlay?.hidePopover()
+        }
+
+        break
+    }
+  }
+
+  #handleToggleEvent(event: ToggleEvent) {
+    const subMenu = event.target as AnchoredPositionElement
+
+    if (event.newState === 'open') {
+      // allow tabbing away from primary menu, but trap focus in sub-menus
+      const isPrimaryMenu = subMenu === this.overlay
+      this.#focusZoneStack.push(subMenu, {trapFocus: !isPrimaryMenu})
+
+      window.requestAnimationFrame(() => {
+        const firstItem = subMenu.querySelector(ActionMenuElement.menuItemSelectors.join(',')) as HTMLElement | null
+        firstItem?.focus()
+      })
+    } else {
+      // Note that this will also cause focus to return to the invoker button, which is
+      // desirable
+      this.#focusZoneStack.pop(subMenu)
+      const item = this.#itemForSubMenu(subMenu)
+      const openPopover = document.querySelector(':popover-open')
+      if (item && !openPopover) {
+        item.focus()
+      }
     }
   }
 
@@ -322,7 +414,7 @@ export class ActionMenuElement extends HTMLElement {
     dialog.addEventListener('cancel', handleDialogClose, {signal})
   }
 
-  #handleItemActivated(item: Element) {
+  #handleItemActivated(item: HTMLElement) {
     // Hide popover after current event loop to prevent changes in focus from
     // altering the target of the event. Not doing this specifically affects
     // <a> tags. It causes the event to be sent to the currently focused element
@@ -391,6 +483,10 @@ export class ActionMenuElement extends HTMLElement {
 
   #hide() {
     this.popoverElement?.hidePopover()
+
+    for (const child of this.childPopoverElements) {
+      child.hidePopover()
+    }
   }
 
   #isOpen() {
@@ -458,11 +554,11 @@ export class ActionMenuElement extends HTMLElement {
   }
 
   get #firstItem(): HTMLElement | null {
-    return this.querySelector(menuItemSelectors.join(','))
+    return this.querySelector(ActionMenuElement.menuItemSelectors.join(','))
   }
 
   get items(): HTMLElement[] {
-    return Array.from(this.querySelectorAll(menuItemSelectors.join(',')))
+    return Array.from(this.querySelectorAll(ActionMenuElement.menuItemSelectors.join(',')))
   }
 
   getItemById(itemId: string): HTMLElement | null {
@@ -521,7 +617,7 @@ export class ActionMenuElement extends HTMLElement {
 
   checkItem(item: Element | null) {
     if (item && (this.selectVariant === 'single' || this.selectVariant === 'multiple')) {
-      const itemContent = item.querySelector('.ActionListContent')!
+      const itemContent = item.querySelector('.ActionListContent')! as HTMLElement
       const ariaChecked = itemContent.getAttribute('aria-checked') === 'true'
 
       if (!ariaChecked) {
@@ -532,13 +628,33 @@ export class ActionMenuElement extends HTMLElement {
 
   uncheckItem(item: Element | null) {
     if (item && (this.selectVariant === 'single' || this.selectVariant === 'multiple')) {
-      const itemContent = item.querySelector('.ActionListContent')!
+      const itemContent = item.querySelector('.ActionListContent')! as HTMLElement
       const ariaChecked = itemContent.getAttribute('aria-checked') === 'true'
 
       if (ariaChecked) {
         this.#handleItemActivated(itemContent)
       }
     }
+  }
+
+  #subMenuForItem(item: HTMLElement): AnchoredPositionElement | null {
+    const popoverId = item.getAttribute('popovertarget')
+
+    if (popoverId) {
+      return this.querySelector(`[id="${popoverId}"]`) as AnchoredPositionElement
+    }
+
+    return null
+  }
+
+  #itemForSubMenu(subMenu: HTMLElement): HTMLElement | null {
+    const anchorId = subMenu.getAttribute('anchor')
+
+    if (anchorId) {
+      return this.querySelector(`[id="${anchorId}"]`) as HTMLElement | null
+    }
+
+    return null
   }
 }
 

--- a/app/components/primer/alpha/action_menu/action_menu_focus_zone_stack.ts
+++ b/app/components/primer/alpha/action_menu/action_menu_focus_zone_stack.ts
@@ -1,0 +1,67 @@
+import AnchoredPositionElement from '../../anchored_position'
+import {FocusKeys, focusTrap, focusZone} from '@primer/behaviors'
+import {ActionMenuElement} from './action_menu_element'
+
+type StackEntry = {
+  element: AnchoredPositionElement
+  abortController?: AbortController
+}
+
+export class ActionMenuFocusZoneStack {
+  #stack: StackEntry[]
+
+  constructor() {
+    this.#stack = []
+  }
+
+  get current(): StackEntry | undefined {
+    return this.#stack[this.#stack.length - 1]
+  }
+
+  push(next: AnchoredPositionElement, options: {trapFocus: boolean} = {trapFocus: true}) {
+    const {trapFocus} = options
+    this.#stack.push({element: next, abortController: this.#setupFocusZone(next, trapFocus)})
+  }
+
+  pop(target?: AnchoredPositionElement) {
+    if (target) {
+      while (this.#stack.length > 0 && this.current?.element !== target) {
+        const entry = this.#stack.pop()
+        entry?.abortController?.abort()
+      }
+    }
+
+    const entry = this.#stack.pop()
+    entry?.abortController?.abort()
+  }
+
+  #setupFocusZone(containerEl: AnchoredPositionElement, trapFocus: boolean): AbortController | undefined {
+    const focusZoneAbortController = focusZone(containerEl, {
+      bindKeys: FocusKeys.ArrowVertical | FocusKeys.ArrowHorizontal | FocusKeys.HomeAndEnd | FocusKeys.Backspace,
+      focusOutBehavior: 'wrap',
+
+      focusableElementFilter: (element: HTMLElement): boolean => {
+        return this.elementIsMenuItem(element) && element.closest('anchored-position') === containerEl
+      },
+    })
+
+    if (trapFocus) {
+      const {signal: focusZoneSignal} = focusZoneAbortController
+      return focusTrap(containerEl, undefined, focusZoneSignal)
+    } else {
+      return focusZoneAbortController
+    }
+  }
+
+  elementIsMenuItem(element: HTMLElement): boolean {
+    return this.#validItemRoles.includes(element.getAttribute('role') || '')
+  }
+
+  get #validItemRoles(): string[] {
+    return ActionMenuElement.validItemRoles
+  }
+
+  get isEmpty(): boolean {
+    return this.#stack.length === 0
+  }
+}

--- a/app/components/primer/alpha/action_menu/list.rb
+++ b/app/components/primer/alpha/action_menu/list.rb
@@ -11,7 +11,9 @@ module Primer
 
         attr_reader :items
 
-        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>
+        delegate :acts_as_form_input?, to: :@list
+
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::ListWrapper) %>
         def initialize(**system_arguments)
           @items = []
           @has_group = false

--- a/app/components/primer/alpha/action_menu/menu.html.erb
+++ b/app/components/primer/alpha/action_menu/menu.html.erb
@@ -1,0 +1,24 @@
+<%= render(@overlay) do |overlay| %>
+  <% overlay.with_body(padding: :none) do %>
+    <% if @src.present? %>
+      <%= render(Primer::Alpha::IncludeFragment.new(src: @src, loading: preload? ? :eager : :lazy, "data-target": "action-menu.includeFragment")) do %>
+        <%= render(Primer::Alpha::ActionMenu::List.new(id: "#{@menu_id}-list", menu_id: @menu_id)) do |list| %>
+          <% list.with_item(
+            aria: { disabled: true },
+            content_arguments: {
+              display: :flex,
+              align_items: :center,
+              justify_content: :center,
+              text_align: :center,
+              autofocus: true
+            }
+          ) do %>
+            <%= render Primer::Beta::Spinner.new(aria: { label: "Loading content..." }) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <%= render(@list) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/primer/alpha/action_menu/menu.rb
+++ b/app/components/primer/alpha/action_menu/menu.rb
@@ -1,0 +1,136 @@
+# typed: false
+# frozen_string_literal: true
+
+module Primer
+  module Alpha
+    class ActionMenu
+      # This component is part of <%= link_to_component(Primer::Alpha::ActionMenu) %> and should not be
+      # used as a standalone component.
+      class Menu < Primer::Component
+        DEFAULT_PRELOAD = false
+
+        DEFAULT_SELECT_VARIANT = :none
+        SELECT_VARIANT_OPTIONS = [
+          :single,
+          :multiple,
+          DEFAULT_SELECT_VARIANT
+        ].freeze
+
+        attr_reader :menu_id, :anchor_side, :anchor_align, :list, :preload, :src, :select_variant, :form_arguments
+
+        delegate :with_item, :with_avatar_item, :with_divider, :with_group, :items, :acts_as_form_input?, to: :@list
+
+        alias preload? preload
+
+        # @!parse
+        #   # Adds an item to the menu.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+        #   def with_item(**system_arguments)
+        #   end
+        #
+        #   # Adds an avatar item to the menu.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+        #   def with_avatar_item(**system_arguments)
+        #   end
+        #
+        #   # Adds a divider to the list. Dividers visually separate items.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
+        #   def with_divider(**system_arguments)
+        #   end
+        #
+        #   # Adds a group to the menu. Groups are a logical set of items with a header.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::Group) %>.
+        #   def with_group(**system_arguments)
+        #   end
+        #
+        #   # Gets the list of configured menu items, which includes regular items, avatar items, groups, and dividers.
+        #   #
+        #   # @return [Array<ViewComponent::Slot>]
+        #   def items
+        #   end
+
+        # @param anchor_align [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_ALIGN_OPTIONS) %>
+        # @param anchor_side [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_SIDE_OPTIONS) %>
+        # @param menu_id [String] Id of the menu.
+        # @param size [Symbol] <%= one_of(Primer::Alpha::Overlay::SIZE_OPTIONS) %>
+        # @param src [String] Used with an `include-fragment` element to load menu content from the given source URL.
+        # @param preload [Boolean] When true, and src is present, loads the `include-fragment` on trigger hover.
+        # @param select_variant [Symbol] <%= one_of(Primer::Alpha::ActionMenu::Menu::SELECT_VARIANT_OPTIONS) %>
+        # @param form_arguments [Hash] Allows an `ActionMenu` to act as a select list in multi- and single-select modes. Pass the `builder:` and `name:` options to this hash. `builder:` should be an instance of `ActionView::Helpers::FormBuilder`, which are created by the standard Rails `#form_with` and `#form_for` helpers. The `name:` option is the desired name of the field that will be included in the params sent to the server on form submission.
+        # @param overlay_arguments [Hash] Arguments to pass to the underlying <%= link_to_component(Primer::Alpha::Overlay) %>
+        # @param list_arguments [Hash] Arguments to pass to the underlying <%= link_to_component(Primer::Alpha::ActionMenu::List) %>
+        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
+        def initialize(
+          anchor_align:,
+          anchor_side:,
+          menu_id: self.class.generate_id,
+          size: Primer::Alpha::Overlay::DEFAULT_SIZE,
+          src: nil,
+          preload: DEFAULT_PRELOAD,
+          select_variant: DEFAULT_SELECT_VARIANT,
+          form_arguments: {},
+          overlay_arguments: {},
+          list_arguments: {},
+          **system_arguments
+        )
+          @menu_id = menu_id
+          @src = src
+          @preload = fetch_or_fallback_boolean(preload, DEFAULT_PRELOAD)
+          @anchor_side = anchor_side
+          @anchor_align = anchor_align
+
+          @select_variant = fetch_or_fallback(SELECT_VARIANT_OPTIONS, select_variant, DEFAULT_SELECT_VARIANT)
+          @form_arguments = form_arguments
+
+          overlay_arguments[:data] = merge_data(
+            overlay_arguments, data: {
+              target: "action-menu.overlay"
+            }
+          )
+
+          @overlay = Primer::Alpha::Overlay.new(
+            id: "#{@menu_id}-overlay",
+            title: "Menu",
+            visually_hide_title: true,
+            anchor_align: anchor_align,
+            anchor_side: anchor_side,
+            size: size,
+            **overlay_arguments
+          )
+
+          @list = Primer::Alpha::ActionMenu::List.new(
+            menu_id: @menu_id,
+            select_variant: select_variant,
+            form_arguments: form_arguments,
+            **list_arguments
+          )
+
+          system_arguments # rubocop:disable Lint/Void
+        end
+
+        # Adds a sub-menu to the menu.
+        #
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::SubMenuItem) %>.
+        def with_sub_menu_item(**system_arguments, &block)
+          @list.with_item(
+            component_klass: SubMenuItem,
+            select_variant: select_variant,
+            form_arguments: form_arguments,
+            **system_arguments,
+            &block
+          )
+        end
+
+        private
+
+        def before_render
+          raise ArgumentError, "`items` cannot be set when `src` is specified" if src.present? && items.any?
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/alpha/action_menu/primary_menu.rb
+++ b/app/components/primer/alpha/action_menu/primary_menu.rb
@@ -1,0 +1,86 @@
+# typed: false
+# frozen_string_literal: true
+
+module Primer
+  module Alpha
+    class ActionMenu
+      # This component is part of <%= link_to_component(Primer::Alpha::ActionMenu) %> and should not be
+      # used as a standalone component.
+      class PrimaryMenu < Menu
+        DEFAULT_ANCHOR_ALIGN = :start
+        DEFAULT_ANCHOR_SIDE = :outside_bottom
+
+        attr_reader :dynamic_label, :dynamic_label_prefix
+
+        # @!parse
+        #   # Adds an item to the menu.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+        #   def with_item(**system_arguments)
+        #   end
+        #
+        #   # Adds an avatar item to the menu.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>'s `item` slot.
+        #   def with_avatar_item(**system_arguments)
+        #   end
+        #
+        #   # Adds a divider to the list. Dividers visually separate items.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList::Divider) %>.
+        #   def with_divider(**system_arguments)
+        #   end
+        #
+        #   # Adds a group to the menu. Groups are a logical set of items with a header.
+        #   #
+        #   # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::Group) %>.
+        #   def with_group(**system_arguments)
+        #   end
+        #
+        #   # Gets the list of configured menu items, which includes regular items, avatar items, groups, and dividers.
+        #   #
+        #   # @return [Array<ViewComponent::Slot>]
+        #   def items
+        #   end
+
+        # @param anchor_align [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_ALIGN_OPTIONS) %>
+        # @param anchor_side [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_SIDE_OPTIONS) %>
+        # @param dynamic_label [Boolean] Whether or not to display the text of the currently selected item in the show button.
+        # @param dynamic_label_prefix [String] If provided, the prefix is prepended to the dynamic label and displayed in the show button.
+        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
+        def initialize(
+          anchor_align: DEFAULT_ANCHOR_ALIGN,
+          anchor_side: DEFAULT_ANCHOR_SIDE,
+          dynamic_label: false,
+          dynamic_label_prefix: nil,
+          **system_arguments
+        )
+          @dynamic_label = dynamic_label
+          @dynamic_label_prefix = dynamic_label_prefix
+
+          system_arguments[:list_arguments] ||= {}
+
+          system_arguments[:list_arguments][:data] = merge_data(
+            system_arguments[:list_arguments],
+            { data: { target: "action-menu.list" } }
+          )
+
+          super(
+            anchor_align: anchor_align,
+            anchor_side: anchor_side,
+            **system_arguments
+          )
+        end
+
+        # Button to activate the menu.
+        #
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::Overlay) %>'s `show_button` slot.
+        def with_show_button(**system_arguments, &block)
+          @overlay.with_show_button(**system_arguments, id: "#{@menu_id}-button", controls: "#{@menu_id}-list") do |button|
+            evaluate_block(button, &block)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/alpha/action_menu/sub_menu.rb
+++ b/app/components/primer/alpha/action_menu/sub_menu.rb
@@ -1,3 +1,4 @@
+# typed: false
 # frozen_string_literal: true
 
 module Primer
@@ -5,7 +6,10 @@ module Primer
     class ActionMenu
       # This component is part of <%= link_to_component(Primer::Alpha::ActionMenu) %> and should not be
       # used as a standalone component.
-      class ListWrapper < Primer::Alpha::ActionList
+      class SubMenu < Menu
+        DEFAULT_ANCHOR_ALIGN = :start
+        DEFAULT_ANCHOR_SIDE = :outside_right
+
         # @!parse
         #   # Adds an item to the menu.
         #   #
@@ -37,33 +41,32 @@ module Primer
         #   def items
         #   end
 
-        add_polymorphic_slot_type(
-          slot_name: :items,
-          type: :group,
-          callable: lambda { |**system_arguments|
-            Primer::Alpha::ActionMenu::Group.new(
-              **system_arguments,
-              role: :group,
-              select_variant: @select_variant
-            )
-          }
+        # @param menu_id [String] Id of the menu.
+        # @param anchor_align [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_ALIGN_OPTIONS) %>
+        # @param anchor_side [Symbol] <%= one_of(Primer::Alpha::Overlay::ANCHOR_SIDE_OPTIONS) %>
+        # @param overlay_arguments [Hash] Arguments to pass to the underlying <%= link_to_component(Primer::Alpha::Overlay) %>
+        # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>.
+        def initialize(
+          menu_id: self.class.generate_id,
+          anchor_align: DEFAULT_ANCHOR_ALIGN,
+          anchor_side: DEFAULT_ANCHOR_SIDE,
+          overlay_arguments: {},
+          **system_arguments
         )
+          overlay_arguments[:anchor] = "#{menu_id}-button"
+          super
+        end
 
-        # @param menu_id [String] ID of the parent menu.
-        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionList) %>
-        def initialize(menu_id:, **system_arguments)
-          @menu_id = menu_id
-
-          system_arguments[:aria] = merge_aria(
-            system_arguments,
-            { aria: { labelledby: "#{@menu_id}-button" } }
+        # Adds a sub-menu to the menu.
+        #
+        # @param system_arguments [Hash] The arguments accepted by <%= link_to_component(Primer::Alpha::ActionMenu::SubMenuItem) %>.
+        def with_sub_menu_item(**system_arguments, &block)
+          super(
+            anchor_align: anchor_align, # carry over to sub-menus
+            anchor_side: anchor_side, # carry over to sub-menus
+            **system_arguments,
+            &block
           )
-
-          system_arguments[:role] = :menu
-          system_arguments[:scheme] = :inset
-          system_arguments[:id] = "#{@menu_id}-list"
-
-          super(**system_arguments)
         end
       end
     end

--- a/app/components/primer/alpha/action_menu/sub_menu_item.html.erb
+++ b/app/components/primer/alpha/action_menu/sub_menu_item.html.erb
@@ -1,0 +1,5 @@
+<% with_trailing_visual_icon(icon: :"chevron-right") %>
+
+<%= render_parent %>
+
+<%= render(@sub_menu) %>

--- a/app/components/primer/alpha/action_menu/sub_menu_item.rb
+++ b/app/components/primer/alpha/action_menu/sub_menu_item.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Primer
+  module Alpha
+    class ActionMenu
+      # This component is part of <%= link_to_component(Primer::Alpha::ActionMenu) %> and should not be
+      # used as a standalone component.
+      class SubMenuItem < ::Primer::Alpha::ActionList::Item
+        def initialize(content_arguments: {}, form_arguments: {}, **system_arguments)
+          # We extract form_arguments from system_arguments here to avoid passing them to the
+          # ActionList::Item base class or to the SubMenu instance. Doing so prevents a form
+          # input from being emitted for sub-menu items, which prevents an extra empty value
+          # from being sent to the server on form submit.
+          @sub_menu = SubMenu.allocate
+          system_arguments = @sub_menu.send(:initialize, **system_arguments)
+          system_arguments[:id] = "#{@sub_menu.menu_id}-button"
+
+          @form_arguments = form_arguments
+
+          content_arguments[:tag] = :button
+          content_arguments[:popovertarget] = "#{@sub_menu.menu_id}-overlay"
+
+          content_arguments[:aria] = merge_aria(
+            content_arguments, {
+              aria: {
+                controls: "#{@sub_menu.menu_id}-list",
+                haspopup: true
+              }
+            }
+          )
+
+          super
+        end
+
+        def with_item(**system_arguments, &block)
+          @sub_menu.with_item(form_arguments: @form_arguments, **system_arguments, &block)
+        end
+
+        def with_avatar_item(**system_arguments, &block)
+          @sub_menu.with_avatar_item(form_arguments: @form_arguments, **system_arguments, &block)
+        end
+
+        def with_sub_menu_item(**system_arguments, &block)
+          @sub_menu.with_sub_menu_item(form_arguments: @form_arguments, **system_arguments, &block)
+        end
+
+        def with_group(**system_arguments, &block)
+          @sub_menu.with_group(form_arguments: @form_arguments, **system_arguments, &block)
+        end
+      end
+    end
+  end
+end

--- a/app/components/primer/alpha/select_panel.rb
+++ b/app/components/primer/alpha/select_panel.rb
@@ -312,7 +312,7 @@ module Primer
       # @return [String]
       attr_reader :body_id
 
-      # <%= one_of(Primer::Alpha::ActionMenu::SELECT_VARIANT_OPTIONS) %>
+      # <%= one_of(Primer::Alpha::ActionMenu::Menu::SELECT_VARIANT_OPTIONS) %>
       #
       # @return [Symbol]
       attr_reader :select_variant
@@ -461,7 +461,7 @@ module Primer
 
         @list = Primer::Alpha::SelectPanel::ItemList.new(
           **list_arguments,
-          form_arguments: @list_form_arguments, 
+          form_arguments: @list_form_arguments,
           id: "#{@panel_id}-list",
           select_variant: @select_variant,
           aria: {

--- a/app/views/primer/view_components/action_menu/deferred.html.erb
+++ b/app/views/primer/view_components/action_menu/deferred.html.erb
@@ -5,18 +5,9 @@
   <% list.with_item(
     label: "Show dialog",
     tag: :button,
+    # this dialog is rendered by demo/app/views/action_menu/deferred.html.erb
     content_arguments: { "data-show-dialog-id": "my-dialog" },
     value: "",
     scheme: :danger
   ) %>
-<% end %>
-
-<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |d| %>
-  <%= render(Primer::Alpha::Dialog::Body.new()) do %>
-    Are you sure you want to delete this?
-  <% end %>
-  <%= render(Primer::Alpha::Dialog::Footer.new()) do %>
-    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
-    <%= render(Primer::Beta::Button.new(scheme: :danger)) { "Delete" } %>
-  <% end %>
 <% end %>

--- a/previews/primer/alpha/action_menu_preview.rb
+++ b/previews/primer/alpha/action_menu_preview.rb
@@ -11,7 +11,9 @@ module Primer
       # @param anchor_side [Symbol] select [outside_bottom, outside_top, outside_left, outside_right]
       # @param size [Symbol] select [auto, small, medium, large, xlarge]
       def playground(
-        select_variant: Primer::Alpha::ActionMenu::DEFAULT_SELECT_VARIANT, anchor_align: Primer::Alpha::Overlay::DEFAULT_ANCHOR_ALIGN, anchor_side: Primer::Alpha::Overlay::DEFAULT_ANCHOR_SIDE,
+        select_variant: Primer::Alpha::ActionMenu::PrimaryMenu::DEFAULT_SELECT_VARIANT,
+        anchor_align: Primer::Alpha::Overlay::DEFAULT_ANCHOR_ALIGN,
+        anchor_side: Primer::Alpha::Overlay::DEFAULT_ANCHOR_SIDE,
         size: Primer::Alpha::Overlay::DEFAULT_SIZE
       )
         render(Primer::Alpha::ActionMenu.new(select_variant: select_variant, anchor_align: anchor_align, anchor_side: anchor_side, size: size)) do |menu|
@@ -55,13 +57,9 @@ module Primer
       # @label With groups
       #
       # @snapshot interactive
-      def with_groups
-        render(Primer::Alpha::ActionMenu.new(menu_id: "menu-1")) do |menu|
-          menu.with_show_button do |button|
-            button.with_trailing_action_icon(icon: :"triangle-down")
-            "Favorite character"
-          end
-
+      # @param nest_in_sub_menu toggle
+      def with_groups(nest_in_sub_menu: false)
+        contents = -> (menu) {
           menu.with_group do |group|
             group.with_heading(title: "Battlestar Galactica")
             group.with_item(label: "William Adama")
@@ -84,6 +82,21 @@ module Primer
             group.with_item(label: "Luke Skywalker")
             group.with_item(label: "Han Solo")
             group.with_item(label: "Chewbacca")
+          end
+        }
+
+        render(Primer::Alpha::ActionMenu.new(menu_id: "menu-1")) do |menu|
+          menu.with_show_button do |button|
+            button.with_trailing_action_icon(icon: :"triangle-down")
+            "Favorite character"
+          end
+
+          if nest_in_sub_menu
+            menu.with_sub_menu_item(label: "Sub-menu") do |sub_menu_item|
+              contents.call(sub_menu_item)
+            end
+          else
+            contents.call(menu)
           end
         end
       end
@@ -159,10 +172,9 @@ module Primer
 
       # @label Multiple select
       #
-      def multiple_select
-        render(Primer::Alpha::ActionMenu.new(select_variant: :multiple)) do |menu|
-          menu.with_show_button { "Menu" }
-
+      # @param nest_in_sub_menu toggle
+      def multiple_select(nest_in_sub_menu: false)
+        content = -> (menu) {
           menu.with_avatar_item(
             src: "https://avatars.githubusercontent.com/u/18661030?v=4",
             username: "langermank",
@@ -189,6 +201,18 @@ module Primer
             avatar_arguments: { shape: :square },
             item_id: :armagan
           )
+        }
+
+        render(Primer::Alpha::ActionMenu.new(select_variant: :multiple)) do |menu|
+          menu.with_show_button { "Menu" }
+
+          if nest_in_sub_menu
+            menu.with_sub_menu_item(label: "Sub-menu") do |sub_menu|
+              content.call(sub_menu)
+            end
+          else
+            content.call(menu)
+          end
         end
       end
 
@@ -218,17 +242,29 @@ module Primer
       # @label Single Select with Internal Label
       #
       # @snapshot interactive
-      def single_select_with_internal_label
-        render(Primer::Alpha::ActionMenu.new(select_variant: :single, dynamic_label: true, dynamic_label_prefix: "Menu")) do |menu|
-          menu.with_show_button do |button|
-            button.with_trailing_action_icon(icon: :"triangle-down")
-            "Menu"
-          end
+      # @param nest_in_sub_menu toggle
+      def single_select_with_internal_label(nest_in_sub_menu: false)
+        contents = -> (menu) {
           menu.with_item(label: "Copy link") do |item|
             item.with_trailing_visual_label(scheme: :accent, inline: true).with_content("Recommended")
           end
           menu.with_item(label: "Quote reply", active: true)
           menu.with_item(label: "Reference in new issue")
+        }
+
+        render(Primer::Alpha::ActionMenu.new(select_variant: :single, dynamic_label: true, dynamic_label_prefix: "Menu")) do |menu|
+          menu.with_show_button do |button|
+            button.with_trailing_action_icon(icon: :"triangle-down")
+            "Menu"
+          end
+
+          if nest_in_sub_menu
+            menu.with_sub_menu_item(label: "Sub-menu") do |sub_menu_item|
+              contents.call(sub_menu_item)
+            end
+          else
+            contents.call(menu)
+          end
         end
       end
 
@@ -266,10 +302,9 @@ module Primer
 
       # @label With deferred content
       #
-      def with_deferred_content
-        render(Primer::Alpha::ActionMenu.new(menu_id: "deferred", src: UrlHelpers.primer_view_components.action_menu_deferred_path)) do |menu|
-          menu.with_show_button { "Menu with deferred content" }
-        end
+      # @param nest_in_sub_menu toggle
+      def with_deferred_content(nest_in_sub_menu: false)
+        render_with_template(locals: { nest_in_sub_menu: nest_in_sub_menu })
       end
 
       # @label With deferred preloaded content
@@ -283,8 +318,13 @@ module Primer
       # @label With actions
       #
       # @param disable_items toggle
-      def with_actions(disable_items: false, route_format: :html)
-        render_with_template(locals: { disable_items: disable_items, route_format: route_format })
+      # @param nest_in_sub_menu toggle
+      def with_actions(disable_items: false, nest_in_sub_menu: false, route_format: :html)
+        render_with_template(locals: {
+          disable_items: disable_items,
+          nest_in_sub_menu: nest_in_sub_menu,
+          route_format: route_format
+        })
       end
 
       # @label Single select form
@@ -295,14 +335,16 @@ module Primer
 
       # @label Single select form items
       #
-      def single_select_form_items(route_format: :html)
-        render_with_template(locals: { route_format: route_format })
+      # @param nest_in_sub_menu toggle
+      def single_select_form_items(route_format: :html, nest_in_sub_menu: false)
+        render_with_template(locals: { route_format: route_format, nest_in_sub_menu: nest_in_sub_menu })
       end
 
       # @label Multiple select form
       #
-      def multiple_select_form(route_format: :html)
-        render_with_template(locals: { route_format: route_format })
+      # @param nest_in_sub_menu toggle
+      def multiple_select_form(route_format: :html, nest_in_sub_menu: false)
+        render_with_template(locals: { route_format: route_format, nest_in_sub_menu: nest_in_sub_menu })
       end
 
       # @label With disabled items
@@ -317,9 +359,11 @@ module Primer
 
       # @label Opens a dialog
       #
-      def opens_dialog(menu_id: "menu-1")
+      # @param nest_in_sub_menu toggle
+      def opens_dialog(menu_id: "menu-1", nest_in_sub_menu: false)
         render_with_template(locals: {
-                               menu_id: menu_id
+                               menu_id: menu_id,
+                               nest_in_sub_menu: nest_in_sub_menu
                              })
       end
 
@@ -405,6 +449,26 @@ module Primer
       # @label Two menus
       #
       def two_menus; end
+
+      # @label Sub-menus
+      #
+      # @param anchor_align [Symbol] select [start, center, end]
+      # @param anchor_side [Symbol] select [outside_bottom, outside_top, outside_left, outside_right]
+      # @param sub_menu_anchor_align [Symbol] select [start, center, end]
+      # @param sub_menu_anchor_side [Symbol] select [outside_bottom, outside_top, outside_left, outside_right]
+      def sub_menus(
+        anchor_align: Primer::Alpha::ActionMenu::PrimaryMenu::DEFAULT_ANCHOR_ALIGN,
+        anchor_side: Primer::Alpha::ActionMenu::PrimaryMenu::DEFAULT_ANCHOR_SIDE,
+        sub_menu_anchor_align: Primer::Alpha::ActionMenu::SubMenu::DEFAULT_ANCHOR_ALIGN,
+        sub_menu_anchor_side: Primer::Alpha::ActionMenu::SubMenu::DEFAULT_ANCHOR_SIDE
+      )
+        render_with_template(locals: {
+          anchor_align: anchor_align.to_sym,
+          anchor_side: anchor_side.to_sym,
+          sub_menu_anchor_align: sub_menu_anchor_align,
+          sub_menu_anchor_side: sub_menu_anchor_side
+        })
+      end
     end
   end
 end

--- a/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
+++ b/previews/primer/alpha/action_menu_preview/multiple_select_form.html.erb
@@ -1,10 +1,19 @@
 <%= form_with(url: primer_view_components.action_menu_form_action_path(format: route_format)) do |f| %>
+  <% content = -> (base) do %>
+    <% base.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
+    <% base.with_item(label: "Recursive", data: { value: "recursive" }) %>
+    <% base.with_item(label: "Ours", data: { value: "ours" }, active: true) %>
+    <% base.with_item(label: "Resolve") %>
+  <% end %>
   <%= render(Primer::Alpha::ActionMenu.new(select_variant: :multiple, dynamic_label: true, dynamic_label_prefix: "Strategy", form_arguments: { builder: f, name: "foo" })) do |menu| %>
     <% menu.with_show_button { "Strategy" } %>
-    <% menu.with_item(label: "Fast forward", data: { value: "fast_forward" }) %>
-    <% menu.with_item(label: "Recursive", data: { value: "recursive" }) %>
-    <% menu.with_item(label: "Ours", data: { value: "ours" }, active: true) %>
-    <% menu.with_item(label: "Resolve") %>
+    <% if nest_in_sub_menu %>
+      <% menu.with_sub_menu_item(label: "Sub-menu") do |sub_menu| %>
+        <% content.call(sub_menu) %>
+      <% end %>
+    <% else %>
+      <% content.call(menu) %>
+    <% end %>
   <% end %>
   <hr>
   <div>

--- a/previews/primer/alpha/action_menu_preview/opens_dialog.html.erb
+++ b/previews/primer/alpha/action_menu_preview/opens_dialog.html.erb
@@ -1,20 +1,29 @@
 <%= render(Primer::Alpha::ActionMenu.new) do |component| %>
   <% component.with_show_button { "Menu" } %>
-  <% component.with_item(label: "Item", tag: :button, value: "") %>
-  <% component.with_item(
-    label: "Show dialog",
-    tag: :button,
-    content_arguments: { "data-show-dialog-id": "my-dialog" },
-    value: "",
-    scheme: :danger
-  ) %>
+  <% contents = -> (base) do %>
+    <% base.with_item(label: "Item", tag: :button, value: "") %>
+    <% base.with_item(
+      label: "Show dialog",
+      tag: :button,
+      content_arguments: { "data-show-dialog-id": "my-dialog" },
+      value: "",
+      scheme: :danger
+    ) %>
+  <% end %>
+  <% if nest_in_sub_menu %>
+    <% component.with_sub_menu_item(label: "Sub-menu") do |sub_menu_item| %>
+      <% contents.call(sub_menu_item) %>
+    <% end %>
+  <% else %>
+    <% contents.call(component) %>
+  <% end %>
 <% end %>
 
-<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |d| %>
-  <%= render(Primer::Alpha::Dialog::Body.new()) do %>
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |dialog| %>
+  <% dialog.with_body do %>
     Are you sure you want to delete this?
   <% end %>
-  <%= render(Primer::Alpha::Dialog::Footer.new()) do %>
+  <% dialog.with_footer do %>
     <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
     <%= render(Primer::Beta::Button.new(scheme: :danger)) { "Delete" } %>
   <% end %>

--- a/previews/primer/alpha/action_menu_preview/single_select_form_items.html.erb
+++ b/previews/primer/alpha/action_menu_preview/single_select_form_items.html.erb
@@ -1,5 +1,4 @@
-<%= render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu| %>
-  <% menu.with_show_button { "Group By" } %>
+<% contents = -> (menu) do %>
   <% menu.with_item(
     label: "Repository",
     href: primer_view_components.action_menu_form_action_path(format: route_format),
@@ -28,4 +27,16 @@
       }]
     }
   ) %>
+<% end %>
+
+<%= render(Primer::Alpha::ActionMenu.new(select_variant: :single)) do |menu| %>
+  <% menu.with_show_button { "Group By" } %>
+
+  <% if nest_in_sub_menu %>
+    <% menu.with_sub_menu_item(label: "Sub-menu") do |sub_menu_item| %>
+      <% contents.call(sub_menu_item) %>
+    <% end %>
+  <% else %>
+    <% contents.call(menu) %>
+  <% end %>
 <% end %>

--- a/previews/primer/alpha/action_menu_preview/sub_menus.html.erb
+++ b/previews/primer/alpha/action_menu_preview/sub_menus.html.erb
@@ -1,0 +1,19 @@
+<%# Center the invoker button to give left-appearing sub-menus enough space %>
+<div style="<%= sub_menu_anchor_side.to_s.include?("left") ? "text-align: center" : "" %>">
+  <%= render(Primer::Alpha::ActionMenu.new(anchor_align: anchor_align, anchor_side: anchor_side)) do |menu| %>
+    <% menu.with_show_button { "Edit" } %>
+    <% menu.with_item(label: "Cut") %>
+    <% menu.with_item(label: "Copy") %>
+    <% menu.with_sub_menu_item(label: "Paste special", anchor_align: sub_menu_anchor_align, anchor_side: sub_menu_anchor_side) do |sub_menu| %>
+      <% sub_menu.with_leading_visual_icon(icon: :"sparkle-fill") %>
+      <% sub_menu.with_item(label: "Paste plain text") %>
+      <% sub_menu.with_item(label: "Paste formulas") %>
+      <% sub_menu.with_item(label: "Paste with formatting") %>
+      <% sub_menu.with_sub_menu_item(label: "Paste from") do |sub_menu| %>
+        <% sub_menu.with_item(label: "Current clipboard") %>
+        <% sub_menu.with_item(label: "History") %>
+        <% sub_menu.with_item(label: "Another device") %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/previews/primer/alpha/action_menu_preview/with_actions.html.erb
+++ b/previews/primer/alpha/action_menu_preview/with_actions.html.erb
@@ -8,15 +8,24 @@
 
 <%= render(Primer::Alpha::ActionMenu.new) do |component| %>
   <% component.with_show_button { "Trigger" } %>
-  <% component.with_item(label: "Alert", tag: :button, id: "alert-item", disabled: disable_items) %>
-  <% component.with_item(label: "Navigate", tag: :a, content_arguments: { href: primer_view_components.action_menu_landing_path }, disabled: disable_items) %>
-  <% component.with_item(label: "Copy text", tag: :"clipboard-copy", content_arguments: { value: "Text to copy" }, disabled: disable_items) %>
-  <% component.with_item(
-    label: "Submit form",
-    href: primer_view_components.action_menu_form_action_path(format: route_format),
-    form_arguments: {
-      name: "foo", value: "bar", method: :post
-    },
-    disabled: disable_items
-  ) %>
+  <% contents = -> (base) do %>
+    <% base.with_item(label: "Alert", tag: :button, id: "alert-item", disabled: disable_items) %>
+    <% base.with_item(label: "Navigate", tag: :a, content_arguments: { href: primer_view_components.action_menu_landing_path }, disabled: disable_items) %>
+    <% base.with_item(label: "Copy text", tag: :"clipboard-copy", content_arguments: { value: "Text to copy" }, disabled: disable_items) %>
+    <% base.with_item(
+      label: "Submit form",
+      href: primer_view_components.action_menu_form_action_path(format: route_format),
+      form_arguments: {
+        name: "foo", value: "bar", method: :post
+      },
+      disabled: disable_items
+    ) %>
+  <% end %>
+  <% if nest_in_sub_menu %>
+    <% component.with_sub_menu_item(label: "Sub-menu") do |sub_menu_item| %>
+      <% contents.call(sub_menu_item) %>
+    <% end %>
+  <% else %>
+    <% contents.call(component) %>
+  <% end %>
 <% end %>

--- a/previews/primer/alpha/action_menu_preview/with_deferred_content.html.erb
+++ b/previews/primer/alpha/action_menu_preview/with_deferred_content.html.erb
@@ -1,0 +1,24 @@
+<% if nest_in_sub_menu %>
+  <%= render(Primer::Alpha::ActionMenu.new) do |menu| %>
+    <% menu.with_show_button { "Menu with deferred content" } %>
+    <% menu.with_sub_menu_item(label: "Sub-menu", menu_id: "deferred", src: primer_view_components.action_menu_deferred_path) %>
+  <% end %>
+<% else %>
+  <%= render(Primer::Alpha::ActionMenu.new(menu_id: "deferred", src: primer_view_components.action_menu_deferred_path)) do |menu| %>
+    <% menu.with_show_button { "Menu with deferred content" } %>
+  <% end %>
+<% end %>
+
+<%# This is used by the items rendered by ActionMenuController#deferred. It needs to be rendered %>
+<%# here and not returned alongside async-rendered menu items in case of sub-menu nesting. Any %>
+<%# additional HTML like this will end up being wrapped in a <ul> that's invisible when the menu is %>
+<%# closed, and appear to never open. %>
+<%= render(Primer::Alpha::Dialog.new(id: "my-dialog", title: "Confirm deletion")) do |d| %>
+  <%= render(Primer::Alpha::Dialog::Body.new()) do %>
+    Are you sure you want to delete this?
+  <% end %>
+  <%= render(Primer::Alpha::Dialog::Footer.new()) do %>
+    <%= render(Primer::Beta::Button.new(data: { "close-dialog-id": "my-dialog" })) { "Cancel" } %>
+    <%= render(Primer::Beta::Button.new(scheme: :danger)) { "Delete" } %>
+  <% end %>
+<% end %>

--- a/test/components/alpha/action_menu_test.rb
+++ b/test/components/alpha/action_menu_test.rb
@@ -20,12 +20,25 @@ module Primer
       def test_renders_with_relevant_accessibility_attributes
         render_preview(:default)
 
-        assert_selector("action-menu") do
-          assert_selector("button[id='menu-1-button'][aria-haspopup='true']", text: "Menu")
-          assert_selector("ul[id='menu-1-list'][aria-labelledby='menu-1-button'][role='menu']", visible: false) do
-            assert_selector("li button[role='menuitem']", visible: false)
+        assert_selector("action-menu") do |menu|
+          menu.assert_selector("button[id='menu-1-button'][aria-haspopup='true']", text: "Menu")
+          menu.assert_selector("ul[id='menu-1-list'][aria-labelledby='menu-1-button'][role='menu']", visible: false) do |ul|
+            ul.assert_selector("li button[role='menuitem']", visible: false)
+          end
+          menu.assert_selector("anchored-position[id='menu-1-overlay'][anchor=menu-1-button]")
+        end
+      end
+
+      def test_accepts_custom_menu_id_for_sub_menus
+        render_inline(Primer::Alpha::ActionMenu.new) do |component|
+          component.with_sub_menu_item(label: "Sub-menu", menu_id: "foobarbaz") do |sub_menu|
+            sub_menu.with_item(label: "Hello, world")
           end
         end
+
+        assert_selector("button[id='foobarbaz-button'][aria-haspopup='true']", text: "Sub-menu")
+        assert_selector("ul[id='foobarbaz-list'][aria-labelledby='foobarbaz-button'][role='menu']", visible: false)
+        assert_selector("anchored-position[id='foobarbaz-overlay'][anchor=foobarbaz-button]")
       end
 
       def test_falls_back_to_button_if_disallowed_tag_is_given
@@ -53,30 +66,24 @@ module Primer
       def test_allows_trigger_button_to_be_icon_button
         render_preview(:with_icon_button)
 
-        assert_selector("action-menu", visible: false) do
-          assert_selector("button[aria-haspopup='true']", visible: false) do
-            assert_selector("svg", visible: false)
+        assert_selector("action-menu", visible: false) do |menu|
+          menu.assert_selector("button[aria-haspopup='true']", visible: false) do |button|
+            button.assert_selector("svg", visible: false)
           end
 
-          assert_selector("tool-tip", text: "Menu", visible: false)
+          menu.assert_selector("tool-tip", text: "Menu", visible: false)
         end
       end
 
       def test_allows_some_tags_as_nested_menu_item
         render_preview(:with_actions)
 
-        assert_selector("action-menu") do
-          assert_selector("button[aria-haspopup='true']", text: "Trigger")
-          assert_selector("ul", visible: false) do
-            assert_selector("li", visible: false) do
-              assert_selector("button[role='menuitem']", text: "Alert", visible: false)
-            end
-            assert_selector("li", visible: false) do
-              assert_selector("a", text: "Navigate", visible: false)
-            end
-            assert_selector("li", visible: false) do
-              assert_selector("clipboard-copy[role='menuitem']", text: "Copy text", visible: false)
-            end
+        assert_selector("action-menu") do |menu|
+          menu.assert_selector("button[aria-haspopup='true']", text: "Trigger")
+          menu.assert_selector("ul", visible: false) do |list|
+            list.assert_selector("li button[role='menuitem']", text: "Alert", visible: false)
+            list.assert_selector("li a", text: "Navigate", visible: false)
+            list.assert_selector("li clipboard-copy[role='menuitem']", text: "Copy text", visible: false)
           end
         end
       end
@@ -86,10 +93,10 @@ module Primer
           component.with_show_button { "Trigger" }
         end
 
-        assert_selector("action-menu") do
-          assert_selector("button[id='deferred-menu-button'][aria-haspopup='true']", text: "Trigger")
-          assert_selector("include-fragment[src='/'][data-target='action-menu.includeFragment']", visible: false) do
-            assert_selector(".ActionListItem[aria-disabled='true']", visible: false)
+        assert_selector("action-menu") do |menu|
+          menu.assert_selector("button[id='deferred-menu-button'][aria-haspopup='true']", text: "Trigger")
+          menu.assert_selector("include-fragment[src='/'][data-target='action-menu.includeFragment']", visible: false) do |fragment|
+            fragment.assert_selector(".ActionListItem[aria-disabled='true']", visible: false)
           end
         end
       end
@@ -103,10 +110,10 @@ module Primer
           component.with_show_button { "Trigger" }
         end
 
-        assert_selector("action-menu[preload='true']") do
-          assert_selector("button[id='deferred-menu-button'][aria-haspopup='true']", text: "Trigger")
-          assert_selector("include-fragment[src='/'][data-target='action-menu.includeFragment']", visible: false) do
-            assert_selector(".ActionListItem[aria-disabled='true']", visible: false)
+        assert_selector("action-menu[preload='true']") do |menu|
+          menu.assert_selector("button[id='deferred-menu-button'][aria-haspopup='true']", text: "Trigger")
+          menu.assert_selector("include-fragment[src='/'][data-target='action-menu.includeFragment']", visible: false) do |fragment|
+            fragment.assert_selector(".ActionListItem[aria-disabled='true']", visible: false)
           end
         end
       end
@@ -114,10 +121,8 @@ module Primer
       def test_disabled
         render_preview(:with_disabled_items)
 
-        assert_selector("li[role=none]") do
-          assert_selector("button.ActionListContent[aria-disabled=true]", text: "Does something")
-          assert_selector("a.ActionListContent[aria-disabled=true]", text: "Site")
-        end
+        assert_selector("li[role='none'] button.ActionListContent[aria-disabled=true]", text: "Does something")
+        assert_selector("li[role='none'] a.ActionListContent[aria-disabled=true]", text: "Site")
       end
 
       def test_renders_a_tag_when_href_provided
@@ -142,6 +147,13 @@ module Primer
         refute_selector ".ActionListItem .avatar.circle"
       end
 
+      def test_avatar_items_appear_in_sub_menus
+        render_preview(:multiple_select, params: { nest_in_sub_menu: true })
+
+        assert_selector ".ActionListItem .avatar"
+        refute_selector ".ActionListItem .avatar.circle"
+      end
+
       def test_renders_groups
         render_preview(:with_groups)
 
@@ -150,6 +162,40 @@ module Primer
           menu.assert_selector("ul[role=group]", count: 3) do |group|
             group.assert_selector("li[role=none]") do |item|
               item.assert_selector "button[role=menuitem]"
+            end
+          end
+        end
+      end
+
+      def test_renders_groups_in_sub_menu
+        render_preview(:with_groups, params: { nest_in_sub_menu: true })
+
+        assert_selector("ul[role=menu] ul[role=menu]") do |menu|
+          menu.assert_selector(".ActionList-sectionDivider .ActionList-sectionDivider-title", count: 3)
+          menu.assert_selector("ul[role=group]", count: 3) do |group|
+            group.assert_selector("li[role=none]") do |item|
+              item.assert_selector "button[role=menuitem]"
+            end
+          end
+        end
+      end
+
+      def test_renders_sub_menus_in_sub_menus
+        render_inline Primer::Alpha::ActionMenu.new(menu_id: "foo") do |component|
+          component.with_show_button { "Trigger" }
+          component.with_sub_menu_item(label: "Level 2") do |level2|
+            level2.with_sub_menu_item(label: "Level 3") do |level3|
+              level3.with_item(label: "Level 4")
+            end
+          end
+        end
+
+        assert_selector("[role=menu]") do |level1|
+          level1.assert_selector("[role='menuitem']", text: "Level 2")
+          level1.assert_selector("[role=menu]") do |level2|
+            level2.assert_selector("[role=menuitem]", text: "Level 3")
+            level2.assert_selector("[role=menu]") do |level3|
+              level3.assert_selector("[role=menuitem]", text: "Level 4")
             end
           end
         end
@@ -203,6 +249,27 @@ module Primer
         end
 
         assert_selector "anchored-position[data-foo=bar]"
+      end
+
+      def test_renders_submenus
+        render_preview(:with_actions, params: { nest_in_sub_menu: true })
+
+        assert_selector("action-menu") do |menu|
+          sub_menu_button = page.find_css("li button", text: "Sub-menu").first
+          popover_id = sub_menu_button["popovertarget"]
+
+          menu.assert_selector("anchored-position##{popover_id} ul", visible: false) do |sub_menu|
+            sub_menu.assert_selector("li button[role='menuitem']", text: "Alert", visible: false)
+            sub_menu.assert_selector("li a", text: "Navigate", visible: false)
+            sub_menu.assert_selector("li clipboard-copy[role='menuitem']", text: "Copy text", visible: false)
+          end
+        end
+      end
+
+      def test_renders_internal_label
+        render_preview(:single_select_with_internal_label)
+
+        assert_selector("button[aria-haspopup='true'] .Button-label", text: "Menu")
       end
     end
   end

--- a/test/components/component_test.rb
+++ b/test/components/component_test.rb
@@ -147,14 +147,18 @@ class PrimerComponentTest < Minitest::Test
       "Primer::Alpha::ActionList::Item",
       "Primer::Alpha::ActionList::Divider",
       "Primer::Alpha::ActionList::FormWrapper",
-      "Primer::Alpha::ActionMenu::Heading",
-      "Primer::Alpha::ActionMenu::List",
-      "Primer::Alpha::ActionMenu::ListWrapper",
       "Primer::Alpha::ActionMenu::Group",
+      "Primer::Alpha::ActionMenu::Heading",
+      "Primer::Alpha::ActionMenu::ListWrapper",
+      "Primer::Alpha::ActionMenu::List",
+      "Primer::Alpha::ActionMenu::Menu",
+      "Primer::Alpha::ActionMenu::PrimaryMenu",
+      "Primer::Alpha::ActionMenu::SubMenuItem",
+      "Primer::Alpha::ActionMenu::SubMenu",
       "Primer::Beta::NavList::Item",
       "Primer::Beta::NavList::Group",
       "Primer::Beta::NavList::Divider",
-      "Primer::Beta::NavList::Header",
+      "Primer::Beta::NavList::Heading",
       "Primer::Alpha::OcticonSymbols",
       "Primer::Component",
       "Primer::Content",
@@ -162,8 +166,16 @@ class PrimerComponentTest < Minitest::Test
       "Primer::ResponsiveArg"
     ]
 
-    primer_component_files_count = Dir["app/components/**/*.rb"].count { |p| p.exclude?("/experimental/") }
-    assert_equal primer_component_files_count, COMPONENTS_WITH_ARGS.length + ignored_components.count, "Primer component added. Please update this test with an entry for your new component <3"
+    primer_component_files = Dir.chdir("app/components") { Dir["**/*.rb"] }.reject { |p| p.include?("/experimental/") }
+    primer_component_class_names = primer_component_files.map { |f| f.chomp(".rb").camelize }
+
+    documented_class_names = [*COMPONENTS_WITH_ARGS.map { |klass, *| klass.name }, *ignored_components]
+    missing = primer_component_class_names - documented_class_names
+
+    assert_empty(
+      missing,
+      "Primer component added. Please update this test with an entry for your new component <3"
+    )
   end
 
   def test_all_components_support_system_arguments

--- a/test/system/alpha/action_bar_test.rb
+++ b/test/system/alpha/action_bar_test.rb
@@ -86,7 +86,6 @@ class IntegrationAlphaActionBarTest < System::TestCase
       end
 
       mouse.click(x: 0, y: 0)
-      keyboard.type(:tab)
 
       # Ensures that ActionMenu trigger is still focusable
       assert_equal page.evaluate_script("document.activeElement.classList.contains('Button--iconOnly')"), true

--- a/test/test_helpers/driver_test_helpers.rb
+++ b/test/test_helpers/driver_test_helpers.rb
@@ -17,10 +17,11 @@ module Primer
     def setup_driver
       if chrome?
         require "test_helpers/cuprite_setup"
-        require "test_helpers/retry"
       elsif firefox?
         require "test_helpers/webdriver_setup"
       end
+
+      require "test_helpers/retry"
     end
 
     private


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

This PR adds multi-level support to the `ActionMenu` component. It enables menus to be nested inside other menus just as can be done for the corresponding [React component](https://primer.style/react/storybook/?path=/story/components-actionmenu-features--submenus).

Since there was no reason to build it, and because it's not clear how it should work, `ActionMenu`s with sub-menus do not support single-select mode.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Alt: A screen recording initially showing only a button labeled "Edit." When the button is clicked, an `ActionMenu` appears containing three items: "Cut," "Copy," and "Paste special." The last item's label is followed by a right-facing chevron icon. This last item is clicked, which causes a sub-menu to appear to the right. This sub-menu contains four items, the last of which also features a right-facing chevron icon. When the last item is clicked, a third sub-menu appears containing 3 additional items. The last item is clicked and all three menus disappear.

https://github.com/user-attachments/assets/5eff167c-5720-4404-99e7-1ef30d72ee97

### Integration
<!-- Does this change require any updates to code in production? -->

Multi-level support has been designed to maintain feature parity with the current `ActionMenu` component so as to be entirely backwards-compatible, at least from an API perspective. The component should generate nearly identical markup with the minor exception of the newly added sub-menu item, which includes a nested `<ul>` and `<anchored-position>`.

However, care should be taken when integrating these changes, since they do represent a significant re-architecting of the component's inner workings.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

This feature was built by introducing a new menu item class called `SubMenuItem`. This class represents the menu item element and renders a `SubMenu` component that essentially contains another `ActionMenu` wrapped in its own `<anchored-position>`. To share code between the primary menu and sub-menus, the original code from the `ActionMenu` class was moved into a base class named `Menu`, from which both `PrimaryMenu` and `SubMenu` now inherit.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge