### PR TITLE
Fix radio button checked state visibility in forced-colors mode

### DIFF
--- a/app/components/primer/alpha/text_field.pcss
+++ b/app/components/primer/alpha/text_field.pcss
@@ -800,6 +800,10 @@
         }
       }
     }
+    @media (forced-colors: active) {
+      background-color: SelectedItem;
+      border-color: SelectedItem;
+    }
   }
 
   &:focus-visible {


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?
Fix radio button checked state visibility under Windows High Contrast themes (forced-colors mode). Currently, .FormControl-radio has a @media (forced-colors: active) block that styles only the base (unchecked) state with canvastext. Since the radio uses appearance: none and relies on border-width changes for the checked indicator, both states appear identical under forced-colors because the browser overrides custom colors.

This adds a @media (forced-colors: active) rule inside &:checked using the SelectedItem system color, mirroring the existing pattern used by .FormControl-checkbox:checked.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

### Integration

#### List the issues that this change affects.
Closes https://github.com/github/accessibility-audits/issues/9855

#### Risk Assessment
- [x] **Low risk** the change is small, highly observable, and easily rolled back.

### What approach did you choose and why?
Used the SelectedItem system color for the checked state to differentiate it from the unchecked canvastext state. This follows the same pattern already used by .FormControl-checkbox:checked at line 739, which also adds a forced-colors block inside its :checked rule.

### Anything you want to highlight for special attention from reviewers?
The unchecked forced-colors block (line 808) uses canvastext. The new checked block uses SelectedItem so the two states are visually distinct. These are CSS system colors defined by the CSS Color Module Level 4 spec.


### Accessibility
- **Fixes axe scan violation** - This change fixes an existing [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violation.


### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
