### PR TITLE
Blankslate: make compact styling the default

### DIFF
--- a/.changeset/blankslate-size-scale.md
+++ b/.changeset/blankslate-size-scale.md
@@ -2,4 +2,4 @@
 "@primer/view-components": minor
 ---
 
-`Blankslate`: The compact styling is now the default. Padding, heading, and body text are reduced, and the redundant responsive `@container` block has been removed since the compact presentation it produced is now the default
+`Blankslate`: The heading and body text now use the smaller compact sizes by default, and the redundant responsive `@container` block has been removed since the compact typography it produced is now the default

--- a/.changeset/blankslate-size-scale.md
+++ b/.changeset/blankslate-size-scale.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": minor
+---
+
+`Blankslate`: The compact styling is now the default. Padding, heading, and body text are reduced, and the redundant responsive `@container` block has been removed since the compact presentation it produced is now the default

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -6,8 +6,8 @@
 }
 
 .blankslate {
-  --blankslate-outer-padding-block: var(--base-size-32);
-  --blankslate-outer-padding-inline: var(--base-size-32);
+  --blankslate-outer-padding-block: var(--base-size-20);
+  --blankslate-outer-padding-inline: var(--base-size-20);
 
   position: relative;
   /* stylelint-disable-next-line primer/spacing */
@@ -16,7 +16,7 @@
 
   /* stylelint-disable-next-line selector-max-type */
   & p {
-    font-size: var(--text-body-size-large);
+    font-size: var(--text-body-size-medium);
     color: var(--fgColor-muted);
   }
 
@@ -53,7 +53,7 @@
 
 .blankslate-heading {
   margin-bottom: var(--base-size-4);
-  font-size: var(--text-title-size-medium);
+  font-size: var(--text-title-size-small);
   font-weight: var(--text-title-weight-medium);
   text-wrap: balance;
 }
@@ -64,16 +64,16 @@
 
 .blankslate-action {
   /* stylelint-disable-next-line primer/spacing */
-  margin-top: var(--stack-gap-normal);
+  margin-top: var(--stack-gap-condensed);
 
   &:first-of-type {
     /* stylelint-disable-next-line primer/spacing */
-    margin-top: var(--stack-gap-spacious);
+    margin-top: var(--stack-gap-normal);
   }
 
   &:last-of-type {
     /* stylelint-disable-next-line primer/spacing */
-    margin-bottom: var(--stack-gap-condensed);
+    margin-bottom: calc(var(--stack-gap-condensed) / 2);
   }
 }
 
@@ -82,8 +82,8 @@
 }
 
 .blankslate-spacious {
-  --blankslate-outer-padding-block: var(--base-size-80);
-  --blankslate-outer-padding-inline: var(--base-size-40);
+  --blankslate-outer-padding-block: var(--base-size-44);
+  --blankslate-outer-padding-inline: var(--base-size-28);
 }
 
 .blankslate-narrow {
@@ -120,47 +120,4 @@
 ** TO DO: deprecate this and use utility instead */
 .blankslate-clean-background {
   border: 0;
-}
-
-/* At the time these styles were written,
-   `34rem` was our "small" breakpoint width */
-@container (max-width: 34rem) {
-  .blankslate {
-    --blankslate-outer-padding-block: var(--base-size-20);
-    --blankslate-outer-padding-inline: var(--base-size-20);
-  }
-
-  .blankslate-spacious {
-    --blankslate-outer-padding-block: var(--base-size-44);
-    --blankslate-outer-padding-inline: var(--base-size-28);
-  }
-
-  .blankslate-icon {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-bottom: var(--stack-gap-condensed);
-  }
-
-  .blankslate-heading {
-    font-size: var(--text-title-size-small);
-  }
-
-  /* stylelint-disable-next-line selector-max-type */
-  .blankslate p {
-    font-size: var(--text-body-size-medium);
-  }
-
-  .blankslate-action {
-    /* stylelint-disable-next-line primer/spacing */
-    margin-top: var(--stack-gap-condensed);
-
-    &:first-of-type {
-      /* stylelint-disable-next-line primer/spacing */
-      margin-top: var(--stack-gap-normal);
-    }
-
-    &:last-of-type {
-      /* stylelint-disable-next-line primer/spacing */
-      margin-bottom: calc(var(--stack-gap-condensed) / 2);
-    }
-  }
 }

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -6,8 +6,8 @@
 }
 
 .blankslate {
-  --blankslate-outer-padding-block: var(--base-size-20);
-  --blankslate-outer-padding-inline: var(--base-size-20);
+  --blankslate-outer-padding-block: var(--base-size-32);
+  --blankslate-outer-padding-inline: var(--base-size-32);
 
   position: relative;
   /* stylelint-disable-next-line primer/spacing */
@@ -75,8 +75,8 @@
 }
 
 .blankslate-spacious {
-  --blankslate-outer-padding-block: var(--base-size-44);
-  --blankslate-outer-padding-inline: var(--base-size-28);
+  --blankslate-outer-padding-block: var(--base-size-80);
+  --blankslate-outer-padding-inline: var(--base-size-40);
 }
 
 .blankslate-narrow {

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -59,14 +59,14 @@
 }
 
 .blankslate-action {
-  margin-top: var(--stack-gap-condensed);
+  margin-top: var(--stack-gap-normal);
 
   &:first-of-type {
-    margin-top: var(--stack-gap-normal);
+    margin-top: var(--stack-gap-spacious);
   }
 
   &:last-of-type {
-    margin-bottom: calc(var(--stack-gap-condensed) / 2);
+    margin-bottom: var(--stack-gap-condensed);
   }
 }
 

--- a/app/components/primer/beta/blankslate.pcss
+++ b/app/components/primer/beta/blankslate.pcss
@@ -37,17 +37,13 @@
 }
 
 .blankslate-icon {
-  /* stylelint-disable-next-line primer/spacing */
   margin-right: var(--control-small-gap);
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: var(--stack-gap-condensed);
-  /* stylelint-disable-next-line primer/spacing */
   margin-left: var(--control-small-gap);
   color: var(--fgColor-muted);
 }
 
 .blankslate-image {
-  /* stylelint-disable-next-line primer/spacing */
   margin-bottom: var(--stack-gap-normal);
 }
 
@@ -63,16 +59,13 @@
 }
 
 .blankslate-action {
-  /* stylelint-disable-next-line primer/spacing */
   margin-top: var(--stack-gap-condensed);
 
   &:first-of-type {
-    /* stylelint-disable-next-line primer/spacing */
     margin-top: var(--stack-gap-normal);
   }
 
   &:last-of-type {
-    /* stylelint-disable-next-line primer/spacing */
     margin-bottom: calc(var(--stack-gap-condensed) / 2);
   }
 }
@@ -102,7 +95,6 @@
 
   /* stylelint-disable-next-line selector-max-type */
   & h3 {
-    /* stylelint-disable-next-line primer/spacing */
     margin: var(--stack-gap-normal) 0;
 
     /* font-size: $h3-size; // This doesn't actually make the text larger. Should this be $h2-size? */


### PR DESCRIPTION
### What are you trying to accomplish?

Mirrors [primer/react#8034](https://github.com/primer/react/pull/8034) for view_components. That PR shifts the `Blankslate` size scale so the compact presentation becomes the default. view_components has no `size` prop, so the portable part of that change is: make the compact typography the default and drop the now-redundant responsive block.

The default `Blankslate` heading and body text now render at the smaller compact sizes (`text-title-size-medium` -> `small` for the heading, `text-body-size-large` -> `medium` for body copy). Padding, spacious padding, and action margins are unchanged from their previous defaults.

### Screenshots

N/A (visual change is a typography restyle of the default; no committed Playwright snapshots exist for Blankslate to regenerate).

### Integration

This restyles the default `Blankslate` typography everywhere it is used. No API changes, so no consumer code updates are required.

#### List the issues that this change affects.

N/A

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

The previous CSS produced the compact typography only below the `34rem` `@container` breakpoint. Since the compact heading and body sizes are now the intended default at all widths, I promoted those values into the base `.blankslate-heading` and `& p` rules and deleted the `@container (max-width: 34rem)` block entirely, rather than leaving a redundant override. I also removed several `primer/spacing` stylelint disable comments that the pinned `@primer/stylelint-config` now reports as needless.

Unlike primer/react#8034, there is no `size` prop, `BlankslateContext`, or `small`/`medium`/`large` scale to rescale here, and `primary_action` already renders a `:medium` button, so those parts of the upstream PR do not apply.

### Anything you want to highlight for special attention from reviewers?

The scope here is narrower than the upstream React PR: only the heading and body typography become compact by default. Padding (default and spacious) and action margins are deliberately left at their existing values.

One judgement call: I marked the changeset as `minor` rather than `major`. primer/react went `major` because it removed the `size="small"` API; view_components has no such API, so this is a visual restyle with no breaking change. Happy to adjust if you would prefer a different bump.

### Accessibility

- **No new axe scan violation** - This change does not introduce any new axe scan violations.

### Merge checklist

- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge