### PR TITLE
Primer Alpha::ToggleSwitch custom status label support

### DIFF
--- a/.changeset/spotty-birds-cough.md
+++ b/.changeset/spotty-birds-cough.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Add custom label support for ToggleSwitch on/off states

--- a/app/components/primer/alpha/toggle_switch.html.erb
+++ b/app/components/primer/alpha/toggle_switch.html.erb
@@ -4,8 +4,8 @@
     <%= render(Primer::Beta::Spinner.new(size: :small, hidden: "true", data: { target: "toggle-switch.loadingSpinner" })) %>
   </span>
   <%= render(Primer::Beta::Text.new(aria: { hidden: true }, classes: "ToggleSwitch-status")) do %>
-    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOn").with_content("On")) %>
-    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content("Off")) %>
+    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOn").with_content(@on_label)) %>
+    <%= render(Primer::Box.new(classes: "ToggleSwitch-statusOff").with_content(@off_label)) %>
   <% end %>
 
   <%= render(Primer::BaseComponent.new(tag: :button, classes: "ToggleSwitch-track", disabled: disabled?, data: { target: "toggle-switch.switch", action: "click:toggle-switch#toggle" }, **@button_arguments)) do %>

--- a/app/components/primer/alpha/toggle_switch.rb
+++ b/app/components/primer/alpha/toggle_switch.rb
@@ -29,6 +29,8 @@ module Primer
       # @param turbo [Boolean] Whether or not to request a turbo stream and render the response as such.
       # @param autofocus [Boolean] Whether switch should be autofocused when rendered.
       # @param system_arguments [Hash] <%= link_to_system_arguments_docs %>
+      # @param on_label [String] Custom label to show when switch is ON. Defaults to On.
+      # @param off_label [String] Custom label to show when switch is OFF. Defaults to Off.
       def initialize(
         src: nil,
         csrf_token: nil,
@@ -38,6 +40,8 @@ module Primer
         status_label_position: STATUS_LABEL_POSITION_DEFAULT,
         turbo: false,
         autofocus: nil,
+        on_label: nil,
+        off_label: nil,
         **system_arguments
       )
         @src = src
@@ -70,6 +74,9 @@ module Primer
         @button_arguments[:autofocus] = true if autofocus
 
         @system_arguments[:src] = @src if @src
+
+        @on_label  = on_label  || "On"
+        @off_label = off_label || "Off"
       end
 
       def on?

--- a/previews/primer/alpha/toggle_switch_preview.rb
+++ b/previews/primer/alpha/toggle_switch_preview.rb
@@ -67,5 +67,9 @@ module Primer
         render(Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.primer_view_components.toggle_switch_index_path, autofocus: true))
       end
     end
+
+    def with_custom_status_label
+      render Primer::Alpha::ToggleSwitch.new(src: UrlHelpers.primer_view_components.toggle_switch_index_path, on_label: "Enabled", off_label: "Disabled")
+    end
   end
 end


### PR DESCRIPTION
### What are you trying to accomplish?
Pass on and off labels to the Primer toggle switch, so it can receive locale

### Screenshots
Before:
<img width="173" height="110" alt="toggle switch default" src="https://github.com/user-attachments/assets/addb999d-524c-4a62-a5a8-bae418701daf" />

After:
<img width="143" height="46" alt="toggle switch with custom status label" src="https://github.com/user-attachments/assets/646996cb-7a79-49b8-a2b0-80b2771cfaf0" />

Closes https://github.com/primer/view_components/issues/3658

### Risk Assessment

- [X]  Low risk the change is small, highly observable, and easily rolled back.
- [ ]  Medium risk changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ]  High risk changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
Pass two strings as the labels for on and off states in toggle switch.
