### PR TITLE
Breadcrumb is not properly left-aligned when it has long items

### DIFF
--- a/app/components/primer/beta/breadcrumbs.pcss
+++ b/app/components/primer/beta/breadcrumbs.pcss
@@ -1,7 +1,5 @@
 .breadcrumb-item {
   display: inline-block;
-  /* stylelint-disable-next-line primer/spacing */
-  margin-left: -0.35em;
   list-style: none;
   max-width: 100%;
 
@@ -10,14 +8,11 @@
     height: 0.8em;
     /* stylelint-disable-next-line primer/spacing */
     margin: 0 0.5em;
+    padding-left: 0.35em;
     content: '';
     /* stylelint-disable-next-line primer/borders */
     border-right: 0.1em solid var(--borderColor-neutral-emphasis);
     transform: rotate(15deg) translateY(0.0625em);
-  }
-
-  &:first-child {
-    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
When a breadcrumb item wraps to a second line, the second line is not left-aligned with the first.
This is due to the negative margin-left shifting the wrapped text, while the first item doesn't have margin-left.

### Screenshots
Before:

<img width="485" height="226" alt="Screenshot 2025-08-04 at 12 09 56" src="https://github.com/user-attachments/assets/61f24664-e69b-4c10-b9dc-6c9abcb95cc7" />

After:
<img width="487" height="201" alt="Screenshot 2025-08-04 at 12 09 15" src="https://github.com/user-attachments/assets/8977fd09-9a1e-4b17-b4cd-e80b388cdf7f" />

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes # (type the GitHub issue number after #)

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [X] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
