### PR TITLE
Fix: Delete the direction from the body arguments

### DIFF
--- a/.changeset/olive-planes-flash.md
+++ b/.changeset/olive-planes-flash.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix: Delete the direction from the body arguments

--- a/app/components/primer/beta/avatar_stack.rb
+++ b/app/components/primer/beta/avatar_stack.rb
@@ -52,6 +52,7 @@ module Primer
 
         @tooltip_arguments = {
           for_id: @body_arguments[:id],
+          direction: @body_arguments.delete(:direction),
         }
 
         @tooltip_arguments[:direction] = @direction || Primer::Alpha::Tooltip::DIRECTION_DEFAULT


### PR DESCRIPTION
Found an error that the tooltip direction was incorrectly being passed to the BaseComponent. 

```
Occurred at: test/components/actions/environments/request_form_item_component_test.rb:122

Minitest::UnexpectedError:ArgumentError: sw is not a valid value for :direction. Use one of [:column, :column_reverse, :row, :row_reverse]
    app/components/actions/environments/request_form_item_component.html.erb:31:in 'Actions::Environments::RequestFormItemComponent#call'
```