### PR TITLE
Bump Lookbook to 2.3.15

### DIFF
--- a/.changeset/bright-books-smile.md
+++ b/.changeset/bright-books-smile.md
@@ -1,0 +1,5 @@
+---
+"@primer/view-components": patch
+---
+
+Update Lookbook to 2.3.15.

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "puma", "~> 8.0.2"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
 
-gem "lookbook", "~> 2.3.14"
+gem "lookbook", "~> 2.3.15"
 if ENV["VIEW_COMPONENT_PATH"]
   gem "view_component", path: ENV["VIEW_COMPONENT_PATH"]
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,15 +129,15 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lookbook (2.3.14)
+    lookbook (2.3.15)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
-      htmlentities (~> 4.3.4)
-      marcel (~> 1.0)
+      htmlentities (~> 4.3)
+      marcel (>= 1.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
-      rouge (>= 3.26, < 5.0)
+      rouge (>= 3.26, < 6.0)
       view_component (>= 2.0)
       yard (~> 0.9)
       zeitwerk (~> 2.5)
@@ -336,7 +336,7 @@ DEPENDENCIES
   erblint-github (~> 1.0.1)
   kramdown (~> 2.5)
   listen (~> 3.10)
-  lookbook (~> 2.3.14)
+  lookbook (~> 2.3.15)
   matrix (~> 0.4.3)
   minitest (~> 5.0)
   mocha

--- a/demo/Gemfile
+++ b/demo/Gemfile
@@ -40,7 +40,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 
 gem "primer_view_components", path: "../"
 gem "view_component", "4.12.0"
-gem "lookbook", "~> 2.3.14" unless rails_version.to_f < 7
+gem "lookbook", "~> 2.3.15" unless rails_version.to_f < 7
 
 gem "vite_rails", "~> 3.11"
 gem "cssbundling-rails", "~> 1.4"

--- a/demo/Gemfile.lock
+++ b/demo/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
       listen (>= 3.0.0)
       railties (>= 7.0.0)
     htmlbeautifier (1.4.3)
-    htmlentities (4.3.4)
+    htmlentities (4.4.2)
     http (5.2.0)
       addressable (~> 2.8)
       base64 (~> 0.1)
@@ -212,19 +212,19 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lookbook (2.3.14)
+    lookbook (2.3.15)
       activemodel
       css_parser
       htmlbeautifier (~> 1.3)
-      htmlentities (~> 4.3.4)
-      marcel (~> 1.0)
+      htmlentities (~> 4.3)
+      marcel (>= 1.0)
       railties (>= 5.0)
       redcarpet (~> 3.5)
-      rouge (>= 3.26, < 5.0)
+      rouge (>= 3.26, < 6.0)
       view_component (>= 2.0)
       yard (~> 0.9)
       zeitwerk (~> 2.5)
-    marcel (1.1.0)
+    marcel (2.1.0)
     method_source (1.1.0)
     mime-types (3.6.0)
       logger
@@ -374,7 +374,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    yard (0.9.44)
+    yard (0.9.45)
     zeitwerk (2.8.2)
 
 PLATFORMS
@@ -395,7 +395,7 @@ DEPENDENCIES
   kuby-core (~> 0.20)
   kuby-kind (~> 0.2)
   listen
-  lookbook (~> 2.3.14)
+  lookbook (~> 2.3.15)
   openssl (>= 3.4)
   primer_view_components!
   pry-byebug

--- a/static/arguments.json
+++ b/static/arguments.json
@@ -4996,13 +4996,19 @@
         "name": "minute",
         "type": "Symbol",
         "default": "`MINUTE_DEFAULT`",
-        "description": "What format minues should take. One of `nil`, `:numeric`, or `:two_digit`."
+        "description": "What format minutes should take. One of `nil`, `:numeric`, or `:two_digit`."
       },
       {
         "name": "hour",
         "type": "Symbol",
         "default": "`HOUR_DEFAULT`",
         "description": "What format hours should take. One of `nil`, `:numeric`, or `:two_digit`."
+      },
+      {
+        "name": "hour_cycle",
+        "type": "Symbol",
+        "default": "`HOUR_CYCLE_DEFAULT`",
+        "description": "What hour cycle should be used. One of `nil`, `:h11`, `:h12`, `:h23`, or `:h24`."
       },
       {
         "name": "weekday",

--- a/static/constants.json
+++ b/static/constants.json
@@ -1402,6 +1402,14 @@
       "narrow"
     ],
     "GeneratedSlotMethods": "Primer::Beta::RelativeTime::GeneratedSlotMethods",
+    "HOUR_CYCLE_DEFAULT": null,
+    "HOUR_CYCLE_OPTIONS": [
+      null,
+      "h11",
+      "h12",
+      "h23",
+      "h24"
+    ],
     "HOUR_DEFAULT": null,
     "HOUR_MAPPINGS": {
       "": null,

--- a/static/info_arch.json
+++ b/static/info_arch.json
@@ -16679,13 +16679,19 @@
         "name": "minute",
         "type": "Symbol",
         "default": "`MINUTE_DEFAULT`",
-        "description": "What format minues should take. One of `nil`, `:numeric`, or `:two_digit`."
+        "description": "What format minutes should take. One of `nil`, `:numeric`, or `:two_digit`."
       },
       {
         "name": "hour",
         "type": "Symbol",
         "default": "`HOUR_DEFAULT`",
         "description": "What format hours should take. One of `nil`, `:numeric`, or `:two_digit`."
+      },
+      {
+        "name": "hour_cycle",
+        "type": "Symbol",
+        "default": "`HOUR_CYCLE_DEFAULT`",
+        "description": "What hour cycle should be used. One of `nil`, `:h11`, `:h12`, `:h23`, or `:h24`."
       },
       {
         "name": "weekday",


### PR DESCRIPTION
## Summary

- update Lookbook from 2.3.14 to 2.3.15
- refresh the root and demo lockfiles
- include transitive dependency updates required by the new release

## Validation

- confirmed the demo bundle resolves and loads Lookbook 2.3.15
- confirmed the root lockfile resolves Lookbook 2.3.15