### PR TITLE
Stop ToggleSwitch jumping when the loading spinner is shown

### DIFF
--- a/.changeset/hungry-poems-shout.md
+++ b/.changeset/hungry-poems-shout.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Reserve height as well as width in `.ToggleSwitch-statusIcon` so the switch doesn't jump when the loading spinner is shown

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -184,7 +184,11 @@
 
 .ToggleSwitch-statusIcon {
   display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
   width: var(--base-size-16);
+  height: var(--base-size-16);
   /* stylelint-disable-next-line primer/spacing */
   margin-top: 0.063rem;
 }

--- a/app/components/primer/alpha/toggle_switch.pcss
+++ b/app/components/primer/alpha/toggle_switch.pcss
@@ -189,6 +189,8 @@
   justify-content: center;
   width: var(--base-size-16);
   height: var(--base-size-16);
+  /* stylelint-disable-next-line primer/typography */
+  line-height: 0;
   /* stylelint-disable-next-line primer/spacing */
   margin-top: 0.063rem;
 }

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -112,7 +112,38 @@ module Alpha
       assert_equal "*/*", Primer::ViewComponents::ToggleSwitchController.last_request.headers["HTTP_ACCEPT"]
     end
 
+    def test_switch_does_not_move_when_loading_spinner_is_shown
+      visit_preview(:small)
+
+      before_top = track_top
+
+      # Show the spinner the same way setLoadingState() does, without racing the request.
+      page.execute_script(
+        "document.querySelector(\"[data-target='toggle-switch.loadingSpinner']\").hidden = false"
+      )
+      assert_selector("[data-target='toggle-switch.loadingSpinner']")
+
+      assert_in_delta before_top, track_top, 0.5
+    end
+
+    def test_switch_does_not_move_when_error_icon_is_shown
+      visit_preview(:small)
+
+      before_top = track_top
+
+      page.execute_script(
+        "document.querySelector(\"[data-target='toggle-switch.errorIcon']\").hidden = false"
+      )
+      assert_selector("[data-target='toggle-switch.errorIcon']")
+
+      assert_in_delta before_top, track_top, 0.5
+    end
+
     private
+
+    def track_top
+      evaluate_script("document.querySelector('.ToggleSwitch-track').getBoundingClientRect().top")
+    end
 
     def wait_for_spinner
       refute_selector("[data-target='toggle-switch.loadingSpinner']")

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -136,6 +136,17 @@ module Alpha
       assert_in_delta before_top, track_top, 0.5
     end
 
+    def test_loading_spinner_is_centered_in_the_status_icon_slot
+      visit_preview(:small)
+
+      unhide(find("[data-target='toggle-switch.loadingSpinner']", visible: :hidden))
+      assert_selector("[data-target='toggle-switch.loadingSpinner']")
+
+      assert_in_delta vertical_center(find("[data-target='toggle-switch.loadingSpinner'] svg")),
+                      vertical_center(find(".ToggleSwitch-statusIcon")),
+                      0.5
+    end
+
     private
 
     # The status icons are hidden with the `hidden` attribute. `hidden` is an HTMLElement IDL
@@ -147,6 +158,13 @@ module Alpha
 
     def track_top
       evaluate_script("arguments[0].getBoundingClientRect().top;", find(".ToggleSwitch-track"))
+    end
+
+    def vertical_center(element)
+      evaluate_script(
+        "(function (r) { return r.top + r.height / 2; })(arguments[0].getBoundingClientRect());",
+        element
+      )
     end
 
     def wait_for_spinner

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -118,9 +118,7 @@ module Alpha
       before_top = track_top
 
       # Show the spinner the same way setLoadingState() does, without racing the request.
-      page.execute_script(
-        "document.querySelector(\"[data-target='toggle-switch.loadingSpinner']\").removeAttribute('hidden')"
-      )
+      unhide(find("[data-target='toggle-switch.loadingSpinner']", visible: :hidden))
       assert_selector("[data-target='toggle-switch.loadingSpinner']")
 
       assert_in_delta before_top, track_top, 0.5
@@ -131,11 +129,8 @@ module Alpha
 
       before_top = track_top
 
-      # Show the error icon the same way setErrorState() does. It's an <svg>, so it has no
-      # `hidden` IDL property and the attribute has to be removed directly.
-      page.execute_script(
-        "document.querySelector(\"[data-target='toggle-switch.errorIcon']\").removeAttribute('hidden')"
-      )
+      # Show the error icon the same way setErrorState() does.
+      unhide(find("[data-target='toggle-switch.errorIcon']", visible: :hidden))
       assert_selector("[data-target='toggle-switch.errorIcon']")
 
       assert_in_delta before_top, track_top, 0.5
@@ -143,8 +138,15 @@ module Alpha
 
     private
 
+    # The status icons are hidden with the `hidden` attribute. `hidden` is an HTMLElement IDL
+    # property, so `el.hidden = false` silently does nothing on the error icon's <svg>. The
+    # component removes the attribute, so do the same here.
+    def unhide(element)
+      execute_script("arguments[0].removeAttribute('hidden');", element)
+    end
+
     def track_top
-      evaluate_script("document.querySelector('.ToggleSwitch-track').getBoundingClientRect().top")
+      evaluate_script("arguments[0].getBoundingClientRect().top;", find(".ToggleSwitch-track"))
     end
 
     def wait_for_spinner

--- a/test/system/alpha/toggle_switch_test.rb
+++ b/test/system/alpha/toggle_switch_test.rb
@@ -119,7 +119,7 @@ module Alpha
 
       # Show the spinner the same way setLoadingState() does, without racing the request.
       page.execute_script(
-        "document.querySelector(\"[data-target='toggle-switch.loadingSpinner']\").hidden = false"
+        "document.querySelector(\"[data-target='toggle-switch.loadingSpinner']\").removeAttribute('hidden')"
       )
       assert_selector("[data-target='toggle-switch.loadingSpinner']")
 
@@ -131,8 +131,10 @@ module Alpha
 
       before_top = track_top
 
+      # Show the error icon the same way setErrorState() does. It's an <svg>, so it has no
+      # `hidden` IDL property and the attribute has to be removed directly.
       page.execute_script(
-        "document.querySelector(\"[data-target='toggle-switch.errorIcon']\").hidden = false"
+        "document.querySelector(\"[data-target='toggle-switch.errorIcon']\").removeAttribute('hidden')"
       )
       assert_selector("[data-target='toggle-switch.errorIcon']")
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes the long-standing bug where a `ToggleSwitch` jumps up 4px the moment its loading spinner appears, then drops back down when the request finishes. Only `size: :small` is affected, which is what #2623 reported in 2024. It resurfaced this week on GitHub's Code scanning settings page, but every `ToggleSwitch` with a `src` is affected.

**Root cause.** `.ToggleSwitch-statusIcon` reserves width but not height:

```css
.ToggleSwitch-statusIcon {
  display: flex;
  width: var(--base-size-16);
  margin-top: 0.063rem;
}
```

With both icons hidden the box has no in-flow children, so it's **0px** tall. Unhiding the spinner makes it **21px**, not 16px, because `Primer::Beta::Spinner` hangs `hidden` on a wrapper `<span>` that also carries `sr-only` "Loading" text, and that inline formatting context adds the font strut descender.

`.ToggleSwitch` is `inline-flex`, so it sits on its line by its baseline, which comes from its first flex item, this box. 0px to 21px moves the baseline and the browser repositions the whole switch. At the default size the 32px track stays the tallest item so nothing moves. At `small` the track is 24px and the 21px slot wins, hence -4px.

The fix reserves the height the same way the width is already reserved, and centers the contents.

### Screenshots

No visual change at rest. The change is that the switch stops moving while loading.

Measured on this PR's preview deployment, `.ToggleSwitch-track` `top` before and after unhiding each icon. Right column is the same page with the new rule overridden back to what ships today:

| browser | slot height | shift, with fix | shift, reverted |
| --- | --- | --- | --- |
| Chrome 150 | 16 → 16 | 0px | -3.5px |
| Edge 150 | 16 → 16 | 0px | -3.5px |
| Firefox 150 | 16 → 16 | 0px | -3.5px |
| WebKit 26.4 (Safari) | 16 → 16 | 0px | -3.28px |

Spinner and error icon give identical numbers in each.

### Integration

CSS only, no API or markup change. Consumers pick it up on the next release.

#### List the issues that this change affects.

Closes #2623

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back.

One rule, one component. The switch's own box height is unchanged (24px small, 32px default) so nothing around it reflows.

### What approach did you choose and why?

The slot already reserves width so the switch can't move horizontally. This makes it reserve height for the same reason.

Two alternatives I measured and discarded:

- **`line-height: 0` on the slot.** Collapses the spinner wrapper 21px to 16px, but the box still goes 0px to 16px, so the baseline still moves and you still get the full -4px.
- **Fixing `Primer::Beta::Spinner`** by giving its wrapper `display: inline-flex`. Worth doing on its own merits, but it doesn't fix this bug for the same reason. Happy to open that separately.

`height` alone gets to 0px. `flex: none` and the centering are belt and braces so the 21px wrapper can't stretch the box when the row is tight.

### Anything you want to highlight for special attention from reviewers?

The tests unhide the icons directly rather than clicking and racing the in-flight request, so they assert the CSS invariant instead of flaking on timing. Both fail without the CSS change, per the right column above.

They use `removeAttribute('hidden')` rather than `.hidden = false` because `hidden` is an `HTMLElement` IDL property and the error icon is an `<svg>`, so assigning to it silently does nothing. CI caught that on my first attempt.

### Accessibility

- **No new axe scan violation** - This change does not introduce any new [axe scan](https://thehub.github.com/epd/engineering/dev-practicals/frontend/accessibility/readiness-routine/development/#axe-scans) violations.

CSS only, no change to markup, roles, or the `sr-only` loading text.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Docs and previews aren't affected, the existing `small` preview already reproduces the bug.


