### PR TITLE
Replace State draft colors with new draft token

### DIFF
--- a/.changeset/every-suns-fold.md
+++ b/.changeset/every-suns-fold.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Replacing color tokens for StateLabel draft with new draft tokens

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -23,7 +23,7 @@
   color: var(--fgColor-onEmphasis);
   background-color: var(--bgColor-draft-emphasis, var(--bgColor-neutral-emphasis));
   border: var(--borderWidth-thin) solid transparent;
-  box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis);
+  box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis, var(--borderColor-neutral-emphasis));
 }
 
 .State--open {

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -24,7 +24,6 @@
   /* stylelint-disable-next-line primer/colors */
   background-color: var(--bgColor-draft-emphasis, var(--bgColor-neutral-emphasis));
   border: var(--borderWidth-thin) solid transparent;
-  /* stylelint-disable-next-line primer/colors */
   box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis, var(--borderColor-neutral-emphasis));
 }
 

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -24,6 +24,7 @@
   /* stylelint-disable-next-line primer/colors */
   background-color: var(--bgColor-draft-emphasis, var(--bgColor-neutral-emphasis));
   border: var(--borderWidth-thin) solid transparent;
+  /* stylelint-disable-next-line primer/colors */
   box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis, var(--borderColor-neutral-emphasis));
 }
 

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -21,6 +21,7 @@
 .State,
 .State--draft {
   color: var(--fgColor-onEmphasis);
+  /* stylelint-disable-next-line primer/colors */
   background-color: var(--bgColor-draft-emphasis, var(--bgColor-neutral-emphasis));
   border: var(--borderWidth-thin) solid transparent;
   box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis, var(--borderColor-neutral-emphasis));

--- a/app/components/primer/beta/state.pcss
+++ b/app/components/primer/beta/state.pcss
@@ -21,9 +21,9 @@
 .State,
 .State--draft {
   color: var(--fgColor-onEmphasis);
-  background-color: var(--bgColor-neutral-emphasis);
+  background-color: var(--bgColor-draft-emphasis, var(--bgColor-neutral-emphasis));
   border: var(--borderWidth-thin) solid transparent;
-  box-shadow: var(--boxShadow-thin) var(--borderColor-neutral-emphasis);
+  box-shadow: var(--boxShadow-thin) var(--borderColor-draft-emphasis);
 }
 
 .State--open {


### PR DESCRIPTION
Closing this issue: https://github.com/github/primer/issues/5903

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

Update the tokens used for StateLabel draft states from neutral to using a new draft token.

There is no visual change.

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
