### PR TITLE
Fix ReusedInstanceError in Dropdown::Menu::Item divider rendering

### DIFF
--- a/.changeset/clear-hounds-read.md
+++ b/.changeset/clear-hounds-read.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Fix ReusedInstanceError in Dropdown::Menu::Item divider rendering

--- a/app/components/primer/alpha/dropdown/menu.rb
+++ b/app/components/primer/alpha/dropdown/menu.rb
@@ -88,7 +88,7 @@ module Primer
                         end
 
             # divider has no content
-            render(component) if divider?
+            return render(component) if divider?
 
             render(component) { content }
           end


### PR DESCRIPTION
## Summary

Fixes three test failures surfaced by ViewComponent/view_component#2691 (which enforces single-use component instances via `ViewComponent::ReusedInstanceError`):

- `Primer::Alpha::Dropdown::MenuTest#test_renders_dividers`
- `Primer::Alpha::Dropdown::MenuTest#test_renders_as_list`
- `PrimerAlphaDropdownTest#test_renders_dropdown_with_divider`

## Root cause

In `Primer::Alpha::Dropdown::Menu::Item#call`, the divider branch was missing an early `return`, so a single `Primer::BaseComponent` instance was rendered twice — first as the divider, then again with a content block:

```ruby
render(component) if divider?
render(component) { content }
```

This has always been latently wrong (the second `render` was invoked even for dividers), but was harmless until view_component started rejecting reused instances.

## Fix

Add `return` to the divider branch so the divider is rendered exactly once and the content branch is skipped.