### PR TITLE
support ViewComponent 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "lookbook", "~> 2.3.11"
 if ENV["VIEW_COMPONENT_PATH"]
   gem "view_component", path: ENV["VIEW_COMPONENT_PATH"]
 else
-  gem "view_component", "4.0.0.rc1"
+  gem "view_component", "4.0.0.rc5"
 end
 
 gem "kramdown", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       octicons (>= 18.0.0)
-      view_component (>= 3.1, < 4.0)
+      view_component (>= 3.1, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -284,7 +284,7 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
-    view_component (4.0.0.rc1)
+    view_component (4.0.0.rc5)
       activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
     vite_rails (3.0.19)
@@ -351,7 +351,7 @@ DEPENDENCIES
   sprockets-rails
   thor
   timecop
-  view_component (= 4.0.0.rc1)
+  view_component (= 4.0.0.rc5)
   vite_rails (~> 3.0)
   webmock
   yard (~> 0.9.37)

--- a/primer_view_components.gemspec
+++ b/primer_view_components.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency     "actionview", ">= 7.1.0"
   spec.add_runtime_dependency     "activesupport", ">= 7.1.0"
   spec.add_runtime_dependency     "octicons", ">= 18.0.0"
-  spec.add_runtime_dependency     "view_component", [">= 3.1", "< 4.0"]
+  spec.add_runtime_dependency     "view_component", [">= 3.1", "< 5.0"]
 end


### PR DESCRIPTION
### What are you trying to accomplish?

This PR updates the `gemspec` to allow usage with ViewComponent 4.0.0.

In practice, PVC is already incompatible with releases before 4.0.0 due to private API changes PVC depends on. I'll follow up with a PR to change the minimum VC version later.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
