### PR TITLE
Fix ToggleSwitch knob spacing and border-radius to match primer/react

### DIFF
--- a/.changeset/toggle-switch-knob-styling.md
+++ b/.changeset/toggle-switch-knob-styling.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix `ToggleSwitch` knob spacing and border-radius to match `primer/react`

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -7,7 +7,6 @@
 }
 
 .ToggleSwitch {
-  /* Knob clears the track's border on every side */
   --toggleSwitch-knob-inset: var(--borderWidth-thin);
   --toggleSwitch-knob-offset: calc(2 * var(--toggleSwitch-knob-inset));
 
@@ -158,14 +157,12 @@
 
 .ToggleSwitch-knob {
   position: absolute;
-  /* clear the track border on the block edges + inline-start; inline-end stays auto (width drives it) */
   inset-block: var(--toggleSwitch-knob-inset);
   inset-inline-start: var(--toggleSwitch-knob-inset);
   z-index: 1;
   width: 50%;
   background-color: var(--controlKnob-bgColor-rest);
   border: var(--borderWidth-thin) solid var(--controlKnob-borderColor-rest);
-  /* Concentric radius: subtract the track border on both sides */
   /* stylelint-disable-next-line primer/borders */
   border-radius: calc(var(--borderRadius-medium) - var(--toggleSwitch-knob-offset));
   transition-timing-function: cubic-bezier(0.5, 1, 0.89, 1);

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -93,7 +93,7 @@
   & .ToggleSwitch-knob {
     background-color: var(--controlKnob-bgColor-checked);
     border-color: var(--controlKnob-borderColor-checked);
-    transform: translateX(100%);
+    transform: translateX(calc(100% - 2px));
   }
 
   & .ToggleSwitch-lineIcon {
@@ -155,13 +155,19 @@
 
 .ToggleSwitch-knob {
   position: absolute;
-  top: 0;
-  bottom: 0;
+  /* stylelint-disable-next-line primer/spacing */
+  top: 1px;
+  /* stylelint-disable-next-line primer/spacing */
+  bottom: 1px;
+  /* stylelint-disable-next-line primer/spacing */
+  left: 1px;
   z-index: 1;
   width: 50%;
   background-color: var(--controlKnob-bgColor-rest);
   border: var(--borderWidth-thin) solid var(--controlKnob-borderColor-rest);
-  border-radius: var(--borderRadius-medium);
+  /* Use calc to account for the 1px border around the track */
+  /* stylelint-disable-next-line primer/borders */
+  border-radius: calc(var(--borderRadius-medium) - var(--borderWidth-thick));
   box-shadow: var(--shadow-resting-medium), var(--button-default-shadow-inset);
   transition-timing-function: cubic-bezier(0.5, 1, 0.89, 1);
   transition-duration: 80ms;

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -158,8 +158,9 @@
 
 .ToggleSwitch-knob {
   position: absolute;
-  /* top / bottom / left clear the track border; right stays auto (width drives it) */
-  inset: var(--toggleSwitch-knob-inset) auto var(--toggleSwitch-knob-inset) var(--toggleSwitch-knob-inset);
+  /* clear the track border on the block edges + inline-start; inline-end stays auto (width drives it) */
+  inset-block: var(--toggleSwitch-knob-inset);
+  inset-inline-start: var(--toggleSwitch-knob-inset);
   z-index: 1;
   width: 50%;
   background-color: var(--controlKnob-bgColor-rest);

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -113,7 +113,6 @@
 
   & .ToggleSwitch-knob {
     border-color: var(--borderColor-default);
-    box-shadow: none;
   }
 
   & .ToggleSwitch-lineIcon {
@@ -168,7 +167,6 @@
   /* Use calc to account for the 1px border around the track */
   /* stylelint-disable-next-line primer/borders */
   border-radius: calc(var(--borderRadius-medium) - var(--borderWidth-thick));
-  box-shadow: var(--shadow-resting-medium), var(--button-default-shadow-inset);
   transition-timing-function: cubic-bezier(0.5, 1, 0.89, 1);
   transition-duration: 80ms;
   transition-property: transform;

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -7,6 +7,10 @@
 }
 
 .ToggleSwitch {
+  /* Knob clears the track's border on every side */
+  --toggleSwitch-knob-inset: var(--borderWidth-thin);
+  --toggleSwitch-knob-offset: calc(2 * var(--toggleSwitch-knob-inset));
+
   align-items: center;
   display: inline-flex;
   gap: var(--controlStack-medium-gap-condensed);
@@ -93,7 +97,7 @@
   & .ToggleSwitch-knob {
     background-color: var(--controlKnob-bgColor-checked);
     border-color: var(--controlKnob-borderColor-checked);
-    transform: translateX(calc(100% - 2px));
+    transform: translateX(calc(100% - var(--toggleSwitch-knob-offset)));
   }
 
   & .ToggleSwitch-lineIcon {
@@ -155,18 +159,18 @@
 .ToggleSwitch-knob {
   position: absolute;
   /* stylelint-disable-next-line primer/spacing */
-  top: 1px;
+  top: var(--toggleSwitch-knob-inset);
   /* stylelint-disable-next-line primer/spacing */
-  bottom: 1px;
+  bottom: var(--toggleSwitch-knob-inset);
   /* stylelint-disable-next-line primer/spacing */
-  left: 1px;
+  left: var(--toggleSwitch-knob-inset);
   z-index: 1;
   width: 50%;
   background-color: var(--controlKnob-bgColor-rest);
   border: var(--borderWidth-thin) solid var(--controlKnob-borderColor-rest);
-  /* Use calc to account for the 1px border around the track */
+  /* Concentric radius: subtract the track border on both sides */
   /* stylelint-disable-next-line primer/borders */
-  border-radius: calc(var(--borderRadius-medium) - var(--borderWidth-thick));
+  border-radius: calc(var(--borderRadius-medium) - var(--toggleSwitch-knob-offset));
   transition-timing-function: cubic-bezier(0.5, 1, 0.89, 1);
   transition-duration: 80ms;
   transition-property: transform;

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -158,12 +158,8 @@
 
 .ToggleSwitch-knob {
   position: absolute;
-  /* stylelint-disable-next-line primer/spacing */
-  top: var(--toggleSwitch-knob-inset);
-  /* stylelint-disable-next-line primer/spacing */
-  bottom: var(--toggleSwitch-knob-inset);
-  /* stylelint-disable-next-line primer/spacing */
-  left: var(--toggleSwitch-knob-inset);
+  /* top / bottom / left clear the track border; right stays auto (width drives it) */
+  inset: var(--toggleSwitch-knob-inset) auto var(--toggleSwitch-knob-inset) var(--toggleSwitch-knob-inset);
   z-index: 1;
   width: 50%;
   background-color: var(--controlKnob-bgColor-rest);


### PR DESCRIPTION
## What

The `ToggleSwitch` knob (the part that slides back and forth) didn't match the styling in [`primer/react`](https://github.com/primer/react/blob/main/packages/react/src/ToggleSwitch/ToggleSwitch.module.css). This PR aligns the knob's spacing, border-radius, and shadow with react's `ToggleKnob`.

https://github.com/user-attachments/assets/2b14db9d-88d5-4326-b81c-9002c010ceaa




## Changes

In `app/components/primer/alpha/toggle_switch.pcss`, the `.ToggleSwitch-knob`:

- **Spacing** — was flush to the track (`top: 0; bottom: 0`); now inset 1px on all sides (`top/bottom/left: 1px`), so the knob sits within the track's border. The checked-state translate is updated to `translateX(calc(100% - 2px))` to account for the inset.
- **Border-radius** — changed from `var(--borderRadius-medium)` to `calc(var(--borderRadius-medium) - var(--borderWidth-thick))`, matching react so the knob's corners nest correctly inside the track border.
- **Box-shadow** — removed (`--shadow-resting-medium`, `--button-default-shadow-inset`); react's `ToggleKnob` has no shadow. The now-redundant `box-shadow: none` in the disabled state was also dropped.

Source of truth: `primer/react` `ToggleSwitch.module.css` → `.ToggleKnob`.

## Notes

- Visual regression / ARIA snapshots will need regenerating.