### PR TITLE
Fix label `for` attribute when not scoped to model

### DIFF
--- a/.changeset/chatty-pants-hang.md
+++ b/.changeset/chatty-pants-hang.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Fix incorrect label `for` attribute value when `scope_id_to_model: false`

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -61,7 +61,6 @@ module Primer
           @input_arguments = system_arguments
           @input_arguments.delete(:id) unless @input_arguments[:id].present?
           @label_arguments = @input_arguments.delete(:label_arguments) || {}
-          @label_arguments[:for] = id if id.present?
 
           @label_arguments[:class] = class_names(
             @label_arguments[:class],
@@ -104,6 +103,8 @@ module Primer
             @input_arguments[:id] = @input_arguments.delete(:id) { name }
           end
           # rubocop:enable Style/IfUnlessModifier
+
+          @label_arguments[:for] = @input_arguments[:id]
 
           # Whether or not to wrap the component in a FormControl, which renders a
           # label above and validation message beneath the input.

--- a/app/lib/primer/forms/dsl/input.rb
+++ b/app/lib/primer/forms/dsl/input.rb
@@ -104,7 +104,10 @@ module Primer
           end
           # rubocop:enable Style/IfUnlessModifier
 
-          @label_arguments[:for] = @input_arguments[:id]
+          # Only set `for` when the id is known. Otherwise leave it unset so
+          # Rails generates the scoped id for both label and input; passing
+          # `for: nil` would suppress that and drop the association.
+          @label_arguments[:for] = @input_arguments[:id] if @input_arguments[:id].present?
 
           # Whether or not to wrap the component in a FormControl, which renders a
           # label above and validation message beneath the input.

--- a/test/lib/primer/forms/input_test.rb
+++ b/test/lib/primer/forms/input_test.rb
@@ -104,6 +104,7 @@ class Primer::Forms::InputTest < Minitest::Test
     end
 
     assert_selector "input#ultimate_answer[name=ultimate_answer]"
+    assert_selector "label[for=ultimate_answer]"
   end
 
   def test_uses_given_id
@@ -116,5 +117,6 @@ class Primer::Forms::InputTest < Minitest::Test
     end
 
     assert_selector "input#foobar[name=ultimate_answer]"
+    assert_selector "label[for=foobar]"
   end
 end

--- a/test/lib/primer/forms/input_test.rb
+++ b/test/lib/primer/forms/input_test.rb
@@ -119,4 +119,26 @@ class Primer::Forms::InputTest < Minitest::Test
     assert_selector "input#foobar[name=ultimate_answer]"
     assert_selector "label[for=foobar]"
   end
+
+  class ModelScopeForm < ApplicationForm
+    form do |model_scope_form|
+      model_scope_form.text_field(
+        name: :ultimate_answer,
+        label: "Ultimate answer"
+      )
+    end
+  end
+
+  def test_label_for_matches_scoped_id_by_default
+    model = DeepThought.new(42)
+
+    render_in_view_context do
+      primer_form_with(model: model, url: "/foo") do |f|
+        render(ModelScopeForm.new(f))
+      end
+    end
+
+    assert_selector "input#deep_thought_ultimate_answer[name='deep_thought[ultimate_answer]']"
+    assert_selector "label[for=deep_thought_ultimate_answer]"
+  end
 end


### PR DESCRIPTION
### What are you trying to accomplish?

Defers assigning label `for` value to later in `initialize` method, ensuring the `scope_id_false: false` option is respected.

### Integration

It may require updating calling code that relies on the incorrect behavior.

#### List the issues that this change affects.

Closes primer/view_components#3695

#### Risk Assessment

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [X] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.


### Merge checklist

- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

