### PR TITLE
Add path mapping for app directory in package.json

### DIFF
--- a/.changeset/sunny-trams-turn.md
+++ b/.changeset/sunny-trams-turn.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Add path mapping for app directory in package.json

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
       "import": "./static/classnames.js",
       "require": "./static/classnames.cjs"
     },
+    "./app/*": {
+      "types": "./app/*.d.ts",
+      "import": "./app/*.js",
+      "default": "./app/*.js"
+    },
     "./*": "./*"
   },
   "repository": "primer/view_components",


### PR DESCRIPTION
### What are you trying to accomplish?

PR #4096 introduced an `exports` map to `package.json` for the first time (to publish the new `./classnames` subpath). Before that PR there was no `exports` field, so consumers could deep-import compiled component modules directly from the filesystem, e.g.:

```ts
import type {ActionMenuElement} from '@primer/view-components/app/components/primer/alpha/action_menu/action_menu_element'
```

Once the `exports` map was added, the only thing covering those deep paths is the catch-all `"./*": "./*"`. Because that target is a **plain string with no `types` condition**, TypeScript (under `moduleResolution: bundler`/`node16`) maps the extensionless import to a literal path with no extension and can't locate the adjacent `.d.ts`. This broke type resolution for every `@primer/view-components/app/...` deep import across consumers (e.g. `github-ui` has ~27 such imports), surfacing as:

> Cannot find module '@primer/view-components/app/components/primer/alpha/action_menu/action_menu_element' or its corresponding type declarations.

This PR restores type resolution for deep `app/*` imports by adding a conditional subpath that exposes the `types`, `import`, and `default` conditions, placed **before** the catch-all so it takes precedence:

```jsonc
"exports": {
  ".": {
    "types": "./app/components/primer/primer.d.ts",
    "import": "./app/components/primer/primer.js",
    "require": "./app/assets/javascripts/primer_view_components.js"
  },
  "./classnames": {
    "types": "./static/classnames.d.ts",
    "import": "./static/classnames.js",
    "require": "./static/classnames.cjs"
  },
  "./app/*": {
    "types": "./app/*.d.ts",
    "import": "./app/*.js",
    "default": "./app/*.js"
  },
  "./*": "./*"
}
```

### Integration

No production runtime/behavior change — this only affects how the published package's subpaths resolve for type-checkers and bundlers. It restores the pre-#4096 ability for consumers to deep-import `app/*` modules with full type information. Consumers (e.g. `github-ui`) require no code changes once a version including this fix is published.

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

This is an additive `exports` subpath that only widens resolution back to pre-#4096 behavior. It is trivially reverted and verifiable via `tsc --traceResolution`.

### What approach did you choose and why?

I chose to add an explicit `./app/*` conditional subpath rather than change the catch-all `"./*"` because:

- The `types` condition is required for TypeScript to map an extensionless deep import to its `.d.ts`; a bare string target (`"./*": "./*"`) cannot express conditions.
- Scoping the conditional pattern to `./app/*` keeps the change narrow and intentional (the published `files` list only ships `app/**` JS/d.ts plus `static/*`), while leaving the catch-all in place for any other static asset paths.
- Ordering matters: the more specific `./app/*` pattern is listed before `./*` so it wins for `app/...` imports.

I verified the fix against the installed package with a resolution trace:

```
Matched 'exports' condition 'types'.
Using 'exports' subpath './app/*' with target './app/components/primer/alpha/action_menu/action_menu_element.d.ts'.
... was successfully resolved
```

### Anything you want to highlight for special attention from reviewers?

- Please confirm the `.` subpath `types`/`import`/`require` targets match the canonical entry points (I mirrored `main`/`module`/`types` from the existing `package.json`).
- Worth double-checking whether any consumers rely on deep-importing non-`app/` paths through `"./*"`; those remain covered by the unchanged catch-all.
- Consider whether this warrants a `patch` changeset framed as a regression fix for #4096.

### Accessibility

<!-- No UI changes; section removed per template guidance. -->

### Merge checklist

- [x] Added/updated tests <!-- if the repo has an exports/resolution test; otherwise note manual `tsc --traceResolution` verification -->
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
