### PR TITLE
Fix ActionMenu mnemonic handling

### DIFF
--- a/app/components/primer/focus_group.ts
+++ b/app/components/primer/focus_group.ts
@@ -120,13 +120,14 @@ export default class FocusGroupElement extends HTMLElement {
       } else if (event.key === 'End' || event.key === 'PageDown') {
         index = items.length - 1
         event.preventDefault()
-      } else if (this.mnemonics && printable.test(key)) {
+      } else if (this.mnemonics && !event.ctrlKey && !event.metaKey && !event.altKey && printable.test(key)) {
         const mnemonic = key.toLowerCase()
         const offset = index > 0 && getMnemonicFor(event.target as Element) === mnemonic ? index : 0
         index = items.findIndex((item, i) => i > offset && getMnemonicFor(item) === mnemonic)
         if (index < 0 && !nowrap) {
           index = items.findIndex(item => getMnemonicFor(item) === mnemonic)
         }
+        if (index < 0) return
       } else {
         return
       }

--- a/test/system/alpha/action_menu_test.rb
+++ b/test/system/alpha/action_menu_test.rb
@@ -620,6 +620,36 @@ module Alpha
       assert_selector "[aria-checked=true]", text: "Recursive", visible: :hidden
     end
 
+    def test_modified_mnemonic_does_not_open_closed_menu
+      visit_preview(:single_select)
+      focus_on_invoker_button
+
+      keyboard.type([:meta, "r"])
+
+      refute_selector "anchored-position:popover-open"
+      assert_equal "Menu", page.evaluate_script("document.activeElement").text
+    end
+
+    def test_unmatched_mnemonic_does_not_open_closed_menu
+      visit_preview(:single_select)
+      focus_on_invoker_button
+
+      keyboard.type("x")
+
+      refute_selector "anchored-position:popover-open"
+      assert_equal "Menu", page.evaluate_script("document.activeElement").text
+    end
+
+    def test_matching_mnemonic_opens_closed_menu_and_focuses_item
+      visit_preview(:single_select)
+      focus_on_invoker_button
+
+      keyboard.type("r")
+
+      assert_selector "anchored-position:popover-open"
+      assert_equal "Recursive", page.evaluate_script("document.activeElement").text
+    end
+
     def test_single_select_item_unchecks_previously_checked_item
       visit_preview(:single_select)
 


### PR DESCRIPTION
- Closes https://github.com/primer/view_components/issues/4167

Prevents modified and unmatched mnemonic keypresses from opening a closed ActionMenu.

### What are you trying to accomplish?

Ignore Control-, Command-, and Alt-modified printable keypresses during mnemonic handling, and leave a closed menu unchanged when no item mnemonic matches. Unmodified matching mnemonics continue to open the menu and focus the matching item.

### Integration

No production integration updates are required.

#### List the issues that this change affects.

- https://github.com/primer/view_components/issues/4167

#### Risk Assessment

- [x] **Low risk** the change is small, highly observable, and easily rolled back. The behavior change is limited to printable-key mnemonic handling and has focused system coverage.
- [ ] **Medium risk** changes that are isolated, reduced in scope or could impact few users. The change will not impact library availability.
- [ ] **High risk** changes are those that could impact customers and SLOs, low or no test coverage, low observability, or slow to rollback.

### What approach did you choose and why?

Check the keyboard event's modifier flags before mnemonic lookup, while intentionally leaving Shift available for case-insensitive mnemonic matching. If lookup produces no matching item, return before popover or focus handling instead of allowing a negative index to select the final item.

This keeps the change at the shared mnemonic behavior boundary without altering arrow-key navigation or matching mnemonic behavior.

### Anything you want to highlight for special attention from reviewers?

`focus-group` is shared by ActionMenu and SelectPanel, so the modifier and unmatched-key guards apply consistently to both components.

### Verification

- `npx eslint app/components/primer/focus_group.ts`
- `npx tsc --noEmit`
- `bundle exec rubocop test/system/alpha/action_menu_test.rb`
- Focused Chrome system tests for modified, unmatched, and matching mnemonics

### Accessibility

- **No new axe scan violation** - This change does not introduce any new axe scan violations.

### Merge checklist

- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Added/updated previews (Lookbook)
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/react/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.