### PR TITLE
Downgrade @oddbird/popover-polyfill to ^0.5.2

### DIFF
--- a/.changeset/downgrade-popover-polyfill.md
+++ b/.changeset/downgrade-popover-polyfill.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Downgrade `@oddbird/popover-polyfill` to `^0.5.2` and pin it via Dependabot ignore so it won't get bumped again.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
       - "dependencies"
       - "skip changeset"
       - "npm"
+    ignore:
+      - dependency-name: "@oddbird/popover-polyfill"
     groups:
       production-dependencies:
         dependency-type: "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@github/relative-time-element": "^5.0.0",
         "@github/remote-input-element": "^0.4.0",
         "@github/tab-container-element": "^3.1.2",
-        "@oddbird/popover-polyfill": "^0.7.0",
+        "@oddbird/popover-polyfill": "^0.5.2",
         "@primer/behaviors": "^1.3.4",
         "@primer/live-region-element": "^0.8.0"
       },
@@ -4635,9 +4635,10 @@
       }
     },
     "node_modules/@oddbird/popover-polyfill": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.7.0.tgz",
-      "integrity": "sha512-lXjKHrRO/OVx+oRxmwRVnE444hk2WyiSge0YJKZ/H60C5zZrZcbwURCuvx0JCWg18p5WHMKr4OKMt5iIHtLnDA=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.5.2.tgz",
+      "integrity": "sha512-iFrvar5SOMtKFOSjYvs4z9UlLqDdJbMx0mgISLcPedv+g0ac5sgeETLGtipHCVIae6HJPclNEH5aCyD1RZaEHw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
@@ -17852,9 +17853,9 @@
       }
     },
     "@oddbird/popover-polyfill": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.7.0.tgz",
-      "integrity": "sha512-lXjKHrRO/OVx+oRxmwRVnE444hk2WyiSge0YJKZ/H60C5zZrZcbwURCuvx0JCWg18p5WHMKr4OKMt5iIHtLnDA=="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@oddbird/popover-polyfill/-/popover-polyfill-0.5.2.tgz",
+      "integrity": "sha512-iFrvar5SOMtKFOSjYvs4z9UlLqDdJbMx0mgISLcPedv+g0ac5sgeETLGtipHCVIae6HJPclNEH5aCyD1RZaEHw=="
     },
     "@oxc-project/types": {
       "version": "0.133.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@github/relative-time-element": "^5.0.0",
     "@github/remote-input-element": "^0.4.0",
     "@github/tab-container-element": "^3.1.2",
-    "@oddbird/popover-polyfill": "^0.7.0",
+    "@oddbird/popover-polyfill": "^0.5.2",
     "@primer/behaviors": "^1.3.4",
     "@primer/live-region-element": "^0.8.0"
   },


### PR DESCRIPTION
### What are you trying to accomplish?

Downgrade `@oddbird/popover-polyfill` from `^0.7.0` to `^0.5.2` and add a Dependabot `ignore` entry so it won't get bumped again.

### Integration

- `package.json` pins the polyfill to `^0.5.2`, `package-lock.json` resolves to `0.5.2`.
- `.github/dependabot.yml` ignores `@oddbird/popover-polyfill` in the root `npm` ecosystem.

#### List the issues that this change affects.

Closes # (type the GitHub issue number after #)

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Version bump plus a Dependabot ignore. Pinning through the config keeps future automated PRs from re-upgrading it.

### Anything you want to highlight for special attention from reviewers?

The `ignore` entry lives under the root `npm` block, so the `/demo` npm config is unaffected.