### PR TITLE
Bugfix: Fix dropdown caret position in CSS styles for clean borders

### DIFF
--- a/.changeset/fix-dropdown-caret-borders.md
+++ b/.changeset/fix-dropdown-caret-borders.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix Dropdown component caret position in CSS styles for clean borders

--- a/app/components/primer/alpha/dropdown.pcss
+++ b/app/components/primer/alpha/dropdown.pcss
@@ -163,7 +163,8 @@
   }
 
   &::after {
-    top: var(--base-size-12);
+    /* stylelint-disable-next-line primer/spacing */
+    top: 11px;
     /* stylelint-disable-next-line primer/spacing */
     right: -14px;
     left: auto;
@@ -190,7 +191,8 @@
   }
 
   &::after {
-    top: var(--base-size-12);
+    /* stylelint-disable-next-line primer/spacing */
+    top: 11px;
     /* stylelint-disable-next-line primer/spacing */
     left: -14px;
     border-color: transparent;
@@ -228,7 +230,7 @@
     /* stylelint-disable-next-line primer/spacing */
     bottom: -7px;
     /* stylelint-disable-next-line primer/spacing */
-    left: 10px;
+    left: 9px;
     /* stylelint-disable-next-line primer/borders, primer/colors */
     border-top: 7px solid var(--overlay-bgColor);
     /* stylelint-disable-next-line primer/borders */
@@ -274,7 +276,7 @@
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
     /* stylelint-disable-next-line primer/spacing */
-    right: 10px;
+    right: 9px;
     left: auto;
   }
 }
@@ -290,6 +292,6 @@
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
     /* stylelint-disable-next-line primer/spacing */
-    left: 10px;
+    left: 9px;
   }
 }

--- a/app/components/primer/alpha/dropdown.pcss
+++ b/app/components/primer/alpha/dropdown.pcss
@@ -164,7 +164,7 @@
 
   &::after {
     /* stylelint-disable-next-line primer/spacing */
-    top: 11px;
+    top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     right: -14px;
     left: auto;
@@ -192,7 +192,7 @@
 
   &::after {
     /* stylelint-disable-next-line primer/spacing */
-    top: 11px;
+    top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     left: -14px;
     border-color: transparent;
@@ -230,7 +230,7 @@
     /* stylelint-disable-next-line primer/spacing */
     bottom: -7px;
     /* stylelint-disable-next-line primer/spacing */
-    left: 9px;
+    left: calc(var(--base-size-8) + var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/borders, primer/colors */
     border-top: 7px solid var(--overlay-bgColor);
     /* stylelint-disable-next-line primer/borders */
@@ -276,7 +276,7 @@
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
     /* stylelint-disable-next-line primer/spacing */
-    right: 9px;
+    right: calc(var(--base-size-8) + var(--borderWidth-thin));
     left: auto;
   }
 }
@@ -292,6 +292,6 @@
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
     /* stylelint-disable-next-line primer/spacing */
-    left: 9px;
+    left: calc(var(--base-size-8) + var(--borderWidth-thin));
   }
 }

--- a/app/components/primer/alpha/dropdown.pcss
+++ b/app/components/primer/alpha/dropdown.pcss
@@ -26,9 +26,7 @@
   left: 0;
   z-index: 100;
   width: 160px;
-  /* stylelint-disable-next-line primer/spacing */
   padding-top: var(--control-small-paddingBlock);
-  /* stylelint-disable-next-line primer/spacing */
   padding-bottom: var(--control-small-paddingBlock);
   margin-top: var(--base-size-2);
   list-style: none;
@@ -36,7 +34,7 @@
   background-clip: padding-box;
   border: var(--borderWidth-thin) solid var(--borderColor-default);
   border-radius: var(--borderRadius-medium);
-  box-shadow: var(--shadow-floating-legacy, var(--color-shadow-large));
+  box-shadow: var(--shadow-floating-small);
 
   &::before,
   &::after {
@@ -70,7 +68,6 @@
   width: auto;
 
   & .dropdown-item {
-    /* stylelint-disable-next-line primer/spacing */
     padding: var(--control-small-paddingBlock) var(--control-medium-paddingInline-spacious);
     overflow: visible;
     text-overflow: inherit;
@@ -80,7 +77,6 @@
 /* Dropdown items (can be links or buttons) */
 .dropdown-item {
   display: block;
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--control-small-paddingBlock) var(--control-medium-paddingInline-condensed) var(--control-small-paddingBlock) var(--control-medium-paddingInline-spacious);
   overflow: hidden;
   color: var(--fgColor-default);
@@ -123,13 +119,11 @@
 .dropdown-divider {
   display: block;
   height: 0;
-  /* stylelint-disable-next-line primer/spacing */
   margin: var(--stack-gap-condensed) 0;
   border-top: var(--borderWidth-thin) solid var(--borderColor-default);
 }
 
 .dropdown-header {
-  /* stylelint-disable-next-line primer/spacing */
   padding: var(--control-small-paddingBlock) var(--control-medium-paddingInline-spacious);
   font-size: var(--text-body-size-small);
   color: var(--fgColor-muted);
@@ -163,6 +157,7 @@
   }
 
   &::after {
+    /* stylelint-disable-next-line primer/spacing */
     top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     right: -14px;
@@ -190,6 +185,7 @@
   }
 
   &::after {
+    /* stylelint-disable-next-line primer/spacing */
     top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     left: -14px;
@@ -227,6 +223,7 @@
   &::after {
     /* stylelint-disable-next-line primer/spacing */
     bottom: -7px;
+    /* stylelint-disable-next-line primer/spacing */
     left: calc(var(--base-size-8) + var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/borders, primer/colors */
     border-top: 7px solid var(--overlay-bgColor);
@@ -272,6 +269,7 @@
   &::after {
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
+    /* stylelint-disable-next-line primer/spacing */
     right: calc(var(--base-size-8) + var(--borderWidth-thin));
     left: auto;
   }

--- a/app/components/primer/alpha/dropdown.pcss
+++ b/app/components/primer/alpha/dropdown.pcss
@@ -163,7 +163,6 @@
   }
 
   &::after {
-    /* stylelint-disable-next-line primer/spacing */
     top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     right: -14px;
@@ -191,7 +190,6 @@
   }
 
   &::after {
-    /* stylelint-disable-next-line primer/spacing */
     top: calc(var(--base-size-12) - var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/spacing */
     left: -14px;
@@ -229,7 +227,6 @@
   &::after {
     /* stylelint-disable-next-line primer/spacing */
     bottom: -7px;
-    /* stylelint-disable-next-line primer/spacing */
     left: calc(var(--base-size-8) + var(--borderWidth-thin));
     /* stylelint-disable-next-line primer/borders, primer/colors */
     border-top: 7px solid var(--overlay-bgColor);
@@ -275,7 +272,6 @@
   &::after {
     /* stylelint-disable-next-line primer/spacing */
     top: -14px;
-    /* stylelint-disable-next-line primer/spacing */
     right: calc(var(--base-size-8) + var(--borderWidth-thin));
     left: auto;
   }

--- a/previews/primer/alpha/dropdown_preview.rb
+++ b/previews/primer/alpha/dropdown_preview.rb
@@ -54,6 +54,8 @@ module Primer
       # @!group Direction
       #
       # @label Direction e
+      #
+      # @snapshot interactive
       def direction_e
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }
@@ -66,6 +68,8 @@ module Primer
       end
 
       # @label Direction ne
+      #
+      # @snapshot interactive
       def direction_ne
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }
@@ -78,6 +82,8 @@ module Primer
       end
 
       # @label Direction s
+      #
+      # @snapshot interactive
       def direction_s
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }
@@ -90,6 +96,8 @@ module Primer
       end
 
       # @label Direction se
+      #
+      # @snapshot interactive
       def direction_se
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }
@@ -102,6 +110,8 @@ module Primer
       end
 
       # @label Direction sw
+      #
+      # @snapshot interactive
       def direction_sw
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }
@@ -114,6 +124,8 @@ module Primer
       end
 
       # @label Direction w
+      #
+      # @snapshot interactive
       def direction_w
         render(Primer::Alpha::Dropdown.new(display: :inline_block)) do |component|
           component.with_button { "Dropdown" }

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -3762,7 +3762,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_e",
         "name": "direction_e",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3775,7 +3775,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_ne",
         "name": "direction_ne",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3788,7 +3788,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_s",
         "name": "direction_s",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3801,7 +3801,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_se",
         "name": "direction_se",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3814,7 +3814,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_sw",
         "name": "direction_sw",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3827,7 +3827,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_w",
         "name": "direction_w",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"

--- a/static/previews.json
+++ b/static/previews.json
@@ -3541,7 +3541,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_e",
         "name": "direction_e",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3554,7 +3554,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_ne",
         "name": "direction_ne",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3567,7 +3567,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_s",
         "name": "direction_s",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3580,7 +3580,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_se",
         "name": "direction_se",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3593,7 +3593,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_sw",
         "name": "direction_sw",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"
@@ -3606,7 +3606,7 @@
       {
         "preview_path": "primer/alpha/dropdown/direction_w",
         "name": "direction_w",
-        "snapshot": "false",
+        "snapshot": "interactive",
         "skip_rules": {
           "wont_fix": [
             "region"


### PR DESCRIPTION
### What are you trying to accomplish?
<!-- Provide a description of the changes. -->
In the PRC Dropdown component, most of the borders on the arrows are broken. South works, but the rest do not. This is an attempt to manually adjust the CSS controlling arrow position to fix the bad 1px offset.

### Screenshots
<!-- Provide before/after screenshots, videos, or graphs for any visual changes; otherwise, remove this section -->

Look closely, we're adjusting the small 1px border on the side of the dropdown menu's arrow.

| Before | After |
|--------|--------|
| <img width="207" height="159" alt="Dropdown e activated with arrow that has a missing border" src="https://github.com/user-attachments/assets/efe3d7d5-5a7b-4078-9d77-46fe6393da85" /> | <img width="202" height="167" alt="Dropdown e activated with arrow with 1px border on all relevant sides" src="https://github.com/user-attachments/assets/014e3c16-7b9c-4000-aac7-f57cc9f0109a" /> |
| <img width="189" height="97" alt="Dropdown ne activated with arrow that has a missing border" src="https://github.com/user-attachments/assets/7a7979c8-bdb5-4780-be58-b7290a81d20c" /> | <img width="188" height="97" alt="Dropdown ne activated with arrow with 1px border on all relevant sides" src="https://github.com/user-attachments/assets/cde128c6-882e-4037-b9d9-20e67a77f830" /> |
| <img width="191" height="192" alt="Dropdown se activated with arrow that has a missing border" src="https://github.com/user-attachments/assets/4908524d-7278-4925-8336-bfa1e0728a98" /> | <img width="212" height="193" alt="Dropdown se activated with arrow with 1px border on all relevant sides" src="https://github.com/user-attachments/assets/0974f91c-4b74-4949-8e22-dbdcbcef4c13" /> |
| <img width="134" height="117" alt="Dropdown sw activated with arrow that has a missing border" src="https://github.com/user-attachments/assets/79e13fa3-43c3-432c-be07-60d7a348a5f2" /> | <img width="137" height="108" alt="Dropdown sw activated with arrow with 1px border on all relevant sides" src="https://github.com/user-attachments/assets/6618984f-f036-4c5f-acc3-be877e80d436" /> |
| <img width="149" height="94" alt="Dropdown w activated with arrow that has a missing border" src="https://github.com/user-attachments/assets/1f147246-5bad-4ae1-b6ec-ead718eb9d5b" /> | <img width="137" height="87" alt="Dropdown w activated with arrow with 1px border on all relevant sides" src="https://github.com/user-attachments/assets/ad671ae6-2bbb-43b8-b830-9ace69744f35" /> | 

#### List the issues that this change affects.
<!--Every code change must address _at least 1_ issue. Fixes a bug, completes a task, every change
      should have a corresponding issue listed here. If one does not already exist, create one. -->

Closes https://github.com/github/primer/issues/5370

#### Risk Assessment
  <!-- Please select from one of the following and detail why this level was chosen -->

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?
<!-- This section is a place for you to describe your thought process in making these changes.
     List any tradeoffs you made to take on or pay down tech debt.
     Identify any work you did to mitigate risk.
     Describe any alternative approaches you considered and why you discarded them. -->

CSS is fun

### Anything you want to highlight for special attention from reviewers?
<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes.
     Highlight anything on which you would like a second (or third) opinion.
     Keep in mind how many component uses cases may be affected by your changes when assessing risk. -->

Check the Lookbook stories for Dropdown, click each dropdown, and ensure the arrow borders are correct. Best to check cross-browser too.

### Accessibility
<!--
  You may remove this section and the "Accessibility" heading above _only_ if the changes in this pull request do not impact UI. Delete all those that don't apply.
  If there are any accessibility-related updates, please describe them here.
-->
- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

### Merge checklist

- [x] Added/updated tests
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.