### PR TITLE
test against ruby 3.4 in CI

### DIFF
--- a/.changeset/dirty-flies-brake.md
+++ b/.changeset/dirty-flies-brake.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+test against ruby 3.4 in CI

--- a/.changeset/dirty-flies-brake.md
+++ b/.changeset/dirty-flies-brake.md
@@ -1,5 +1,0 @@
----
-"@primer/view-components": patch
----
-
-test against ruby 3.4 in CI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.3'
+        ruby-version: '3.4'
         bundler-cache: true
     - uses: actions/setup-node@v4
       with:
@@ -57,9 +57,9 @@ jobs:
           - rails_version: "7.1.3"
             ruby_version: "3.3"
           - rails_version: "main"
-            ruby_version: "3.2"
-          - rails_version: "main"
             ruby_version: "3.3"
+          - rails_version: "main"
+            ruby_version: "3.4"
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,9 +99,9 @@ jobs:
           - rails_version: "7.1.3"
             ruby_version: "3.3"
           - rails_version: "main"
-            ruby_version: "3.2"
-          - rails_version: "main"
             ruby_version: "3.3"
+          - rails_version: "main"
+            ruby_version: "3.4"
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
@@ -141,9 +141,9 @@ jobs:
           - rails_version: "7.1.3"
             ruby_version: "3.3"
           - rails_version: "main"
-            ruby_version: "3.2"
-          - rails_version: "main"
             ruby_version: "3.3"
+          - rails_version: "main"
+            ruby_version: "3.4"
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1

--- a/test/performance/bench_octicons.rb
+++ b/test/performance/bench_octicons.rb
@@ -17,7 +17,7 @@ class BenchOcticons < Minitest::Benchmark
   def bench_allocations_without_cache
     Primer::Beta::Octicon.new(**@options)
     Primer::Octicon::Cache.clear!
-    assert_allocations "3.4" => 26, "3.3" => 26, "3.2" => 26, "3.1" => 28, "3.0" => 28 do
+    assert_allocations "3.4" => 25, "3.3" => 26, "3.2" => 26, "3.1" => 28, "3.0" => 28 do
       Primer::Beta::Octicon.new(**@options)
     end
   ensure
@@ -26,7 +26,7 @@ class BenchOcticons < Minitest::Benchmark
 
   def bench_allocations_with_cache
     Primer::Octicon::Cache.preload!
-    assert_allocations "3.4" => 10, "3.3" => 10, "3.2" => 10, "3.1" => 11, "3.0" => 11 do
+    assert_allocations "3.4" => 9, "3.3" => 10, "3.2" => 10, "3.1" => 11, "3.0" => 11 do
       Primer::Beta::Octicon.new(**@options)
     end
   end


### PR DESCRIPTION
### What are you trying to accomplish?

I'm looking to ensure PVC is compatible with Ruby 3.4. I went ahead and changed some of the builds to use different Ruby versions without adding any new builds. We've taken this hodgepodge approach on the ViewComponent repository without issue.

I also fixed the 3.4 allocation counts, which we incorrect and causing VC main CI to fail.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
