### PR TITLE
Fix low contrast for Lookbook preview group labels in dark theme

### DIFF
--- a/demo/app/views/lookbook/previews/group.html.erb
+++ b/demo/app/views/lookbook/previews/group.html.erb
@@ -1,0 +1,15 @@
+<% if scenarios.many? %>
+  <% scenarios = scenarios.filter(&:visible?) %>
+  <%# Render a group of scenarios %>
+  <% scenarios.each do |scenario| %>
+    <div style="margin-bottom: 30px !important; display: block !important;">
+      <h6 style="all: unset; display: block; color: var(--fgColor-muted, #555); font-family: sans-serif; font-size: 14px; margin-top: 0; margin-bottom: 10px;">
+        <%= scenario.label %>
+      </h6>
+      <%= scenario.output %>
+    </div>
+  <% end %>
+<% else %>
+  <%# Render a single scenario %>
+  <%= scenarios.first.output %>
+<% end %>


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->

Fixes low color contrast for Lookbook preview group labels (e.g., "Size small", "Size medium") in dark themes.

#### Problem

The default Lookbook [`group.html.erb`](https://github.com/lookbook-hq/lookbook/blob/main/app/views/lookbook/previews/group.html.erb) template uses a hardcoded `color: #555` for preview group labels. This produces a contrast ratio of only **2.5:1** against the dark theme background, which fails the WCAG AA requirement of **4.5:1**.

#### Solution

Created a custom `group.html.erb` template in `demo/app/views/lookbook/previews/` that overrides Lookbook's default. The fix replaces `color: #555;` with `color: var(--fgColor-muted, #555);`


### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

**ActionBar**:

  | Before | After |
  |--------|-------|
  |   <img width="647" height="317" alt="Screenshot 2026-01-21 at 11 38 59 AM" src="https://github.com/user-attachments/assets/d49f96d5-e578-4fbd-b650-f402712f9609" />  |  <img width="646" height="320" alt="Screenshot 2026-01-21 at 11 38 42 AM" src="https://github.com/user-attachments/assets/8ba011df-fbea-4d07-9725-48a61d55f1b9" />   |

**SegementedControl**:

  | Before | After |
  |--------|-------|
  |  <img width="648" height="410" alt="Screenshot 2026-01-21 at 11 41 06 AM" src="https://github.com/user-attachments/assets/bb8a62ba-e993-4287-ad74-5001660bc35e" />   |  <img width="647" height="405" alt="Screenshot 2026-01-21 at 11 40 55 AM" src="https://github.com/user-attachments/assets/b511991d-b675-4913-a12d-7c1d5c7af6e0" />   |

### Integration
<!-- Does this change require any updates to code in production? -->

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Related issues: https://github.com/github/accessibility-audits/issues/14647 and https://github.com/github/accessibility-audits/issues/14695

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
