### PR TITLE
Skip visual tests for pull request events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,7 +188,8 @@ jobs:
           USE_BROWSER=firefox bundle exec rake test:system
   visual:
     name: Visual and Semantic Markup Regressions
-    if: ${{ github.event_name == 'pull_request' }}
+    # Temp skip this run
+    if: ${{ github.event_name == 'pull_request' && false }}
     timeout-minutes: 20
     runs-on: ubuntu-latest-8-cores
     steps:


### PR DESCRIPTION
The VRT tests have been causing friction, temp disabling while we can diagnose what's happening

