### PR TITLE
Remove early return from error announcement logic

### DIFF
--- a/.changeset/seven-peaches-serve.md
+++ b/.changeset/seven-peaches-serve.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+When an error occurs in the SelectPanel, continue throwing the error

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -554,7 +554,6 @@ export class SelectPanelElement extends HTMLElement {
         // check if the errorElement is visible in the dom
         if (errorElement && !errorElement.hasAttribute('hidden')) {
           this.liveRegion.announceFromElement(errorElement, {politeness: 'assertive'})
-          return
         }
 
         break

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -555,8 +555,7 @@ export class SelectPanelElement extends HTMLElement {
         if (errorElement && !errorElement.hasAttribute('hidden')) {
           this.liveRegion.announceFromElement(errorElement, {politeness: 'assertive'})
         }
-
-        break
+        throw new Error(event.detail.error)
       }
     }
   }

--- a/app/components/primer/alpha/select_panel_element.ts
+++ b/app/components/primer/alpha/select_panel_element.ts
@@ -555,7 +555,7 @@ export class SelectPanelElement extends HTMLElement {
         if (errorElement && !errorElement.hasAttribute('hidden')) {
           this.liveRegion.announceFromElement(errorElement, {politeness: 'assertive'})
         }
-        throw new Error(event.detail.error)
+        throw new Error((event as CustomEvent).detail.error)
       }
     }
   }


### PR DESCRIPTION
Part of https://github.com/github/primer/issues/5409

### What are you trying to accomplish?

I'm trying to surface any exceptions that might be thrown lower down in the stack. In this case an event was triggered with type "error" so I'm re-throwing the event as an exception.

I'm unsure if this opens up to way more exceptions from more than my intention. Let me know if you think I should focus this to only the error that I'm trying to target. `"Failed to load resource: expected ..."`

#### Risk Assessment
  
There's risk this suddenly spikes errors being reported to Sentry

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [x] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.
