### PR TITLE
Accept keyword arguments in `render_in` methods

### DIFF
--- a/.changeset/soft-stamps-camp.md
+++ b/.changeset/soft-stamps-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Accept keyword arguments in `render_in` methods

--- a/app/components/primer/alpha/tree_view/sub_tree_node.rb
+++ b/app/components/primer/alpha/tree_view/sub_tree_node.rb
@@ -164,7 +164,7 @@ module Primer
           )
         end
 
-        def render_in(*args, &block)
+        def render_in(*args, **_kwargs, &block)
           super.tap do
             # check this _after_ rendering so @sub_tree's slots are defined
             if @node.select_variant != :none && @sub_tree.defer?

--- a/app/components/primer/alpha/tree_view/visual.rb
+++ b/app/components/primer/alpha/tree_view/visual.rb
@@ -17,7 +17,7 @@ module Primer
           @label = label
         end
 
-        def render_in(_view_context, &block)
+        def render_in(_view_context, **_kwargs, &block)
           block&.call(@visual)
           super
         end

--- a/app/components/primer/beta/button_group.rb
+++ b/app/components/primer/beta/button_group.rb
@@ -107,7 +107,7 @@ module Primer
           @button = @menu.with_show_button(icon: "triangle-down", **button_arguments)
         end
 
-        def render_in(view_context, &block)
+        def render_in(view_context, **_kwargs, &block)
           super(view_context) do
             block.call(@menu, @button)
           end

--- a/app/lib/primer/forms/acts_as_component.rb
+++ b/app/lib/primer/forms/acts_as_component.rb
@@ -10,7 +10,7 @@ module Primer
       module InstanceMethods
         delegate :render, :content_tag, :output_buffer, :capture, to: :@view_context
 
-        def render_in(view_context, &block)
+        def render_in(view_context, **_kwargs, &block)
           @view_context = view_context
           before_render
           perform_render(&block)

--- a/app/lib/primer/forms/toggle_switch_form.rb
+++ b/app/lib/primer/forms/toggle_switch_form.rb
@@ -69,7 +69,7 @@ module Primer
       # assumes the presence of a builder so we create our own here. A builder
       # cannot be constructed without a corresponding view context, which is why
       # we have to override render_in and can't create it in the initializer.
-      def render_in(view_context, &block)
+      def render_in(view_context, **_kwargs, &block)
         @builder = Primer::Forms::Builder.new(
           nil, nil, view_context, {}
         )

--- a/lib/primer/form_components.rb
+++ b/lib/primer/form_components.rb
@@ -16,7 +16,7 @@ module Primer
           @system_arguments = system_arguments
         end
 
-        def render_in(view_context, &block)
+        def render_in(view_context, **_kwargs, &block)
           builder = Primer::Forms::Builder.new(
             nil, nil, view_context, {}
           )


### PR DESCRIPTION
_Authors: Please fill out this form carefully and completely._

_Reviewers: By approving this Pull Request you are approving the code change, as well as its deployment and mitigation plans._
_Please read this description carefully. If you feel there is anything unclear or missing, please ask for updates._

### What are you trying to accomplish?

- Rails `main` [now](https://github.com/rails/rails/commit/4870c5f9355823e7052568f8aca1d16a6933059b) deprecates renderable objects whose `render_in` method only accepts a single positional argument. The args don't have to be used, hence why they're `_` prefixed here: the arity check is very basic.
- Uses of primer_view_components in applications on Rails `main` were seeing ActionView deprecation warnings:

```
  Change #render_in to accept keyword arguments.
   (called from block (2 levels) in FooComponent#call at app/components/foo_component.html.erb:8)
  DEPRECATION WARNING: Action View support for #render_in without options is deprecated.
```

### Screenshots

N/A.

### Integration

N/A.

#### List the issues that this change affects.

N/A (not linking the internal one).

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
      - Building the gem from this branch locally fixed the deprecation warnings. 
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

- See above.

### Anything you want to highlight for special attention from reviewers?

N/A.

### Merge checklist

- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
