### PR TITLE
Fix: Always use `aria-selected` for ActionList items with `role="option"`

### DIFF
--- a/.changeset/slick-walls-retire.md
+++ b/.changeset/slick-walls-retire.md
@@ -1,0 +1,5 @@
+---
+'@primer/view-components': patch
+---
+
+Always use `aria-selected` for ActionList items with role="option".

--- a/app/components/primer/alpha/action_list/item.rb
+++ b/app/components/primer/alpha/action_list/item.rb
@@ -302,7 +302,8 @@ module Primer
           if @list.allows_selection?
             @content_arguments[:aria] = merge_aria(
               @content_arguments,
-              { aria: @list.aria_selection_variant == :selected ? { selected: active? } : { checked: active? } }
+              # Always use aria-selected for listbox (role="option" requires aria-selected per WAI-ARIA 1.2)
+              { aria: @list.acts_as_listbox? || @list.aria_selection_variant == :selected ? { selected: active? } : { checked: active? } }
             )
           end
 


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
Ensures that ActionList items with `role="option"` (i.e., items in a listbox) always use `aria-selected` instead of `aria-checked`.

Related issue: https://github.com/github/accessibility-audits/issues/14576

My previous fix in [#3875](https://github.com/primer/view_components/pull/3875) addressed the double announcement issue ("not selected not checked") for SelectPanel by changing `aria_selection_variant` to always use `:selected`. It only applies when using `SelectPanel::ItemList`.

This follow-up fix enforces correct ARIA semantics at the `ActionList::Item` level by checking if the parent list has `role="listbox"`. Per [WAI-ARIA 1.2 specification](https://www.w3.org/TR/wai-aria-1.2/#option), the `option` role requires `aria-selected` as its selection state,`aria-checked` is only a supported attribute, not the primary selection indicator.
 
### Integration
<!-- Does this change require any updates to code in production? -->
 
#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [ ] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.
- **New axe violation** - This change introduces a new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation. Please describe why the violation cannot be resolved below.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
