### PR TITLE
Raise minimum Ruby OpenSSL version to 3.4

### DIFF
--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "openssl", ">= 3.3"
+gem "openssl", ">= 3.4"
 
 rails_version = (ENV["RAILS_VERSION"] || "7.2.2.1").to_s
 

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -396,7 +396,7 @@ DEPENDENCIES
   kuby-kind (~> 0.2)
   listen
   lookbook (~> 2.3.14)
-  openssl (>= 3.3)
+  openssl (>= 3.4)
   primer_view_components!
   pry-byebug
   puma (~> 8.0.2)


### PR DESCRIPTION
## Summary

- require Ruby OpenSSL 3.4 or newer in the demo Gemfile
- keep the lockfile dependency constraint in sync
- retain the existing resolved OpenSSL 4.0.2 release